### PR TITLE
3102

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.1
+current_version = 3.10.2
 commit = True
 tag = True
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,4 +25,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.1
+          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - gf.import_gds has an optional gdsdir argument
 - remove unused max_name_length in gf.import_gds
 - bring back matplotlib as the default plotter backend
+- add_fiber_array prints warning if grating coupler port is not facing west
 
 ## 3.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - write_cells uses gdspy interface directly
 - gf.import_gds has an optional gdsdir argument
-- gf.import_gds does not accept `kwargs` anymore
+- remove unused max_name_length in gf.import_gds
+- bring back matplotlib as the default plotter backend
 
 ## 3.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 3.10.2
 
-- write_cells uses gdspy interface directly
+- write_cells in gf.write_cells uses gdspy interface directly
 - gf.import_gds has an optional gdsdir argument
 - remove unused max_name_length in gf.import_gds
-- bring back matplotlib as the default plotter backend
+- bring back matplotlib as the default plotter backend. Holoviews does not work well with some `sphinx.autodoc`
 - add_fiber_array prints warning if grating coupler port is not facing west
 
 ## 3.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3.10.2
+
+- write_cells uses gdspy interface directly
+- gf.import_gds has an optional gdsdir argument
+- gf.import_gds does not accept `kwargs` anymore
+
 ## 3.10.1
 
 - You can set up the default plotter from the gdsfactory config `gf.CONF.plotter = 'matplotlib'`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.10.1
