### PR TITLE
Keep simple name when no args or kwargs are passed

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -125,19 +125,21 @@ def cell_without_validator(func):
         sig = inspect.signature(func)
         args_as_kwargs = dict(zip(sig.parameters.keys(), args))
         args_as_kwargs.update(**kwargs)
-        args_as_kwargs_string_list = [
-            f"{key}={clean_value(args_as_kwargs[key])}"
-            for key in sorted(args_as_kwargs.keys())
-        ]
+        if args_as_kwargs:
+            args_as_kwargs_string_list = [
+                f"{key}={clean_value(args_as_kwargs[key])}"
+                for key in sorted(args_as_kwargs.keys())
+            ]
+            arguments = "_".join(args_as_kwargs_string_list)
+            arguments_hash = hashlib.md5(arguments.encode()).hexdigest()[:8]
 
-        arguments = "_".join(args_as_kwargs_string_list)
-        arguments_hash = hashlib.md5(arguments.encode()).hexdigest()[:8]
+            # for key in sorted(args_as_kwargs.keys()):
+            #     print(f"{key}={clean_value(args_as_kwargs[key])}")
+            # print(arguments)
 
-        # for key in sorted(args_as_kwargs.keys()):
-        #     print(f"{key}={clean_value(args_as_kwargs[key])}")
-        # print(arguments)
-
-        name_signature = clean_name(f"{prefix}_{arguments_hash}")
+            name_signature = clean_name(f"{prefix}_{arguments_hash}")
+        else:
+            name_signature = prefix
         name = name or name_signature
         decorator = kwargs.pop("decorator", None)
         name = get_name_short(name, max_name_length=max_name_length)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ loguru
 lytest==0.0.20
 matplotlib~=3.5.1
 networkx==2.6.3
-numpy
+numpy>=1.20.0
 omegaconf==2.1.1
 pandas
 phidl==1.6.0


### PR DESCRIPTION
In one of the recent commits, naming behavior was changed for cells with no parameters passed. This fixes this behavior so there is no hash appended to the cell name when no args or kwargs are passed to the component factory function.

On an unrelated note, numpy.typing is being used which requires numpy>=1.20.0, so I updated the requirements.txt