### PR TITLE
Added option to use built-in, dispersive materials from Meep database

### DIFF
--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -1,15 +1,45 @@
-from functools import partial
-
 import meep as mp
 import meep.materials as mat
+
+# Dictionary for materials with different names in Meep
+MATERIAL_NAME_TO_MEEP = {
+    "sin": "Si3N4",
+}
 
 MATERIALS = [m for m in dir(mat) if not m.startswith("_")]
 
 
-def get_index(
-    wavelength: float = 1.55,
-    name: str = "Si",
-) -> float:
+def get_material(
+    name: str = "Si", wavelength: float = 1.55, dispersive: bool = False
+) -> mp.Medium:
+    """Returns Meep Medium from database
+
+    Args:
+        name: material name
+        wavelength: wavelength (um)
+        dispersive: set to True for built-in Meep index model, False for simple, non-dispersive model
+
+    Note:
+        Using the built-in models can be problematic at low resolution. If fields are NaN or Inf, increase resolution
+        or use a non-dispersive model
+    """
+
+    materials_lower = [material.lower() for material in MATERIALS]
+    if name in MATERIAL_NAME_TO_MEEP.keys():
+        name = MATERIAL_NAME_TO_MEEP[name]
+    if name.lower() not in materials_lower:
+        raise ValueError(f"material, name = {name!r} not in {MATERIALS}")
+
+    name = MATERIALS[materials_lower.index(name.lower())]
+    medium = getattr(mat, name)
+
+    if dispersive:
+        return medium
+    else:
+        return mp.Medium(epsilon=medium.epsilon(1 / wavelength)[0][0])
+
+
+def get_index(wavelength: float = 1.55, name: str = "Si") -> float:
     """Returns refractive index from Meep's material database.
 
     Args:
@@ -17,44 +47,18 @@ def get_index(
         wavelength: wavelength (um)
 
     """
-    if name not in MATERIALS:
-        raise ValueError(f"{name!r} not in {MATERIALS}")
+    medium = get_material(name, wavelength)
 
-    medium = getattr(mat, name)
     epsilon_matrix = medium.epsilon(1 / wavelength)
     epsilon11 = epsilon_matrix[0][0]
     return epsilon11 ** 0.5
 
 
-def get_material(
-    wavelength: float = 1.55,
-    name: str = "Si",
-) -> mp.Medium:
-    """Returns Meep Medium from database
-
-    Args:
-        name: material name
-        wavelength: wavelength (um)
-
-    """
-
-    # FIXME: need to remove this. If I remove this, then I get no fields.
-    if name == "SiO2":
-        return mp.Medium(epsilon=2.25)
-    elif name.lower() == "si":
-        return mp.Medium(epsilon=12)
-    elif name.lower() == "sin":
-        return mp.Medium(epsilon=4)
-    else:
-        raise ValueError(f"material, name = {name!r} not in {MATERIALS}")
-
-    return getattr(mat, name)
-
-
-si = partial(get_index, name="Si")
-
-sio2 = partial(get_index, name="SiO2")
+#
+# si = partial(get_index, name="Si")
+#
+# sio2 = partial(get_index, name="SiO2")
 
 
 if __name__ == "__main__":
-    print(get_index(name="Si"))
+    print(get_index(name="sin"))

--- a/gdsfactory/simulation/gmeep/get_simulation.py
+++ b/gdsfactory/simulation/gmeep/get_simulation.py
@@ -15,13 +15,6 @@ from gdsfactory.tech import LAYER_STACK, LayerStack
 mp.verbosity(0)
 
 
-MATERIAL_NAME_TO_MEEP = {
-    "si": "Si",
-    "sio2": "SiO2",
-    "sin": "Si3N4",
-}
-
-
 @pydantic.validate_arguments
 def get_simulation(
     component: Component,


### PR DESCRIPTION
This replaces the hard-coded index values in get_material.py and provides an option to switch dispersion on/off when needed. I haven't used this library extensively yet but to the best of my knowledge it doesn't break things.