### PR TITLE
fix naming for components with long funcnames (already over 24 chars)

### DIFF
--- a/pp/name.py
+++ b/pp/name.py
@@ -167,7 +167,7 @@ def get_name(component_type: str, name: str) -> str:
     if not isinstance(name, str):
         raise ValueError(f"{name} needs to be a sting")
     if len(name) > MAX_NAME_LENGTH:
-        name = f"{component_type}_{hashlib.md5(name.encode()).hexdigest()[:8]}"
+        name = f"{component_type[:(MAX_NAME_LENGTH - 8)]}_{hashlib.md5(name.encode()).hexdigest()[:8]}"
     return clean_name(name)
 
 


### PR DESCRIPTION
Hi Joaquin,

The current `get_name()` function is potentially problematic for any component with a function name over 24 characters.

**Case 1:** Function name is 25-32 characters + parameters
- Component name will potentially be longer than 32 characters after "truncation"

**Case 2:** Function name is over 32 characters (default OR parameterized)
- Component name will always be even 8 characters longer than when you started

This fix resolves both cases by truncating the `component_type` to 24 characters MAX before appending the 8 character hash.