### PR TITLE
get_bundle_from_waypoints with only one route

### DIFF
--- a/gdsfactory/routing/get_bundle_from_waypoints.py
+++ b/gdsfactory/routing/get_bundle_from_waypoints.py
@@ -220,8 +220,8 @@ def _generate_manhattan_bundle_waypoints(
 
     # if separation is defined, the offsets should increment from the reference port in the same direction
     # as the original offsets
-    # also, if there are no intermediate waypoints, we should not try to correct this
-    if separation and len(offsets_start) > 1:
+    # also, if there is only one route, we should skip this step as it is irrelevant
+    if separation and len(ports1) > 1:
         # the default case when we start with the reference port
         offsets_mid = [
             np.sign(offsets_start[1]) * separation * i

--- a/gdsfactory/routing/get_bundle_from_waypoints.py
+++ b/gdsfactory/routing/get_bundle_from_waypoints.py
@@ -220,7 +220,8 @@ def _generate_manhattan_bundle_waypoints(
 
     # if separation is defined, the offsets should increment from the reference port in the same direction
     # as the original offsets
-    if separation:
+    # also, if there are no intermediate waypoints, we should not try to correct this
+    if separation and len(offsets_start) > 1:
         # the default case when we start with the reference port
         offsets_mid = [
             np.sign(offsets_start[1]) * separation * i


### PR DESCRIPTION
get_bundle_from_waypoints may be used with just a single route. currently the implementation throws an index out of bounds error in this case. this PR fixes that error