### PR TITLE
3101b

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.0
+current_version = 3.10.1
 commit = True
 tag = True
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,4 +25,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.0
+          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 3.10.1
 
 - You can set up the default plotter from the gdsfactory config `gf.CONF.plotter = 'matplotlib'`
+- [PR 142](https://github.com/gdsfactory/gdsfactory/pull/142)
+    * dispersive flag to meep simulations
+    * fixed bug where adding a layer would throw an error if "visible" or "transparent" were undefined in the .lyp file
+- remove p_start (starting period) from grating_coupler_elliptical
 
 ## 3.10.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.10.0
+# gdsfactory 3.10.1
 
 ![docs](https://github.com/gdsfactory/gdsfactory/actions/workflows/pages.yml/badge.svg)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from gdsfactory.types import ComponentFactoryDict
 autodoc_type_aliases = {ComponentFactoryDict: "ComponentFactoryDict"}
 
 project = "gdsfactory"
-release = "3.10.0"
+release = "3.10.1"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -128,7 +128,7 @@ __all__ = [
     "write_cells",
     "Label",
 ]
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -58,6 +58,10 @@ def grating_coupler_elliptical_arbitrary(
         fiber_marker_layer
         spiked: grating teeth have sharp spikes to avoid non-manhattan drc errors
 
+    https://en.wikipedia.org/wiki/Ellipse
+    c = (a1 ** 2 - b1 ** 2) ** 0.5
+    e = (1 - (b1 / a1) ** 2) ** 0.5
+    print(e)
 
     .. code::
 
@@ -83,12 +87,6 @@ def grating_coupler_elliptical_arbitrary(
     b1 = round(b1, 3)
     x1 = round(x1, 3)
     period = a1 + x1
-
-    # https://en.wikipedia.org/wiki/Ellipse
-    c = (a1 ** 2 - b1 ** 2) ** 0.5
-
-    # e = (1 - (b1 / a1) ** 2) ** 0.5
-    # print(e)
 
     c = gf.Component()
     c.info.polarization = polarization

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 import io
 import json
 import os

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 from gdsfactory.write_cells import write_cells as write_cells_to_separate_gds
 
-VERSION = "3.10.0"
+VERSION = "3.10.1"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nitride_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nitride_c_.yml
@@ -48,7 +48,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -74,7 +73,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -116,7 +114,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -142,7 +139,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -163,7 +159,7 @@ ports:
     - 34
     - 0
     midpoint:
-    - 0.85
+    - 0
     - 0
     name: o1
     orientation: 180
@@ -174,7 +170,7 @@ ports:
     - 203
     - 0
     midpoint:
-    - 17.45
+    - 22.1
     - 0
     name: vertical_te
     orientation: 0

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
@@ -40,7 +40,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -66,7 +65,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -100,7 +98,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -126,7 +123,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -147,7 +143,7 @@ ports:
     - 1
     - 0
     midpoint:
-    - 0.721
+    - 0
     - 0
     name: o1
     orientation: 180
@@ -158,7 +154,7 @@ ports:
     - 203
     - 0
     midpoint:
-    - 17.322
+    - 22.1
     - 0
     name: vertical_te
     orientation: 0

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
@@ -40,7 +40,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -66,7 +65,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -100,7 +98,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -126,7 +123,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -147,7 +143,7 @@ ports:
     - 1
     - 0
     midpoint:
-    - 0.721
+    - 0
     - 0
     name: o1
     orientation: 180
@@ -158,7 +154,7 @@ ports:
     - 203
     - 0
     midpoint:
-    - 17.322
+    - 22.1
     - 0
     name: vertical_te
     orientation: 0

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
@@ -49,7 +49,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -75,7 +74,6 @@ cells:
       n_periods: 16
       nclad: 1.443
       neff: 1.8
-      p_start: 26
       polarization: tm
       slab_offset: 2
       slab_xmin: -2
@@ -118,7 +116,6 @@ info:
     n_periods: 30
     nclad: 1.443
     neff: 2.638
-    p_start: 26
     polarization: te
     slab_offset: 2
     slab_xmin: -1
@@ -144,7 +141,6 @@ info:
     n_periods: 16
     nclad: 1.443
     neff: 1.8
-    p_start: 26
     polarization: tm
     slab_offset: 2
     slab_xmin: -2
@@ -165,7 +161,7 @@ ports:
     - 1
     - 0
     midpoint:
-    - -2.421
+    - 0
     - 0
     name: o1
     orientation: 180
@@ -176,7 +172,7 @@ ports:
     - 204
     - 0
     midpoint:
-    - 27.578
+    - 35.5
     - 0
     name: vertical_tm
     orientation: 0

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
@@ -70,7 +70,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -96,7 +95,6 @@ cells:
       n_periods: 30
       nclad: 1.443
       neff: 2.638
-      p_start: 26
       polarization: te
       slab_offset: 2
       slab_xmin: -1
@@ -133,6 +131,52 @@ cells:
     length: 429.5
     module: gdsfactory.components.straight
     name: straight_09267a6d
+    width: 0.5
+  straight_2480e476:
+    changed:
+      cross_section:
+        function: cross_section
+      length: 24.2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 24.2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 24.2
+    module: gdsfactory.components.straight
+    name: straight_2480e476
+    width: 0.5
+  straight_2ac686be:
+    changed:
+      cross_section:
+        function: cross_section
+      length: 33.2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 33.2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 33.2
+    module: gdsfactory.components.straight
+    name: straight_2ac686be
     width: 0.5
   straight_35279b0d:
     changed:
@@ -180,52 +224,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight_8535e376
     width: 0.5
-  straight_999e033a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 25
-    module: gdsfactory.components.straight
-    name: straight_999e033a
-    width: 0.5
-  straight_9fd15a43:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 29.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 29.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 29.5
-    module: gdsfactory.components.straight
-    name: straight_9fd15a43
-    width: 0.5
   straight_aa45e1cb:
     changed:
       cross_section:
@@ -248,6 +246,29 @@ cells:
     length: 302.5
     module: gdsfactory.components.straight
     name: straight_aa45e1cb
+    width: 0.5
+  straight_aea980a7:
+    changed:
+      cross_section:
+        function: cross_section
+      length: 28.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 28.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 28.7
+    module: gdsfactory.components.straight
+    name: straight_aea980a7
     width: 0.5
   straight_array_e79eb4c6:
     changed:
@@ -315,29 +336,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_tree
     name: straight_array_e79eb4c6_dc3919be
-  straight_b5891e42:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 34
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 34
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 34
-    module: gdsfactory.components.straight
-    name: straight_b5891e42
-    width: 0.5
   straight_d41d8cd9:
     changed: {}
     default:
@@ -358,11 +356,11 @@ cells:
     module: gdsfactory.components.straight
     name: straight_d41d8cd9
     width: 0.5
-  straight_f57ff793:
+  straight_d9504b06:
     changed:
       cross_section:
         function: cross_section
-      length: 38.5
+      length: 37.7
     default:
       cross_section:
         function: cross_section
@@ -372,14 +370,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 38.5
+      length: 37.7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 38.5
+    length: 37.7
     module: gdsfactory.components.straight
-    name: straight_f57ff793
+    name: straight_d9504b06
     width: 0.5
 info:
   changed: {}
@@ -436,7 +434,7 @@ ports:
     - 0
     midpoint:
     - -439.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_00
     orientation: 270
     port_type: vertical_te
@@ -447,7 +445,7 @@ ports:
     - 0
     midpoint:
     - -312.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_01
     orientation: 270
     port_type: vertical_te
@@ -458,7 +456,7 @@ ports:
     - 0
     midpoint:
     - -185.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_02
     orientation: 270
     port_type: vertical_te
@@ -468,8 +466,8 @@ ports:
     - 203
     - 0
     midpoint:
-    - -58.5
-    - -51.601
+    - -58.50000000000001
+    - -56.300000000000004
     name: vertical_te_03
     orientation: 270
     port_type: vertical_te
@@ -480,7 +478,7 @@ ports:
     - 0
     midpoint:
     - 68.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_04
     orientation: 270
     port_type: vertical_te
@@ -491,7 +489,7 @@ ports:
     - 0
     midpoint:
     - 195.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_05
     orientation: 270
     port_type: vertical_te
@@ -502,7 +500,7 @@ ports:
     - 0
     midpoint:
     - 322.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_06
     orientation: 270
     port_type: vertical_te
@@ -513,7 +511,7 @@ ports:
     - 0
     midpoint:
     - 449.5
-    - -51.601
+    - -56.300000000000004
     name: vertical_te_07
     orientation: 270
     port_type: vertical_te

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_install_requires_pip():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.10.0",
+    version="3.10.1",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- You can set up the default plotter from the gdsfactory config `gf.CONF.plotter = 'matplotlib'`
- [PR 142](https://github.com/gdsfactory/gdsfactory/pull/142)
    * dispersive flag to meep simulations
    * fixed bug where adding a layer would throw an error if "visible" or "transparent" were undefined in the .lyp file
- remove p_start (starting period) from grating_coupler_elliptical
