### PR TITLE
3104

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.10.3
+current_version = 3.10.4
 commit = True
 tag = True
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,4 +25,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.3
+          tags: joamatab/gdsfactory:latest,joamatab/gdsfactory:3.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.10.4
+
+- use matplotlib for default plotter instead of holoviews
+- add_ports default prefix is 'o' for optical and 'e' for electrical ports
+
 ## 3.10.3
 
 - [plot Sparameters uses lowercase s11, s21 ...](https://github.com/gdsfactory/gdsfactory/pull/146)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gdsfactory 3.10.3
+# gdsfactory 3.10.4
 
 ![docs](https://github.com/gdsfactory/gdsfactory/actions/workflows/pages.yml/badge.svg)
 [![](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ gdsfactory is written in python and requires some basic knowledge of python. If 
 
 Once you are familiar with python, you can also:
 
-- [read online docs](https://www.gdsfactory.com/)
+- [read online docs](https://gdsfactory.github.io/gdsfactory/)
 - run gdsfactory/samples
 - run [docs/notebooks](https://gdsfactory.readthedocs.io/en/latest/notebooks.html)
 
@@ -236,7 +236,7 @@ Open source heroes:
 
 ## Links
 
-- [gdsfactory github repo](https://github.com/gdsfactory/gdsfactory) and [docs](https://www.gdsfactory.com/)
+- [gdsfactory github repo](https://github.com/gdsfactory/gdsfactory) and [docs](https://gdsfactory.github.io/gdsfactory/)
 - [gdslib](https://github.com/gdsfactory/gdslib): separate package for component circuit models (based on Sparameters).
 - [ubc PDK](https://github.com/gdsfactory/ubc): sample open source PDK from edx course.
 - [awesome photonics list](https://github.com/joamatab/awesome_photonics)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ from gdsfactory.types import ComponentFactoryDict
 autodoc_type_aliases = {ComponentFactoryDict: "ComponentFactoryDict"}
 
 project = "gdsfactory"
-release = "3.10.3"
+release = "3.10.4"
 copyright = "2019, PsiQ"
 author = "PsiQ"
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -128,7 +128,7 @@ __all__ = [
     "write_cells",
     "Label",
 ]
-__version__ = "3.10.3"
+__version__ = "3.10.4"
 
 
 if __name__ == "__main__":

--- a/gdsfactory/add_loopback.py
+++ b/gdsfactory/add_loopback.py
@@ -20,8 +20,9 @@ def gen_loopback(
     straight: ComponentFactory = gf.components.straight,
     y_bot_align_route: None = None,
 ) -> List[ComponentReference]:
-    """
-    Add a loopback (grating coupler align reference) to a start port and and end port
+    """Returns loopback (grating coupler align reference) references
+    from a start_port and end_port
+
     Input grating generated on the left of start_port
     Output grating generated on the right of end_port
 

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -68,7 +68,7 @@ def add_ports_from_markers_center(
     skip_square_ports: bool = False,
     xcenter: Optional[float] = None,
     ycenter: Optional[float] = None,
-    port_name_prefix: str = "o",
+    port_name_prefix: Optional[str] = None,
     port_type: str = "optical",
     auto_rename_ports: bool = True,
 ) -> Component:
@@ -79,8 +79,8 @@ def add_ports_from_markers_center(
     guess port orientation from the component center (xcenter)
 
     Args:
-        component: to read polygons from and to write ports to
-        pin_layer: GDS layer for maker [int, int]
+        component: to read polygons from and to write ports to.
+        pin_layer: GDS layer for maker [int, int].
         port_layer: for the new created port
         inside: True-> markers  inside. False-> markers at center
         tol: tolerance for comparing how rectangular is the pin
@@ -90,7 +90,7 @@ def add_ports_from_markers_center(
         skip_square_ports: skips square ports (hard to guess orientation)
         xcenter: for guessing orientation of rectangular ports
         ycenter: for guessing orientation of rectangular ports
-        port_name_prefix: o for optical ports (o1, o2, o3)
+        port_name_prefix: defaults to 'o' for optical and 'e' for electrical ports.
         port_type: type of port (optical, electrical ...)
         auto_rename_ports:
 
@@ -149,6 +149,9 @@ def add_ports_from_markers_center(
     port_locations = []
 
     ports = {}
+
+    port_name_prefix_default = "o" if port_type == "optical" else "e"
+    port_name_prefix = port_name_prefix or port_name_prefix_default
 
     for i, p in enumerate(port_markers.polygons):
         port_name = f"{port_name_prefix}{i+1}" if port_name_prefix else i

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -11,7 +11,7 @@ You can access the config dictionary with `print_config`
 
 """
 
-__version__ = "3.10.3"
+__version__ = "3.10.4"
 import io
 import json
 import os

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -55,7 +55,7 @@ logger.add(sink=logpath)
 
 default_config = io.StringIO(
     """
-plotter: holoviews
+plotter: matplotlib
 """
 )
 

--- a/gdsfactory/gf.py
+++ b/gdsfactory/gf.py
@@ -25,7 +25,7 @@ from gdsfactory.tech import LAYER
 from gdsfactory.types import PathType
 from gdsfactory.write_cells import write_cells as write_cells_to_separate_gds
 
-VERSION = "3.10.3"
+VERSION = "3.10.4"
 log_directory = CONFIG.get("log_directory")
 cwd = pathlib.Path.cwd()
 LAYER_LABEL = LAYER.LABEL

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -14,8 +14,8 @@ from pathlib import PosixPath
 from functools import partial
 import gdsfactory as gf
 
-add_ports_optical = gf.partial(gf.add_ports.add_ports_from_markers_inside, port_layer=(1, 0))
-add_ports_electrical = gf.partial(gf.add_ports.add_ports_from_markers_inside, port_layer=(41, 0))
+add_ports_optical = gf.partial(gf.add_ports.add_ports_from_markers_inside, pin_layer=(1, 0), port_layer=(2, 0))
+add_ports_electrical = gf.partial(gf.add_ports.add_ports_from_markers_inside, pin_layer=(41, 0), port_layer=(1, 0))
 add_ports = gf.compose(add_ports_optical, add_ports_electrical)
 
 """

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_install_requires_pip():
 setup(
     name="gdsfactory",
     url="https://github.com/gdsfactory/gdsfactory",
-    version="3.10.3",
+    version="3.10.4",
     author="gdsfactory community",
     scripts=["gdsfactory/gf.py"],
     description="python libraries to generate GDS layouts",


### PR DESCRIPTION
- use matplotlib for default plotter instead of holoviews
- add_ports default prefix is 'o' for optical and 'e' for electrical ports
