### PR TITLE
3100

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.28
+current_version = 3.10.0
 commit = True
 tag = True
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,4 +25,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.9.28
+          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 3.10.0
+
+- add Component.ploth() to plot with holoviews (inspired by dphox)
+- Component.plot(plotter='holoviews') accepts plotter argument for plotting backend (matplotlib or holoviews)
+- use holoviews as the default plotting backend
+- remove clear_cache from Component.plot() and Component.show(), it's easier to just do `gf.clear_cache()`
+
 ## 3.9.28
 
 - seal_ring accepts bbox instead of component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## 3.10.0
 
 - add Component.ploth() to plot with holoviews (inspired by dphox)
-- Component.plot(plotter='holoviews') accepts plotter argument for plotting backend (matplotlib or holoviews)
+- Component.plot(plotter='holoviews') accepts plotter argument for plotting backend (matplotlib, qt or holoviews)
 - use holoviews as the default plotting backend
 - remove clear_cache from Component.plot() and Component.show(), it's easier to just do `gf.clear_cache()`
+- remove `Component.plotqt` as the qt plotter is not available under `Component.plot(plotter='qt')`
 
 ## 3.9.28
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For Photonics IC layout I used [IPKISS](https://github.com/jtambasco/ipkiss) for
 
 IPKISS is quite slow when working with large layouts, so in 2019 I stopped using it.
 
-Then I tried all the commercial (Luceda, Cadence, Synopsis) and open source EDA tools (phidl, gdspy, picwriter, klayout-zero-pdk, nazca) looking for a fast and easy to use workflow.
+Then I tried all the commercial (Luceda, Cadence, Synopsys) and open source EDA tools (phidl, gdspy, picwriter, klayout-zero-pdk, nazca) looking for a fast and easy to use workflow.
 
 The metrics for the benchmark were:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.9.28
+# gdsfactory 3.10.0
 
 [![](https://readthedocs.org/projects/gdsfactory/badge/?version=latest)](https://gdsfactory.readthedocs.io/en/latest/?badge=latest)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from gdsfactory.types import ComponentFactoryDict
 autodoc_type_aliases = {ComponentFactoryDict: "ComponentFactoryDict"}
 
 project = "gdsfactory"
-release = "3.9.28"
+release = "3.10.0"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -127,7 +127,7 @@ __all__ = [
     "write_cells",
     "Label",
 ]
-__version__ = "3.9.28"
+__version__ = "3.10.0"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -9,7 +9,7 @@ They without modifying the cell name
 
 """
 import json
-from typing import Callable, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 from numpy import ndarray
@@ -26,20 +26,8 @@ def _rotate(v: ndarray, m: ndarray) -> ndarray:
     return np.dot(m, v)
 
 
-def add_pin_triangle(
-    component: Component,
-    port: Port,
-    layer: Tuple[int, int] = LAYER.PORT,
-    layer_label: Optional[Tuple[int, int]] = LAYER.TEXT,
-) -> None:
-    """Add triangle pin with a right angle, pointing out of the port
-
-    Args:
-        component:
-        port: Port
-        layer: for the pin marker
-        layer_label: for the label
-    """
+def get_pin_triangle_polygon_tip(port: Port) -> Tuple[List[float], Tuple[float, float]]:
+    """Returns triangle polygon and tip position"""
     p = port
 
     a = p.orientation
@@ -57,11 +45,30 @@ def add_pin_triangle(
     p1 = p.position + _rotate(dtop, rot_mat)
     ptip = p.position + _rotate(dtip, rot_mat)
     polygon = [p0, p1, ptip]
+    polygon = np.stack(polygon)
+    return polygon, ptip
+
+
+def add_pin_triangle(
+    component: Component,
+    port: Port,
+    layer: Tuple[int, int] = LAYER.PORT,
+    layer_label: Optional[Tuple[int, int]] = LAYER.TEXT,
+) -> None:
+    """Add triangle pin with a right angle, pointing out of the port
+
+    Args:
+        component:
+        port: Port
+        layer: for the pin marker
+        layer_label: for the label
+    """
+    polygon, ptip = get_pin_triangle_polygon_tip(port=port)
     component.add_polygon(polygon, layer=layer)
 
     if layer_label:
         component.add_label(
-            text=str(p.name),
+            text=str(port.name),
             position=ptip,
             layer=layer_label,
         )

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1173,6 +1173,8 @@ class Component(Device):
             Holoviews Overlay to display all polygons.
 
         """
+        from gdsfactory.add_pins import get_pin_triangle_polygon_tip
+
         try:
             import holoviews as hv
         except ImportError:
@@ -1211,14 +1213,30 @@ class Component(Device):
                 )
             )
         for name, port in self.ports.items():
-            x = port.x
-            y = port.y
+            polygon, ptip = get_pin_triangle_polygon_tip(port=port)
+
             plots_to_overlay.append(
-                hv.Polygons([{"x": x, "y": y}]).opts(
-                    data_aspect=1, frame_height=200, color="red", line_alpha=0
+                hv.Polygons(polygon, label=port.name).opts(
+                    data_aspect=1,
+                    frame_height=200,
+                    fill_alpha=0,
+                    ylim=(b[1], b[3]),
+                    xlim=(b[0], b[2]),
+                    color="red",
+                    line_alpha=layer.alpha,
+                    tools=["hover"],
                 )
-                * hv.Text(x, y, port.name)
+                * hv.Text(ptip[0], ptip[1], port.name)
             )
+
+            # x = port.x
+            # y = port.y
+            # plots_to_overlay.append(
+            #     hv.Polygons([{"x": x, "y": y}]).opts(
+            #         data_aspect=1, frame_height=200, color="red", line_alpha=0
+            #     )
+            #     * hv.Text(x, y, port.name)
+            # )
 
         return hv.Overlay(plots_to_overlay).opts(
             show_legend=True, shared_axes=False, ylim=(b[1], b[3]), xlim=(b[0], b[2])

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1217,7 +1217,7 @@ class Component(Device):
             polygon, ptip = get_pin_triangle_polygon_tip(port=port)
 
             plots_to_overlay.append(
-                hv.Polygons(polygon, label=port.name).opts(
+                hv.Polygons(polygon, label=name).opts(
                     data_aspect=1,
                     frame_height=200,
                     fill_alpha=0,
@@ -1227,7 +1227,7 @@ class Component(Device):
                     line_alpha=layer.alpha,
                     tools=["hover"],
                 )
-                * hv.Text(ptip[0], ptip[1], port.name)
+                * hv.Text(ptip[0], ptip[1], name)
             )
 
         return hv.Overlay(plots_to_overlay).opts(

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -39,10 +39,7 @@ from gdsfactory.port import (
 )
 from gdsfactory.snap import snap_to_grid
 
-Plotter = Literal[
-    "holoviews",
-    "matplotlib",
-]
+Plotter = Literal["holoviews", "matplotlib", "qt"]
 
 
 class MutabilityError(ValueError):
@@ -1131,14 +1128,14 @@ class Component(Device):
         return self.__str__()
 
     def plot(self, plotter: Plotter = "holoviews", **kwargs) -> None:
-        """Returns component plot
+        """Return component plot.
 
         Args:
-            plotter: plotting backend
+            plotter: plotting backend ('holoviews', 'matplotlib', 'qt').
 
         KeyError Args:
             layers_excluded: list of layers to exclude.
-            layer_set: layer_set colors loaded from Klayout
+            layer_set: layer_set colors loaded from Klayout.
             min_aspect: minimum aspect ratio.
 
         """
@@ -1146,13 +1143,17 @@ class Component(Device):
         if plotter == "matplotlib":
             from phidl import quickplot as plot
 
-            return plot(self)
+            plot(self)
         elif plotter == "holoviews":
             import holoviews as hv
 
             hv.extension("bokeh")
-
             return self.ploth(**kwargs)
+
+        elif plotter == "qt":
+            from phidl.quickplotter import quickplot2
+
+            quickplot2(self)
 
     def ploth(
         self,
@@ -1229,15 +1230,6 @@ class Component(Device):
                 * hv.Text(ptip[0], ptip[1], port.name)
             )
 
-            # x = port.x
-            # y = port.y
-            # plots_to_overlay.append(
-            #     hv.Polygons([{"x": x, "y": y}]).opts(
-            #         data_aspect=1, frame_height=200, color="red", line_alpha=0
-            #     )
-            #     * hv.Text(x, y, port.name)
-            # )
-
         return hv.Overlay(plots_to_overlay).opts(
             show_legend=True, shared_axes=False, ylim=(b[1], b[3]), xlim=(b[0], b[2])
         )
@@ -1247,12 +1239,10 @@ class Component(Device):
         show_ports: bool = True,
         show_subports: bool = False,
     ) -> None:
-        """Show component in klayout
+        """Show component in klayout.
 
-        if show_subports = True
-        We add pins in a new component
-        that contains a reference to the old component
-        so we don't modify the original component
+        show_subports = True adds pins in a component copy (only used for display)
+        so the original component remains as it was
 
         Args:
             show_ports: shows component with port markers and labels
@@ -1273,11 +1263,6 @@ class Component(Device):
             component = self
 
         show(component)
-
-    def plotqt(self):
-        from phidl.quickplotter import quickplot2
-
-        quickplot2(self)
 
     def write_gds(
         self,

--- a/gdsfactory/components/bend_circular.py
+++ b/gdsfactory/components/bend_circular.py
@@ -75,8 +75,8 @@ if __name__ == "__main__":
     c.pprint()
     c.show()
 
-    # c = bend_circular180()
-    # c.plotqt()
+    c = bend_circular180()
+    c.plot("qt")
 
     # from phidl.quickplotter import quickplot2
     # c = bend_circular_trenches()

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.9.28"
+__version__ = "3.10.0"
 import json
 import os
 import pathlib

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 from gdsfactory.write_cells import write_cells as write_cells_to_separate_gds
 
-VERSION = "3.9.28"
+VERSION = "3.10.0"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/layers.py
+++ b/gdsfactory/layers.py
@@ -90,8 +90,8 @@ class LayerSet(LayerSetPhidl):
             description: Layer description.
             color: Hex code of color for the Layer.
             inverted: If true, inverts the Layer.
-            alpha: layer opacity between 0 and 1.
-            dither: KLayout dither style, only used in phidl.utilities.write_lyp().
+            alpha: layer opacity between 0 and 1 (0: invisible,  1: opaque).
+            dither: KLayout dither style, only used for phidl.utilities.write_lyp().
         """
         new_layer = LayerPhidl(
             gds_layer=gds_layer,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,10 @@
+bokeh~=2.2.3
 doc8
 docutils
 flake8
 flake8-rst-docstrings
 furo
+holoviews~=1.14.6
 ipykernel
 klayout~=0.27.5
 mypy

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_install_requires_pip():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.9.28",
+    version="3.10.0",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- add Component.ploth() to plot with holoviews (inspired by dphox)
- Component.plot(plotter='holoviews') accepts plotter argument for plotting backend (matplotlib, qt or holoviews)
- use holoviews as the default plotting backend
- remove clear_cache from Component.plot() and Component.show(), it's easier to just do `gf.clear_cache()`
- remove `Component.plotqt` as the qt plotter is not available under `Component.plot(plotter='qt')`