+# gdsfactory 3.10.2
 
 ![docs](https://github.com/gdsfactory/gdsfactory/actions/workflows/pages.yml/badge.svg)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -1141,7 +1141,7 @@ grating_coupler_elliptical
 
   import gdsfactory as gf
 
-  c = gf.components.grating_coupler_elliptical(polarization='te', taper_length=16.6, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.343, wg_width=0.5, neff=2.638, nclad=1.443, layer=(1, 0), p_start=26, n_periods=30, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-1.0, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(203, 0), spiked=True)
+  c = gf.components.grating_coupler_elliptical(polarization='te', taper_length=16.6, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.343, wg_width=0.5, neff=2.638, nclad=1.443, layer=(1, 0), n_periods=30, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-1.0, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(203, 0), spiked=True)
   c.plot()
 
 
@@ -1186,7 +1186,7 @@ grating_coupler_elliptical_te
 
   import gdsfactory as gf
 
-  c = gf.components.grating_coupler_elliptical_te(polarization='te', taper_length=16.6, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.343, wg_width=0.5, neff=2.638, nclad=1.443, layer=(1, 0), p_start=26, n_periods=30, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-1.0, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(203, 0), spiked=True)
+  c = gf.components.grating_coupler_elliptical_te(polarization='te', taper_length=16.6, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.343, wg_width=0.5, neff=2.638, nclad=1.443, layer=(1, 0), n_periods=30, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-1.0, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(203, 0), spiked=True)
   c.plot()
 
 
@@ -1201,7 +1201,7 @@ grating_coupler_elliptical_tm
 
   import gdsfactory as gf
 
-  c = gf.components.grating_coupler_elliptical_tm(polarization='tm', taper_length=30, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.707, wg_width=0.5, neff=1.8, nclad=1.443, layer=(1, 0), p_start=26, n_periods=16, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-2, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(204, 0), spiked=True)
+  c = gf.components.grating_coupler_elliptical_tm(polarization='tm', taper_length=30, taper_angle=40.0, wavelength=1.554, fiber_angle=15.0, grating_line_width=0.707, wg_width=0.5, neff=1.8, nclad=1.443, layer=(1, 0), n_periods=16, big_last_tooth=False, layer_slab=(2, 0), slab_xmin=-2, slab_offset=2.0, fiber_marker_width=11.0, fiber_marker_layer=(204, 0), spiked=True)
   c.plot()
 
 
@@ -2626,7 +2626,7 @@ version_stamp
 
   import gdsfactory as gf
 
-  c = gf.components.version_stamp(labels=('demo_label',), with_qr_code=False, layer=(1, 0), pixel_size=1, version='3.10.0', text_size=10)
+  c = gf.components.version_stamp(labels=('demo_label',), with_qr_code=False, layer=(1, 0), pixel_size=1, version='3.10.2', text_size=10)
   c.plot()
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from gdsfactory.types import ComponentFactoryDict
 autodoc_type_aliases = {ComponentFactoryDict: "ComponentFactoryDict"}
 
 project = "gdsfactory"
-release = "3.10.1"
+release = "3.10.2"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/docs/notebooks/00__python_intro.ipynb
+++ b/docs/notebooks/00__python_intro.ipynb
@@ -34,6 +34,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
+    "gf.CONF.plotter = 'holoviews' \n",
     "\n",
     "c = gf.Component(name='my_fist_class')\n",
     "c.add_polygon([(-8, 6, 7, 9), (-6, 8, 17, 5)], layer=(1,0))\n",

--- a/docs/notebooks/00_geometry.ipynb
+++ b/docs/notebooks/00_geometry.ipynb
@@ -30,7 +30,8 @@
    "source": [
     "import gdsfactory as gf\n",
     "\n",
-    "gf.asserts.version(\">=3.8.11\")\n",
+    "gf.CONF.plotter = 'holoviews' \n",
+    "gf.asserts.version(\">=3.10.1\")\n",
     "\n",
     "# Create a blank component (essentially an empty GDS cell with some special features)\n",
     "c = gf.Component(\"myComponent\")\n",

--- a/docs/notebooks/00_geometry.ipynb
+++ b/docs/notebooks/00_geometry.ipynb
@@ -30,8 +30,8 @@
    "source": [
     "import gdsfactory as gf\n",
     "\n",
-    "gf.CONF.plotter = 'holoviews' \n",
     "gf.asserts.version(\">=3.10.1\")\n",
+    "gf.CONF.plotter = 'holoviews' \n",
     "\n",
     "# Create a blank component (essentially an empty GDS cell with some special features)\n",
     "c = gf.Component(\"myComponent\")\n",

--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -34,6 +34,7 @@
     "import gdsfactory as gf\n",
     "\n",
     "gf.config.set_plot_options(show_subports=False)\n",
+    "gf.CONF.plotter = 'holoviews' \n",
     "\n",
     "# Create a blank Component\n",
     "c = gf.Component('Component1')\n",

--- a/docs/notebooks/02_movement.ipynb
+++ b/docs/notebooks/02_movement.ipynb
@@ -22,6 +22,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
+    "gf.CONF.plotter = 'holoviews' \n",
     "\n",
     "# Start with a blank Component\n",
     "D = gf.Component()\n",

--- a/docs/notebooks/03_cells_autoname_and_cache.ipynb
+++ b/docs/notebooks/03_cells_autoname_and_cache.ipynb
@@ -42,6 +42,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
+    "gf.CONF.plotter = 'holoviews' \n",
     "\n",
     "\n",
     "@gf.cell\n",

--- a/docs/notebooks/03_layers.ipynb
+++ b/docs/notebooks/03_layers.ipynb
@@ -24,7 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gdsfactory as gf"
+    "import gdsfactory as gf\n",
+    "gf.CONF.plotter = 'holoviews' "
    ]
   },
   {

--- a/docs/notebooks/03_waveguides_paths_crossections.ipynb
+++ b/docs/notebooks/03_waveguides_paths_crossections.ipynb
@@ -36,6 +36,8 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "gf.CONF.plotter = 'holoviews' \n",
+    "\n",
     "P = gf.Path()\n",
     "P.append(gf.path.arc(radius=10, angle=90))  # Circular arc\n",
     "P.append(gf.path.straight(length=10))  # Straight section\n",

--- a/docs/notebooks/04_components_hierarchy.ipynb
+++ b/docs/notebooks/04_components_hierarchy.ipynb
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gdsfactory as gf"
+    "import gdsfactory as gf\n",
+    "gf.CONF.plotter = 'holoviews' \n"
    ]
   },
   {

--- a/docs/notebooks/05_GDS.ipynb
+++ b/docs/notebooks/05_GDS.ipynb
@@ -372,7 +372,18 @@
    "source": [
     "# lets create a sample PDK (for demo purposes only)\n",
     "sample_pdk_cells = gf.grid([gf.c.straight, gf.c.bend_euler, gf.c.grating_coupler_elliptical])\n",
-    "sample_pdk_cells.write_gds('extra/pdk.gds')"
+    "sample_pdk_cells.write_gds('extra/pdk.gds')\n",
+    "sample_pdk_cells.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "213f9c07-3acb-4593-92e5-eef3a9975349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_pdk_cells.get_dependencies()"
    ]
   },
   {
@@ -384,7 +395,7 @@
    "source": [
     "# we write the sample PDK into a single GDS file\n",
     "gf.clear_cache()\n",
-    "gf.write_cells.write_cells('extra/pdk.gds')"
+    "gf.write_cells.write_cells(gdspath='extra/pdk.gds', dirpath='extra/gds')"
    ]
   },
   {
@@ -399,14 +410,6 @@
     "import gdsfactory as gf\n",
     "print(gf.write_cells.get_import_gds_script('extra/gds'))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b6b8a710-ace5-4247-936f-c179cca85797",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -128,7 +128,7 @@ __all__ = [
     "write_cells",
     "Label",
 ]
-__version__ = "3.10.1"
+__version__ = "3.10.2"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -65,7 +65,7 @@ def add_ports_from_markers_center(
     pin_extra_width: float = 0.0,
     min_pin_area_um2: Optional[float] = None,
     max_pin_area_um2: float = 150.0 * 150.0,
-    skip_square_ports: bool = True,
+    skip_square_ports: bool = False,
     xcenter: Optional[float] = None,
     ycenter: Optional[float] = None,
     port_name_prefix: str = "o",
@@ -195,6 +195,7 @@ def add_ports_from_markers_center(
 
         # port markers have same width and height
         # check which edge (E, W, N, S) they are closer to
+
         elif pxmax > xmax - tol:  # east
             orientation = 0
             width = dy
@@ -211,6 +212,16 @@ def add_ports_from_markers_center(
             orientation = 270
             width = dx
             y = p.ymin
+
+        elif pxmax > xc:
+            orientation = 0
+            width = dy
+            x = p.x if inside else p.xmax
+
+        elif pxmax < xc:
+            orientation = 180
+            width = dy
+            x = p.x if inside else p.xmin
 
         x = snap_to_grid(x)
         y = snap_to_grid(y)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1131,7 +1131,7 @@ class Component(Device):
         """Return component plot.
 
         Args:
-            plotter: plotting backend ('holoviews', 'matplotlib', 'qt').
+            plotter: backend ('holoviews', 'matplotlib', 'qt'). Defaults to matplotlib
 
         KeyError Args:
             layers_excluded: list of layers to exclude.
@@ -1139,7 +1139,7 @@ class Component(Device):
             min_aspect: minimum aspect ratio.
 
         """
-        plotter = plotter or CONF.get("plotter", "holoviews")
+        plotter = plotter or CONF.get("plotter", "matplotlib")
 
         if plotter == "matplotlib":
             from phidl import quickplot as plot

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.10.1"
+__version__ = "3.10.2"
 import io
 import json
 import os

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 from gdsfactory.write_cells import write_cells as write_cells_to_separate_gds
 
-VERSION = "3.10.1"
+VERSION = "3.10.2"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/klayout/tech/layers.lyp
+++ b/gdsfactory/klayout/tech/layers.lyp
@@ -1391,7 +1391,7 @@
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name>1/10 PIN</name>
+  <name>PIN 1/10</name>
   <source>1/10@1</source>
  </properties>
  <properties>

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -21,8 +21,8 @@ def import_gds(
     snap_to_grid_nm: Optional[int] = None,
     name: Optional[str] = None,
     decorator: Optional[Callable] = None,
-    max_name_length: int = 32,
     gdsdir: Optional[Union[str, Path]] = None,
+    **kwargs,
 ) -> Component:
     """Returns a Componenent from a GDS file.
 
@@ -35,8 +35,8 @@ def import_gds(
         snap_to_grid_nm: snap to different nm grid (does not snap if False)
         name: Optional name. Over-rides the default imported name.
         decorator: function to apply over the imported gds.
-        max_name_length: can truncate the name of the cell before importing it.
         gdsdir: optional GDS directory.
+        kwargs: settings for the imported component (polarization, wavelength ...).
     """
     gdspath = Path(gdsdir) / Path(gdspath) if gdsdir else Path(gdspath)
     if not gdspath.exists():
@@ -177,6 +177,7 @@ def import_gds(
 
         component.info = metadata.info
 
+    component.info.update(**kwargs)
     component.name = name
     component.info.name = name
 

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -22,23 +22,23 @@ def import_gds(
     name: Optional[str] = None,
     decorator: Optional[Callable] = None,
     max_name_length: int = 32,
-    **kwargs,
+    gdsdir: Optional[Union[str, Path]] = None,
 ) -> Component:
     """Returns a Componenent from a GDS file.
 
     Adapted from phidl/geometry.py
 
     Args:
-        gdspath: path of GDS file
-        cellname: cell of the name to import (None) imports top cell
+        gdspath: path of GDS file.
+        cellname: cell of the name to import (None) imports top cell.
         flatten: if True returns flattened (no hierarchy)
         snap_to_grid_nm: snap to different nm grid (does not snap if False)
-        name: Optional name
-        decorator: function to apply over the imported gds
-        max_name_length: can truncate the name of the cell before importing it
-        kwargs: component.info
+        name: Optional name. Over-rides the default imported name.
+        decorator: function to apply over the imported gds.
+        max_name_length: can truncate the name of the cell before importing it.
+        gdsdir: optional GDS directory.
     """
-    gdspath = Path(gdspath)
+    gdspath = Path(gdsdir) / Path(gdspath) if gdsdir else Path(gdspath)
     if not gdspath.exists():
         raise FileNotFoundError(f"No file {gdspath!r} found")
 
@@ -177,7 +177,6 @@ def import_gds(
 
         component.info = metadata.info
 
-    component.info.update(**kwargs)
     component.name = name
     component.info.name = name
 

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Optional, Tuple
 
 import gdsfactory as gf
@@ -96,6 +97,15 @@ def add_fiber_array(
     else:
         gc = grating_coupler
     gc = gf.call_if_func(gc)
+
+    orientation = int(gc.ports[gc_port_name].orientation)
+
+    if orientation != 180:
+        warnings.warn(
+            "add_fiber_array requires a grating coupler port facing west "
+            f"(orientation = 180). "
+            f"Got orientation = {orientation} degrees for port {gc_port_name!r}"
+        )
 
     if gc_port_name not in gc.ports:
         raise ValueError(f"gc_port_name={gc_port_name} not in {gc.ports.keys()}")
@@ -197,6 +207,7 @@ if __name__ == "__main__":
         # get_route_factory=route_fiber_single,
         # get_route_factory=route_fiber_array,
         grating_coupler=[gcte, gctm, gcte, gctm],
+        # grating_coupler=gf.functions.rotate(gcte, angle=180),
         auto_widen=True,
         # layer=(2, 0),
         gc_port_labels=["loop_in", "in", "out", "loop_out"],

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -1,22 +1,23 @@
+import datetime
 import pathlib
 from typing import Optional
 
 import gdspy
 
-from gdsfactory.component import Component
-from gdsfactory.config import CONFIG
+from gdsfactory.component import _timestamp2019
+from gdsfactory.config import CONFIG, logger
 from gdsfactory.name import clean_name
-from gdsfactory.read.import_gds import import_gds
 from gdsfactory.types import PathType
 
 script_prefix = """
 from pathlib import PosixPath
+from functools import partial
 import gdsfactory as gf
 
-# Only umcomment 1 line from the next 3 lines
-decorator = gf.add_ports.add_ports_from_markers_inside
-# decorator = gf.add_ports.add_ports_from_markers_center
-# decorator = None
+add_ports_optical = gf.partial(gf.add_ports.add_ports_from_markers_inside, port_layer=(1, 0))
+add_ports_electrical = gf.partial(gf.add_ports.add_ports_from_markers_inside, port_layer=(41, 0))
+add_ports = gf.compose(add_ports_optical, add_ports_electrical)
+
 """
 
 
@@ -26,54 +27,97 @@ def get_import_gds_script(dirpath: PathType) -> str:
     script = [script_prefix]
     script += [f"gdsdir = {dirpath.absolute()!r}\n"]
     script += [
-        f"{clean_name(cell.stem)} = gf.import_gds(gdsdir / {cell.stem + cell.suffix!r}, decorator=decorator)"
+        "import_gds = partial(gf.import_gds, gdsdir=gdsdir, decorator=add_ports)\n"
+    ]
+
+    cells = [
+        f"{clean_name(cell.stem)} = partial(import_gds, "
+        f"{cell.stem + cell.suffix!r})"
         for cell in dirpath.glob("*.gds")
     ]
+    script += sorted(cells)
     return "\n".join(script)
 
 
+def write_cells_recursively(
+    cell: gdspy.Cell,
+    unit: float = 1e-6,
+    precision: float = 1e-9,
+    timestamp: Optional[datetime.datetime] = _timestamp2019,
+    dirpath: pathlib.Path = Optional[pathlib.Path],
+):
+    """Write gdspy cells recursively
+
+    Args:
+        cell: gdspy cell
+        unit: unit size for objects in library. 1um by default.
+        precision: for object dimensions in the library (m). 1nm by default.
+        timestamp: Defaults to 2019-10-25. If None uses current time.
+        dirpath: directory for the GDS file
+    """
+    dirpath = dirpath or pathlib.Path.cwd()
+
+    for cell in cell.get_dependencies():
+        gdspath = f"{pathlib.Path(dirpath)/cell.name}.gds"
+        lib = gdspy.GdsLibrary(unit=unit, precision=precision)
+        lib.write_gds(gdspath, cells=[cell], timestamp=timestamp)
+        logger.info(f"Write GDS to {gdspath}")
+
+        if cell.get_dependencies():
+            write_cells_recursively(
+                cell=cell,
+                unit=unit,
+                precision=precision,
+                timestamp=timestamp,
+                dirpath=dirpath,
+            )
+
+
 def write_cells(
-    gdspath: PathType, dirpath: Optional[PathType] = None, recursively: bool = True
+    gdspath: Optional[PathType] = None,
+    cell: Optional[gdspy.Cell] = None,
+    dirpath: Optional[PathType] = None,
+    unit: float = 1e-6,
+    precision: float = 1e-9,
+    timestamp: Optional[datetime.datetime] = _timestamp2019,
+    recursively: bool = True,
 ) -> None:
     """Writes cells into separate GDS files.
 
     Args:
-        gdspath: to read cells from
-        dirpath: directory path to store gds cells
-        recursively: writes all subcells
+        gdspath: GDS file. You need to define either gdspath or cell.
+        cell: gdspy cell. You need to define either gdspath or cell.
+        unit: unit size for objects in library. 1um by default.
+        precision: for object dimensions in the library (m). 1nm by default.
+        timestamp: Defaults to 2019-10-25. If None uses current time.
+        dirpath: directory for the GDS file. Defaults to current working directory.
+        recursively: writes all cells recursively. If False writes only top cells.
     """
-    gdspath = pathlib.Path(gdspath)
-    dirpath = dirpath or gdspath.parent / "gds"
+    if cell is None and gdspath is None:
+        raise ValueError("You need to specify component or gdspath")
 
     gdsii_lib = gdspy.GdsLibrary()
     gdsii_lib.read_gds(gdspath)
     top_level_cells = gdsii_lib.top_level()
-    cellnames = [c.name for c in top_level_cells]
 
-    for cellname in cellnames:
-        component = import_gds(gdspath, cellname=cellname)
-        component.write_gds(f"{pathlib.Path(dirpath)/cellname}.gds")
-        if recursively:
-            write_cells_from_component(component=component, dirpath=dirpath)
-
-
-def write_cells_from_component(
-    component: Component, dirpath: Optional[PathType] = None
-) -> None:
-    """Writes all Component cells.
-
-    Args:
-        component:
-        dirpath: directory path to write GDS (defaults to CWD)
-    """
     dirpath = dirpath or pathlib.Path.cwd()
-    if component.references:
-        for ref in component.references:
-            component = ref.parent
-            component.write_gds(f"{pathlib.Path(dirpath)/component.name}.gds")
-            write_cells_from_component(component=component, dirpath=dirpath)
-    else:
-        component.write_gds(f"{pathlib.Path(dirpath)/component.name}.gds")
+    dirpath = pathlib.Path(dirpath)
+    dirpath.mkdir(exist_ok=True, parents=True)
+
+    for cell in top_level_cells:
+        gdspath = f"{pathlib.Path(dirpath)/cell.name}.gds"
+        lib = gdspy.GdsLibrary(unit=unit, precision=precision)
+        lib.write_gds(gdspath, cells=[cell], timestamp=timestamp)
+        logger.info(f"Write GDS to {gdspath}")
+
+        if recursively:
+            write_cells_recursively(
+                cell=cell,
+                unit=unit,
+                precision=precision,
+                timestamp=timestamp,
+                dirpath=dirpath,
+            )
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 click
-gdspy==1.6.10
+gdspy==1.6.11
 ipympl
 jsondiff
 loguru

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_install_requires_pip():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.10.1",
+    version="3.10.2",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- write_cells in gf.write_cells uses gdspy interface directly
- gf.import_gds has an optional gdsdir argument
- remove unused max_name_length parameter in gf.import_gds
- bring back matplotlib as the default plotter backend. Holoviews does not work well with some `sphinx.autodoc` docs
- add_fiber_array prints warning if grating coupler port is not facing west
