### PR TITLE
fixes an error when a parameter's name attribute is not actually a str

### DIFF
--- a/pp/name.py
+++ b/pp/name.py
@@ -146,7 +146,11 @@ def clean_value(value: Any) -> str:
         value = dict2name(**value)
     elif isinstance(value, Device):
         value = clean_name(value.name)
-    elif isinstance(value, object) and hasattr(value, "name"):
+    elif (
+        isinstance(value, object)
+        and hasattr(value, "name")
+        and isinstance(value.name, str)
+    ):
         value = clean_name(value.name)
     elif callable(value):
         value = value.__name__


### PR DESCRIPTION
sometimes even though a parameter has an attribute 'name', it might not be a string. i.e. it might be None. In this case, we should turn to the final else clause of this conditional