### PR TITLE
359m

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.8
+current_version = 3.5.9
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Maybe:
 - mypy passing
 - pass force-regen flag from pytest
 
+## 3.5.9
+
+- gf.simulation.get_sparameters_path takes kwargs with simulation_settings
+- cross have port_type argument
+- splitter_tree exposes bend_s info
+
 ## 3.5.8
 
 - gf.components.extend_ports uses port.cross_section to extend the port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Maybe:
 - gf.simulation.get_sparameters_path takes kwargs with simulation_settings
 - cross have port_type argument
 - splitter_tree exposes bend_s info
+- change simulation_settings default values
+    - port_margin = 0.5 -> 1.5
+    - port_extension = 2.0 -> 5.0
+- route with auto_taper was missing a mirror
 
 ## 3.5.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Maybe:
 - change simulation_settings default values
     - port_margin = 0.5 -> 1.5
     - port_extension = 2.0 -> 5.0
+    - xmargin = 0.5 -> 3.0
+    - ymargin = 2.0 -> 3.0
+    - remove pml_width as it was redundant with xmargin and ymargin
 - route with auto_taper was missing a mirror
 
 ## 3.5.8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.5.8
+# gdsfactory 3.5.9
 
 [![](https://readthedocs.org/projects/gdsfactory/badge/?version=latest)](https://gdsfactory.readthedocs.io/en/latest/?badge=latest)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 project = "gdsfactory"
-release = "3.5.8"
+release = "3.5.9"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/docs/notebooks/04_routing.ipynb
+++ b/docs/notebooks/04_routing.ipynb
@@ -1627,7 +1627,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = gf.components.cross(length=200, width=2)\n",
+    "c = gf.components.cross(length=200, width=2, port_type='optical')\n",
     "cc = gf.routing.add_fiber_single(component=c, with_loopback=False)\n",
     "cc"
    ]

--- a/fixme/done/route_with_taper.py
+++ b/fixme/done/route_with_taper.py
@@ -1,0 +1,45 @@
+import gdsfactory as gf
+from gdsfactory.cross_section import Section
+
+
+WIDTH_WIDE = 2.0
+
+xs_pin_m1 = gf.partial(
+    gf.cross_section.strip_auto_widen,
+    width=0.5,
+    width_wide=WIDTH_WIDE,
+    sections=(
+        Section(width=1, offset=2, layer=gf.LAYER.NPP, name="n+"),
+        Section(width=1, offset=3, layer=gf.LAYER.M1, name="m1"),
+    ),
+)
+
+xs_pin = gf.partial(
+    gf.cross_section.strip_auto_widen,
+    sections=(Section(width=1, offset=2, layer=gf.LAYER.NPP, name="n+"),),
+)
+
+
+@gf.cell
+def taper_pin(length: float = 5, **kwargs) -> gf.Component:
+    trans = gf.path.transition(
+        cross_section1=xs_pin(),
+        cross_section2=xs_pin(width=WIDTH_WIDE),
+        width_type="linear",
+    )
+    path = gf.path.straight(length=length)
+    return gf.path.extrude(path, cross_section=trans)
+
+
+if __name__ == "__main__":
+    c = gf.Component()
+    route = gf.routing.get_route_from_waypoints(
+        [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
+        cross_section=xs_pin_m1,
+        bend=gf.partial(gf.c.bend_euler, cross_section=xs_pin),
+        taper_factory=taper_pin,
+        radius=30,
+    )
+    c.add(route.references)
+
+    c.show()

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -120,7 +120,7 @@ __all__ = [
     "write_doe",
     "Label",
 ]
-__version__ = "3.5.8"
+__version__ = "3.5.9"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -759,7 +759,15 @@ class Component(Device):
         h_mirror: bool = False,
         v_mirror: bool = False,
     ) -> ComponentReference:
-        """Returns Component reference."""
+        """Returns Component reference.
+
+        Args:
+            position:
+            port_id: name of the port
+            rotation:
+            h_mirror: horizontal mirror using y axis (x, 1) (1, 0)
+            v_mirror: vertical mirror using x axis (1, y) (0, y)
+        """
         _ref = ComponentReference(self)
 
         if port_id and port_id not in self.ports:

--- a/gdsfactory/components/cross.py
+++ b/gdsfactory/components/cross.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -10,59 +10,64 @@ def cross(
     length: float = 10.0,
     width: float = 3.0,
     layer: Tuple[int, int] = LAYER.WG,
+    port_type: Optional[str] = None,
 ) -> Component:
-    """Generates a right-angle cross from two rectangles of specified length and width.
+    """Returns a cross from two rectangles of length and width.
 
     Args:
         length: float Length of the cross from one end to the other
         width: float Width of the arms of the cross
-        layer: int, array-like[2], or set Specific layer(s) to put polygon geometry on
+        layer: layer for geometry
+        port_type:
 
     """
-
     c = gf.Component()
     R = gf.components.rectangle(size=(width, length), layer=layer)
     r1 = c.add_ref(R).rotate(90)
     r2 = c.add_ref(R)
     r1.center = (0, 0)
     r2.center = (0, 0)
-    c.add_port(
-        1,
-        width=width,
-        layer=layer,
-        orientation=0,
-        midpoint=(+length / 2, 0),
-    )
-    c.add_port(
-        2,
-        width=width,
-        layer=layer,
-        orientation=180,
-        midpoint=(-length / 2, 0),
-    )
-    c.add_port(
-        3,
-        width=width,
-        layer=layer,
-        orientation=90,
-        midpoint=(0, length / 2),
-    )
-    c.add_port(
-        4,
-        width=width,
-        layer=layer,
-        orientation=270,
-        midpoint=(0, -length / 2),
-    )
-    c.absorb(r1)
-    c.absorb(r2)
-    c.auto_rename_ports()
+
+    if port_type:
+        c.add_port(
+            1,
+            width=width,
+            layer=layer,
+            orientation=0,
+            midpoint=(+length / 2, 0),
+            port_type=port_type,
+        )
+        c.add_port(
+            2,
+            width=width,
+            layer=layer,
+            orientation=180,
+            midpoint=(-length / 2, 0),
+            port_type=port_type,
+        )
+        c.add_port(
+            3,
+            width=width,
+            layer=layer,
+            orientation=90,
+            midpoint=(0, length / 2),
+            port_type=port_type,
+        )
+        c.add_port(
+            4,
+            width=width,
+            layer=layer,
+            orientation=270,
+            midpoint=(0, -length / 2),
+            port_type=port_type,
+        )
+        c.auto_rename_ports()
     return c
 
 
 if __name__ == "__main__":
     c = cross()
     c.show()
-    c.pprint_ports()
-    cc = gf.routing.add_fiber_array(component=c)
-    cc.show()
+    # c.pprint_ports()
+    # cc = gf.routing.add_fiber_array(component=c)
+    # cc.show()

--- a/gdsfactory/components/extension.py
+++ b/gdsfactory/components/extension.py
@@ -177,7 +177,7 @@ def extend_ports(
 def test_extend_ports() -> Component:
     import gdsfactory.components as pc
 
-    c = pc.cross(width=2)
+    c = pc.cross(width=2, port_type="optical")
     ce = extend_ports(component=c)
     assert len(c.ports) == len(ce.ports)
     p = len(ce.polygons)

--- a/gdsfactory/components/manhattan_font.py
+++ b/gdsfactory/components/manhattan_font.py
@@ -15,13 +15,13 @@ def manhattan_text(
     justify: str = "left",
     layer: Tuple[int, int] = (1, 0),
 ) -> Component:
-    """Pixel based font, guaranteed to be manhattan, without accute angles.
+    """Pixel based font, guaranteed to be manhattan, without acute angles.
 
     Args:
         text:
         size: pixel size
         position: coordinate
-        justify
+        justify: left, right or center
         layer:
 
     """

--- a/gdsfactory/components/splitter_tree.py
+++ b/gdsfactory/components/splitter_tree.py
@@ -66,6 +66,7 @@ def splitter_tree(
             size=(bend_s_xsize, bend_s_ysize),
             **kwargs,
         )
+        c.info.bend_s = bend_s.info
     cols = int(np.log2(noutputs))
     i = 0
 

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.5.8"
+__version__ = "3.5.9"
 import json
 import os
 import pathlib

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -26,7 +26,7 @@ from gdsfactory.types import PathType
 # from gdsfactory.write_doe_from_yaml import write_doe_from_yaml
 from gdsfactory.write_doe_from_yaml import import_custom_doe_factories
 
-VERSION = "3.5.8"
+VERSION = "3.5.9"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -563,7 +563,7 @@ def round_corners(
         cross_section:
         on_route_error: function to run when route fails
         with_point_markers: add route points markers (easy for debugging)
-        **kwargs: cross_section settings
+        kwargs: cross_section settings
     """
     x = cross_section(**kwargs)
 
@@ -720,16 +720,7 @@ def round_corners(
         bsx = np.sign(bend_points[2 * i + 1][0] - bend_points[2 * i][0])
         bsy = np.sign(bend_points[2 * i + 1][1] - bend_points[2 * i][1])
         if bsx * sx == -1 or bsy * sy == -1:
-            # print("error", bsx * sx, bsy * sy)
-            # references += [gf.c.rectangle(size=(2, 2)).ref(position=point)]
             return on_route_error(points=points, cross_section=x, references=references)
-
-    # for i, point in enumerate(bend_points[:-1]):
-    #     bsx = bend_points[i + 1][0] - point[0]
-    #     bsy = bend_points[i + 1][1] - point[1]
-    #     if abs(bsx) > 0.001 and abs(bsy) > 0.001:
-    #         print(i, point, bsx, bsy)
-    #         # return on_route_error(points=points, cross_section=x, references=references)
 
     wg_refs = []
     for straight_origin, angle, length in straight_sections:
@@ -794,19 +785,24 @@ def round_corners(
             pname_west, pname_east = [
                 p.name for p in _get_straight_ports(taper, layer=x.info["layer"])
             ]
-            taper_ref = taper.ref(
-                position=taper_origin, port_id=pname_east, rotation=angle + 180
-            )
 
+            taper_ref = taper.ref(
+                position=taper_origin,
+                port_id=pname_east,
+                rotation=angle + 180,
+                v_mirror=True,
+            )
+            # references += [
+            #     gf.Label(
+            #         text=f"a{angle}",
+            #         position=taper_ref.center,
+            #         layer=2,
+            #         texttype=0,
+            #     )
+            # ]
             references.append(taper_ref)
             wg_refs += [taper_ref]
             port_index_out = 0
-
-    # route = Component()
-    # route.add(references)
-    # netlist = route.get_netlist()
-    # if len(netlist["connections"]) != len(references) - 1:
-    #     return on_route_error(points=points, cross_section=x, references=references)
 
     if with_point_markers:
         route = get_route_error(points, cross_section=x)

--- a/gdsfactory/simulation/get_sparameters_path.py
+++ b/gdsfactory/simulation/get_sparameters_path.py
@@ -21,9 +21,10 @@ def get_sparameters_path(
 
     Args:
         component:
-        dirpath
-        layer_to_material: GDSlayer to material alias
-        layer_to_thickness: GDSlayer to thickness (nm)
+        layer_to_material: GDSlayer tuple to material alias
+        layer_to_thickness: GDSlayer tuple to thickness (nm)
+        dirpath:
+        kwargs: simulation settings
     """
     dirpath = pathlib.Path(dirpath)
     dirpath = (

--- a/gdsfactory/simulation/read.py
+++ b/gdsfactory/simulation/read.py
@@ -131,6 +131,7 @@ def read_sparameters_pandas(
     component: Component,
     layer_stack: LayerStack = LAYER_STACK,
     dirpath: Path = gf.CONFIG["sparameters"],
+    **kwargs,
 ) -> pd.DataFrame:
     """Returns Sparameters in a pandas DataFrame.
 
@@ -140,6 +141,7 @@ def read_sparameters_pandas(
         component: Component
         layer_stack:
         dirpath: path where to look for the Sparameters
+        kwargs: simulation settings
 
     """
     filepath = get_sparameters_path(
@@ -147,6 +149,7 @@ def read_sparameters_pandas(
         dirpath=dirpath,
         layer_to_material=layer_stack.get_layer_to_material(),
         layer_to_thickness=layer_stack.get_layer_to_thickness(),
+        **kwargs,
     )
     df = pd.read_csv(filepath.with_suffix(".csv"))
     df.index = df["wavelength_nm"]

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -1,6 +1,4 @@
-"""Write Sparameters with Lumerical FDTD.
-
-"""
+"""Write Sparameters with Lumerical FDTD."""
 
 import dataclasses
 import time
@@ -25,7 +23,7 @@ from gdsfactory.types import ComponentOrFactory
 run_false_warning = """
 You have passed run=False to debug the simulation
 
-run=False returns the simulation session for you to debug and make sure it's correct
+run=False returns the simulation session for you to debug and make sure it is correct
 
 To compute the Sparameters you need to pass run=True
 """
@@ -97,6 +95,8 @@ def write_sparameters_lumerical(
             wavelength_points: 500
             simulation_time: (s) related to max path length 3e8/2.4*10e-12*1e6 = 1.25mm
             simulation_temperature: in kelvin (default = 300)
+            frequency_dependendent_profile: computes mode profiles for different wavelengths
+            field_profile_samples: number of wavelengths to compute field profile
 
 
     .. code::
@@ -201,15 +201,6 @@ def write_sparameters_lumerical(
     x_max = (component.xmax + ss.xmargin) * 1e-6
     y_min = (component.ymin - ss.ymargin) * 1e-6
     y_max = (component.ymax + ss.ymargin) * 1e-6
-
-    port_orientations = [p.orientation for p in ports]
-
-    # bend
-    if 90 in port_orientations:
-        y_max -= ss.ymargin * 1e-6
-
-    if 270 in port_orientations:
-        y_min += ss.ymargin * 1e-6
 
     layers_thickness = [
         layer_to_thickness[layer]

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -342,7 +342,7 @@ def write_sparameters_lumerical(
         s.setnamed(p, "z", z * 1e-6)
         s.setnamed(p, "z span", zspan * 1e-6)
         s.setnamed(
-            p, "frequency_dependendent_profile", ss.frequency_dependendent_profile
+            p, "frequency dependendent profile", ss.frequency_dependendent_profile
         )
         s.setnamed(p, "number of field profile samples", ss.field_profile_samples)
 

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -92,7 +92,6 @@ def write_sparameters_lumerical(
             zmargin: for the FDTD region (um)
             ymargin: for the FDTD region (um)
             xmargin: for the FDTD region (um)
-            pml_margin: gap for all the FDTD region
             wavelength_start: 1.2 (um)
             wavelength_stop: 1.6 (um)
             wavelength_points: 500
@@ -156,7 +155,7 @@ def write_sparameters_lumerical(
     for setting in settings.keys():
         if setting not in sim_settings:
             raise ValueError(
-                f"`{setting}` is not a valid setting ({list(sim_settings.keys()) + simulation_settings})"
+                f"Invalid setting `{setting}` not in ({list(sim_settings.keys())})"
             )
 
     sim_settings.update(**settings)
@@ -198,10 +197,10 @@ def write_sparameters_lumerical(
         print(run_false_warning)
 
     logger.info(f"Writing Sparameters to {filepath_csv}")
-    x_min = (component.xmin - ss.xmargin - ss.pml_margin) * 1e-6
-    x_max = (component.xmax + ss.xmargin + ss.pml_margin) * 1e-6
-    y_min = (component.ymin - ss.ymargin - ss.pml_margin) * 1e-6
-    y_max = (component.ymax + ss.ymargin + ss.pml_margin) * 1e-6
+    x_min = (component.xmin - ss.xmargin) * 1e-6
+    x_max = (component.xmax + ss.xmargin) * 1e-6
+    y_min = (component.ymin - ss.ymargin) * 1e-6
+    y_max = (component.ymax + ss.ymargin) * 1e-6
 
     port_orientations = [p.orientation for p in ports]
 

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -342,9 +342,9 @@ def write_sparameters_lumerical(
         s.setnamed(p, "z", z * 1e-6)
         s.setnamed(p, "z span", zspan * 1e-6)
         s.setnamed(
-            p, "multifrequency mode calculation", ss.multifrequency_mode_calculation
+            p, "frequency_dependendent_profile", ss.frequency_dependendent_profile
         )
-        s.setnamed(p, "frequency points", ss.multifrequency_mode_calculation_points)
+        s.setnamed(p, "number of field profile samples", ss.field_profile_samples)
 
         deg = int(port.orientation)
         # if port.orientation not in [0, 90, 180, 270]:

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -342,6 +342,10 @@ def write_sparameters_lumerical(
         s.setnamed(p, "y", port.y * 1e-6)
         s.setnamed(p, "z", z * 1e-6)
         s.setnamed(p, "z span", zspan * 1e-6)
+        s.setnamed(
+            p, "multifrequency mode calculation", ss.multifrequency_mode_calculation
+        )
+        s.setnamed(p, "frequency points", ss.multifrequency_mode_calculation_points)
 
         deg = int(port.orientation)
         # if port.orientation not in [0, 90, 180, 270]:

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -47,7 +47,7 @@ def write_sparameters_lumerical(
     simulation_settings: SimulationSettings = SIMULATION_SETTINGS,
     **settings,
 ) -> pd.DataFrame:
-    """Returns and writes component Sparameters using Lumerical FDTD.
+    r"""Returns and writes component Sparameters using Lumerical FDTD.
 
     If simulation exists it returns the Sparameters directly unless overwrite=True
     which forces a re-run of the simulation
@@ -83,7 +83,7 @@ def write_sparameters_lumerical(
         dirpath: where to store the Sparameters
         layer_stack: layer_stack
         simulation_settings: dataclass with all simulation_settings
-        **settings: overwrite any simulation settings
+        settings: overwrite any simulation settings
             background_material: for the background
             port_margin: on both sides of the port width (um)
             port_height: port height (um)
@@ -92,12 +92,49 @@ def write_sparameters_lumerical(
             zmargin: for the FDTD region (um)
             ymargin: for the FDTD region (um)
             xmargin: for the FDTD region (um)
-            pml_margin: for all the FDTD region
+            pml_margin: gap for all the FDTD region
             wavelength_start: 1.2 (um)
             wavelength_stop: 1.6 (um)
             wavelength_points: 500
             simulation_time: (s) related to max path length 3e8/2.4*10e-12*1e6 = 1.25mm
             simulation_temperature: in kelvin (default = 300)
+
+
+    .. code::
+
+         top view
+              ________________________________
+             |                               |
+             | xmargin                       | port_extension
+             |<------>          port_margin ||<-->
+          ___|___________          _________||___
+             |           \        /          |
+             |            \      /           |
+             |             ======            |
+             |            /      \           |
+          ___|___________/        \__________|___
+             |   |                           |
+             |   |ymargin                    |
+             |   |                           |
+             |___|___________________________|
+
+        side view
+              ________________________________
+             |                               |
+             |                               |
+             |                               |
+             |ymargin                        |
+             |<---> _____         _____      |
+             |     |     |       |     |     |
+             |     |     |       |     |     |
+             |     |_____|       |_____|     |
+             |       |                       |
+             |       |                       |
+             |       |zmargin                |
+             |       |                       |
+             |_______|_______________________|
+
+
 
     Return:
         Sparameters pandas DataFrame (wavelength_nm, S11m, S11a, S12a ...)
@@ -436,7 +473,8 @@ def _sample_convergence_wavelength():
 
 
 if __name__ == "__main__":
-    component = gf.components.straight(length=2.5)
+    # component = gf.components.straight(length=2.5)
+    component = gf.components.mmi1x2()
     r = write_sparameters_lumerical(
         component=component, mesh_accuracy=1, wavelength_points=200, run=False
     )

--- a/gdsfactory/simulation/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/write_sparameters_lumerical.py
@@ -341,9 +341,7 @@ def write_sparameters_lumerical(
         s.setnamed(p, "y", port.y * 1e-6)
         s.setnamed(p, "z", z * 1e-6)
         s.setnamed(p, "z span", zspan * 1e-6)
-        s.setnamed(
-            p, "frequency dependendent profile", ss.frequency_dependendent_profile
-        )
+        s.setnamed(p, "frequency dependent profile", ss.frequency_dependendent_profile)
         s.setnamed(p, "number of field profile samples", ss.field_profile_samples)
 
         deg = int(port.orientation)

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -263,9 +263,8 @@ class SimulationSettings:
     port_extension: float = 5.0
     mesh_accuracy: int = 2
     zmargin: float = 1.0
-    ymargin: float = 2.0
-    xmargin: float = 0.5
-    pml_margin: float = 0.5
+    ymargin: float = 3.0
+    xmargin: float = 3.0
     wavelength_start: float = 1.2
     wavelength_stop: float = 1.6
     wavelength_points: int = 500

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -258,6 +258,26 @@ class Section:
 
 @pydantic.dataclasses.dataclass
 class SimulationSettings:
+    """
+    Args:
+        background_material: for the background
+        port_margin: on both sides of the port width (um)
+        port_height: port height (um)
+        port_extension: port extension (um)
+        mesh_accuracy: 2 (1: coarse, 2: fine, 3: superfine)
+        zmargin: for the FDTD region (um)
+        ymargin: for the FDTD region (um)
+        xmargin: for the FDTD region (um)
+        wavelength_start: 1.2 (um)
+        wavelength_stop: 1.6 (um)
+        wavelength_points: 500
+        simulation_time: (s) related to max path length 3e8/2.4*10e-12*1e6 = 1.25mm
+        simulation_temperature: in kelvin (default = 300)
+        frequency_dependendent_profile: computes mode profiles for different wavelengths
+        field_profile_samples: number of wavelengths to compute field profile
+
+    """
+
     background_material: str = "sio2"
     port_margin: float = 1.5
     port_extension: float = 5.0

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -270,8 +270,8 @@ class SimulationSettings:
     wavelength_points: int = 500
     simulation_time: float = 10e-12
     simulation_temperature: float = 300
-    multifrequency_mode_calculation: bool = True
-    multifrequency_mode_calculation_points: int = 15
+    frequency_dependendent_profile: bool = True
+    field_profile_samples: int = 15
 
     mode_index: int = 0
     n_modes: int = 2

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -259,8 +259,8 @@ class Section:
 @pydantic.dataclasses.dataclass
 class SimulationSettings:
     background_material: str = "sio2"
-    port_margin: float = 0.5
-    port_extension: float = 2.0
+    port_margin: float = 1.5
+    port_extension: float = 5.0
     mesh_accuracy: int = 2
     zmargin: float = 1.0
     ymargin: float = 2.0

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -271,6 +271,8 @@ class SimulationSettings:
     wavelength_points: int = 500
     simulation_time: float = 10e-12
     simulation_temperature: float = 300
+    multifrequency_mode_calculation: bool = True
+    multifrequency_mode_calculation_points: int = 15
 
     mode_index: int = 0
     n_modes: int = 2

--- a/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
@@ -81,6 +81,35 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_26e1f2bc
+  compass_6c863878:
+    changed:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10.0
+      - 80.0
+    default:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4.0
+      - 2.0
+    full:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10.0
+      - 80.0
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_6c863878
   compass_cad5131e:
     changed:
       layer:
@@ -122,12 +151,14 @@ cells:
       - 1
       - 0
       length: 10.0
+      port_type: null
       width: 3.0
     full:
       layer:
       - 1
       - 0
       length: 80.0
+      port_type: null
       width: 10.0
     function_name: cross
     info_version: 1
@@ -164,6 +195,36 @@ cells:
     info_version: 1
     module: gdsfactory.components.rectangle
     name: rectangle_070e5949
+  rectangle_617f8716:
+    changed:
+      layer:
+      - 1
+      - 0
+      size:
+      - 10.0
+      - 80.0
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4.0
+      - 2.0
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10.0
+      - 80.0
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_617f8716
   rectangle_68da8230:
     changed:
       centered: true

--- a/gdsfactory/tests/test_components/test_settings_cross_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cross_.yml
@@ -1,4 +1,33 @@
 cells:
+  compass_61f9fdf6:
+    changed:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 3.0
+      - 10.0
+    default:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4.0
+      - 2.0
+    full:
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 3.0
+      - 10.0
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_61f9fdf6
   cross:
     changed: {}
     default:
@@ -6,17 +35,49 @@ cells:
       - 1
       - 0
       length: 10.0
+      port_type: null
       width: 3.0
     full:
       layer:
       - 1
       - 0
       length: 10.0
+      port_type: null
       width: 3.0
     function_name: cross
     info_version: 1
     module: gdsfactory.components.cross
     name: cross
+  rectangle_0273adbb:
+    changed:
+      layer:
+      - 1
+      - 0
+      size:
+      - 3.0
+      - 10.0
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4.0
+      - 2.0
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 3.0
+      - 10.0
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_0273adbb
 info:
   changed: {}
   default:
@@ -24,60 +85,18 @@ info:
     - 1
     - 0
     length: 10.0
+    port_type: null
     width: 3.0
   full:
     layer:
     - 1
     - 0
     length: 10.0
+    port_type: null
     width: 3.0
   function_name: cross
   info_version: 1
   module: gdsfactory.components.cross
   name: cross
-ports:
-  o1:
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - -5.0
-    - 0.0
-    name: o1
-    orientation: 180.0
-    port_type: optical
-    width: 3.0
-  o2:
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - 0.0
-    - 5.0
-    name: o2
-    orientation: 90.0
-    port_type: optical
-    width: 3.0
-  o3:
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - 5.0
-    - 0.0
-    name: o3
-    orientation: 0.0
-    port_type: optical
-    width: 3.0
-  o4:
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - 0.0
-    - -5.0
-    name: o4
-    orientation: 270.0
-    port_type: optical
-    width: 3.0
+ports: {}
 version: 1

--- a/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
@@ -22,6 +22,35 @@ cells:
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
   splitter_tree:
+    bend_s:
+      changed:
+        cross_section:
+          function: cross_section
+        size:
+        - 90.0
+        - 11.875
+      default:
+        nb_points: 99
+        size:
+        - 10.0
+        - 2.0
+        with_cladding_box: true
+      end_angle: 0.155
+      full:
+        cross_section:
+          function: cross_section
+        nb_points: 99
+        size:
+        - 90.0
+        - 11.875
+        with_cladding_box: true
+      function_name: bend_s
+      info_version: 1
+      length: 91.103
+      min_bend_radius: 129.147
+      module: gdsfactory.components.bend_s
+      name: bend_s_6267eca1
+      start_angle: 0.155
     changed: {}
     default:
       bend_s_xsize: null
@@ -40,6 +69,35 @@ cells:
     module: gdsfactory.components.splitter_tree
     name: splitter_tree
 info:
+  bend_s:
+    changed:
+      cross_section:
+        function: cross_section
+      size:
+      - 90.0
+      - 11.875
+    default:
+      nb_points: 99
+      size:
+      - 10.0
+      - 2.0
+      with_cladding_box: true
+    end_angle: 0.155
+    full:
+      cross_section:
+        function: cross_section
+      nb_points: 99
+      size:
+      - 90.0
+      - 11.875
+      with_cladding_box: true
+    function_name: bend_s
+    info_version: 1
+    length: 91.103
+    min_bend_radius: 129.147
+    module: gdsfactory.components.bend_s
+    name: bend_s_6267eca1
+    start_angle: 0.155
   changed: {}
   default:
     bend_s_xsize: null

--- a/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
@@ -134,6 +134,35 @@ cells:
     module: gdsfactory.components.mzi_arm
     name: mzi_arm_f8b34917
   splitter_tree_776bbad8:
+    bend_s:
+      changed:
+        cross_section:
+          function: cross_section
+        size:
+        - 500.0
+        - 24.375
+      default:
+        nb_points: 99
+        size:
+        - 10.0
+        - 2.0
+        with_cladding_box: true
+      end_angle: 0.057
+      full:
+        cross_section:
+          function: cross_section
+        nb_points: 99
+        size:
+        - 500.0
+        - 24.375
+        with_cladding_box: true
+      function_name: bend_s
+      info_version: 1
+      length: 500.845
+      min_bend_radius: 1870.03
+      module: gdsfactory.components.bend_s
+      name: bend_s_7e3fe90a
+      start_angle: 0.057
     changed:
       coupler:
         combiner: mmi2x2
@@ -171,6 +200,35 @@ cells:
     module: gdsfactory.components.splitter_tree
     name: splitter_tree_776bbad8
 info:
+  bend_s:
+    changed:
+      cross_section:
+        function: cross_section
+      size:
+      - 500.0
+      - 24.375
+    default:
+      nb_points: 99
+      size:
+      - 10.0
+      - 2.0
+      with_cladding_box: true
+    end_angle: 0.057
+    full:
+      cross_section:
+        function: cross_section
+      nb_points: 99
+      size:
+      - 500.0
+      - 24.375
+      with_cladding_box: true
+    function_name: bend_s
+    info_version: 1
+    length: 500.845
+    min_bend_radius: 1870.03
+    module: gdsfactory.components.bend_s
+    name: bend_s_7e3fe90a
+    start_angle: 0.057
   changed:
     coupler:
       combiner: mmi2x2

--- a/gdsfactory/tests/test_get_route_auto_widen.py
+++ b/gdsfactory/tests/test_get_route_auto_widen.py
@@ -1,0 +1,59 @@
+import gdsfactory as gf
+from gdsfactory.cross_section import Section
+from gdsfactory.difftest import difftest
+
+WIDTH_WIDE = 2.0
+
+xs_pin_m1 = gf.partial(
+    gf.cross_section.strip_auto_widen,
+    width=0.5,
+    width_wide=WIDTH_WIDE,
+    sections=(
+        Section(width=1, offset=2, layer=gf.LAYER.NPP, name="n+"),
+        Section(width=1, offset=3, layer=gf.LAYER.M1, name="m1"),
+    ),
+)
+
+xs_pin = gf.partial(
+    gf.cross_section.strip_auto_widen,
+    sections=(Section(width=1, offset=2, layer=gf.LAYER.NPP, name="n+"),),
+)
+
+
+@gf.cell
+def taper_pin(length: float = 5, **kwargs) -> gf.Component:
+    trans = gf.path.transition(
+        cross_section1=xs_pin(),
+        cross_section2=xs_pin(width=WIDTH_WIDE),
+        width_type="linear",
+    )
+    path = gf.path.straight(length=length)
+    return gf.path.extrude(path, cross_section=trans)
+
+
+def test_get_route_auto_widen() -> gf.Component:
+    c = gf.Component()
+    route = gf.routing.get_route_from_waypoints(
+        [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
+        cross_section=xs_pin_m1,
+        bend=gf.partial(gf.c.bend_euler, cross_section=xs_pin),
+        taper_factory=taper_pin,
+        radius=30,
+    )
+    c.add(route.references)
+    difftest(c)
+    return c
+
+
+if __name__ == "__main__":
+    c = gf.Component()
+    route = gf.routing.get_route_from_waypoints(
+        [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
+        cross_section=xs_pin_m1,
+        bend=gf.partial(gf.c.bend_euler, cross_section=xs_pin),
+        taper_factory=taper_pin,
+        radius=30,
+    )
+    c.add(route.references)
+
+    c.show()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_install_requires_dev():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.5.8",
+    version="3.5.9",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- gf.simulation.get_sparameters_path takes kwargs with simulation_settings
- cross have port_type argument
- splitter_tree exposes bend_s info
- change simulation_settings default values
    - port_margin = 0.5 -> 1.5
    - port_extension = 2.0 -> 5.0
    - xmargin = 0.5 -> 3.0
    - ymargin = 2.0 -> 3.0
    - remove pml_width as it was redundant with xmargin and ymargin
- route with auto_taper was missing a mirror
