### PR TITLE
371

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.0
+current_version = 3.7.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Maybe:
 - mypy passing
 - pass force-regen flag from pytest
 
+## 3.7.1
+
+- small patch to keep python3.7 functionality when using `gf.functions.cache` decorator
+- add_fiber_array accepts ComponentOrFactory
+
 ## 3.7.0
 
 - fix clean_name
@@ -24,7 +29,7 @@ Maybe:
     - toolz.compose functions hash both the functions and first function
     - casting foats to ints when possible, so straight(length=5) and straight(length=5.0) return the same component
 - set Component._cached = True when adding Component into cache, and raises MutabilityError when adding any element to it.
-- Component.flatten() returns a copy of the component, that includes the flattened component. New name adds `_flat` suffix to oringinal name
+- Component.flatten() returns a copy of the component, that includes the flattened component. New name adds `_flat` suffix to original name
 - add bias to grating_coupler_lumerical
 - try to cast float to int when exporting info
 - remove `ComponentSweep` as it was trivial to define as a list comprehension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Maybe:
 
 ## 3.7.1
 
-- small patch to keep python3.7 functionality when using `gf.functions.cache` decorator
-- add_fiber_array accepts ComponentOrFactory
+- keep python3.7 compatibility for `gf.functions.cache` decorator by using `cache = lru_cache(maxsize=None)` instead of `cache = lru_cache`
+- `add_fiber_array` accepts ComponentOrFactory, convenient for testing the function without building a component
 
 ## 3.7.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.7.0
+# gdsfactory 3.7.1
 
 [![](https://readthedocs.org/projects/gdsfactory/badge/?version=latest)](https://gdsfactory.readthedocs.io/en/latest/?badge=latest)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 project = "gdsfactory"
-release = "3.7.0"
+release = "3.7.1"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -121,7 +121,7 @@ __all__ = [
     "sweep",
     "Label",
 ]
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 import json
 import os
 import pathlib

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -6,7 +6,7 @@ from gdsfactory.component import Component
 from gdsfactory.port import auto_rename_ports
 from gdsfactory.types import Float2, Optional
 
-cache = lru_cache
+cache = lru_cache(maxsize=None)
 
 
 def add_port(component: Component, **kwargs) -> Component:

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.sweep.write_sweep_from_yaml import import_custom_doe_factories
 from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 
-VERSION = "3.7.0"
+VERSION = "3.7.1"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -12,6 +12,7 @@ from gdsfactory.routing.route_fiber_array import route_fiber_array
 from gdsfactory.routing.sort_ports import sort_ports_x
 from gdsfactory.types import (
     ComponentFactory,
+    ComponentOrFactory,
     ComponentOrFactoryOrList,
     CrossSectionFactory,
 )
@@ -19,7 +20,7 @@ from gdsfactory.types import (
 
 @gf.cell
 def add_fiber_array(
-    component: Component,
+    component: ComponentOrFactory,
     grating_coupler: ComponentOrFactoryOrList = grating_coupler_te,
     straight: ComponentFactory = straight_function,
     bend: ComponentFactory = bend_euler,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_install_requires_dev():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.7.0",
+    version="3.7.1",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- keep python3.7 compatibility for `gf.functions.cache` decorator by using `cache = lru_cache(maxsize=None)` instead of `cache = lru_cache`
- `add_fiber_array` accepts ComponentOrFactory, convenient for testing the function without building a component
