### PR TITLE
adds support for netlisting back mirrored references

### DIFF
--- a/pp/get_netlist.py
+++ b/pp/get_netlist.py
@@ -89,7 +89,7 @@ def get_netlist(
         instances[reference_name] = dict(
             component=c.function_name, settings=settings["settings"],
         )
-        placements[reference_name] = dict(x=x, y=y, rotation=int(reference.rotation))
+        placements[reference_name] = dict(x=x, y=y, rotation=int(reference.rotation), mirror=reference.x_reflection)
 
     # store where ports are located
     name2port = {}


### PR DESCRIPTION
Currently the `get_netlist()` function does not consider mirrored references. This fixes that.