### PR TITLE
377

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.7.6
+current_version = 3.7.7
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Maybe:
 - pass force-regen flag from pytest
 
 ## 3.7.7
+
 - warning includes the number of unnamed cells
+- cells that include decorators that return a new cell now name both cells
+- pack includes a name_prefix to avoid unnamed cells
+- add `taper_cross_section` into a container so we can use a decorator over it without triggering InmutabilityError
 
 ## 3.7.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Maybe:
 - mypy passing
 - pass force-regen flag from pytest
 
+## 3.7.7
+- warning includes the number of unnamed cells
+
 ## 3.7.6
 
 - to dict accepts component and function prefixes of the structures that we want to ignore when saving the settings dict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ Maybe:
 
 ## 3.7.7
 
-- warning includes the number of unnamed cells
-- cells that include decorators that return a new cell now name both cells
+- `write_gds` prints warning when writing GDS files with Unnamed cells. Unnamed cells don't get deterministic names. warning includes the number of unnamed cells
+- cells with `decorator=function` that return a new cell do not leave Unnamed cells now
 - pack includes a name_prefix to avoid unnamed cells
 - add `taper_cross_section` into a container so we can use a decorator over it without triggering InmutabilityError
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.7.6
+# gdsfactory 3.7.7
 
 [![](https://readthedocs.org/projects/gdsfactory/badge/?version=latest)](https://gdsfactory.readthedocs.io/en/latest/?badge=latest)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 project = "gdsfactory"
-release = "3.7.6"
+release = "3.7.7"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -121,7 +121,7 @@ __all__ = [
     "sweep",
     "Label",
 ]
-__version__ = "3.7.6"
+__version__ = "3.7.7"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1203,9 +1203,14 @@ class Component(Device):
         referenced_cells = list(self.get_dependencies(recursive=True))
         all_cells = [self] + referenced_cells
 
-        for cell in all_cells:
-            if cell.name.startswith("Unnamed"):
-                warnings.warn(f"Component {self.name} contains Unnamed cells")
+        no_name_cells = [
+            cell.name for cell in all_cells if cell.name.startswith("Unnamed")
+        ]
+
+        if no_name_cells:
+            warnings.warn(
+                f"Component {self.name} contains {len(no_name_cells)} Unnamed cells"
+            )
 
         lib = gdspy.GdsLibrary(unit=unit, precision=precision)
         lib.write_gds(gdspath, cells=all_cells, timestamp=timestamp)

--- a/gdsfactory/components/taper_cross_section.py
+++ b/gdsfactory/components/taper_cross_section.py
@@ -47,7 +47,11 @@ def taper_cross_section(
         width_type="linear" if linear else "sine",
     )
     taper_path = gf.path.straight(length=length, npoints=npoints)
-    return gf.path.extrude(taper_path, transition)
+
+    c = gf.Component()
+    ref = c << gf.path.extrude(taper_path, transition)
+    c.add_ports(ref.ports)
+    return c
 
 
 taper_cross_section_linear = gf.partial(taper_cross_section, linear=True, npoints=2)

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.7.6"
+__version__ = "3.7.7"
 import json
 import os
 import pathlib

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.sweep.write_sweep_from_yaml import import_custom_doe_factories
 from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 
-VERSION = "3.7.6"
+VERSION = "3.7.7"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/name.py
+++ b/gdsfactory/name.py
@@ -6,6 +6,7 @@ import inspect
 from typing import Any, Iterable
 
 import numpy as np
+import pydantic
 import toolz
 from phidl import Device, Port
 from phidl.device_layout import Path as PathPhidl
@@ -14,6 +15,15 @@ from gdsfactory.hash_points import hash_points
 from gdsfactory.snap import snap_to_grid
 
 MAX_NAME_LENGTH = 32
+
+
+@pydantic.validate_arguments
+def get_name_short(name: str, max_name_length=MAX_NAME_LENGTH) -> str:
+    """Returns a short name."""
+    if len(name) > max_name_length:
+        name_hash = hashlib.md5(name.encode()).hexdigest()[:8]
+        name = f"{name[:(max_name_length - 9)]}_{name_hash}"
+    return name
 
 
 def join_first_letters(name: str) -> str:
@@ -182,23 +192,6 @@ def clean_value(value: Any) -> str:
         value = "_".join(clean_value(v) for v in value)
 
     return str(value)
-
-
-def get_name_short(name: str):
-    if len(name) > MAX_NAME_LENGTH:
-        name_hash = hashlib.md5(name.encode()).hexdigest()[:8]
-        name = f"{name[:(MAX_NAME_LENGTH - 9)]}_{name_hash}"
-    return clean_name(name)
-
-
-def get_name(name: str) -> str:
-    """Returns name with correct number of characters"""
-    if not isinstance(name, str):
-        raise ValueError(f"{name} needs to be a string")
-    if len(name) > MAX_NAME_LENGTH:
-        name_hash = hashlib.md5(name.encode()).hexdigest()[:8]
-        name = f"{name[:(MAX_NAME_LENGTH - 9)]}_{name_hash}"
-    return clean_name(name)
 
 
 def test_clean_value() -> None:

--- a/gdsfactory/pack.py
+++ b/gdsfactory/pack.py
@@ -225,8 +225,12 @@ def test_pack() -> Component:
 def test_pack_with_settings() -> Component:
     import gdsfactory as gf
 
-    component_list = [gf.components.rectangle(size=(i, i)) for i in range(1, 10)]
-    component_list += [gf.components.rectangle(size=(i, i)) for i in range(1, 10)]
+    component_list = [
+        gf.components.rectangle(size=(i, i), port_type=None) for i in range(1, 10)
+    ]
+    component_list += [
+        gf.components.rectangle(size=(i, i), port_type=None) for i in range(1, 10)
+    ]
 
     components_packed_list = pack(
         component_list,  # Must be a list or tuple of Components
@@ -244,7 +248,7 @@ def test_pack_with_settings() -> Component:
 
 
 if __name__ == "__main__":
-    test_pack()
+    # test_pack()
     import gdsfactory as gf
 
     # c = test_pack_with_settings()
@@ -254,7 +258,7 @@ if __name__ == "__main__":
     # c.write_gds_with_metadata("mask.gds")
 
     p = pack(
-        [gf.components.rectangle(size=(i, i)) for i in range(1, 10)],
+        [gf.components.rectangle(size=(i, i), port_type=None) for i in range(1, 10)],
         spacing=10.0,
         max_size=(100, 100),
         text=gf.c.text,

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -445,6 +445,28 @@ cells:
     size:
     - 10
     - 10
+  extrude_f34680de:
+    changed:
+      cross_section: {}
+      p: path_df9f9721565520dc57f5cb1446179439
+    default:
+      cross_section: null
+      layer: null
+      simplify: null
+      width: null
+      widths: null
+    full:
+      cross_section: {}
+      layer: null
+      p: path_df9f9721565520dc57f5cb1446179439
+      simplify: null
+      width: null
+      widths: null
+    function_name: extrude
+    info_version: 1
+    length: 10
+    module: gdsfactory.path
+    name: extrude_f34680de
   straight_f9c8624e:
     changed:
       cross_section:
@@ -616,7 +638,6 @@ cells:
       npoints: 100
     function_name: taper_cross_section
     info_version: 1
-    length: 10
     module: gdsfactory.components.taper_cross_section
     name: taper_cross_section
 info:

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -1,4 +1,26 @@
 cells:
+  extrude_465e033e:
+    changed:
+      cross_section: {}
+      p: path_c939b54c37f7fe69df0534ac53495b62
+    default:
+      cross_section: null
+      layer: null
+      simplify: null
+      width: null
+      widths: null
+    full:
+      cross_section: {}
+      layer: null
+      p: path_c939b54c37f7fe69df0534ac53495b62
+      simplify: null
+      width: null
+      widths: null
+    function_name: extrude
+    info_version: 1
+    length: 10
+    module: gdsfactory.path
+    name: extrude_465e033e
   taper_cross_section_f1747efd:
     changed:
       linear: true
@@ -37,7 +59,6 @@ cells:
       npoints: 2
     function_name: taper_cross_section
     info_version: 1
-    length: 10
     module: gdsfactory.components.taper_cross_section
     name: taper_cross_section_f1747efd
 info:
@@ -78,7 +99,6 @@ info:
     npoints: 2
   function_name: taper_cross_section
   info_version: 1
-  length: 10
   module: gdsfactory.components.taper_cross_section
   name: taper_cross_section_f1747efd
 ports:

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -1,4 +1,26 @@
 cells:
+  extrude_96406c1e:
+    changed:
+      cross_section: {}
+      p: path_ed76b77e33fcc87170ee125e6372cc8f
+    default:
+      cross_section: null
+      layer: null
+      simplify: null
+      width: null
+      widths: null
+    full:
+      cross_section: {}
+      layer: null
+      p: path_ed76b77e33fcc87170ee125e6372cc8f
+      simplify: null
+      width: null
+      widths: null
+    function_name: extrude
+    info_version: 1
+    length: 10
+    module: gdsfactory.path
+    name: extrude_96406c1e
   taper_cross_section_11c0a1bc:
     changed:
       linear: false
@@ -37,7 +59,6 @@ cells:
       npoints: 101
     function_name: taper_cross_section
     info_version: 1
-    length: 10
     module: gdsfactory.components.taper_cross_section
     name: taper_cross_section_11c0a1bc
 info:
@@ -78,7 +99,6 @@ info:
     npoints: 101
   function_name: taper_cross_section
   info_version: 1
-  length: 10
   module: gdsfactory.components.taper_cross_section
   name: taper_cross_section_11c0a1bc
 ports:

--- a/gdsfactory/tests/test_get_route_auto_widen.py
+++ b/gdsfactory/tests/test_get_route_auto_widen.py
@@ -32,7 +32,7 @@ def taper_pin(length: float = 5, **kwargs) -> gf.Component:
 
 
 def test_get_route_auto_widen() -> gf.Component:
-    c = gf.Component()
+    c = gf.Component("test_get_route_auto_widen")
     route = gf.routing.get_route_from_waypoints(
         [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
         cross_section=xs_pin_m1,
@@ -48,12 +48,12 @@ def test_get_route_auto_widen() -> gf.Component:
 if __name__ == "__main__":
     c = gf.Component()
     route = gf.routing.get_route_from_waypoints(
-        [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
+        # [(0, 0), (300, 0), (300, 300), (-600, 300), (-600, -300)],
+        [(0, 0), (300, 0), (300, 300), (300, 600), (600, 600)],
         cross_section=xs_pin_m1,
         bend=gf.partial(gf.c.bend_euler, cross_section=xs_pin),
         taper=taper_pin,
         radius=30,
     )
     c.add(route.references)
-
     c.show()

--- a/gdsfactory/tests/test_name_with_decorator.py
+++ b/gdsfactory/tests/test_name_with_decorator.py
@@ -1,0 +1,64 @@
+import gdsfactory as gf
+
+
+@gf.cell
+def straight_with_pins(**kwargs):
+    c = gf.Component()
+    ref = c << gf.c.straight()
+    c.add_ports(ref.ports)
+    return c
+
+
+def test_name_with_decorator():
+    c = gf.Component("test_name_with_decorator")
+    c1 = c << straight_with_pins(decorator=gf.add_padding_container)
+    c2 = c << straight_with_pins()
+
+    c1.movey(-10)
+    c2.movey(100)
+
+    cells = c.get_dependencies()
+    cell_names = [cell.name for cell in list(cells)]
+    cell_names_unique = set(cell_names)
+
+    if len(cell_names) != len(set(cell_names)):
+        for cell_name in cell_names_unique:
+            cell_names.remove(cell_name)
+
+        cell_names_duplicated = "\n".join(set(cell_names))
+        raise ValueError(f"Duplicated cell names in {c.name}:\n{cell_names_duplicated}")
+
+    referenced_cells = list(c.get_dependencies(recursive=True))
+    all_cells = [c] + referenced_cells
+
+    no_name_cells = [cell.name for cell in all_cells if cell.name.startswith("Unnamed")]
+    assert (
+        len(no_name_cells) == 0
+    ), f"Component {c.name} contains {len(no_name_cells)} Unnamed cells"
+
+
+if __name__ == "__main__":
+    c = gf.Component("test_name_with_decorator")
+    c1 = c << straight_with_pins(decorator=gf.add_padding_container)
+    c2 = c << straight_with_pins()
+    c1.movey(-10)
+    c2.movey(100)
+
+    cells = c.get_dependencies()
+    cell_names = [cell.name for cell in list(cells)]
+    cell_names_unique = set(cell_names)
+
+    if len(cell_names) != len(set(cell_names)):
+        for cell_name in cell_names_unique:
+            cell_names.remove(cell_name)
+
+        cell_names_duplicated = "\n".join(set(cell_names))
+        raise ValueError(f"Duplicated cell names in {c.name}:\n{cell_names_duplicated}")
+
+    referenced_cells = list(c.get_dependencies(recursive=True))
+    all_cells = [c] + referenced_cells
+
+    no_name_cells = [cell.name for cell in all_cells if cell.name.startswith("Unnamed")]
+    assert (
+        len(no_name_cells) == 0
+    ), f"Component {c.name} contains {len(no_name_cells)} Unnamed cells"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_install_requires_dev():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.7.6",
+    version="3.7.7",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- `write_gds` prints warning when writing GDS files with Unnamed cells. Unnamed cells don't get deterministic names. warning includes the number of unnamed cells
- cells with `decorator=function` that return a new cell do not leave Unnamed cells now
- pack includes a name_prefix to avoid unnamed cells
- add `taper_cross_section` into a container so we can use a decorator over it without triggering InmutabilityError
