### PR TITLE
4.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,51 +1,92 @@
----
-image: python3
+image: python:3.9
 
 before_script:
-    - eval $(ssh-agent -s)
-    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
-    - mkdir -p ~/.ssh
-    - chmod 700 ~/.ssh
-    - echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
-    - chmod 644 ~/.ssh/known_hosts
-    - pyenv shell 3.7.2
-    - virtualenv venv
-    - source venv/bin/activate
-    - pip install -r requirements.txt --upgrade
-    - python setup.py develop
-    - pip list
-    - python -V # Print out python version for debugging
-    - which python # Print out which python for debugging
-
+  - pip list
+  - python -V # Print out python version for debugging
+  - which python # Print out which python for debugging
+  - pip install -r requirements.txt --upgrade
+  - pip install -r requirements_pip.txt --upgrade
+  - pip install -r requirements_dev.txt --upgrade
+  - python setup.py develop
 
 stages:
-    - linter
-    - test
-    - release
+  - test
+  - release
+  - docs
 
-linter:
-    stage: linter
-    script:
-        - pip install pyflakes
-        - pyflakes gdsfactory
+pre-commit:
+  stage: test
+  script:
+    - pip install pre-commit
+    - pre-commit install
+    - pre-commit run -a
 
 test:
-    stage: test
-    script:
-        - pytest
+  stage: test
+  script:
+    - pytest
 
-docs:
-    stage: test
-    script:
-        - pip install sphinx sphinx_rtd_theme recommonmark sphinx-markdown-tables
-        - cd docs
-        - make clean html upload
-    only:
-        - master
+pages:
+  stage: docs
+  script:
+    - pip install -r requirements_dev.txt
+    - mkdir public
+    - cd docs
+    - make html
+    - cp -r build/html/* ../public
+  artifacts:
+    paths:
+      - public
+  only:
+    - master
+    - /docs/
 
-release:
-    stage: release
-    script:
-        - make clean build release
-    only:
-        - master
+
+# python37:
+#   image: python:3.7
+#   stage: test
+#   script:
+#     - python -m pip install tox
+#     - python -m tox -e py37
+
+# python38:
+#   image: python:3.8
+#   stage: test
+#   script:
+#     - python -m pip install tox
+#     - python -m tox -e py38
+
+# python39:
+#   image: python:3.9
+#   stage: test
+#   script:
+#     - python -m pip install tox
+#     - python -m tox -e py39
+
+
+# doctest:
+#   stage: test
+#   script:
+#     - python -m pip install tox
+#     - python -m tox -e docs
+
+flake8:
+  stage: test
+  script:
+    - python -m pip install tox
+    - python -m tox -e flake8
+
+# mypy:
+#   stage: test
+#   script:
+#     - python -m pip install tox
+#     - python -m tox -e mypy
+
+
+# docs:
+#   stage: release
+#   script:
+#     - cd docs
+#     - make install clean html upload
+#   only:
+#     - release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ before_script:
   - python -V # Print out python version for debugging
   - which python # Print out which python for debugging
   - pip install -r requirements.txt --upgrade
+  - pip install -r requirements_full.txt --upgrade
   - pip install -r requirements_pip.txt --upgrade
   - pip install -r requirements_dev.txt --upgrade
   - python setup.py develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - meep plugin write_sparameters_meep_mpi overwrite removes old file for an actual overwrite
 - ensure write_sparameters_meep `**kwargs` are valid simmulation settings
+- fix component lattice mutability issue
+- add `Component.is_unlocked` that raises MutabilityError when calling auto_rename_ports over a locked component
+
 
 ## 3.12.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ensure write_sparameters_meep `**kwargs` are valid simmulation settings
 - fix component lattice mutability issue
 - add `Component.is_unlocked` that raises MutabilityError
+- rename component_lattice components to symbol_to_component
 
 
 ## 3.12.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - meep plugin write_sparameters_meep_mpi overwrite removes old file for an actual overwrite
 - ensure write_sparameters_meep `**kwargs` are valid simmulation settings
 - fix component lattice mutability issue
-- add `Component.is_unlocked` that raises MutabilityError when calling auto_rename_ports over a locked component
+- add `Component.is_unlocked` that raises MutabilityError
 
 
 ## 3.12.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # CHANGELOG
 
-## 3.13.0
+## 4.0.0
 
 - Consider only changed component args and kwargs when calculating hash for component name
 - meep plugin write_sparameters_meep_mpi overwrite removes old file for an actual overwrite
-- ensure write_sparameters_meep `**kwargs` are valid simmulation settings
+- ensure write_sparameters_meep `**kwargs` are valid simulation settings
 - fix component lattice mutability issue
-- add `Component.is_unlocked` that raises MutabilityError
+- add `Component.is_unlocked()` that raises MutabilityError
 - rename component_lattice components to symbol_to_component
 - raise error when trying to add two ports with the same name in `gf.add_ports.add_ports_from_markers_center`
 - difftest adds failed test to logger.error
-- clean_value calls clean_value_json
+- clean_value calls clean_value_json, so we only need to maintain one function serializing settings and name
 
 
 ## 3.12.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - fix component lattice mutability issue
 - add `Component.is_unlocked` that raises MutabilityError
 - rename component_lattice components to symbol_to_component
-- raise error when trying to add two ports with the same name
+- raise error when trying to add two ports with the same name in `gf.add_ports.add_ports_from_markers_center`
+- difftest adds failed test to logger.error
 
 
 ## 3.12.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.12.11
+
+- meep plugin write_sparameters_meep_mpi overwrite removes old file for an actual overwrite
+- ensure write_sparameters_meep `**kwargs` are valid simmulation settings
+
 ## 3.12.9
 
 - fix tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # CHANGELOG
 
-## 3.12.11
+## 3.13.0
 
+- Consider only changed component args and kwargs when calculating hash for component name
 - meep plugin write_sparameters_meep_mpi overwrite removes old file for an actual overwrite
 - ensure write_sparameters_meep `**kwargs` are valid simmulation settings
 - fix component lattice mutability issue
 - add `Component.is_unlocked` that raises MutabilityError
 - rename component_lattice components to symbol_to_component
+- raise error when trying to add two ports with the same name
 
 
 ## 3.12.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - rename component_lattice components to symbol_to_component
 - raise error when trying to add two ports with the same name in `gf.add_ports.add_ports_from_markers_center`
 - difftest adds failed test to logger.error
+- clean_value calls clean_value_json
 
 
 ## 3.12.9

--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -555,9 +555,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = gf.c.straight_heater_metal()\n",
-    "c.auto_rename_ports_layer_orientation()\n",
-    "c.ports"
+    "c0 = gf.c.straight_heater_metal()\n",
+    "c0.ports"
    ]
   },
   {
@@ -566,8 +565,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c.auto_rename_ports()\n",
-    "c.ports"
+    "c1 = c0.copy()\n",
+    "c1.auto_rename_ports_layer_orientation()\n",
+    "c1.ports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2 = c0.copy()\n",
+    "c2.auto_rename_ports()\n",
+    "c2.ports"
    ]
   },
   {

--- a/docs/notebooks/05_GDS.ipynb
+++ b/docs/notebooks/05_GDS.ipynb
@@ -253,49 +253,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gf.add_ports.add_ports_from_markers_inside(c2)"
+    "c3 = gf.import_gds(gdspath, decorator=gf.add_ports.add_ports_from_markers_inside)\n",
+    "c3"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c801862-a5e1-4826-abb2-95b4cbbf949d",
+   "id": "1c753748-291f-4387-afb7-9b734f13ba2c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "c2.ports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3097f180-03d7-473f-bdfb-650f47a0d303",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# you can also add it as a decorator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b388718e-4721-4f4a-bb4f-5dc12bdbaaf5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gf.clear_cache()\n",
-    "c2 = gf.import_gds(gdspath, decorator=gf.add_ports.add_ports_from_markers_inside)\n",
-    "c2.plot()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d49c43dc-a932-4ff9-be52-22d2782c90e1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c2.ports"
+    "c3.ports"
    ]
   },
   {

--- a/docs/notebooks/06_component_circuit_mask.ipynb
+++ b/docs/notebooks/06_component_circuit_mask.ipynb
@@ -477,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/06_mask.ipynb
+++ b/docs/notebooks/06_mask.ipynb
@@ -355,16 +355,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ee20853-ae19-4d18-bd1e-0d2a9dfecda0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tm.spiral_inner_io_6dc6250a.full.length"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "30a2031d-780d-4ea5-b2df-d06aa170b4c0",
    "metadata": {},
    "outputs": [],
@@ -405,14 +395,6 @@
     "gc_taper_angles = [test_metadata[name].full.taper_angle for name in gc_names]\n",
     "gc_taper_angles"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9def5a85-3423-41f3-8eb0-c5309ad04036",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -431,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/common_mistakes.ipynb
+++ b/docs/notebooks/common_mistakes.ipynb
@@ -118,6 +118,7 @@
     "\n",
     "c = die_bad(cache=False)\n",
     "print(c.references)\n",
+    "c.show()\n",
     "c.plot()"
    ]
   },
@@ -145,6 +146,7 @@
     "\n",
     "c = die_good(cache=False)\n",
     "print(c.references)\n",
+    "c.show()\n",
     "c.plot()"
    ]
   },
@@ -153,7 +155,7 @@
    "id": "19b0376f-ea0b-411b-a7ea-fb6129530c32",
    "metadata": {},
    "source": [
-    "**Solution2** You can flatten the cell, but you will lose the memory savings from cell references. Try using Solution1"
+    "**Solution2** You can flatten the cell, but you will lose the memory savings from cell references. Solution1 is more elegant."
    ]
   },
   {
@@ -174,6 +176,7 @@
     "\n",
     "c = die_flat(cache=False)\n",
     "print(c.references)\n",
+    "c.show()\n",
     "c.plot()"
    ]
   },
@@ -202,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -166,14 +166,16 @@ def add_ports_from_markers_center(
         y = p.y
 
         if min_pin_area_um2 and dx * dy < min_pin_area_um2:
-            warnings.warn(f"skipping port with min_pin_area_um2 {dx * dy}")
+            warnings.warn(
+                f"skipping port at ({x}, {y}) with min_pin_area_um2 {dx * dy}"
+            )
             continue
 
         if max_pin_area_um2 and dx * dy > max_pin_area_um2:
             continue
 
         if skip_square_ports and snap_to_grid(dx) == snap_to_grid(dy):
-            warnings.warn("skipping square port with no clear orientation")
+            warnings.warn(f"skipping square port at ({x}, {y})")
             continue
 
         pxmax = p.xmax

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -244,10 +244,10 @@ def add_ports_from_markers_center(
             )
 
     ports = sort_ports_clockwise(ports)
-    component_ports = list(component.ports.keys())
 
     for port_name, port in ports.items():
         if port_name in component.ports:
+            component_ports = list(component.ports.keys())
             raise ValueError(
                 f"port {port_name!r} already in {component_ports}. "
                 "You can pass a port_name_prefix to add it with a different name."
@@ -300,14 +300,21 @@ def add_ports_from_labels(
         elif y < yc:  # south
             orientation = 270
 
-        component.add_port(
-            name=port_name,
-            midpoint=(x, y),
-            width=port_width,
-            orientation=orientation,
-            port_type=port_type,
-            layer=port_layer,
-        )
+        if port_name in component.ports:
+            component_ports = list(component.ports.keys())
+            raise ValueError(
+                f"port {port_name!r} already in {component_ports}. "
+                "You can pass a port_name_prefix to add it with a different name."
+            )
+        else:
+            component.add_port(
+                name=port_name,
+                midpoint=(x, y),
+                width=port_width,
+                orientation=orientation,
+                port_type=port_type,
+                layer=port_layer,
+            )
     return component
 
 

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -118,7 +118,8 @@ def cell_without_validator(func):
         changed_arg_set = set(passed_args_list).difference(default_args_list)
         changed_arg_list = sorted(changed_arg_set)
 
-        # if any args were different from default, append a hash of those args. else, keep only the base name
+        # if any args were different from default, append a hash of those args.
+        # else, keep only the base name
         if changed_arg_list:
             named_args_string = "_".join(changed_arg_list)
             named_args_hash = hashlib.md5(named_args_string.encode()).hexdigest()[:8]

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -99,18 +99,36 @@ def cell_without_validator(func):
             if not p.default == inspect._empty
         }
         changed = args_as_kwargs
-        default = default
         full = copy.deepcopy(default)
         full.update(**args_as_kwargs)
 
-        named_args_list = [
-            f"{key}={clean_value(changed[key])}" for key in sorted(changed.keys())
+        default2 = copy.deepcopy(default)
+        changed2 = copy.deepcopy(changed)
+
+        # list of default args as strings
+        default_args_list = [
+            f"{key}={clean_value(default2[key])}" for key in sorted(default.keys())
         ]
-        named_args_string = "_".join(named_args_list)
-        named_args_hash = hashlib.md5(named_args_string.encode()).hexdigest()[:8]
-        name_signature = (
-            clean_name(f"{prefix}_{named_args_hash}") if named_args_list else prefix
-        )
+        # list of explicitly passed args as strings
+        passed_args_list = [
+            f"{key}={clean_value(changed2[key])}" for key in sorted(changed.keys())
+        ]
+
+        # get only the args which are explicitly passed and different from defaults
+        changed_arg_set = set(passed_args_list).difference(default_args_list)
+        changed_arg_list = sorted(changed_arg_set)
+
+        # if any args were different from default, append a hash of those args. else, keep only the base name
+        if changed_arg_list:
+            named_args_string = "_".join(changed_arg_list)
+            named_args_hash = hashlib.md5(named_args_string.encode()).hexdigest()[:8]
+            name_signature = clean_name(f"{prefix}_{named_args_hash}")
+        else:
+            name_signature = prefix
+
+        # filter the changed dictionary to only keep entries which have truly changed
+        changed_arg_names = [carg.split("=")[0] for carg in changed_arg_list]
+        changed = {k: changed[k] for k in changed_arg_names}
 
         name = name or name_signature
         decorator = kwargs.pop("decorator", None)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -488,9 +488,9 @@ class ComponentReference(DeviceReference):
         """Return Component reference where a port or port_name connects to a destination
 
         Args:
-            port: origin port or port_name
-            destination: destination port
-            overlap: how deep does the port go inside
+            port: origin (port or port_name) to connect.
+            destination: destination port.
+            overlap: how deep does the port go inside.
 
         Returns:
             ComponentReference
@@ -525,7 +525,7 @@ class ComponentReference(DeviceReference):
     def get_ports_list(self, **kwargs) -> List[Port]:
         """Return a list of ports.
 
-        Args:
+        Keyword Args:
             layer: port GDS layer
             prefix: port name prefix
             orientation: in degrees
@@ -539,7 +539,7 @@ class ComponentReference(DeviceReference):
     def get_ports_dict(self, **kwargs) -> Dict[str, Port]:
         """Return a dict of ports.
 
-        Args:
+        Keyword Args:
             layer: port GDS layer
             prefix: port name prefix
             orientation: in degrees
@@ -578,7 +578,7 @@ class ComponentReference(DeviceReference):
     def get_ports_xsize(self, **kwargs) -> float:
         """Return xdistance from east to west ports
 
-        Args:
+        Keyword Args:
             kwargs: orientation, port_type, layer
         """
         ports_cw = self.get_ports_list(clockwise=True, **kwargs)
@@ -642,7 +642,7 @@ class Component(Device):
         self.changelog = changelog
 
     def unlock(self):
-        """I reccommend doing this only if you know what you are doing."""
+        """I recommend doing this only if you know what you are doing."""
         self._locked = False
 
     def lock(self):
@@ -675,7 +675,7 @@ class Component(Device):
     @property
     def bbox(self):
         """Return the bounding box of the DeviceReference.
-        it snaps to 3 decimals in um (0.001um = 1nm precission)
+        it snaps to 3 decimals in um (0.001um = 1nm precision)
         """
         bbox = self.get_bounding_box()
         if bbox is None:
@@ -706,15 +706,29 @@ class Component(Device):
     def get_ports_xsize(self, **kwargs) -> float:
         """Return xdistance from east to west ports
 
-        Args:
-            kwargs: orientation, port_type, layer
+        Keyword Args:
+            layer: port GDS layer
+            prefix: with in port name
+            orientation: in degrees
+            width:
+            layers_excluded: List of layers to exclude
+            port_type: optical, electrical, ...
         """
         ports_cw = self.get_ports_list(clockwise=True, **kwargs)
         ports_ccw = self.get_ports_list(clockwise=False, **kwargs)
         return snap_to_grid(ports_ccw[0].x - ports_cw[0].x)
 
     def get_ports_ysize(self, **kwargs) -> float:
-        """Return ydistance from east to west ports"""
+        """Return ydistance from east to west ports
+
+        Keyword Args:
+            layer: port GDS layer
+            prefix: with in port name
+            orientation: in degrees
+            width:
+            layers_excluded: List of layers to exclude
+            port_type: optical, electrical, ...
+        """
         ports_cw = self.get_ports_list(clockwise=True, **kwargs)
         ports_ccw = self.get_ports_list(clockwise=False, **kwargs)
         return snap_to_grid(ports_ccw[0].y - ports_cw[0].y)
@@ -1285,8 +1299,8 @@ class Component(Device):
     ) -> None:
         """Show component in klayout.
 
-        show_subports = True adds pins in a component copy (only used for display)
-        so the original component remains as it was
+        show_subports = True adds pins to a component copy (only used for display)
+        so the original component remains intact.
 
         Args:
             show_ports: shows component with port markers and labels
@@ -1380,7 +1394,7 @@ class Component(Device):
         ignore_components_prefix: Optional[List[str]] = None,
         ignore_functions_prefix: Optional[List[str]] = None,
     ) -> DictConfig:
-        """Returna DictConfig Component representation.
+        """Return DictConfig Component representation.
 
         Args:
             ignore_components_prefix: for components to ignore when exporting
@@ -1429,7 +1443,7 @@ class Component(Device):
         return OmegaConf.create(d)
 
     def auto_rename_ports(self, **kwargs) -> None:
-        """Renames ports by orientation NSEW (north, south, east, west).
+        """Rename ports by orientation NSEW (north, south, east, west).
 
         Keyword Args:
             function: to rename ports
@@ -1461,7 +1475,7 @@ class Component(Device):
         auto_rename_ports_layer_orientation(self, **kwargs)
 
     def auto_rename_ports_orientation(self, **kwargs) -> None:
-        """Renames ports by orientation NSEW (north, south, east, west).
+        """Rename ports by orientation NSEW (north, south, east, west).
 
         Keyword Args:
             function: to rename ports
@@ -1495,7 +1509,7 @@ class Component(Device):
         Args:
             origin: of component
             destination:
-            axis: x or y axis
+            axis: x or y
         """
         from gdsfactory.functions import move
 
@@ -1757,7 +1771,7 @@ if __name__ == "__main__":
     hv.extension("bokeh")
     output_file("plot.html")
 
-    c = gf.components.rectangle(size=(10, 3), layer=(0, 0))
+    c = gf.components.rectangle(size=(4, 2), layer=(0, 0))
     # c = gf.components.straight(length=2, info=dict(ng=4.2, wavelength=1.55))
     # c.show()
     p = c.ploth()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1447,12 +1447,15 @@ class Component(Device):
                  8   7
 
         """
+        self.is_unlocked()
         auto_rename_ports(self, **kwargs)
 
     def auto_rename_ports_counter_clockwise(self, **kwargs) -> None:
+        self.is_unlocked()
         auto_rename_ports_counter_clockwise(self, **kwargs)
 
     def auto_rename_ports_layer_orientation(self, **kwargs) -> None:
+        self.is_unlocked()
         auto_rename_ports_layer_orientation(self, **kwargs)
 
     def auto_rename_ports_orientation(self, **kwargs) -> None:
@@ -1476,6 +1479,7 @@ class Component(Device):
                 S0   S1
 
         """
+        self.is_unlocked()
         auto_rename_ports_orientation(self, **kwargs)
 
     def move(

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1447,15 +1447,12 @@ class Component(Device):
                  8   7
 
         """
-        self.is_unlocked()
         auto_rename_ports(self, **kwargs)
 
     def auto_rename_ports_counter_clockwise(self, **kwargs) -> None:
-        self.is_unlocked()
         auto_rename_ports_counter_clockwise(self, **kwargs)
 
     def auto_rename_ports_layer_orientation(self, **kwargs) -> None:
-        self.is_unlocked()
         auto_rename_ports_layer_orientation(self, **kwargs)
 
     def auto_rename_ports_orientation(self, **kwargs) -> None:
@@ -1479,7 +1476,6 @@ class Component(Device):
                 S0   S1
 
         """
-        self.is_unlocked()
         auto_rename_ports_orientation(self, **kwargs)
 
     def move(

--- a/gdsfactory/components/component_lattice.py
+++ b/gdsfactory/components/component_lattice.py
@@ -258,6 +258,7 @@ def component_lattice(
             j += 1
         x += L
 
+    component.auto_rename_ports()
     return component
 
 

--- a/gdsfactory/components/component_lattice.py
+++ b/gdsfactory/components/component_lattice.py
@@ -182,7 +182,6 @@ def component_lattice(
     }
 
     # Find y spacing and check that all components have same y spacing
-
     y_spacing = None
     for component in symbol_to_component.values():
         component = gf.call_if_func(component)
@@ -251,8 +250,9 @@ def component_lattice(
                         component.add_port(gen_tmp_port_name(), port=_p)
 
             else:
+                symbols = list(symbol_to_component.keys())
                 raise ValueError(
-                    f"symbol {c} not in symbol_to_component dict {symbol_to_component.keys()}"
+                    f"symbol {c!r} not in symbol_to_component dict {symbols}"
                 )
 
             j += 1
@@ -305,5 +305,5 @@ if __name__ == "__main__":
     # c= gf.routing.fanout2x2(component=gf.components.coupler(), port_spacing=40.0)
     # c= crossing45(port_spacing=40.0)
     # c = compensation_path(crossing45=crossing45(port_spacing=40.0))
-    c.pprint()
+    c.pprint_ports()
     c.show()

--- a/gdsfactory/components/component_lattice.py
+++ b/gdsfactory/components/component_lattice.py
@@ -175,10 +175,11 @@ def component_lattice(
       c.plot()
 
     """
+    x = crossing45(port_spacing=40)
     symbol_to_component = symbol_to_component or {
         "C": gf.routing.fanout2x2(component=coupler(), port_spacing=40.0),
-        "X": crossing45(port_spacing=40.0),
-        "-": compensation_path(crossing45=crossing45(port_spacing=40.0)),
+        "X": x,
+        "-": compensation_path(x),
     }
 
     # Find y spacing and check that all components have same y spacing

--- a/gdsfactory/components/component_sequence.py
+++ b/gdsfactory/components/component_sequence.py
@@ -104,8 +104,8 @@ def component_sequence(
         }
 
         # Each character in the sequence represents a component
-        sequence = "AB-H-H-H-H-BA"
-        c = gf.components.component_sequence(sequence=sequence, symbol_to_component=symbol_to_component)
+        s = "AB-H-H-H-H-BA"
+        c = gf.c.component_sequence(sequence=s, symbol_to_component=symbol_to_component)
         c.plot()
 
     """

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -222,8 +222,8 @@ def crossing45(
     crossing = crossing() if callable(crossing) else crossing
 
     c = Component()
-    x = crossing.ref(rotation=45)
-    c.add(x)
+    x = c << crossing
+    x.rotate(45)
 
     # Add bends
     p_e = x.ports["o3"].midpoint
@@ -269,7 +269,6 @@ def crossing45(
         c.absorb(cmp_ref)
 
     c.info.bezier_length = bend.info.length
-    c.info.crossing = crossing.info
     c.info.min_bend_radius = b_br.info.min_bend_radius
 
     c.bezier = bend
@@ -370,9 +369,7 @@ def compensation_path(
     sbend = bezier(control_points=get_control_pts(x0, y_bend))
 
     c = Component()
-    crossing0 = crossing45.crossing.ref()
-    c.add(crossing0)
-
+    crossing0 = c << crossing45.crossing
     sbend_left = sbend.ref(
         position=crossing0.ports["o1"], port_id="o2", v_mirror=v_mirror
     )
@@ -426,6 +423,6 @@ if __name__ == "__main__":
     # c = crossing_from_taper()
     # c.pprint()
     # c = crossing_etched()
-    # c = compensation_path()
-    c = crossing45(port_spacing=40)
+    c = compensation_path()
+    # c = crossing45(port_spacing=40)
     c.show()

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -370,6 +370,7 @@ def compensation_path(
 
     c = Component()
     crossing0 = c << crossing45.crossing
+
     sbend_left = sbend.ref(
         position=crossing0.ports["o1"], port_id="o2", v_mirror=v_mirror
     )

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -222,17 +222,17 @@ def crossing45(
     crossing = crossing() if callable(crossing) else crossing
 
     c = Component()
-    _crossing = crossing.ref(rotation=45)
-    c.add(_crossing)
+    x = crossing.ref(rotation=45)
+    c.add(x)
 
     # Add bends
-    p_e = _crossing.ports["o3"].midpoint
-    p_w = _crossing.ports["o1"].midpoint
-    p_n = _crossing.ports["o2"].midpoint
-    p_s = _crossing.ports["o4"].midpoint
+    p_e = x.ports["o3"].midpoint
+    p_w = x.ports["o1"].midpoint
+    p_n = x.ports["o2"].midpoint
+    p_s = x.ports["o4"].midpoint
 
     # Flatten the crossing - not an SRef anymore
-    c.absorb(_crossing)
+    c.absorb(x)
     dx = dx or port_spacing
     dy = port_spacing / 2
 
@@ -275,12 +275,11 @@ def crossing45(
     c.bezier = bend
     c.crossing = crossing
 
-    c.add_port("o1", port=b_br.ports["o2"])
-    c.add_port("o2", port=b_tr.ports["o2"])
-    c.add_port("o3", port=b_bl.ports["o2"])
-    c.add_port("o4", port=b_tl.ports["o2"])
+    c.add_port("o1", port=b_bl.ports["o2"])
+    c.add_port("o2", port=b_tl.ports["o2"])
+    c.add_port("o3", port=b_tr.ports["o2"])
+    c.add_port("o4", port=b_br.ports["o2"])
     c.snap_ports_to_grid()
-    c.auto_rename_ports()
     return c
 
 
@@ -370,9 +369,9 @@ def compensation_path(
 
     sbend = bezier(control_points=get_control_pts(x0, y_bend))
 
-    component = Component()
+    c = Component()
     crossing0 = crossing45.crossing.ref()
-    component.add(crossing0)
+    c.add(crossing0)
 
     sbend_left = sbend.ref(
         position=crossing0.ports["o1"], port_id="o2", v_mirror=v_mirror
@@ -381,15 +380,15 @@ def compensation_path(
         position=crossing0.ports["o3"], port_id="o2", h_mirror=True, v_mirror=v_mirror
     )
 
-    component.add(sbend_left)
-    component.add(sbend_right)
+    c.add(sbend_left)
+    c.add(sbend_right)
 
-    component.add_port("o1", port=sbend_left.ports["o1"])
-    component.add_port("o2", port=sbend_right.ports["o1"])
+    c.add_port("o1", port=sbend_left.ports["o1"])
+    c.add_port("o2", port=sbend_right.ports["o1"])
 
-    component.info["min_bend_radius"] = sbend.info["min_bend_radius"]
-    component.info.sbend = sbend.info
-    return component
+    c.info["min_bend_radius"] = sbend.info["min_bend_radius"]
+    c.info.sbend = sbend.info
+    return c
 
 
 def _demo():
@@ -421,12 +420,12 @@ def _demo():
 if __name__ == "__main__":
     # c = compensation_path()
     # c = crossing()
-    # c = crossing45(port_spacing=40)
     # print(c.ports["E1"].y - c.ports['o2'].y)
     # print(c.get_ports_array())
     # _demo()
     # c = crossing_from_taper()
     # c.pprint()
     # c = crossing_etched()
-    c = compensation_path()
+    # c = compensation_path()
+    c = crossing45(port_spacing=40)
     c.show()

--- a/gdsfactory/components/mzi_arm.py
+++ b/gdsfactory/components/mzi_arm.py
@@ -66,11 +66,11 @@ def mzi_arm(
     sequence = "bLB-BRb"
     c = component_sequence(sequence=sequence, symbol_to_component=symbol_to_component)
 
-    # Add any electrical ports from aliases
-
+    # Add any electrical ports from references
     for ref_name, ref in c.aliases.items():
         c.add_ports(ref.get_ports_list(port_type="electrical"), prefix=ref_name)
 
+    c.unlock()
     c.auto_rename_ports()
     c.info.length_x = float(length_x)
     c.info.length_xsize = straight_x.get_ports_xsize()

--- a/gdsfactory/components/splitter_tree.py
+++ b/gdsfactory/components/splitter_tree.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     c = splitter_tree(
         noutputs=2 ** 2,
         # bend_length=30,
-        # bend_s=None,
+        bend_s=None,
     )
     c.show()
     # print(len(c.ports))

--- a/gdsfactory/components/taper_from_csv.py
+++ b/gdsfactory/components/taper_from_csv.py
@@ -1,6 +1,7 @@
-""" adiabatic tapers from CSV files
+"""Adiabatic tapers from CSV files
 """
 import pathlib
+from functools import partial
 from pathlib import Path
 from typing import Tuple
 
@@ -10,12 +11,12 @@ import pandas as pd
 import gdsfactory as gf
 from gdsfactory.component import Component
 
-data_path = pathlib.Path(__file__).parent / "csv_data"
+data = pathlib.Path(__file__).parent / "csv_data"
 
 
 @gf.cell
 def taper_from_csv(
-    filepath: Path = data_path / "taper_strip_0p5_3_36.csv",
+    filepath: Path = data / "taper_strip_0p5_3_36.csv",
     layer: Tuple[int, int] = (1, 0),
     layer_cladding: Tuple[int, int] = gf.LAYER.WGCLAD,
     cladding_offset: float = 3.0,
@@ -57,44 +58,16 @@ def taper_from_csv(
     return c
 
 
-@gf.cell
-def taper_0p5_to_3_l36(**kwargs) -> Component:
-    filepath = data_path / "taper_strip_0p5_3_36.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
-
-
-@gf.cell
-def taper_w10_l100(**kwargs):
-    filepath = data_path / "taper_strip_0p5_10_100.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
-
-
-@gf.cell
-def taper_w10_l150(**kwargs):
-    filepath = data_path / "taper_strip_0p5_10_150.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
-
-
-@gf.cell
-def taper_w10_l200(**kwargs):
-    filepath = data_path / "taper_strip_0p5_10_200.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
-
-
-@gf.cell
-def taper_w11_l200(**kwargs):
-    filepath = data_path / "taper_strip_0p5_11_200.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
-
-
-@gf.cell
-def taper_w12_l200(**kwargs):
-    filepath = data_path / "taper_strip_0p5_12_200.csv"
-    return taper_from_csv(filepath=filepath, **kwargs)
+taper_0p5_to_3_l36 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_3_36.csv")
+taper_w10_l100 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_10_100.csv")
+taper_w10_l150 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_10_150.csv")
+taper_w10_l200 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_10_200.csv")
+taper_w11_l200 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_11_200.csv")
+taper_w12_l200 = partial(taper_from_csv, filepath=data / "taper_strip_0p5_12_200.csv")
 
 
 if __name__ == "__main__":
-    c = taper_0p5_to_3_l36()
-    # c = taper_w10_l100()
+    # c = taper_0p5_to_3_l36()
+    c = taper_w10_l100()
     # c = taper_w11_l200()
     c.show()

--- a/gdsfactory/components/wire_sbend.py
+++ b/gdsfactory/components/wire_sbend.py
@@ -27,6 +27,7 @@ def wire_sbend(dx: float = 20.0, dy: float = 10.0, **kwargs) -> Component:
     c = gf.components.component_sequence(
         sequence=sequence, symbol_to_component=symbol_to_component
     )
+    c.unlock()
     c.auto_rename_ports()
     return c
 

--- a/gdsfactory/components/wire_sbend.py
+++ b/gdsfactory/components/wire_sbend.py
@@ -8,9 +8,9 @@ def wire_sbend(dx: float = 20.0, dy: float = 10.0, **kwargs) -> Component:
     """Sbend corner with manhattan wires
 
     Args:
-        dx: length
-        dy: height
-        **kwargs: cross_section settings
+        dx: xsize
+        dy: ysize
+        kwargs: cross_section settings
     """
     sx = wire_straight(length=dx / 2, **kwargs)
     sy = wire_straight(length=dy, **kwargs)

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -113,7 +113,7 @@ class CrossSection(CrossSectionPhidl):
         X = CrossSection()
         X.info = self.info.copy()
         X.sections = list(self.sections)
-        X.ports = tuple(self.ports)
+        X.ports = tuple(sorted(list(self.ports)))
         X.aliases = dict(self.aliases)
         X.port_types = tuple(self.port_types)
         return X

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -25,6 +25,7 @@ from typing import Optional
 from lytest.kdb_xor import GeometryDifference, run_xor
 
 from gdsfactory.component import Component
+from gdsfactory.config import logger
 from gdsfactory.gdsdiff.gdsdiff import gdsdiff
 
 cwd = pathlib.Path.cwd()
@@ -81,7 +82,7 @@ def difftest(
         run_xor(str(ref_file), str(run_file), tolerance=1, verbose=False)
     except GeometryDifference as error:
         print()
-        print(error)
+        logger.error(error)
         diff = gdsdiff(ref_file, run_file, name=test_name, xor=xor)
         diff.write_gds(diff_file)
         diff.show(show_ports=False)

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -18,6 +18,7 @@ from gdsfactory.components.text_rectangular import text_rectangular_multi_layer
 from gdsfactory.port import auto_rename_ports
 from gdsfactory.types import (
     Anchor,
+    Axis,
     ComponentFactory,
     ComponentOrFactory,
     Float2,
@@ -31,7 +32,7 @@ cache = lru_cache(maxsize=None)
 
 
 def add_port(component: Component, **kwargs) -> Component:
-    """Returns Component with a new port."""
+    """Return Component with a new port."""
     component.add_port(**kwargs)
     return component
 
@@ -44,7 +45,7 @@ def add_text(
     text_anchor: Anchor = "cc",
     text_factory: ComponentFactory = text_rectangular_multi_layer,
 ) -> Component:
-    """Returns component inside a new component with text geometry.
+    """Return component inside a new component with text geometry.
 
     Args:
         component:
@@ -72,7 +73,7 @@ def add_texts(
     index0: int = 0,
     **kwargs,
 ) -> List[Component]:
-    """Returns a list of Component with text labels.
+    """Return a list of Component with text labels.
 
     Args:
         components: list of components
@@ -95,7 +96,7 @@ def rotate(
     component: ComponentOrFactory,
     angle: int = 90,
 ) -> Component:
-    """Returns rotated component inside a new component.
+    """Return rotated component inside a new component.
 
     Most times you just need to place a reference and rotate it.
     This rotate function just encapsulates the rotated reference into a new component.
@@ -121,7 +122,7 @@ rotate180 = partial(rotate, angle=180)
 
 @cell
 def mirror(component: Component, p1: Float2 = (0, 1), p2: Float2 = (0, 0)) -> Component:
-    """Returns mirrored component inside a new component.
+    """Return new Component with a mirrored reference.
 
     Args:
         p1: first point to define mirror axis
@@ -141,9 +142,15 @@ def move(
     component: Component,
     origin=(0, 0),
     destination=None,
-    axis: Optional[str] = None,
+    axis: Optional[Axis] = None,
 ) -> Component:
-    """Return container that contains a reference to the original component."""
+    """Return new Component with a moved reference to the original component.
+
+    Args:
+        origin: of component
+        destination:
+        axis: x or y axis
+    """
     component_new = Component()
     component_new.component = component
     ref = component_new.add_ref(component)
@@ -154,7 +161,7 @@ def move(
 
 
 def move_port_to_zero(component: Component, port_name: str = "o1"):
-    """Returns a container that contains a reference to the original component.
+    """Return a container that contains a reference to the original component.
     where the new component has port_name in (0, 0)
     """
     if port_name not in component.ports:
@@ -165,7 +172,7 @@ def move_port_to_zero(component: Component, port_name: str = "o1"):
 
 
 def update_info(component: Component, **kwargs) -> Component:
-    """Returns Component with updated info."""
+    """Return Component with updated info."""
     component.info.update(**kwargs)
     return component
 

--- a/gdsfactory/name.py
+++ b/gdsfactory/name.py
@@ -1,5 +1,6 @@
 """Define names, clean values for names.
 """
+import copy
 import functools
 import hashlib
 import inspect
@@ -162,6 +163,7 @@ def clean_value(value: Any) -> str:
         and len(value) > 0
         and not isinstance(list(value.keys())[0], str)
     ):
+        value = copy.deepcopy(value)
         value = [
             f"{clean_value(key)}={clean_value(value[key])}"
             for key in sorted(value.keys())
@@ -169,8 +171,8 @@ def clean_value(value: Any) -> str:
         value = "_".join(value)
 
     elif isinstance(value, dict):
+        value = copy.deepcopy(value)
         value = dict2name(**value)
-        # value = [f"{k}={v!r}" for k, v in value.items()]
     elif isinstance(value, Port):
         value = f"{value.name}_{value.width}_{value.x}_{value.y}"
     elif isinstance(value, PathPhidl):
@@ -213,8 +215,8 @@ def test_clean_name() -> None:
 
 if __name__ == "__main__":
     # test_cell()
-    testclean_value_json()
-    import gdsfactory as gf
+    # testclean_value_json()
+    # import gdsfactory as gf
 
     # print(clean_value(gf.components.straight))
     # c = gf.components.straight(polarization="TMeraer")
@@ -222,8 +224,8 @@ if __name__ == "__main__":
     # print(clean_value(11.001))
     # layers_cladding = (gf.LAYER.WGCLAD, gf.LAYER.NO_TILE_SI)
     # layers_cladding = (gf.LAYER.WGCLAD,)
-    c = gf.components.straight(length=10)
-    c = gf.components.straight(length=10)
+    # c = gf.components.straight(length=10)
+    # c = gf.components.straight(length=10)
 
     # print(c.name)
     # print(c)
@@ -236,3 +238,11 @@ if __name__ == "__main__":
     # print(clean_value([1, 2.4324324, 3]))
     # print(clean_value((0.001, 24)))
     # print(clean_value({"a": 1, "b": 2}))
+    import gdsfactory as gf
+
+    d = {
+        "X": gf.c.crossing45(port_spacing=40.0),
+        "-": gf.c.compensation_path(crossing45=gf.c.crossing45(port_spacing=40.0)),
+    }
+    d2 = clean_value(d)
+    print(d2)

--- a/gdsfactory/routing/fanout.py
+++ b/gdsfactory/routing/fanout.py
@@ -17,6 +17,7 @@ def fanout_component(
     pitch: Tuple[float, float] = (0.0, 20.0),
     dx: float = 20.0,
     sort_ports: bool = True,
+    auto_rename_ports: bool = True,
     **kwargs,
 ) -> Component:
     """Returns component with Sbend fanout routes.
@@ -61,6 +62,8 @@ def fanout_component(
         if port.name not in port_names:
             c.add_port(port.name, port=port)
 
+    if auto_rename_ports:
+        c.auto_rename_ports()
     return c
 
 

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -107,6 +107,27 @@ cells:
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
+  straight_0d8c15db:
+    changed:
+      length: 18.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 18.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 18.5
+    module: gdsfactory.components.straight
+    name: straight_0d8c15db
+    width: 0.5
   straight_373b1ebb:
     changed:
       length: 20
@@ -299,49 +320,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_52c0fe19
     width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_7af131b6:
-    changed:
-      length: 33.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 33.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 33.5
-    module: gdsfactory.components.straight
-    name: straight_7af131b6
-    width: 0.5
-  straight_831943ee:
+  straight_764e0e0e:
     changed:
       length: 35.552
     default:
@@ -360,11 +339,11 @@ cells:
     info_version: 1
     length: 35.552
     module: gdsfactory.components.straight
-    name: straight_831943ee
+    name: straight_764e0e0e
     width: 0.5
-  straight_a03fba79:
+  straight_b81889b2:
     changed:
-      length: 18.5
+      length: 43.5
     default:
       cross_section:
         function: cross_section
@@ -374,14 +353,35 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 18.5
+      length: 43.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 18.5
+    length: 43.5
     module: gdsfactory.components.straight
-    name: straight_a03fba79
+    name: straight_b81889b2
+    width: 0.5
+  straight_c17e8a1a:
+    changed:
+      length: 33.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 33.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 33.5
+    module: gdsfactory.components.straight
+    name: straight_c17e8a1a
     width: 0.5
   taper_bea08b71:
     changed:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,56 +103,10 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_06b7497a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_06b7497a
-    width: 0.5
-  straight_35a9b97f:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 33.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 33.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 33.5
-    module: gdsfactory.components.straight
-    name: straight_35a9b97f
-    width: 0.5
   straight_373b1ebb:
     changed:
       length: 20
@@ -327,56 +278,8 @@ cells:
     info_version: 1
     module: gdsfactory.add_tapers
     name: straight_373b1ebb_add_t_9b5da3e4
-  straight_763e1ea3:
+  straight_52c0fe19:
     changed:
-      cross_section:
-        function: cross_section
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_763e1ea3
-    width: 0.5
-  straight_7e153a04:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 18.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 18.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 18.5
-    module: gdsfactory.components.straight
-    name: straight_7e153a04
-    width: 0.5
-  straight_c4828fc0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 234
     default:
       cross_section:
@@ -394,7 +297,91 @@ cells:
     info_version: 1
     length: 234
     module: gdsfactory.components.straight
-    name: straight_c4828fc0
+    name: straight_52c0fe19
+    width: 0.5
+  straight_5656be49:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_7af131b6:
+    changed:
+      length: 33.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 33.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 33.5
+    module: gdsfactory.components.straight
+    name: straight_7af131b6
+    width: 0.5
+  straight_831943ee:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_831943ee
+    width: 0.5
+  straight_a03fba79:
+    changed:
+      length: 18.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 18.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 18.5
+    module: gdsfactory.components.straight
+    name: straight_a03fba79
     width: 0.5
   taper_bea08b71:
     changed:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,8 +48,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  coupler_12df0178:
+    name: circle_925ccccf
+  coupler_a078f3c8:
     changed:
       gap: 0.244
       length: 5.67
@@ -80,10 +80,10 @@ cells:
     length: 10.313
     min_bend_radius: 9.465
     module: gdsfactory.components.coupler
-    name: coupler_12df0178
-  coupler_12df0178_add_fi_b940b28a:
+    name: coupler_a078f3c8
+  coupler_a078f3c8_add_fi_17159ba2:
     changed:
-      component: coupler_12df0178
+      component: coupler_a078f3c8
       optical_routing_type: 0
     child:
       changed:
@@ -116,7 +116,7 @@ cells:
       length: 10.313
       min_bend_radius: 9.465
       module: gdsfactory.components.coupler
-      name: coupler_12df0178
+      name: coupler_a078f3c8
     default:
       bend:
         function: bend_euler
@@ -142,7 +142,7 @@ cells:
     full:
       bend:
         function: bend_euler
-      component: coupler_12df0178
+      component: coupler_a078f3c8
       component_name: null
       cross_section:
         function: cross_section
@@ -166,7 +166,7 @@ cells:
     function_name: add_fiber_array
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
-    name: coupler_12df0178_add_fi_b940b28a
+    name: coupler_a078f3c8_add_fi_17159ba2
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -225,133 +225,7 @@ cells:
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_09aa7466:
-    changed:
-      length: 167.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 167.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 167.7
-    module: gdsfactory.components.straight
-    name: straight_09aa7466
-    width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_59da0769:
-    changed:
-      length: 48.672
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 48.672
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 48.672
-    module: gdsfactory.components.straight
-    name: straight_59da0769
-    width: 0.5
-  straight_613027c6:
-    changed:
-      length: 40.63
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.63
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.63
-    module: gdsfactory.components.straight
-    name: straight_613027c6
-    width: 0.5
-  straight_64d3d90a:
-    changed:
-      length: 40.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.7
-    module: gdsfactory.components.straight
-    name: straight_64d3d90a
-    width: 0.5
-  straight_831943ee:
-    changed:
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_831943ee
-    width: 0.5
-  straight_97e21a97:
+  straight_5282e4b1:
     changed:
       length: 167.63
     default:
@@ -370,9 +244,93 @@ cells:
     info_version: 1
     length: 167.63
     module: gdsfactory.components.straight
-    name: straight_97e21a97
+    name: straight_5282e4b1
     width: 0.5
-  straight_dba75604:
+  straight_764e0e0e:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_764e0e0e
+    width: 0.5
+  straight_96a4b086:
+    changed:
+      length: 48.672
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 48.672
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 48.672
+    module: gdsfactory.components.straight
+    name: straight_96a4b086
+    width: 0.5
+  straight_a96cd818:
+    changed:
+      length: 40.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.7
+    module: gdsfactory.components.straight
+    name: straight_a96cd818
+    width: 0.5
+  straight_b81889b2:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_b81889b2
+    width: 0.5
+  straight_bc6fa145:
     changed:
       length: 43.672
     default:
@@ -391,7 +349,28 @@ cells:
     info_version: 1
     length: 43.672
     module: gdsfactory.components.straight
-    name: straight_dba75604
+    name: straight_bc6fa145
+    width: 0.5
+  straight_cba4033f:
+    changed:
+      length: 167.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 167.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 167.7
+    module: gdsfactory.components.straight
+    name: straight_cba4033f
     width: 0.5
   straight_f0fa08f8:
     changed:
@@ -414,9 +393,30 @@ cells:
     module: gdsfactory.components.straight
     name: straight_f0fa08f8
     width: 0.5
+  straight_f2e7eb26:
+    changed:
+      length: 40.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.63
+    module: gdsfactory.components.straight
+    name: straight_f2e7eb26
+    width: 0.5
 info:
   changed:
-    component: coupler_12df0178
+    component: coupler_a078f3c8
     optical_routing_type: 0
   child:
     changed:
@@ -449,7 +449,7 @@ info:
     length: 10.313
     min_bend_radius: 9.465
     module: gdsfactory.components.coupler
-    name: coupler_12df0178
+    name: coupler_a078f3c8
   default:
     bend:
       function: bend_euler
@@ -475,7 +475,7 @@ info:
   full:
     bend:
       function: bend_euler
-    component: coupler_12df0178
+    component: coupler_a078f3c8
     component_name: null
     cross_section:
       function: cross_section
@@ -499,7 +499,7 @@ info:
   function_name: add_fiber_array
   info_version: 1
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_12df0178_add_fi_b940b28a
+  name: coupler_a078f3c8_add_fi_17159ba2
 ports:
   vertical_te_00:
     layer:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -169,9 +167,8 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
     name: coupler_12df0178_add_fi_b940b28a
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -224,152 +221,12 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_06b7497a:
+  straight_09aa7466:
     changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_06b7497a
-    width: 0.5
-  straight_42f2ed13:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 43.672
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.672
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.672
-    module: gdsfactory.components.straight
-    name: straight_42f2ed13
-    width: 0.5
-  straight_63b82305:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 40.63
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.63
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.63
-    module: gdsfactory.components.straight
-    name: straight_63b82305
-    width: 0.5
-  straight_70301b8e:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 48.672
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 48.672
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 48.672
-    module: gdsfactory.components.straight
-    name: straight_70301b8e
-    width: 0.5
-  straight_763e1ea3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_763e1ea3
-    width: 0.5
-  straight_8d8c66e1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 167.63
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 167.63
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 167.63
-    module: gdsfactory.components.straight
-    name: straight_8d8c66e1
-    width: 0.5
-  straight_962f27ff:
-    changed:
-      cross_section:
-        function: cross_section
       length: 167.7
     default:
       cross_section:
@@ -387,13 +244,11 @@ cells:
     info_version: 1
     length: 167.7
     module: gdsfactory.components.straight
-    name: straight_962f27ff
+    name: straight_09aa7466
     width: 0.5
-  straight_ca7e7c8f:
+  straight_5656be49:
     changed:
-      cross_section:
-        function: cross_section
-      length: 488
+      length: 43.5
     default:
       cross_section:
         function: cross_section
@@ -403,19 +258,59 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 488
+      length: 43.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 488
+    length: 43.5
     module: gdsfactory.components.straight
-    name: straight_ca7e7c8f
+    name: straight_5656be49
     width: 0.5
-  straight_f24061d4:
+  straight_59da0769:
     changed:
+      length: 48.672
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 48.672
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 48.672
+    module: gdsfactory.components.straight
+    name: straight_59da0769
+    width: 0.5
+  straight_613027c6:
+    changed:
+      length: 40.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.63
+    module: gdsfactory.components.straight
+    name: straight_613027c6
+    width: 0.5
+  straight_64d3d90a:
+    changed:
       length: 40.7
     default:
       cross_section:
@@ -433,7 +328,91 @@ cells:
     info_version: 1
     length: 40.7
     module: gdsfactory.components.straight
-    name: straight_f24061d4
+    name: straight_64d3d90a
+    width: 0.5
+  straight_831943ee:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_831943ee
+    width: 0.5
+  straight_97e21a97:
+    changed:
+      length: 167.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 167.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 167.63
+    module: gdsfactory.components.straight
+    name: straight_97e21a97
+    width: 0.5
+  straight_dba75604:
+    changed:
+      length: 43.672
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.672
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.672
+    module: gdsfactory.components.straight
+    name: straight_dba75604
+    width: 0.5
+  straight_f0fa08f8:
+    changed:
+      length: 488
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 488
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 488
+    module: gdsfactory.components.straight
+    name: straight_f0fa08f8
     width: 0.5
 info:
   changed:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
@@ -1,9 +1,6 @@
 cells:
-  bend_euler_0c3469c8:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -16,7 +13,6 @@ cells:
     dy: 10
     full:
       angle: 90
-      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -28,13 +24,12 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_0c3469c8
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_1da190e0:
+  bend_euler_2630f5fb:
     changed:
-      cross_section:
-        function: cross_section
+      auto_widen: true
     default:
       angle: 90
       cross_section:
@@ -47,6 +42,7 @@ cells:
     dy: 10
     full:
       angle: 90
+      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -58,7 +54,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -201,9 +197,8 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
     name: coupler_70441075_add_fi_49620dbe
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -256,205 +251,34 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_02352a98:
+  straight_0723ff82:
+    changed:
+      length: 11
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 11
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 11
+    module: gdsfactory.components.straight
+    name: straight_0723ff82
+    width: 0.5
+  straight_28680a03:
     changed:
       auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 1
-    module: gdsfactory.components.straight
-    name: straight_02352a98
-    width: 0.5
-  straight_06b7497a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_06b7497a
-    width: 0.5
-  straight_1795b20c:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 6.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 6.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 6.25
-    module: gdsfactory.components.straight
-    name: straight_1795b20c
-    width: 0.5
-  straight_650b3161:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 12.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 12.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 12.25
-    module: gdsfactory.components.straight
-    name: straight_650b3161
-    width: 0.5
-  straight_6c1c731d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 20
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 20
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 20
-    module: gdsfactory.components.straight
-    name: straight_6c1c731d
-    width: 0.5
-  straight_763e1ea3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_763e1ea3
-    width: 0.5
-  straight_7a1490a4:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.5
-    module: gdsfactory.components.straight
-    name: straight_7a1490a4
-    width: 0.5
-  straight_7e6a8575:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 5.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 5.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 5.5
-    module: gdsfactory.components.straight
-    name: straight_7e6a8575
-    width: 0.5
-  straight_b3ed30dd:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -473,12 +297,138 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_b3ed30dd
+    name: straight_28680a03
     width: 0.5
-  straight_bc29f1fe:
+  straight_33871118:
     changed:
+      length: 6.25
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 6.25
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 6.25
+    module: gdsfactory.components.straight
+    name: straight_33871118
+    width: 0.5
+  straight_53bdf814:
+    changed:
+      auto_widen: true
+      length: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 0.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.5
+    module: gdsfactory.components.straight
+    name: straight_53bdf814
+    width: 0.5
+  straight_5656be49:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_831943ee:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_831943ee
+    width: 0.5
+  straight_870620aa:
+    changed:
+      length: 20
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 20
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 20
+    module: gdsfactory.components.straight
+    name: straight_870620aa
+    width: 0.5
+  straight_aee55669:
+    changed:
+      length: 12.25
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 12.25
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 12.25
+    module: gdsfactory.components.straight
+    name: straight_aee55669
+    width: 0.5
+  straight_b1688d7b:
+    changed:
       length: 17
     default:
       cross_section:
@@ -496,58 +446,10 @@ cells:
     info_version: 1
     length: 17
     module: gdsfactory.components.straight
-    name: straight_bc29f1fe
+    name: straight_b1688d7b
     width: 0.5
-  straight_c7b35a9f:
+  straight_cb6e01c9:
     changed:
-      cross_section:
-        function: cross_section
-      length: 11
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 11
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 11
-    module: gdsfactory.components.straight
-    name: straight_c7b35a9f
-    width: 0.5
-  straight_ca7e7c8f:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 488
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 488
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 488
-    module: gdsfactory.components.straight
-    name: straight_ca7e7c8f
-    width: 0.5
-  straight_ef8909f9:
-    changed:
-      cross_section:
-        function: cross_section
       length: 141
     default:
       cross_section:
@@ -565,7 +467,74 @@ cells:
     info_version: 1
     length: 141
     module: gdsfactory.components.straight
-    name: straight_ef8909f9
+    name: straight_cb6e01c9
+    width: 0.5
+  straight_d0db4c52:
+    changed:
+      auto_widen: true
+      length: 1
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 1
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 1
+    module: gdsfactory.components.straight
+    name: straight_d0db4c52
+    width: 0.5
+  straight_e04fd69e:
+    changed:
+      auto_widen: true
+      length: 5.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 5.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5.5
+    module: gdsfactory.components.straight
+    name: straight_e04fd69e
+    width: 0.5
+  straight_f0fa08f8:
+    changed:
+      length: 488
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 488
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 488
+    module: gdsfactory.components.straight
+    name: straight_f0fa08f8
     width: 0.5
 info:
   changed:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
@@ -57,7 +57,7 @@ cells:
     name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -78,8 +78,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  coupler_70441075:
+    name: circle_925ccccf
+  coupler_bcc4a0b5:
     changed:
       gap: 0.2
       length: 5
@@ -110,10 +110,10 @@ cells:
     length: 10.319
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
-    name: coupler_70441075
-  coupler_70441075_add_fi_49620dbe:
+    name: coupler_bcc4a0b5
+  coupler_bcc4a0b5_add_fi_15615773:
     changed:
-      component: coupler_70441075
+      component: coupler_bcc4a0b5
       optical_routing_type: 1
     child:
       changed:
@@ -146,7 +146,7 @@ cells:
       length: 10.319
       min_bend_radius: 9.387
       module: gdsfactory.components.coupler
-      name: coupler_70441075
+      name: coupler_bcc4a0b5
     default:
       bend:
         function: bend_euler
@@ -172,7 +172,7 @@ cells:
     full:
       bend:
         function: bend_euler
-      component: coupler_70441075
+      component: coupler_bcc4a0b5
       component_name: null
       cross_section:
         function: cross_section
@@ -196,7 +196,7 @@ cells:
     function_name: add_fiber_array
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
-    name: coupler_70441075_add_fi_49620dbe
+    name: coupler_bcc4a0b5_add_fi_15615773
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -299,7 +299,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_28680a03
     width: 0.5
-  straight_33871118:
+  straight_2dd0f66c:
     changed:
       length: 6.25
     default:
@@ -318,9 +318,30 @@ cells:
     info_version: 1
     length: 6.25
     module: gdsfactory.components.straight
-    name: straight_33871118
+    name: straight_2dd0f66c
     width: 0.5
-  straight_53bdf814:
+  straight_471dcf32:
+    changed:
+      length: 12.25
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 12.25
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 12.25
+    module: gdsfactory.components.straight
+    name: straight_471dcf32
+    width: 0.5
+  straight_66a04034:
     changed:
       auto_widen: true
       length: 0.5
@@ -341,30 +362,9 @@ cells:
     info_version: 1
     length: 0.5
     module: gdsfactory.components.straight
-    name: straight_53bdf814
+    name: straight_66a04034
     width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_831943ee:
+  straight_764e0e0e:
     changed:
       length: 35.552
     default:
@@ -383,7 +383,7 @@ cells:
     info_version: 1
     length: 35.552
     module: gdsfactory.components.straight
-    name: straight_831943ee
+    name: straight_764e0e0e
     width: 0.5
   straight_870620aa:
     changed:
@@ -406,27 +406,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight_870620aa
     width: 0.5
-  straight_aee55669:
-    changed:
-      length: 12.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 12.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 12.25
-    module: gdsfactory.components.straight
-    name: straight_aee55669
-    width: 0.5
   straight_b1688d7b:
     changed:
       length: 17
@@ -447,6 +426,27 @@ cells:
     length: 17
     module: gdsfactory.components.straight
     name: straight_b1688d7b
+    width: 0.5
+  straight_b81889b2:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_b81889b2
     width: 0.5
   straight_cb6e01c9:
     changed:
@@ -492,7 +492,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_d0db4c52
     width: 0.5
-  straight_e04fd69e:
+  straight_e791237d:
     changed:
       auto_widen: true
       length: 5.5
@@ -513,7 +513,7 @@ cells:
     info_version: 1
     length: 5.5
     module: gdsfactory.components.straight
-    name: straight_e04fd69e
+    name: straight_e791237d
     width: 0.5
   straight_f0fa08f8:
     changed:
@@ -538,7 +538,7 @@ cells:
     width: 0.5
 info:
   changed:
-    component: coupler_70441075
+    component: coupler_bcc4a0b5
     optical_routing_type: 1
   child:
     changed:
@@ -571,7 +571,7 @@ info:
     length: 10.319
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
-    name: coupler_70441075
+    name: coupler_bcc4a0b5
   default:
     bend:
       function: bend_euler
@@ -597,7 +597,7 @@ info:
   full:
     bend:
       function: bend_euler
-    component: coupler_70441075
+    component: coupler_bcc4a0b5
     component_name: null
     cross_section:
       function: cross_section
@@ -621,7 +621,7 @@ info:
   function_name: add_fiber_array
   info_version: 1
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_70441075_add_fi_49620dbe
+  name: coupler_bcc4a0b5_add_fi_15615773
 ports:
   vertical_te_00:
     layer:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
@@ -1,9 +1,6 @@
 cells:
-  bend_euler_0c3469c8:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -16,7 +13,6 @@ cells:
     dy: 10
     full:
       angle: 90
-      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -28,13 +24,12 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_0c3469c8
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_1da190e0:
+  bend_euler_2630f5fb:
     changed:
-      cross_section:
-        function: cross_section
+      auto_widen: true
     default:
       angle: 90
       cross_section:
@@ -47,6 +42,7 @@ cells:
     dy: 10
     full:
       angle: 90
+      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -58,7 +54,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -201,9 +197,8 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
     name: coupler_12df0178_add_fi_2d5e5eab
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -256,40 +251,13 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_02352a98:
+  straight_0723ff82:
     changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 1
-    module: gdsfactory.components.straight
-    name: straight_02352a98
-    width: 0.5
-  straight_06b7497a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
+      length: 11
     default:
       cross_section:
         function: cross_section
@@ -299,161 +267,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 43.5
+      length: 11
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 43.5
+    length: 11
     module: gdsfactory.components.straight
-    name: straight_06b7497a
+    name: straight_0723ff82
     width: 0.5
-  straight_0e0b9619:
+  straight_1b6cbabd:
     changed:
-      cross_section:
-        function: cross_section
-      length: 140.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 140.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 140.7
-    module: gdsfactory.components.straight
-    name: straight_0e0b9619
-    width: 0.5
-  straight_1e55fbdd:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 140.63
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 140.63
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 140.63
-    module: gdsfactory.components.straight
-    name: straight_1e55fbdd
-    width: 0.5
-  straight_67307aab:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 6.172
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 6.172
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 6.172
-    module: gdsfactory.components.straight
-    name: straight_67307aab
-    width: 0.5
-  straight_763e1ea3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_763e1ea3
-    width: 0.5
-  straight_7a1490a4:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.5
-    module: gdsfactory.components.straight
-    name: straight_7a1490a4
-    width: 0.5
-  straight_7e6a8575:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 5.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 5.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 5.5
-    module: gdsfactory.components.straight
-    name: straight_7e6a8575
-    width: 0.5
-  straight_86a1e0dd:
-    changed:
-      cross_section:
-        function: cross_section
       length: 19.63
     default:
       cross_section:
@@ -471,36 +295,11 @@ cells:
     info_version: 1
     length: 19.63
     module: gdsfactory.components.straight
-    name: straight_86a1e0dd
+    name: straight_1b6cbabd
     width: 0.5
-  straight_9e5184d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 12.172
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 12.172
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 12.172
-    module: gdsfactory.components.straight
-    name: straight_9e5184d1
-    width: 0.5
-  straight_b3ed30dd:
+  straight_28680a03:
     changed:
       auto_widen: true
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -519,12 +318,117 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_b3ed30dd
+    name: straight_28680a03
     width: 0.5
-  straight_bc29f1fe:
+  straight_53bdf814:
     changed:
+      auto_widen: true
+      length: 0.5
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 0.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.5
+    module: gdsfactory.components.straight
+    name: straight_53bdf814
+    width: 0.5
+  straight_5656be49:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_577db044:
+    changed:
+      length: 140.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 140.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 140.63
+    module: gdsfactory.components.straight
+    name: straight_577db044
+    width: 0.5
+  straight_7319d085:
+    changed:
+      length: 6.172
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 6.172
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 6.172
+    module: gdsfactory.components.straight
+    name: straight_7319d085
+    width: 0.5
+  straight_831943ee:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_831943ee
+    width: 0.5
+  straight_b1688d7b:
+    changed:
       length: 17
     default:
       cross_section:
@@ -542,13 +446,11 @@ cells:
     info_version: 1
     length: 17
     module: gdsfactory.components.straight
-    name: straight_bc29f1fe
+    name: straight_b1688d7b
     width: 0.5
-  straight_c7b35a9f:
+  straight_b852c6dc:
     changed:
-      cross_section:
-        function: cross_section
-      length: 11
+      length: 140.7
     default:
       cross_section:
         function: cross_section
@@ -558,42 +460,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 11
+      length: 140.7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 11
+    length: 140.7
     module: gdsfactory.components.straight
-    name: straight_c7b35a9f
+    name: straight_b852c6dc
     width: 0.5
-  straight_ca7e7c8f:
+  straight_bb9e2b83:
     changed:
-      cross_section:
-        function: cross_section
-      length: 488
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 488
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 488
-    module: gdsfactory.components.straight
-    name: straight_ca7e7c8f
-    width: 0.5
-  straight_f6e2241b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 19.7
     default:
       cross_section:
@@ -611,7 +488,95 @@ cells:
     info_version: 1
     length: 19.7
     module: gdsfactory.components.straight
-    name: straight_f6e2241b
+    name: straight_bb9e2b83
+    width: 0.5
+  straight_d0db4c52:
+    changed:
+      auto_widen: true
+      length: 1
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 1
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 1
+    module: gdsfactory.components.straight
+    name: straight_d0db4c52
+    width: 0.5
+  straight_e04fd69e:
+    changed:
+      auto_widen: true
+      length: 5.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 5.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5.5
+    module: gdsfactory.components.straight
+    name: straight_e04fd69e
+    width: 0.5
+  straight_f0fa08f8:
+    changed:
+      length: 488
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 488
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 488
+    module: gdsfactory.components.straight
+    name: straight_f0fa08f8
+    width: 0.5
+  straight_f579261b:
+    changed:
+      length: 12.172
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 12.172
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 12.172
+    module: gdsfactory.components.straight
+    name: straight_f579261b
     width: 0.5
 info:
   changed:

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
@@ -57,7 +57,7 @@ cells:
     name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -78,8 +78,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  coupler_12df0178:
+    name: circle_925ccccf
+  coupler_a078f3c8:
     changed:
       gap: 0.244
       length: 5.67
@@ -110,10 +110,10 @@ cells:
     length: 10.313
     min_bend_radius: 9.465
     module: gdsfactory.components.coupler
-    name: coupler_12df0178
-  coupler_12df0178_add_fi_2d5e5eab:
+    name: coupler_a078f3c8
+  coupler_a078f3c8_add_fi_fbc7ef6a:
     changed:
-      component: coupler_12df0178
+      component: coupler_a078f3c8
       optical_routing_type: 2
     child:
       changed:
@@ -146,7 +146,7 @@ cells:
       length: 10.313
       min_bend_radius: 9.465
       module: gdsfactory.components.coupler
-      name: coupler_12df0178
+      name: coupler_a078f3c8
     default:
       bend:
         function: bend_euler
@@ -172,7 +172,7 @@ cells:
     full:
       bend:
         function: bend_euler
-      component: coupler_12df0178
+      component: coupler_a078f3c8
       component_name: null
       cross_section:
         function: cross_section
@@ -196,7 +196,7 @@ cells:
     function_name: add_fiber_array
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
-    name: coupler_12df0178_add_fi_2d5e5eab
+    name: coupler_a078f3c8_add_fi_fbc7ef6a
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -276,9 +276,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_0723ff82
     width: 0.5
-  straight_1b6cbabd:
+  straight_10d6dbaa:
     changed:
-      length: 19.63
+      length: 19.7
     default:
       cross_section:
         function: cross_section
@@ -288,14 +288,35 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 19.63
+      length: 19.7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 19.63
+    length: 19.7
     module: gdsfactory.components.straight
-    name: straight_1b6cbabd
+    name: straight_10d6dbaa
+    width: 0.5
+  straight_18239a38:
+    changed:
+      length: 140.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 140.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 140.63
+    module: gdsfactory.components.straight
+    name: straight_18239a38
     width: 0.5
   straight_28680a03:
     changed:
@@ -320,7 +341,28 @@ cells:
     module: gdsfactory.components.straight
     name: straight_28680a03
     width: 0.5
-  straight_53bdf814:
+  straight_4855ab1f:
+    changed:
+      length: 140.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 140.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 140.7
+    module: gdsfactory.components.straight
+    name: straight_4855ab1f
+    width: 0.5
+  straight_66a04034:
     changed:
       auto_widen: true
       length: 0.5
@@ -341,72 +383,9 @@ cells:
     info_version: 1
     length: 0.5
     module: gdsfactory.components.straight
-    name: straight_53bdf814
+    name: straight_66a04034
     width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_577db044:
-    changed:
-      length: 140.63
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 140.63
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 140.63
-    module: gdsfactory.components.straight
-    name: straight_577db044
-    width: 0.5
-  straight_7319d085:
-    changed:
-      length: 6.172
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 6.172
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 6.172
-    module: gdsfactory.components.straight
-    name: straight_7319d085
-    width: 0.5
-  straight_831943ee:
+  straight_764e0e0e:
     changed:
       length: 35.552
     default:
@@ -425,7 +404,7 @@ cells:
     info_version: 1
     length: 35.552
     module: gdsfactory.components.straight
-    name: straight_831943ee
+    name: straight_764e0e0e
     width: 0.5
   straight_b1688d7b:
     changed:
@@ -448,9 +427,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b1688d7b
     width: 0.5
-  straight_b852c6dc:
+  straight_b81889b2:
     changed:
-      length: 140.7
+      length: 43.5
     default:
       cross_section:
         function: cross_section
@@ -460,35 +439,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 140.7
+      length: 43.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 140.7
+    length: 43.5
     module: gdsfactory.components.straight
-    name: straight_b852c6dc
-    width: 0.5
-  straight_bb9e2b83:
-    changed:
-      length: 19.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 19.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 19.7
-    module: gdsfactory.components.straight
-    name: straight_bb9e2b83
+    name: straight_b81889b2
     width: 0.5
   straight_d0db4c52:
     changed:
@@ -513,7 +471,28 @@ cells:
     module: gdsfactory.components.straight
     name: straight_d0db4c52
     width: 0.5
-  straight_e04fd69e:
+  straight_e1ebbf6d:
+    changed:
+      length: 19.63
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 19.63
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 19.63
+    module: gdsfactory.components.straight
+    name: straight_e1ebbf6d
+    width: 0.5
+  straight_e791237d:
     changed:
       auto_widen: true
       length: 5.5
@@ -534,7 +513,28 @@ cells:
     info_version: 1
     length: 5.5
     module: gdsfactory.components.straight
-    name: straight_e04fd69e
+    name: straight_e791237d
+    width: 0.5
+  straight_ecb5af35:
+    changed:
+      length: 12.172
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 12.172
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 12.172
+    module: gdsfactory.components.straight
+    name: straight_ecb5af35
     width: 0.5
   straight_f0fa08f8:
     changed:
@@ -557,9 +557,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_f0fa08f8
     width: 0.5
-  straight_f579261b:
+  straight_f277582a:
     changed:
-      length: 12.172
+      length: 6.172
     default:
       cross_section:
         function: cross_section
@@ -569,18 +569,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 12.172
+      length: 6.172
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 12.172
+    length: 6.172
     module: gdsfactory.components.straight
-    name: straight_f579261b
+    name: straight_f277582a
     width: 0.5
 info:
   changed:
-    component: coupler_12df0178
+    component: coupler_a078f3c8
     optical_routing_type: 2
   child:
     changed:
@@ -613,7 +613,7 @@ info:
     length: 10.313
     min_bend_radius: 9.465
     module: gdsfactory.components.coupler
-    name: coupler_12df0178
+    name: coupler_a078f3c8
   default:
     bend:
       function: bend_euler
@@ -639,7 +639,7 @@ info:
   full:
     bend:
       function: bend_euler
-    component: coupler_12df0178
+    component: coupler_a078f3c8
     component_name: null
     cross_section:
       function: cross_section
@@ -663,7 +663,7 @@ info:
   function_name: add_fiber_array
   info_version: 1
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_12df0178_add_fi_2d5e5eab
+  name: coupler_a078f3c8_add_fi_fbc7ef6a
 ports:
   vertical_te_00:
     layer:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_c_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_40e83c11:
+  bend_euler_3463ad1a:
     changed:
       cross_section:
         function: cross_section
@@ -44,7 +44,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_40e83c11
+    name: bend_euler_3463ad1a
     radius: 10
     radius_min: 7.061
 info:
@@ -92,7 +92,7 @@ info:
   info_version: 1
   length: 16.637
   module: gdsfactory.components.bend_euler
-  name: bend_euler_40e83c11
+  name: bend_euler_3463ad1a
   radius: 10
   radius_min: 7.061
 ports:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nitride_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nitride_c_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,8 +20,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  grating_coupler_ellipti_4d17128b:
+    name: circle_925ccccf
+  grating_coupler_ellipti_596d0092:
     changed:
       decorator:
         function: add_pins
@@ -84,7 +84,7 @@ cells:
     function_name: grating_coupler_elliptical
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical
-    name: grating_coupler_ellipti_4d17128b
+    name: grating_coupler_ellipti_596d0092
     polarization: te
     wavelength: 1.554
 info:
@@ -150,7 +150,7 @@ info:
   function_name: grating_coupler_elliptical
   info_version: 1
   module: gdsfactory.components.grating_coupler_elliptical
-  name: grating_coupler_ellipti_4d17128b
+  name: grating_coupler_ellipti_596d0092
   polarization: te
   wavelength: 1.554
 ports:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nitride_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nitride_c_.yml
@@ -1,5 +1,5 @@
 cells:
-  mmi1x2_6c65a522:
+  mmi1x2_5349d18e:
     changed:
       cross_section:
         function: cross_section
@@ -50,7 +50,7 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_6c65a522
+    name: mmi1x2_5349d18e
 info:
   changed:
     cross_section:
@@ -102,7 +102,7 @@ info:
   function_name: mmi1x2
   info_version: 1
   module: gdsfactory.components.mmi1x2
-  name: mmi1x2_6c65a522
+  name: mmi1x2_5349d18e
 ports:
   o1:
     layer:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nitride_o_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nitride_o_.yml
@@ -1,5 +1,5 @@
 cells:
-  mmi1x2_4e81d408:
+  mmi1x2_9e32c934:
     changed:
       cross_section:
         function: cross_section
@@ -49,7 +49,7 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_4e81d408
+    name: mmi1x2_9e32c934
 info:
   changed:
     cross_section:
@@ -100,7 +100,7 @@ info:
   function_name: mmi1x2
   info_version: 1
   module: gdsfactory.components.mmi1x2
-  name: mmi1x2_4e81d408
+  name: mmi1x2_9e32c934
 ports:
   o1:
     layer:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nitride_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nitride_c_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_40e83c11:
+  bend_euler_3463ad1a:
     changed:
       cross_section:
         function: cross_section
@@ -44,10 +44,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_40e83c11
+    name: bend_euler_3463ad1a
     radius: 10
     radius_min: 7.061
-  mmi1x2_6c65a522:
+  mmi1x2_5349d18e:
     changed:
       cross_section:
         function: cross_section
@@ -98,8 +98,8 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_6c65a522
-  mzi_e7ad0424:
+    name: mmi1x2_5349d18e
+  mzi_4121b99a:
     changed:
       bend:
         cross_section:
@@ -244,8 +244,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_e7ad0424
-  straight_387e668b:
+    name: mzi_4121b99a
+  straight_420aeeed:
     changed:
       cross_section:
         function: cross_section
@@ -284,9 +284,9 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_387e668b
+    name: straight_420aeeed
     width: 1
-  straight_4c537e1c:
+  straight_5ec13676:
     changed:
       cross_section:
         function: cross_section
@@ -325,9 +325,9 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_4c537e1c
+    name: straight_5ec13676
     width: 1
-  straight_8bcc53df:
+  straight_906c8992:
     changed:
       cross_section:
         function: cross_section
@@ -366,9 +366,9 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_8bcc53df
+    name: straight_906c8992
     width: 1
-  straight_af934e5c:
+  straight_aace3d93:
     changed:
       cross_section:
         function: cross_section
@@ -407,9 +407,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_af934e5c
+    name: straight_aace3d93
     width: 1
-  straight_cef8998d:
+  straight_c79f112e:
     changed:
       cross_section:
         function: cross_section
@@ -448,7 +448,7 @@ cells:
     info_version: 1
     length: 2
     module: gdsfactory.components.straight
-    name: straight_cef8998d
+    name: straight_c79f112e
     width: 1
 info:
   changed:
@@ -595,7 +595,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_e7ad0424
+  name: mzi_4121b99a
 ports:
   o1:
     layer:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nitride_o_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nitride_o_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_4196e3b7:
+  bend_euler_3cac7503:
     changed:
       cross_section:
         function: cross_section
@@ -44,10 +44,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_4196e3b7
+    name: bend_euler_3cac7503
     radius: 10
     radius_min: 7.061
-  mmi1x2_4e81d408:
+  mmi1x2_9e32c934:
     changed:
       cross_section:
         function: cross_section
@@ -97,8 +97,8 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_4e81d408
-  mzi_ab885bdb:
+    name: mmi1x2_9e32c934
+  mzi_d235e57a:
     changed:
       bend:
         cross_section:
@@ -241,131 +241,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_ab885bdb
-  straight_65276dc9:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_65276dc9
-    width: 0.9
-  straight_79ad5022:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_79ad5022
-    width: 0.9
-  straight_9d5365bf:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 34
-        - 0
-        layers_cladding:
-        - - 36
-          - 0
-        width: 0.9
-      decorator:
-        function: add_pins
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_9d5365bf
-    width: 0.9
-  straight_b96a1fbe:
+    name: mzi_d235e57a
+  straight_0783d17e:
     changed:
       cross_section:
         function: cross_section
@@ -404,9 +281,9 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_b96a1fbe
+    name: straight_0783d17e
     width: 0.9
-  straight_d2d623c6:
+  straight_3acb644d:
     changed:
       cross_section:
         function: cross_section
@@ -445,7 +322,130 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_d2d623c6
+    name: straight_3acb644d
+    width: 0.9
+  straight_3eae2dce:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_3eae2dce
+    width: 0.9
+  straight_439cc7ac:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_439cc7ac
+    width: 0.9
+  straight_bf2b54ca:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 34
+        - 0
+        layers_cladding:
+        - - 36
+          - 0
+        width: 0.9
+      decorator:
+        function: add_pins
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_bf2b54ca
     width: 0.9
 info:
   changed:
@@ -590,7 +590,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_ab885bdb
+  name: mzi_d235e57a
 ports:
   o1:
     layer:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_c_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_c_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_40e83c11:
+  straight_3463ad1a:
     changed:
       cross_section:
         function: cross_section
@@ -37,7 +37,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_40e83c11
+    name: straight_3463ad1a
     width: 1
 info:
   changed:
@@ -77,7 +77,7 @@ info:
   info_version: 1
   length: 10
   module: gdsfactory.components.straight
-  name: straight_40e83c11
+  name: straight_3463ad1a
   width: 1
 ports:
   o1:

--- a/gdsfactory/simulation/get_sparameters_path.py
+++ b/gdsfactory/simulation/get_sparameters_path.py
@@ -60,7 +60,7 @@ get_sparameters_data_meep = partial(_get_sparameters_data, tool="meep")
 get_sparameters_data_lumerical = partial(_get_sparameters_data, tool="lumerical")
 
 
-def test_get_sparameters_path() -> None:
+def test_get_sparameters_path(test: bool = True) -> None:
     import gdsfactory as gf
 
     layer_to_thickness_sample = {
@@ -72,10 +72,10 @@ def test_get_sparameters_path() -> None:
         LAYER.SLAB90: "si",
     }
 
-    name1 = "straight_713b8220"
-    name2 = "straight_cf5c9898_713b8220"
-    name3 = "straight_cf5c9898_5f6ae1fd"
-    name4 = "straight_2031115e"
+    name1 = "straight_d6c50235"
+    name2 = "straight_75fbe695_d6c50235"
+    name3 = "straight_75fbe695_181e701b"
+    name4 = "straight_eb75434e"
 
     c = gf.components.straight()
     p = get_sparameters_path_lumerical(
@@ -83,8 +83,10 @@ def test_get_sparameters_path() -> None:
         layer_to_thickness=layer_to_thickness_sample,
         layer_to_material=layer_to_material_sample,
     )
-    assert p.stem == name1, p.stem
-    # print(f"name1 = {p.stem!r}")
+    if test:
+        assert p.stem == name1, p.stem
+    else:
+        print(f"name1 = {p.stem!r}")
 
     c = gf.components.straight(layer=LAYER.SLAB90)
     p = get_sparameters_path_lumerical(
@@ -92,13 +94,18 @@ def test_get_sparameters_path() -> None:
         layer_to_thickness=layer_to_thickness_sample,
         layer_to_material=layer_to_material_sample,
     )
-    assert p.stem == name2, p.stem
-    # print(f"name2 = {p.stem!r}")
+    if test:
+        assert p.stem == name2, p.stem
+    else:
+        print(f"name2 = {p.stem!r}")
 
     c = gf.components.straight(layer=LAYER.SLAB90)
     p = get_sparameters_path_meep(c, layer_stack=LAYER_STACK)
-    assert p.stem == name3, p.stem
-    # print(f"name3 = {p.stem!r}")
+
+    if test:
+        assert p.stem == name3, p.stem
+    else:
+        print(f"name3 = {p.stem!r}")
 
     c = gf.components.straight()
     p = get_sparameters_path_meep(
@@ -106,8 +113,10 @@ def test_get_sparameters_path() -> None:
         layer_to_thickness=layer_to_thickness_sample,
         layer_to_material=layer_to_material_sample,
     )
-    assert p.stem == name4, p.stem
-    # print(f"name4 = {p.stem!r}")
+    if test:
+        assert p.stem == name4, p.stem
+    else:
+        print(f"name4 = {p.stem!r}")
 
 
 if __name__ == "__main__":
@@ -116,4 +125,4 @@ if __name__ == "__main__":
     # p = get_sparameters_path(c)
     # print(p)
 
-    test_get_sparameters_path()
+    test_get_sparameters_path(test=False)

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -1,5 +1,6 @@
 """Compute and write Sparameters using Meep."""
 
+import inspect
 import multiprocessing
 import pathlib
 import re
@@ -20,7 +21,10 @@ from gdsfactory.config import logger, sparameters_path
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_meep as get_sparameters_path,
 )
-from gdsfactory.simulation.gmeep.get_simulation import get_simulation
+from gdsfactory.simulation.gmeep.get_simulation import (
+    get_simulation,
+    settings_get_simulation,
+)
 from gdsfactory.tech import LAYER_STACK, LayerStack
 from gdsfactory.types import PortSymmetries
 
@@ -259,6 +263,9 @@ def write_sparameters_meep(
             where `a` is the angle in radians and `m` the module
 
     """
+    for setting in settings.keys():
+        if setting not in settings_get_simulation:
+            raise ValueError(f"{setting} not in {settings_get_simulation}")
 
     port_symmetries = port_symmetries or {}
 
@@ -527,6 +534,11 @@ write_sparameters_meep_lr = gf.partial(
 
 write_sparameters_meep_lt = gf.partial(
     write_sparameters_meep, ymargin_bot=3, xmargin_right=3
+)
+
+sig = inspect.signature(write_sparameters_meep)
+settings_write_sparameters_meep = set(sig.parameters.keys()).union(
+    settings_get_simulation
 )
 
 if __name__ == "__main__":

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -121,7 +121,7 @@ def write_sparameters_meep_mpi(
         logger.info(f"Simulation {filepath!r} already exists")
         return filepath
 
-    if overwrite:
+    if filepath.exists() and overwrite:
         filepath.unlink()
 
     # Save the component object to simulation for later retrieval

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -17,7 +17,10 @@ from gdsfactory.config import logger, sparameters_path
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_meep as get_sparameters_path,
 )
-from gdsfactory.simulation.gmeep.write_sparameters_meep import remove_simulation_kwargs
+from gdsfactory.simulation.gmeep.write_sparameters_meep import (
+    remove_simulation_kwargs,
+    settings_write_sparameters_meep,
+)
 from gdsfactory.tech import LAYER_STACK, LayerStack
 
 ncores = multiprocessing.cpu_count()
@@ -102,6 +105,10 @@ def write_sparameters_meep_mpi(
         filepath for sparameters CSV (wavelengths, s11a, s12m, ...)
             where `a` is the angle in radians and `m` the module
     """
+    for setting in kwargs.keys():
+        if setting not in settings_write_sparameters_meep:
+            raise ValueError(f"{setting} not in {settings_write_sparameters_meep}")
+
     settings = remove_simulation_kwargs(kwargs)
     filepath = filepath or get_sparameters_path(
         component=component,
@@ -113,6 +120,9 @@ def write_sparameters_meep_mpi(
     if filepath.exists() and not overwrite:
         logger.info(f"Simulation {filepath!r} already exists")
         return filepath
+
+    if overwrite:
+        filepath.unlink()
 
     # Save the component object to simulation for later retrieval
     temp_dir.mkdir(exist_ok=True, parents=True)
@@ -169,20 +179,14 @@ write_sparameters_meep_mpi_lt = gf.partial(
 
 
 if __name__ == "__main__":
-    c1 = gf.c.straight(length=5)
-    p = 3
-    c1 = gf.add_padding_container(c1, default=0, top=p, bottom=p)
-
-    instance_dict = {
-        "component": c1,
-        "run": True,
-        "overwrite": True,
-        "lazy_parallelism": True,
-        "filepath": "instance_dict.csv",
-    }
-
-    proc = write_sparameters_meep_mpi(
-        instance=instance_dict,
+    c1 = gf.c.straight(length=10)
+    filepath = write_sparameters_meep_mpi(
+        component=c1,
+        ymargin=3,
         cores=3,
-        verbosity=True,
+        run=True,
+        overwrite=True,
+        # lazy_parallelism=True,
+        lazy_parallelism=False,
+        # filepath="instance_dict.csv",
     )

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_False_.yml
@@ -1,96 +1,72 @@
 connections:
-  bend_euler_4725f0ef_225p125_204p875,o1: straight_ab370e58_135p0_200p0,o2
-  bend_euler_4725f0ef_225p125_204p875,o2: straight_95cf111d_230p0_380p0,o1
-  bend_euler_4725f0ef_234p875_555p125,o1: straight_95cf111d_230p0_380p0,o2
-  bend_euler_4725f0ef_234p875_555p125,o2: straight_99672b3b_365p0_560p0,o1
-  bend_euler_4725f0ef_234p875_584p875,o1: straight_99672b3b_365p0_580p0,o2
-  bend_euler_4725f0ef_234p875_584p875,o2: bend_euler_4725f0ef_234p875_595p125,o1
-  bend_euler_4725f0ef_234p875_595p125,o2: straight_b28806b6_545p0_600p0,o1
-  bend_euler_4725f0ef_255p125_4p875,o1: straight_3bc3129a_150p0_0p0,o2
-  bend_euler_4725f0ef_255p125_4p875,o2: straight_95cf111d_260p0_180p0,o1
-  bend_euler_4725f0ef_264p875_355p125,o1: straight_95cf111d_260p0_180p0,o2
-  bend_euler_4725f0ef_264p875_355p125,o2: straight_99672b3b_395p0_360p0,o1
-  bend_euler_4725f0ef_264p875_384p875,o1: straight_99672b3b_395p0_380p0,o2
-  bend_euler_4725f0ef_264p875_384p875,o2: bend_euler_4725f0ef_264p875_395p125,o1
-  bend_euler_4725f0ef_264p875_395p125,o2: straight_7b1e3316_560p0_400p0,o1
-  bend_euler_4725f0ef_495p125_564p875,o1: straight_99672b3b_365p0_560p0,o2
-  bend_euler_4725f0ef_495p125_564p875,o2: bend_euler_4725f0ef_495p125_575p125,o1
-  bend_euler_4725f0ef_495p125_575p125,o2: straight_99672b3b_365p0_580p0,o1
-  bend_euler_4725f0ef_525p125_364p875,o1: straight_99672b3b_395p0_360p0,o2
-  bend_euler_4725f0ef_525p125_364p875,o2: bend_euler_4725f0ef_525p125_375p125,o1
-  bend_euler_4725f0ef_525p125_375p125,o2: straight_99672b3b_395p0_380p0,o1
+  bend_euler_2e0a66fe_225p125_204p875,o1: straight_80b7924a_135p0_200p0,o2
+  bend_euler_2e0a66fe_225p125_204p875,o2: straight_aa7b6441_230p0_380p0,o1
+  bend_euler_2e0a66fe_234p875_555p125,o1: straight_aa7b6441_230p0_380p0,o2
+  bend_euler_2e0a66fe_234p875_555p125,o2: straight_1a88079a_365p0_560p0,o1
+  bend_euler_2e0a66fe_234p875_584p875,o1: straight_1a88079a_365p0_580p0,o2
+  bend_euler_2e0a66fe_234p875_584p875,o2: bend_euler_2e0a66fe_234p875_595p125,o1
+  bend_euler_2e0a66fe_234p875_595p125,o2: straight_76c7a705_545p0_600p0,o1
+  bend_euler_2e0a66fe_255p125_4p875,o1: straight_730b39a8_150p0_0p0,o2
+  bend_euler_2e0a66fe_255p125_4p875,o2: straight_aa7b6441_260p0_180p0,o1
+  bend_euler_2e0a66fe_264p875_355p125,o1: straight_aa7b6441_260p0_180p0,o2
+  bend_euler_2e0a66fe_264p875_355p125,o2: straight_1a88079a_395p0_360p0,o1
+  bend_euler_2e0a66fe_264p875_384p875,o1: straight_1a88079a_395p0_380p0,o2
+  bend_euler_2e0a66fe_264p875_384p875,o2: bend_euler_2e0a66fe_264p875_395p125,o1
+  bend_euler_2e0a66fe_264p875_395p125,o2: straight_e3b83c00_560p0_400p0,o1
+  bend_euler_2e0a66fe_495p125_564p875,o1: straight_1a88079a_365p0_560p0,o2
+  bend_euler_2e0a66fe_495p125_564p875,o2: bend_euler_2e0a66fe_495p125_575p125,o1
+  bend_euler_2e0a66fe_495p125_575p125,o2: straight_1a88079a_365p0_580p0,o1
+  bend_euler_2e0a66fe_525p125_364p875,o1: straight_1a88079a_395p0_360p0,o2
+  bend_euler_2e0a66fe_525p125_364p875,o2: bend_euler_2e0a66fe_525p125_375p125,o1
+  bend_euler_2e0a66fe_525p125_375p125,o2: straight_1a88079a_395p0_380p0,o1
 instances:
-  bend_euler_4725f0ef_225p125_204p875:
+  bend_euler_2e0a66fe_225p125_204p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_234p875_555p125:
+  bend_euler_2e0a66fe_234p875_555p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_234p875_584p875:
+  bend_euler_2e0a66fe_234p875_584p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_234p875_595p125:
+  bend_euler_2e0a66fe_234p875_595p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_255p125_4p875:
+  bend_euler_2e0a66fe_255p125_4p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_264p875_355p125:
+  bend_euler_2e0a66fe_264p875_355p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_264p875_384p875:
+  bend_euler_2e0a66fe_264p875_384p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_264p875_395p125:
+  bend_euler_2e0a66fe_264p875_395p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_495p125_564p875:
+  bend_euler_2e0a66fe_495p125_564p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_495p125_575p125:
+  bend_euler_2e0a66fe_495p125_575p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_525p125_364p875:
+  bend_euler_2e0a66fe_525p125_364p875:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_525p125_375p125:
+  bend_euler_2e0a66fe_525p125_375p125:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
   bl:
     component: pad
@@ -98,75 +74,55 @@ instances:
   br:
     component: pad
     settings: {}
-  straight_3bc3129a_150p0_0p0:
+  straight_1a88079a_365p0_560p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
+      length: 250
+      radius: 10
+  straight_1a88079a_365p0_580p0:
+    component: straight
+    settings:
+      length: 250
+      radius: 10
+  straight_1a88079a_395p0_360p0:
+    component: straight
+    settings:
+      length: 250
+      radius: 10
+  straight_1a88079a_395p0_380p0:
+    component: straight
+    settings:
+      length: 250
+      radius: 10
+  straight_730b39a8_150p0_0p0:
+    component: straight
+    settings:
       length: 200
       radius: 10
-  straight_7b1e3316_560p0_400p0:
+  straight_76c7a705_545p0_600p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
-      length: 580
+      length: 610
       radius: 10
-  straight_95cf111d_230p0_380p0:
+  straight_80b7924a_135p0_200p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
-      length: 340
-      radius: 10
-  straight_95cf111d_260p0_180p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 340
-      radius: 10
-  straight_99672b3b_365p0_560p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      radius: 10
-  straight_99672b3b_365p0_580p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      radius: 10
-  straight_99672b3b_395p0_360p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      radius: 10
-  straight_99672b3b_395p0_380p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      radius: 10
-  straight_ab370e58_135p0_200p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
       length: 170
       radius: 10
-  straight_b28806b6_545p0_600p0:
+  straight_aa7b6441_230p0_380p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
-      length: 610
+      length: 340
+      radius: 10
+  straight_aa7b6441_260p0_180p0:
+    component: straight
+    settings:
+      length: 340
+      radius: 10
+  straight_e3b83c00_560p0_400p0:
+    component: straight
+    settings:
+      length: 580
       radius: 10
   tl:
     component: pad
@@ -176,62 +132,62 @@ instances:
     settings: {}
 name: sample_path_length_matching
 placements:
-  bend_euler_4725f0ef_225p125_204p875:
+  bend_euler_2e0a66fe_225p125_204p875:
     mirror: false
     rotation: 0
     x: 220.0
     y: 200.0
-  bend_euler_4725f0ef_234p875_555p125:
+  bend_euler_2e0a66fe_234p875_555p125:
     mirror: true
     rotation: 90
     x: 230.0
     y: 550.0
-  bend_euler_4725f0ef_234p875_584p875:
+  bend_euler_2e0a66fe_234p875_584p875:
     mirror: true
     rotation: 180
     x: 240.0
     y: 580.0
-  bend_euler_4725f0ef_234p875_595p125:
+  bend_euler_2e0a66fe_234p875_595p125:
     mirror: true
     rotation: 90
     x: 230.0
     y: 590.0
-  bend_euler_4725f0ef_255p125_4p875:
+  bend_euler_2e0a66fe_255p125_4p875:
     mirror: false
     rotation: 0
     x: 250.0
     y: 0.0
-  bend_euler_4725f0ef_264p875_355p125:
+  bend_euler_2e0a66fe_264p875_355p125:
     mirror: true
     rotation: 90
     x: 260.0
     y: 350.0
-  bend_euler_4725f0ef_264p875_384p875:
+  bend_euler_2e0a66fe_264p875_384p875:
     mirror: true
     rotation: 180
     x: 270.0
     y: 380.0
-  bend_euler_4725f0ef_264p875_395p125:
+  bend_euler_2e0a66fe_264p875_395p125:
     mirror: true
     rotation: 90
     x: 260.0
     y: 390.0
-  bend_euler_4725f0ef_495p125_564p875:
+  bend_euler_2e0a66fe_495p125_564p875:
     mirror: false
     rotation: 0
     x: 490.0
     y: 560.0
-  bend_euler_4725f0ef_495p125_575p125:
+  bend_euler_2e0a66fe_495p125_575p125:
     mirror: false
     rotation: 90
     x: 500.0
     y: 570.0
-  bend_euler_4725f0ef_525p125_364p875:
+  bend_euler_2e0a66fe_525p125_364p875:
     mirror: false
     rotation: 0
     x: 520.0
     y: 360.0
-  bend_euler_4725f0ef_525p125_375p125:
+  bend_euler_2e0a66fe_525p125_375p125:
     mirror: false
     rotation: 90
     x: 530.0
@@ -246,56 +202,56 @@ placements:
     rotation: 0
     x: 900.0
     y: 400.0
-  straight_3bc3129a_150p0_0p0:
-    mirror: false
-    rotation: 0
-    x: 50.0
-    y: 0.0
-  straight_7b1e3316_560p0_400p0:
-    mirror: false
-    rotation: 0
-    x: 270.0
-    y: 400.0
-  straight_95cf111d_230p0_380p0:
-    mirror: false
-    rotation: 90
-    x: 230.0
-    y: 210.0
-  straight_95cf111d_260p0_180p0:
-    mirror: false
-    rotation: 90
-    x: 260.0
-    y: 10.0
-  straight_99672b3b_365p0_560p0:
+  straight_1a88079a_365p0_560p0:
     mirror: false
     rotation: 0
     x: 240.0
     y: 560.0
-  straight_99672b3b_365p0_580p0:
+  straight_1a88079a_365p0_580p0:
     mirror: false
     rotation: 180
     x: 490.0
     y: 580.0
-  straight_99672b3b_395p0_360p0:
+  straight_1a88079a_395p0_360p0:
     mirror: false
     rotation: 0
     x: 270.0
     y: 360.0
-  straight_99672b3b_395p0_380p0:
+  straight_1a88079a_395p0_380p0:
     mirror: false
     rotation: 180
     x: 520.0
     y: 380.0
-  straight_ab370e58_135p0_200p0:
+  straight_730b39a8_150p0_0p0:
     mirror: false
     rotation: 0
     x: 50.0
-    y: 200.0
-  straight_b28806b6_545p0_600p0:
+    y: 0.0
+  straight_76c7a705_545p0_600p0:
     mirror: false
     rotation: 0
     x: 240.0
     y: 600.0
+  straight_80b7924a_135p0_200p0:
+    mirror: false
+    rotation: 0
+    x: 50.0
+    y: 200.0
+  straight_aa7b6441_230p0_380p0:
+    mirror: false
+    rotation: 90
+    x: 230.0
+    y: 210.0
+  straight_aa7b6441_260p0_180p0:
+    mirror: false
+    rotation: 90
+    x: 260.0
+    y: 10.0
+  straight_e3b83c00_560p0_400p0:
+    mirror: false
+    rotation: 0
+    x: 270.0
+    y: 400.0
   tl:
     mirror: false
     rotation: 0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_True_.yml
@@ -1,26 +1,26 @@
 connections:
-  bend_euler_4725f0ef_225p125_204p875,o1: straight_ab370e58_135p0_200p0,o2
-  bend_euler_4725f0ef_225p125_204p875,o2: straight_95cf111d_230p0_380p0,o1
-  bend_euler_4725f0ef_234p875_555p125,o1: straight_95cf111d_230p0_380p0,o2
-  bend_euler_4725f0ef_234p875_555p125,o2: straight_99672b3b_365p0_560p0,o1
-  bend_euler_4725f0ef_234p875_584p875,o1: straight_99672b3b_365p0_580p0,o2
-  bend_euler_4725f0ef_234p875_584p875,o2: bend_euler_4725f0ef_234p875_595p125,o1
-  bend_euler_4725f0ef_234p875_595p125,o2: straight_b28806b6_545p0_600p0,o1
-  bend_euler_4725f0ef_255p125_4p875,o1: straight_3bc3129a_150p0_0p0,o2
-  bend_euler_4725f0ef_255p125_4p875,o2: straight_95cf111d_260p0_180p0,o1
-  bend_euler_4725f0ef_264p875_355p125,o1: straight_95cf111d_260p0_180p0,o2
-  bend_euler_4725f0ef_264p875_355p125,o2: straight_99672b3b_395p0_360p0,o1
-  bend_euler_4725f0ef_264p875_384p875,o1: straight_99672b3b_395p0_380p0,o2
-  bend_euler_4725f0ef_264p875_384p875,o2: bend_euler_4725f0ef_264p875_395p125,o1
-  bend_euler_4725f0ef_264p875_395p125,o2: straight_7b1e3316_560p0_400p0,o1
-  bend_euler_4725f0ef_495p125_564p875,o1: straight_99672b3b_365p0_560p0,o2
-  bend_euler_4725f0ef_495p125_564p875,o2: bend_euler_4725f0ef_495p125_575p125,o1
-  bend_euler_4725f0ef_495p125_575p125,o2: straight_99672b3b_365p0_580p0,o1
-  bend_euler_4725f0ef_525p125_364p875,o1: straight_99672b3b_395p0_360p0,o2
-  bend_euler_4725f0ef_525p125_364p875,o2: bend_euler_4725f0ef_525p125_375p125,o1
-  bend_euler_4725f0ef_525p125_375p125,o2: straight_99672b3b_395p0_380p0,o1
+  bend_euler_2e0a66fe_225p125_204p875,o1: straight_80b7924a_135p0_200p0,o2
+  bend_euler_2e0a66fe_225p125_204p875,o2: straight_aa7b6441_230p0_380p0,o1
+  bend_euler_2e0a66fe_234p875_555p125,o1: straight_aa7b6441_230p0_380p0,o2
+  bend_euler_2e0a66fe_234p875_555p125,o2: straight_1a88079a_365p0_560p0,o1
+  bend_euler_2e0a66fe_234p875_584p875,o1: straight_1a88079a_365p0_580p0,o2
+  bend_euler_2e0a66fe_234p875_584p875,o2: bend_euler_2e0a66fe_234p875_595p125,o1
+  bend_euler_2e0a66fe_234p875_595p125,o2: straight_76c7a705_545p0_600p0,o1
+  bend_euler_2e0a66fe_255p125_4p875,o1: straight_730b39a8_150p0_0p0,o2
+  bend_euler_2e0a66fe_255p125_4p875,o2: straight_aa7b6441_260p0_180p0,o1
+  bend_euler_2e0a66fe_264p875_355p125,o1: straight_aa7b6441_260p0_180p0,o2
+  bend_euler_2e0a66fe_264p875_355p125,o2: straight_1a88079a_395p0_360p0,o1
+  bend_euler_2e0a66fe_264p875_384p875,o1: straight_1a88079a_395p0_380p0,o2
+  bend_euler_2e0a66fe_264p875_384p875,o2: bend_euler_2e0a66fe_264p875_395p125,o1
+  bend_euler_2e0a66fe_264p875_395p125,o2: straight_e3b83c00_560p0_400p0,o1
+  bend_euler_2e0a66fe_495p125_564p875,o1: straight_1a88079a_365p0_560p0,o2
+  bend_euler_2e0a66fe_495p125_564p875,o2: bend_euler_2e0a66fe_495p125_575p125,o1
+  bend_euler_2e0a66fe_495p125_575p125,o2: straight_1a88079a_365p0_580p0,o1
+  bend_euler_2e0a66fe_525p125_364p875,o1: straight_1a88079a_395p0_360p0,o2
+  bend_euler_2e0a66fe_525p125_364p875,o2: bend_euler_2e0a66fe_525p125_375p125,o1
+  bend_euler_2e0a66fe_525p125_375p125,o2: straight_1a88079a_395p0_380p0,o1
 instances:
-  bend_euler_4725f0ef_225p125_204p875:
+  bend_euler_2e0a66fe_225p125_204p875:
     component: bend_euler
     settings:
       angle: 90
@@ -32,7 +32,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_234p875_555p125:
+  bend_euler_2e0a66fe_234p875_555p125:
     component: bend_euler
     settings:
       angle: 90
@@ -44,7 +44,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_234p875_584p875:
+  bend_euler_2e0a66fe_234p875_584p875:
     component: bend_euler
     settings:
       angle: 90
@@ -56,7 +56,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_234p875_595p125:
+  bend_euler_2e0a66fe_234p875_595p125:
     component: bend_euler
     settings:
       angle: 90
@@ -68,7 +68,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_255p125_4p875:
+  bend_euler_2e0a66fe_255p125_4p875:
     component: bend_euler
     settings:
       angle: 90
@@ -80,7 +80,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_264p875_355p125:
+  bend_euler_2e0a66fe_264p875_355p125:
     component: bend_euler
     settings:
       angle: 90
@@ -92,7 +92,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_264p875_384p875:
+  bend_euler_2e0a66fe_264p875_384p875:
     component: bend_euler
     settings:
       angle: 90
@@ -104,7 +104,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_264p875_395p125:
+  bend_euler_2e0a66fe_264p875_395p125:
     component: bend_euler
     settings:
       angle: 90
@@ -116,7 +116,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_495p125_564p875:
+  bend_euler_2e0a66fe_495p125_564p875:
     component: bend_euler
     settings:
       angle: 90
@@ -128,7 +128,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_495p125_575p125:
+  bend_euler_2e0a66fe_495p125_575p125:
     component: bend_euler
     settings:
       angle: 90
@@ -140,7 +140,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_525p125_364p875:
+  bend_euler_2e0a66fe_525p125_364p875:
     component: bend_euler
     settings:
       angle: 90
@@ -152,7 +152,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_525p125_375p125:
+  bend_euler_2e0a66fe_525p125_375p125:
     component: bend_euler
     settings:
       angle: 90
@@ -188,7 +188,43 @@ instances:
       size:
       - 100
       - 100
-  straight_3bc3129a_150p0_0p0:
+  straight_1a88079a_365p0_560p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 250
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_1a88079a_365p0_580p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 250
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_1a88079a_395p0_360p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 250
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_1a88079a_395p0_380p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 250
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_730b39a8_150p0_0p0:
     component: straight
     settings:
       cross_section:
@@ -197,70 +233,16 @@ instances:
       npoints: 2
       radius: 10
       with_cladding_box: true
-  straight_7b1e3316_560p0_400p0:
+  straight_76c7a705_545p0_600p0:
     component: straight
     settings:
       cross_section:
         function: cross_section
-      length: 580
+      length: 610
       npoints: 2
       radius: 10
       with_cladding_box: true
-  straight_95cf111d_230p0_380p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 340
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_95cf111d_260p0_180p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 340
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_99672b3b_365p0_560p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_99672b3b_365p0_580p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_99672b3b_395p0_360p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_99672b3b_395p0_380p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 250
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-  straight_ab370e58_135p0_200p0:
+  straight_80b7924a_135p0_200p0:
     component: straight
     settings:
       cross_section:
@@ -269,12 +251,30 @@ instances:
       npoints: 2
       radius: 10
       with_cladding_box: true
-  straight_b28806b6_545p0_600p0:
+  straight_aa7b6441_230p0_380p0:
     component: straight
     settings:
       cross_section:
         function: cross_section
-      length: 610
+      length: 340
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_aa7b6441_260p0_180p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 340
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+  straight_e3b83c00_560p0_400p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 580
       npoints: 2
       radius: 10
       with_cladding_box: true
@@ -304,62 +304,62 @@ instances:
       - 100
 name: sample_path_length_matching
 placements:
-  bend_euler_4725f0ef_225p125_204p875:
+  bend_euler_2e0a66fe_225p125_204p875:
     mirror: false
     rotation: 0
     x: 220.0
     y: 200.0
-  bend_euler_4725f0ef_234p875_555p125:
+  bend_euler_2e0a66fe_234p875_555p125:
     mirror: true
     rotation: 90
     x: 230.0
     y: 550.0
-  bend_euler_4725f0ef_234p875_584p875:
+  bend_euler_2e0a66fe_234p875_584p875:
     mirror: true
     rotation: 180
     x: 240.0
     y: 580.0
-  bend_euler_4725f0ef_234p875_595p125:
+  bend_euler_2e0a66fe_234p875_595p125:
     mirror: true
     rotation: 90
     x: 230.0
     y: 590.0
-  bend_euler_4725f0ef_255p125_4p875:
+  bend_euler_2e0a66fe_255p125_4p875:
     mirror: false
     rotation: 0
     x: 250.0
     y: 0.0
-  bend_euler_4725f0ef_264p875_355p125:
+  bend_euler_2e0a66fe_264p875_355p125:
     mirror: true
     rotation: 90
     x: 260.0
     y: 350.0
-  bend_euler_4725f0ef_264p875_384p875:
+  bend_euler_2e0a66fe_264p875_384p875:
     mirror: true
     rotation: 180
     x: 270.0
     y: 380.0
-  bend_euler_4725f0ef_264p875_395p125:
+  bend_euler_2e0a66fe_264p875_395p125:
     mirror: true
     rotation: 90
     x: 260.0
     y: 390.0
-  bend_euler_4725f0ef_495p125_564p875:
+  bend_euler_2e0a66fe_495p125_564p875:
     mirror: false
     rotation: 0
     x: 490.0
     y: 560.0
-  bend_euler_4725f0ef_495p125_575p125:
+  bend_euler_2e0a66fe_495p125_575p125:
     mirror: false
     rotation: 90
     x: 500.0
     y: 570.0
-  bend_euler_4725f0ef_525p125_364p875:
+  bend_euler_2e0a66fe_525p125_364p875:
     mirror: false
     rotation: 0
     x: 520.0
     y: 360.0
-  bend_euler_4725f0ef_525p125_375p125:
+  bend_euler_2e0a66fe_525p125_375p125:
     mirror: false
     rotation: 90
     x: 530.0
@@ -374,56 +374,56 @@ placements:
     rotation: 0
     x: 900.0
     y: 400.0
-  straight_3bc3129a_150p0_0p0:
-    mirror: false
-    rotation: 0
-    x: 50.0
-    y: 0.0
-  straight_7b1e3316_560p0_400p0:
-    mirror: false
-    rotation: 0
-    x: 270.0
-    y: 400.0
-  straight_95cf111d_230p0_380p0:
-    mirror: false
-    rotation: 90
-    x: 230.0
-    y: 210.0
-  straight_95cf111d_260p0_180p0:
-    mirror: false
-    rotation: 90
-    x: 260.0
-    y: 10.0
-  straight_99672b3b_365p0_560p0:
+  straight_1a88079a_365p0_560p0:
     mirror: false
     rotation: 0
     x: 240.0
     y: 560.0
-  straight_99672b3b_365p0_580p0:
+  straight_1a88079a_365p0_580p0:
     mirror: false
     rotation: 180
     x: 490.0
     y: 580.0
-  straight_99672b3b_395p0_360p0:
+  straight_1a88079a_395p0_360p0:
     mirror: false
     rotation: 0
     x: 270.0
     y: 360.0
-  straight_99672b3b_395p0_380p0:
+  straight_1a88079a_395p0_380p0:
     mirror: false
     rotation: 180
     x: 520.0
     y: 380.0
-  straight_ab370e58_135p0_200p0:
+  straight_730b39a8_150p0_0p0:
     mirror: false
     rotation: 0
     x: 50.0
-    y: 200.0
-  straight_b28806b6_545p0_600p0:
+    y: 0.0
+  straight_76c7a705_545p0_600p0:
     mirror: false
     rotation: 0
     x: 240.0
     y: 600.0
+  straight_80b7924a_135p0_200p0:
+    mirror: false
+    rotation: 0
+    x: 50.0
+    y: 200.0
+  straight_aa7b6441_230p0_380p0:
+    mirror: false
+    rotation: 90
+    x: 230.0
+    y: 210.0
+  straight_aa7b6441_260p0_180p0:
+    mirror: false
+    rotation: 90
+    x: 260.0
+    y: 10.0
+  straight_e3b83c00_560p0_400p0:
+    mirror: false
+    rotation: 0
+    x: 270.0
+    y: 400.0
   tl:
     mirror: false
     rotation: 0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_False_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_67p115_m5p5,o1: straight_3aa6a47c_51p995_m0p625,o2
-  bend_euler_67p115_m5p5,o2: straight_d0ae2c31_71p99_m20p0,o1
-  bend_euler_76p865_m34p5,o1: straight_d0ae2c31_71p99_m20p0,o2
-  bend_euler_76p865_m34p5,o2: straight_c138f2c4_81p995_m39p375,o1
-  mmi_bot,o1: straight_c138f2c4_81p995_m39p375,o2
-  mmi_top,o3: straight_3aa6a47c_51p995_m0p625,o1
+  bend_euler_67p115_m5p5,o1: straight_775184d2_51p995_m0p625,o2
+  bend_euler_67p115_m5p5,o2: straight_720ba455_71p99_m20p0,o1
+  bend_euler_76p865_m34p5,o1: straight_720ba455_71p99_m20p0,o2
+  bend_euler_76p865_m34p5,o2: straight_c49ce9c6_81p995_m39p375,o1
+  mmi_bot,o1: straight_c49ce9c6_81p995_m39p375,o2
+  mmi_top,o3: straight_775184d2_51p995_m0p625,o1
 instances:
   bend_euler_67p115_m5p5:
     component: bend_euler
@@ -22,18 +22,18 @@ instances:
     settings:
       length_mmi: 22
       width_mmi: 6
-  straight_3aa6a47c_51p995_m0p625:
-    component: straight
-    settings:
-      length: 19.99
-  straight_c138f2c4_81p995_m39p375:
-    component: straight
-    settings:
-      length: 0.01
-  straight_d0ae2c31_71p99_m20p0:
+  straight_720ba455_71p99_m20p0:
     component: straight
     settings:
       length: 18.75
+  straight_775184d2_51p995_m0p625:
+    component: straight
+    settings:
+      length: 19.99
+  straight_c49ce9c6_81p995_m39p375:
+    component: straight
+    settings:
+      length: 0.01
 name: sample_docstring
 placements:
   bend_euler_67p115_m5p5:
@@ -56,19 +56,19 @@ placements:
     rotation: 0
     x: 21.0
     y: 0.0
-  straight_3aa6a47c_51p995_m0p625:
-    mirror: false
-    rotation: 0
-    x: 42.0
-    y: -0.625
-  straight_c138f2c4_81p995_m39p375:
-    mirror: false
-    rotation: 0
-    x: 81.99
-    y: -39.375
-  straight_d0ae2c31_71p99_m20p0:
+  straight_720ba455_71p99_m20p0:
     mirror: false
     rotation: 270
     x: 71.99
     y: -10.625
+  straight_775184d2_51p995_m0p625:
+    mirror: false
+    rotation: 0
+    x: 42.0
+    y: -0.625
+  straight_c49ce9c6_81p995_m39p375:
+    mirror: false
+    rotation: 0
+    x: 81.99
+    y: -39.375
 ports: {}

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_False_.yml
@@ -1,21 +1,17 @@
 connections:
-  bend_euler_1da190e0_67p115_m5p5,o1: straight_466a3c74_51p995_m0p625,o2
-  bend_euler_1da190e0_67p115_m5p5,o2: straight_b649c633_71p99_m20p0,o1
-  bend_euler_1da190e0_76p865_m34p5,o1: straight_b649c633_71p99_m20p0,o2
-  bend_euler_1da190e0_76p865_m34p5,o2: straight_5743d35a_81p995_m39p375,o1
-  mmi_bot,o1: straight_5743d35a_81p995_m39p375,o2
-  mmi_top,o3: straight_466a3c74_51p995_m0p625,o1
+  bend_euler_67p115_m5p5,o1: straight_3aa6a47c_51p995_m0p625,o2
+  bend_euler_67p115_m5p5,o2: straight_d0ae2c31_71p99_m20p0,o1
+  bend_euler_76p865_m34p5,o1: straight_d0ae2c31_71p99_m20p0,o2
+  bend_euler_76p865_m34p5,o2: straight_c138f2c4_81p995_m39p375,o1
+  mmi_bot,o1: straight_c138f2c4_81p995_m39p375,o2
+  mmi_top,o3: straight_3aa6a47c_51p995_m0p625,o1
 instances:
-  bend_euler_1da190e0_67p115_m5p5:
+  bend_euler_67p115_m5p5:
     component: bend_euler
-    settings:
-      cross_section:
-        function: cross_section
-  bend_euler_1da190e0_76p865_m34p5:
+    settings: {}
+  bend_euler_76p865_m34p5:
     component: bend_euler
-    settings:
-      cross_section:
-        function: cross_section
+    settings: {}
   mmi_bot:
     component: mmi1x2
     settings:
@@ -26,32 +22,26 @@ instances:
     settings:
       length_mmi: 22
       width_mmi: 6
-  straight_466a3c74_51p995_m0p625:
+  straight_3aa6a47c_51p995_m0p625:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
       length: 19.99
-  straight_5743d35a_81p995_m39p375:
+  straight_c138f2c4_81p995_m39p375:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
       length: 0.01
-  straight_b649c633_71p99_m20p0:
+  straight_d0ae2c31_71p99_m20p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
       length: 18.75
 name: sample_docstring
 placements:
-  bend_euler_1da190e0_67p115_m5p5:
+  bend_euler_67p115_m5p5:
     mirror: true
     rotation: 0
     x: 61.99
     y: -0.625
-  bend_euler_1da190e0_76p865_m34p5:
+  bend_euler_76p865_m34p5:
     mirror: false
     rotation: 270
     x: 71.99
@@ -66,17 +56,17 @@ placements:
     rotation: 0
     x: 21.0
     y: 0.0
-  straight_466a3c74_51p995_m0p625:
+  straight_3aa6a47c_51p995_m0p625:
     mirror: false
     rotation: 0
     x: 42.0
     y: -0.625
-  straight_5743d35a_81p995_m39p375:
+  straight_c138f2c4_81p995_m39p375:
     mirror: false
     rotation: 0
     x: 81.99
     y: -39.375
-  straight_b649c633_71p99_m20p0:
+  straight_d0ae2c31_71p99_m20p0:
     mirror: false
     rotation: 270
     x: 71.99

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_True_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_67p115_m5p5,o1: straight_3aa6a47c_51p995_m0p625,o2
-  bend_euler_67p115_m5p5,o2: straight_d0ae2c31_71p99_m20p0,o1
-  bend_euler_76p865_m34p5,o1: straight_d0ae2c31_71p99_m20p0,o2
-  bend_euler_76p865_m34p5,o2: straight_c138f2c4_81p995_m39p375,o1
-  mmi_bot,o1: straight_c138f2c4_81p995_m39p375,o2
-  mmi_top,o3: straight_3aa6a47c_51p995_m0p625,o1
+  bend_euler_67p115_m5p5,o1: straight_775184d2_51p995_m0p625,o2
+  bend_euler_67p115_m5p5,o2: straight_720ba455_71p99_m20p0,o1
+  bend_euler_76p865_m34p5,o1: straight_720ba455_71p99_m20p0,o2
+  bend_euler_76p865_m34p5,o2: straight_c49ce9c6_81p995_m39p375,o1
+  mmi_bot,o1: straight_c49ce9c6_81p995_m39p375,o2
+  mmi_top,o3: straight_775184d2_51p995_m0p625,o1
 instances:
   bend_euler_67p115_m5p5:
     component: bend_euler
@@ -56,7 +56,15 @@ instances:
       width_mmi: 6
       width_taper: 1
       with_cladding_box: true
-  straight_3aa6a47c_51p995_m0p625:
+  straight_720ba455_71p99_m20p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 18.75
+      npoints: 2
+      with_cladding_box: true
+  straight_775184d2_51p995_m0p625:
     component: straight
     settings:
       cross_section:
@@ -64,20 +72,12 @@ instances:
       length: 19.99
       npoints: 2
       with_cladding_box: true
-  straight_c138f2c4_81p995_m39p375:
+  straight_c49ce9c6_81p995_m39p375:
     component: straight
     settings:
       cross_section:
         function: cross_section
       length: 0.01
-      npoints: 2
-      with_cladding_box: true
-  straight_d0ae2c31_71p99_m20p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 18.75
       npoints: 2
       with_cladding_box: true
 name: sample_docstring
@@ -102,19 +102,19 @@ placements:
     rotation: 0
     x: 21.0
     y: 0.0
-  straight_3aa6a47c_51p995_m0p625:
-    mirror: false
-    rotation: 0
-    x: 42.0
-    y: -0.625
-  straight_c138f2c4_81p995_m39p375:
-    mirror: false
-    rotation: 0
-    x: 81.99
-    y: -39.375
-  straight_d0ae2c31_71p99_m20p0:
+  straight_720ba455_71p99_m20p0:
     mirror: false
     rotation: 270
     x: 71.99
     y: -10.625
+  straight_775184d2_51p995_m0p625:
+    mirror: false
+    rotation: 0
+    x: 42.0
+    y: -0.625
+  straight_c49ce9c6_81p995_m39p375:
+    mirror: false
+    rotation: 0
+    x: 81.99
+    y: -39.375
 ports: {}

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_True_.yml
@@ -1,12 +1,12 @@
 connections:
-  bend_euler_1da190e0_67p115_m5p5,o1: straight_466a3c74_51p995_m0p625,o2
-  bend_euler_1da190e0_67p115_m5p5,o2: straight_b649c633_71p99_m20p0,o1
-  bend_euler_1da190e0_76p865_m34p5,o1: straight_b649c633_71p99_m20p0,o2
-  bend_euler_1da190e0_76p865_m34p5,o2: straight_5743d35a_81p995_m39p375,o1
-  mmi_bot,o1: straight_5743d35a_81p995_m39p375,o2
-  mmi_top,o3: straight_466a3c74_51p995_m0p625,o1
+  bend_euler_67p115_m5p5,o1: straight_3aa6a47c_51p995_m0p625,o2
+  bend_euler_67p115_m5p5,o2: straight_d0ae2c31_71p99_m20p0,o1
+  bend_euler_76p865_m34p5,o1: straight_d0ae2c31_71p99_m20p0,o2
+  bend_euler_76p865_m34p5,o2: straight_c138f2c4_81p995_m39p375,o1
+  mmi_bot,o1: straight_c138f2c4_81p995_m39p375,o2
+  mmi_top,o3: straight_3aa6a47c_51p995_m0p625,o1
 instances:
-  bend_euler_1da190e0_67p115_m5p5:
+  bend_euler_67p115_m5p5:
     component: bend_euler
     settings:
       angle: 90
@@ -17,7 +17,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_1da190e0_76p865_m34p5:
+  bend_euler_76p865_m34p5:
     component: bend_euler
     settings:
       angle: 90
@@ -56,7 +56,7 @@ instances:
       width_mmi: 6
       width_taper: 1
       with_cladding_box: true
-  straight_466a3c74_51p995_m0p625:
+  straight_3aa6a47c_51p995_m0p625:
     component: straight
     settings:
       cross_section:
@@ -64,7 +64,7 @@ instances:
       length: 19.99
       npoints: 2
       with_cladding_box: true
-  straight_5743d35a_81p995_m39p375:
+  straight_c138f2c4_81p995_m39p375:
     component: straight
     settings:
       cross_section:
@@ -72,7 +72,7 @@ instances:
       length: 0.01
       npoints: 2
       with_cladding_box: true
-  straight_b649c633_71p99_m20p0:
+  straight_d0ae2c31_71p99_m20p0:
     component: straight
     settings:
       cross_section:
@@ -82,12 +82,12 @@ instances:
       with_cladding_box: true
 name: sample_docstring
 placements:
-  bend_euler_1da190e0_67p115_m5p5:
+  bend_euler_67p115_m5p5:
     mirror: true
     rotation: 0
     x: 61.99
     y: -0.625
-  bend_euler_1da190e0_76p865_m34p5:
+  bend_euler_76p865_m34p5:
     mirror: false
     rotation: 270
     x: 71.99
@@ -102,17 +102,17 @@ placements:
     rotation: 0
     x: 21.0
     y: 0.0
-  straight_466a3c74_51p995_m0p625:
+  straight_3aa6a47c_51p995_m0p625:
     mirror: false
     rotation: 0
     x: 42.0
     y: -0.625
-  straight_5743d35a_81p995_m39p375:
+  straight_c138f2c4_81p995_m39p375:
     mirror: false
     rotation: 0
     x: 81.99
     y: -39.375
-  straight_b649c633_71p99_m20p0:
+  straight_d0ae2c31_71p99_m20p0:
     mirror: false
     rotation: 270
     x: 71.99

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_False_.yml
@@ -1,21 +1,17 @@
 connections:
-  bend_euler_1da190e0_120p135_5p5,o1: straight_c96c7cf4_63p755_0p625,o2
-  bend_euler_1da190e0_120p135_5p5,o2: straight_c8d42def_125p01_50p312,o1
-  bend_euler_1da190e0_120p135_95p125,o1: straight_c8d42def_125p01_50p312,o2
-  bend_euler_1da190e0_120p135_95p125,o2: straight_5743d35a_115p005_100p0,o1
-  mmi_long,o1: straight_5743d35a_115p005_100p0,o2
-  mmi_short,o2: straight_c96c7cf4_63p755_0p625,o1
+  bend_euler_120p135_5p5,o1: straight_94fc1711_63p755_0p625,o2
+  bend_euler_120p135_5p5,o2: straight_f5e73eb6_125p01_50p312,o1
+  bend_euler_120p135_95p125,o1: straight_f5e73eb6_125p01_50p312,o2
+  bend_euler_120p135_95p125,o2: straight_c138f2c4_115p005_100p0,o1
+  mmi_long,o1: straight_c138f2c4_115p005_100p0,o2
+  mmi_short,o2: straight_94fc1711_63p755_0p625,o1
 instances:
-  bend_euler_1da190e0_120p135_5p5:
+  bend_euler_120p135_5p5:
     component: bend_euler
-    settings:
-      cross_section:
-        function: cross_section
-  bend_euler_1da190e0_120p135_95p125:
+    settings: {}
+  bend_euler_120p135_95p125:
     component: bend_euler
-    settings:
-      cross_section:
-        function: cross_section
+    settings: {}
   mmi_long:
     component: mmi1x2
     settings:
@@ -26,32 +22,26 @@ instances:
     settings:
       length_mmi: 5
       width_mmi: 4.5
-  straight_5743d35a_115p005_100p0:
+  straight_94fc1711_63p755_0p625:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
-      length: 0.01
-  straight_c8d42def_125p01_50p312:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 79.375
-  straight_c96c7cf4_63p755_0p625:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
       length: 102.51
+  straight_c138f2c4_115p005_100p0:
+    component: straight
+    settings:
+      length: 0.01
+  straight_f5e73eb6_125p01_50p312:
+    component: straight
+    settings:
+      length: 79.375
 name: Unnamed_a491ff8b
 placements:
-  bend_euler_1da190e0_120p135_5p5:
+  bend_euler_120p135_5p5:
     mirror: false
     rotation: 0
     x: 115.01
     y: 0.625
-  bend_euler_1da190e0_120p135_95p125:
+  bend_euler_120p135_95p125:
     mirror: false
     rotation: 90
     x: 125.01
@@ -66,21 +56,21 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_5743d35a_115p005_100p0:
-    mirror: false
-    rotation: 180
-    x: 115.01
-    y: 100.0
-  straight_c8d42def_125p01_50p312:
-    mirror: false
-    rotation: 90
-    x: 125.01
-    y: 10.625
-  straight_c96c7cf4_63p755_0p625:
+  straight_94fc1711_63p755_0p625:
     mirror: false
     rotation: 0
     x: 12.5
     y: 0.625
+  straight_c138f2c4_115p005_100p0:
+    mirror: false
+    rotation: 180
+    x: 115.01
+    y: 100.0
+  straight_f5e73eb6_125p01_50p312:
+    mirror: false
+    rotation: 90
+    x: 125.01
+    y: 10.625
 ports:
   o1: mmi_short,o1
   o2: mmi_long,o2

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_False_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_120p135_5p5,o1: straight_94fc1711_63p755_0p625,o2
-  bend_euler_120p135_5p5,o2: straight_f5e73eb6_125p01_50p312,o1
-  bend_euler_120p135_95p125,o1: straight_f5e73eb6_125p01_50p312,o2
-  bend_euler_120p135_95p125,o2: straight_c138f2c4_115p005_100p0,o1
-  mmi_long,o1: straight_c138f2c4_115p005_100p0,o2
-  mmi_short,o2: straight_94fc1711_63p755_0p625,o1
+  bend_euler_120p135_5p5,o1: straight_7a57a71b_63p755_0p625,o2
+  bend_euler_120p135_5p5,o2: straight_e4b574c8_125p01_50p312,o1
+  bend_euler_120p135_95p125,o1: straight_e4b574c8_125p01_50p312,o2
+  bend_euler_120p135_95p125,o2: straight_c49ce9c6_115p005_100p0,o1
+  mmi_long,o1: straight_c49ce9c6_115p005_100p0,o2
+  mmi_short,o2: straight_7a57a71b_63p755_0p625,o1
 instances:
   bend_euler_120p135_5p5:
     component: bend_euler
@@ -22,15 +22,15 @@ instances:
     settings:
       length_mmi: 5
       width_mmi: 4.5
-  straight_94fc1711_63p755_0p625:
+  straight_7a57a71b_63p755_0p625:
     component: straight
     settings:
       length: 102.51
-  straight_c138f2c4_115p005_100p0:
+  straight_c49ce9c6_115p005_100p0:
     component: straight
     settings:
       length: 0.01
-  straight_f5e73eb6_125p01_50p312:
+  straight_e4b574c8_125p01_50p312:
     component: straight
     settings:
       length: 79.375
@@ -56,17 +56,17 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_94fc1711_63p755_0p625:
+  straight_7a57a71b_63p755_0p625:
     mirror: false
     rotation: 0
     x: 12.5
     y: 0.625
-  straight_c138f2c4_115p005_100p0:
+  straight_c49ce9c6_115p005_100p0:
     mirror: false
     rotation: 180
     x: 115.01
     y: 100.0
-  straight_f5e73eb6_125p01_50p312:
+  straight_e4b574c8_125p01_50p312:
     mirror: false
     rotation: 90
     x: 125.01

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_True_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_120p135_5p5,o1: straight_94fc1711_63p755_0p625,o2
-  bend_euler_120p135_5p5,o2: straight_f5e73eb6_125p01_50p312,o1
-  bend_euler_120p135_95p125,o1: straight_f5e73eb6_125p01_50p312,o2
-  bend_euler_120p135_95p125,o2: straight_c138f2c4_115p005_100p0,o1
-  mmi_long,o1: straight_c138f2c4_115p005_100p0,o2
-  mmi_short,o2: straight_94fc1711_63p755_0p625,o1
+  bend_euler_120p135_5p5,o1: straight_7a57a71b_63p755_0p625,o2
+  bend_euler_120p135_5p5,o2: straight_e4b574c8_125p01_50p312,o1
+  bend_euler_120p135_95p125,o1: straight_e4b574c8_125p01_50p312,o2
+  bend_euler_120p135_95p125,o2: straight_c49ce9c6_115p005_100p0,o1
+  mmi_long,o1: straight_c49ce9c6_115p005_100p0,o2
+  mmi_short,o2: straight_7a57a71b_63p755_0p625,o1
 instances:
   bend_euler_120p135_5p5:
     component: bend_euler
@@ -56,7 +56,7 @@ instances:
       width_mmi: 4.5
       width_taper: 1
       with_cladding_box: true
-  straight_94fc1711_63p755_0p625:
+  straight_7a57a71b_63p755_0p625:
     component: straight
     settings:
       cross_section:
@@ -64,7 +64,7 @@ instances:
       length: 102.51
       npoints: 2
       with_cladding_box: true
-  straight_c138f2c4_115p005_100p0:
+  straight_c49ce9c6_115p005_100p0:
     component: straight
     settings:
       cross_section:
@@ -72,7 +72,7 @@ instances:
       length: 0.01
       npoints: 2
       with_cladding_box: true
-  straight_f5e73eb6_125p01_50p312:
+  straight_e4b574c8_125p01_50p312:
     component: straight
     settings:
       cross_section:
@@ -102,17 +102,17 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_94fc1711_63p755_0p625:
+  straight_7a57a71b_63p755_0p625:
     mirror: false
     rotation: 0
     x: 12.5
     y: 0.625
-  straight_c138f2c4_115p005_100p0:
+  straight_c49ce9c6_115p005_100p0:
     mirror: false
     rotation: 180
     x: 115.01
     y: 100.0
-  straight_f5e73eb6_125p01_50p312:
+  straight_e4b574c8_125p01_50p312:
     mirror: false
     rotation: 90
     x: 125.01

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_True_.yml
@@ -1,12 +1,12 @@
 connections:
-  bend_euler_1da190e0_120p135_5p5,o1: straight_c96c7cf4_63p755_0p625,o2
-  bend_euler_1da190e0_120p135_5p5,o2: straight_c8d42def_125p01_50p312,o1
-  bend_euler_1da190e0_120p135_95p125,o1: straight_c8d42def_125p01_50p312,o2
-  bend_euler_1da190e0_120p135_95p125,o2: straight_5743d35a_115p005_100p0,o1
-  mmi_long,o1: straight_5743d35a_115p005_100p0,o2
-  mmi_short,o2: straight_c96c7cf4_63p755_0p625,o1
+  bend_euler_120p135_5p5,o1: straight_94fc1711_63p755_0p625,o2
+  bend_euler_120p135_5p5,o2: straight_f5e73eb6_125p01_50p312,o1
+  bend_euler_120p135_95p125,o1: straight_f5e73eb6_125p01_50p312,o2
+  bend_euler_120p135_95p125,o2: straight_c138f2c4_115p005_100p0,o1
+  mmi_long,o1: straight_c138f2c4_115p005_100p0,o2
+  mmi_short,o2: straight_94fc1711_63p755_0p625,o1
 instances:
-  bend_euler_1da190e0_120p135_5p5:
+  bend_euler_120p135_5p5:
     component: bend_euler
     settings:
       angle: 90
@@ -17,7 +17,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_1da190e0_120p135_95p125:
+  bend_euler_120p135_95p125:
     component: bend_euler
     settings:
       angle: 90
@@ -56,23 +56,7 @@ instances:
       width_mmi: 4.5
       width_taper: 1
       with_cladding_box: true
-  straight_5743d35a_115p005_100p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-  straight_c8d42def_125p01_50p312:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 79.375
-      npoints: 2
-      with_cladding_box: true
-  straight_c96c7cf4_63p755_0p625:
+  straight_94fc1711_63p755_0p625:
     component: straight
     settings:
       cross_section:
@@ -80,14 +64,30 @@ instances:
       length: 102.51
       npoints: 2
       with_cladding_box: true
+  straight_c138f2c4_115p005_100p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+  straight_f5e73eb6_125p01_50p312:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 79.375
+      npoints: 2
+      with_cladding_box: true
 name: Unnamed_a491ff8b
 placements:
-  bend_euler_1da190e0_120p135_5p5:
+  bend_euler_120p135_5p5:
     mirror: false
     rotation: 0
     x: 115.01
     y: 0.625
-  bend_euler_1da190e0_120p135_95p125:
+  bend_euler_120p135_95p125:
     mirror: false
     rotation: 90
     x: 125.01
@@ -102,21 +102,21 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_5743d35a_115p005_100p0:
-    mirror: false
-    rotation: 180
-    x: 115.01
-    y: 100.0
-  straight_c8d42def_125p01_50p312:
-    mirror: false
-    rotation: 90
-    x: 125.01
-    y: 10.625
-  straight_c96c7cf4_63p755_0p625:
+  straight_94fc1711_63p755_0p625:
     mirror: false
     rotation: 0
     x: 12.5
     y: 0.625
+  straight_c138f2c4_115p005_100p0:
+    mirror: false
+    rotation: 180
+    x: 115.01
+    y: 100.0
+  straight_f5e73eb6_125p01_50p312:
+    mirror: false
+    rotation: 90
+    x: 125.01
+    y: 10.625
 ports:
   o1: mmi_short,o1
   o2: mmi_long,o2

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_False_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_False_.yml
@@ -1,147 +1,110 @@
 connections:
-  bend_euler_93ab05a3_154p875_145p125,o1: straight_0e209496_150p0_70p0,o2
-  bend_euler_93ab05a3_154p875_145p125,o2: straight_b169702d_350p0_150p0,o1
-  bend_euler_93ab05a3_395p125_304p875,o1: straight_b169702d_200p0_300p0,o2
-  bend_euler_93ab05a3_395p125_304p875,o2: straight_61c245c0_400p0_350p0,o1
-  bend_euler_93ab05a3_395p125_395p125,o1: straight_61c245c0_400p0_350p0,o2
-  bend_euler_93ab05a3_395p125_395p125,o2: straight_1a997572_75p0_400p0,o1
-  bend_euler_93ab05a3_4p875_295p125,o1: straight_27026560_0p0_145p0,o2
-  bend_euler_93ab05a3_4p875_295p125,o2: straight_b169702d_200p0_300p0,o1
-  bend_euler_93ab05a3_545p125_154p875,o1: straight_b169702d_350p0_150p0,o2
-  bend_euler_93ab05a3_545p125_154p875,o2: straight_b169702d_550p0_350p0,o1
-  bend_euler_93ab05a3_545p125_545p125,o1: straight_b169702d_550p0_350p0,o2
-  bend_euler_93ab05a3_545p125_545p125,o2: straight_1a997572_225p0_550p0,o1
-  bend_euler_93ab05a3_m245p125_404p875,o1: straight_1a997572_75p0_400p0,o2
-  bend_euler_93ab05a3_m245p125_404p875,o2: straight_9dca303a_m250p0_705p0,o1
-  bend_euler_93ab05a3_m95p125_554p875,o1: straight_1a997572_225p0_550p0,o2
-  bend_euler_93ab05a3_m95p125_554p875,o2: straight_d04bc13d_m100p0_780p0,o1
+  bend_euler_107bf6b2_154p875_145p125,o1: straight_a01b1c4b_150p0_70p0,o2
+  bend_euler_107bf6b2_154p875_145p125,o2: straight_152c11f4_350p0_150p0,o1
+  bend_euler_107bf6b2_395p125_304p875,o1: straight_152c11f4_200p0_300p0,o2
+  bend_euler_107bf6b2_395p125_304p875,o2: straight_2b932af0_400p0_350p0,o1
+  bend_euler_107bf6b2_395p125_395p125,o1: straight_2b932af0_400p0_350p0,o2
+  bend_euler_107bf6b2_395p125_395p125,o2: straight_b2910871_75p0_400p0,o1
+  bend_euler_107bf6b2_4p875_295p125,o1: straight_1efce1c9_0p0_145p0,o2
+  bend_euler_107bf6b2_4p875_295p125,o2: straight_152c11f4_200p0_300p0,o1
+  bend_euler_107bf6b2_545p125_154p875,o1: straight_152c11f4_350p0_150p0,o2
+  bend_euler_107bf6b2_545p125_154p875,o2: straight_152c11f4_550p0_350p0,o1
+  bend_euler_107bf6b2_545p125_545p125,o1: straight_152c11f4_550p0_350p0,o2
+  bend_euler_107bf6b2_545p125_545p125,o2: straight_b2910871_225p0_550p0,o1
+  bend_euler_107bf6b2_m245p125_404p875,o1: straight_b2910871_75p0_400p0,o2
+  bend_euler_107bf6b2_m245p125_404p875,o2: straight_a9485c4a_m250p0_705p0,o1
+  bend_euler_107bf6b2_m95p125_554p875,o1: straight_b2910871_225p0_550p0,o2
+  bend_euler_107bf6b2_m95p125_554p875,o2: straight_bda70908_m100p0_780p0,o1
 instances:
   b:
     component: pad_array
     settings:
       orientation: 90
-  bend_euler_93ab05a3_154p875_145p125:
+  bend_euler_107bf6b2_154p875_145p125:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_395p125_304p875:
+  bend_euler_107bf6b2_395p125_304p875:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_395p125_395p125:
+  bend_euler_107bf6b2_395p125_395p125:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_4p875_295p125:
+  bend_euler_107bf6b2_4p875_295p125:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_545p125_154p875:
+  bend_euler_107bf6b2_545p125_154p875:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_545p125_545p125:
+  bend_euler_107bf6b2_545p125_545p125:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_m245p125_404p875:
+  bend_euler_107bf6b2_m245p125_404p875:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  bend_euler_93ab05a3_m95p125_554p875:
+  bend_euler_107bf6b2_m95p125_554p875:
     component: bend_euler
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-  straight_0e209496_150p0_70p0:
+  straight_152c11f4_200p0_300p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 140
-  straight_1a997572_225p0_550p0:
+      length: 380
+  straight_152c11f4_350p0_150p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 630
-  straight_1a997572_75p0_400p0:
+      length: 380
+  straight_152c11f4_550p0_350p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 630
-  straight_27026560_0p0_145p0:
+      length: 380
+  straight_1efce1c9_0p0_145p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
       length: 290
-  straight_61c245c0_400p0_350p0:
+  straight_2b932af0_400p0_350p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
       length: 80
-  straight_9dca303a_m250p0_705p0:
+  straight_a01b1c4b_150p0_70p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
+      length: 140
+  straight_a9485c4a_m250p0_705p0:
+    component: straight
+    settings:
+      auto_widen: false
       length: 590
-  straight_b169702d_200p0_300p0:
+  straight_b2910871_225p0_550p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 380
-  straight_b169702d_350p0_150p0:
+      length: 630
+  straight_b2910871_75p0_400p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 380
-  straight_b169702d_550p0_350p0:
+      length: 630
+  straight_bda70908_m100p0_780p0:
     component: straight
     settings:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 380
-  straight_d04bc13d_m100p0_780p0:
-    component: straight
-    settings:
-      auto_widen: false
-      cross_section:
-        function: cross_section
       length: 440
   t:
     component: pad_array
-    settings:
-      orientation: 270
+    settings: {}
 name: sample_waypoints
 placements:
   b:
@@ -149,92 +112,92 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  bend_euler_93ab05a3_154p875_145p125:
+  bend_euler_107bf6b2_154p875_145p125:
     mirror: true
     rotation: 90
     x: 150.0
     y: 140.0
-  bend_euler_93ab05a3_395p125_304p875:
+  bend_euler_107bf6b2_395p125_304p875:
     mirror: false
     rotation: 0
     x: 390.0
     y: 300.0
-  bend_euler_93ab05a3_395p125_395p125:
+  bend_euler_107bf6b2_395p125_395p125:
     mirror: false
     rotation: 90
     x: 400.0
     y: 390.0
-  bend_euler_93ab05a3_4p875_295p125:
+  bend_euler_107bf6b2_4p875_295p125:
     mirror: true
     rotation: 90
     x: 0.0
     y: 290.0
-  bend_euler_93ab05a3_545p125_154p875:
+  bend_euler_107bf6b2_545p125_154p875:
     mirror: false
     rotation: 0
     x: 540.0
     y: 150.0
-  bend_euler_93ab05a3_545p125_545p125:
+  bend_euler_107bf6b2_545p125_545p125:
     mirror: false
     rotation: 90
     x: 550.0
     y: 540.0
-  bend_euler_93ab05a3_m245p125_404p875:
+  bend_euler_107bf6b2_m245p125_404p875:
     mirror: true
     rotation: 180
     x: -240.0
     y: 400.0
-  bend_euler_93ab05a3_m95p125_554p875:
+  bend_euler_107bf6b2_m95p125_554p875:
     mirror: true
     rotation: 180
     x: -90.0
     y: 550.0
-  straight_0e209496_150p0_70p0:
-    mirror: false
-    rotation: 90
-    x: 150.0
-    y: 0.0
-  straight_1a997572_225p0_550p0:
-    mirror: false
-    rotation: 180
-    x: 540.0
-    y: 550.0
-  straight_1a997572_75p0_400p0:
-    mirror: false
-    rotation: 180
-    x: 390.0
-    y: 400.0
-  straight_27026560_0p0_145p0:
-    mirror: false
-    rotation: 90
-    x: 0.0
-    y: 0.0
-  straight_61c245c0_400p0_350p0:
-    mirror: false
-    rotation: 90
-    x: 400.0
-    y: 310.0
-  straight_9dca303a_m250p0_705p0:
-    mirror: false
-    rotation: 90
-    x: -250.0
-    y: 410.0
-  straight_b169702d_200p0_300p0:
+  straight_152c11f4_200p0_300p0:
     mirror: false
     rotation: 0
     x: 10.0
     y: 300.0
-  straight_b169702d_350p0_150p0:
+  straight_152c11f4_350p0_150p0:
     mirror: false
     rotation: 0
     x: 160.0
     y: 150.0
-  straight_b169702d_550p0_350p0:
+  straight_152c11f4_550p0_350p0:
     mirror: false
     rotation: 90
     x: 550.0
     y: 160.0
-  straight_d04bc13d_m100p0_780p0:
+  straight_1efce1c9_0p0_145p0:
+    mirror: false
+    rotation: 90
+    x: 0.0
+    y: 0.0
+  straight_2b932af0_400p0_350p0:
+    mirror: false
+    rotation: 90
+    x: 400.0
+    y: 310.0
+  straight_a01b1c4b_150p0_70p0:
+    mirror: false
+    rotation: 90
+    x: 150.0
+    y: 0.0
+  straight_a9485c4a_m250p0_705p0:
+    mirror: false
+    rotation: 90
+    x: -250.0
+    y: 410.0
+  straight_b2910871_225p0_550p0:
+    mirror: false
+    rotation: 180
+    x: 540.0
+    y: 550.0
+  straight_b2910871_75p0_400p0:
+    mirror: false
+    rotation: 180
+    x: 390.0
+    y: 400.0
+  straight_bda70908_m100p0_780p0:
     mirror: false
     rotation: 90
     x: -100.0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_True_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_True_.yml
@@ -1,20 +1,20 @@
 connections:
-  bend_euler_93ab05a3_154p875_145p125,o1: straight_0e209496_150p0_70p0,o2
-  bend_euler_93ab05a3_154p875_145p125,o2: straight_b169702d_350p0_150p0,o1
-  bend_euler_93ab05a3_395p125_304p875,o1: straight_b169702d_200p0_300p0,o2
-  bend_euler_93ab05a3_395p125_304p875,o2: straight_61c245c0_400p0_350p0,o1
-  bend_euler_93ab05a3_395p125_395p125,o1: straight_61c245c0_400p0_350p0,o2
-  bend_euler_93ab05a3_395p125_395p125,o2: straight_1a997572_75p0_400p0,o1
-  bend_euler_93ab05a3_4p875_295p125,o1: straight_27026560_0p0_145p0,o2
-  bend_euler_93ab05a3_4p875_295p125,o2: straight_b169702d_200p0_300p0,o1
-  bend_euler_93ab05a3_545p125_154p875,o1: straight_b169702d_350p0_150p0,o2
-  bend_euler_93ab05a3_545p125_154p875,o2: straight_b169702d_550p0_350p0,o1
-  bend_euler_93ab05a3_545p125_545p125,o1: straight_b169702d_550p0_350p0,o2
-  bend_euler_93ab05a3_545p125_545p125,o2: straight_1a997572_225p0_550p0,o1
-  bend_euler_93ab05a3_m245p125_404p875,o1: straight_1a997572_75p0_400p0,o2
-  bend_euler_93ab05a3_m245p125_404p875,o2: straight_9dca303a_m250p0_705p0,o1
-  bend_euler_93ab05a3_m95p125_554p875,o1: straight_1a997572_225p0_550p0,o2
-  bend_euler_93ab05a3_m95p125_554p875,o2: straight_d04bc13d_m100p0_780p0,o1
+  bend_euler_107bf6b2_154p875_145p125,o1: straight_a01b1c4b_150p0_70p0,o2
+  bend_euler_107bf6b2_154p875_145p125,o2: straight_152c11f4_350p0_150p0,o1
+  bend_euler_107bf6b2_395p125_304p875,o1: straight_152c11f4_200p0_300p0,o2
+  bend_euler_107bf6b2_395p125_304p875,o2: straight_2b932af0_400p0_350p0,o1
+  bend_euler_107bf6b2_395p125_395p125,o1: straight_2b932af0_400p0_350p0,o2
+  bend_euler_107bf6b2_395p125_395p125,o2: straight_b2910871_75p0_400p0,o1
+  bend_euler_107bf6b2_4p875_295p125,o1: straight_1efce1c9_0p0_145p0,o2
+  bend_euler_107bf6b2_4p875_295p125,o2: straight_152c11f4_200p0_300p0,o1
+  bend_euler_107bf6b2_545p125_154p875,o1: straight_152c11f4_350p0_150p0,o2
+  bend_euler_107bf6b2_545p125_154p875,o2: straight_152c11f4_550p0_350p0,o1
+  bend_euler_107bf6b2_545p125_545p125,o1: straight_152c11f4_550p0_350p0,o2
+  bend_euler_107bf6b2_545p125_545p125,o2: straight_b2910871_225p0_550p0,o1
+  bend_euler_107bf6b2_m245p125_404p875,o1: straight_b2910871_75p0_400p0,o2
+  bend_euler_107bf6b2_m245p125_404p875,o2: straight_a9485c4a_m250p0_705p0,o1
+  bend_euler_107bf6b2_m95p125_554p875,o1: straight_b2910871_225p0_550p0,o2
+  bend_euler_107bf6b2_m95p125_554p875,o2: straight_bda70908_m100p0_780p0,o1
 instances:
   b:
     component: pad_array
@@ -27,7 +27,7 @@ instances:
       spacing:
       - 150
       - 150
-  bend_euler_93ab05a3_154p875_145p125:
+  bend_euler_107bf6b2_154p875_145p125:
     component: bend_euler
     settings:
       angle: 90
@@ -39,7 +39,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_395p125_304p875:
+  bend_euler_107bf6b2_395p125_304p875:
     component: bend_euler
     settings:
       angle: 90
@@ -51,7 +51,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_395p125_395p125:
+  bend_euler_107bf6b2_395p125_395p125:
     component: bend_euler
     settings:
       angle: 90
@@ -63,7 +63,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_4p875_295p125:
+  bend_euler_107bf6b2_4p875_295p125:
     component: bend_euler
     settings:
       angle: 90
@@ -75,7 +75,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_545p125_154p875:
+  bend_euler_107bf6b2_545p125_154p875:
     component: bend_euler
     settings:
       angle: 90
@@ -87,7 +87,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_545p125_545p125:
+  bend_euler_107bf6b2_545p125_545p125:
     component: bend_euler
     settings:
       angle: 90
@@ -99,7 +99,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_m245p125_404p875:
+  bend_euler_107bf6b2_m245p125_404p875:
     component: bend_euler
     settings:
       angle: 90
@@ -111,7 +111,7 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_93ab05a3_m95p125_554p875:
+  bend_euler_107bf6b2_m95p125_554p875:
     component: bend_euler
     settings:
       angle: 90
@@ -123,34 +123,34 @@ instances:
       p: 0.5
       with_arc_floorplan: true
       with_cladding_box: true
-  straight_0e209496_150p0_70p0:
+  straight_152c11f4_200p0_300p0:
     component: straight
     settings:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 140
+      length: 380
       npoints: 2
       with_cladding_box: true
-  straight_1a997572_225p0_550p0:
+  straight_152c11f4_350p0_150p0:
     component: straight
     settings:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 630
+      length: 380
       npoints: 2
       with_cladding_box: true
-  straight_1a997572_75p0_400p0:
+  straight_152c11f4_550p0_350p0:
     component: straight
     settings:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 630
+      length: 380
       npoints: 2
       with_cladding_box: true
-  straight_27026560_0p0_145p0:
+  straight_1efce1c9_0p0_145p0:
     component: straight
     settings:
       auto_widen: false
@@ -159,7 +159,7 @@ instances:
       length: 290
       npoints: 2
       with_cladding_box: true
-  straight_61c245c0_400p0_350p0:
+  straight_2b932af0_400p0_350p0:
     component: straight
     settings:
       auto_widen: false
@@ -168,7 +168,16 @@ instances:
       length: 80
       npoints: 2
       with_cladding_box: true
-  straight_9dca303a_m250p0_705p0:
+  straight_a01b1c4b_150p0_70p0:
+    component: straight
+    settings:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 140
+      npoints: 2
+      with_cladding_box: true
+  straight_a9485c4a_m250p0_705p0:
     component: straight
     settings:
       auto_widen: false
@@ -177,34 +186,25 @@ instances:
       length: 590
       npoints: 2
       with_cladding_box: true
-  straight_b169702d_200p0_300p0:
+  straight_b2910871_225p0_550p0:
     component: straight
     settings:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 380
+      length: 630
       npoints: 2
       with_cladding_box: true
-  straight_b169702d_350p0_150p0:
+  straight_b2910871_75p0_400p0:
     component: straight
     settings:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 380
+      length: 630
       npoints: 2
       with_cladding_box: true
-  straight_b169702d_550p0_350p0:
-    component: straight
-    settings:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 380
-      npoints: 2
-      with_cladding_box: true
-  straight_d04bc13d_m100p0_780p0:
+  straight_bda70908_m100p0_780p0:
     component: straight
     settings:
       auto_widen: false
@@ -231,92 +231,92 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  bend_euler_93ab05a3_154p875_145p125:
+  bend_euler_107bf6b2_154p875_145p125:
     mirror: true
     rotation: 90
     x: 150.0
     y: 140.0
-  bend_euler_93ab05a3_395p125_304p875:
+  bend_euler_107bf6b2_395p125_304p875:
     mirror: false
     rotation: 0
     x: 390.0
     y: 300.0
-  bend_euler_93ab05a3_395p125_395p125:
+  bend_euler_107bf6b2_395p125_395p125:
     mirror: false
     rotation: 90
     x: 400.0
     y: 390.0
-  bend_euler_93ab05a3_4p875_295p125:
+  bend_euler_107bf6b2_4p875_295p125:
     mirror: true
     rotation: 90
     x: 0.0
     y: 290.0
-  bend_euler_93ab05a3_545p125_154p875:
+  bend_euler_107bf6b2_545p125_154p875:
     mirror: false
     rotation: 0
     x: 540.0
     y: 150.0
-  bend_euler_93ab05a3_545p125_545p125:
+  bend_euler_107bf6b2_545p125_545p125:
     mirror: false
     rotation: 90
     x: 550.0
     y: 540.0
-  bend_euler_93ab05a3_m245p125_404p875:
+  bend_euler_107bf6b2_m245p125_404p875:
     mirror: true
     rotation: 180
     x: -240.0
     y: 400.0
-  bend_euler_93ab05a3_m95p125_554p875:
+  bend_euler_107bf6b2_m95p125_554p875:
     mirror: true
     rotation: 180
     x: -90.0
     y: 550.0
-  straight_0e209496_150p0_70p0:
-    mirror: false
-    rotation: 90
-    x: 150.0
-    y: 0.0
-  straight_1a997572_225p0_550p0:
-    mirror: false
-    rotation: 180
-    x: 540.0
-    y: 550.0
-  straight_1a997572_75p0_400p0:
-    mirror: false
-    rotation: 180
-    x: 390.0
-    y: 400.0
-  straight_27026560_0p0_145p0:
-    mirror: false
-    rotation: 90
-    x: 0.0
-    y: 0.0
-  straight_61c245c0_400p0_350p0:
-    mirror: false
-    rotation: 90
-    x: 400.0
-    y: 310.0
-  straight_9dca303a_m250p0_705p0:
-    mirror: false
-    rotation: 90
-    x: -250.0
-    y: 410.0
-  straight_b169702d_200p0_300p0:
+  straight_152c11f4_200p0_300p0:
     mirror: false
     rotation: 0
     x: 10.0
     y: 300.0
-  straight_b169702d_350p0_150p0:
+  straight_152c11f4_350p0_150p0:
     mirror: false
     rotation: 0
     x: 160.0
     y: 150.0
-  straight_b169702d_550p0_350p0:
+  straight_152c11f4_550p0_350p0:
     mirror: false
     rotation: 90
     x: 550.0
     y: 160.0
-  straight_d04bc13d_m100p0_780p0:
+  straight_1efce1c9_0p0_145p0:
+    mirror: false
+    rotation: 90
+    x: 0.0
+    y: 0.0
+  straight_2b932af0_400p0_350p0:
+    mirror: false
+    rotation: 90
+    x: 400.0
+    y: 310.0
+  straight_a01b1c4b_150p0_70p0:
+    mirror: false
+    rotation: 90
+    x: 150.0
+    y: 0.0
+  straight_a9485c4a_m250p0_705p0:
+    mirror: false
+    rotation: 90
+    x: -250.0
+    y: 410.0
+  straight_b2910871_225p0_550p0:
+    mirror: false
+    rotation: 180
+    x: 540.0
+    y: 550.0
+  straight_b2910871_75p0_400p0:
+    mirror: false
+    rotation: 180
+    x: 390.0
+    y: 400.0
+  straight_bda70908_m100p0_780p0:
     mirror: false
     rotation: 90
     x: -100.0

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_connections_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_connections_.yml
@@ -1,6 +1,6 @@
 cells:
   sample_connections: {}
-  straight_b8776d87:
+  straight_1a5e6830:
     changed:
       length: 0.5
     default:
@@ -19,7 +19,7 @@ cells:
     info_version: 1
     length: 0.5
     module: gdsfactory.components.straight
-    name: straight_b8776d87
+    name: straight_1a5e6830
     width: 0.5
   straight_e15cfb47:
     changed:

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
@@ -29,7 +29,7 @@ cells:
     name: bend_euler_2e0a66fe
     radius: 10
     radius_min: 7.061
-  compass_a0b38c11:
+  compass_7a93663b:
     changed:
       layer:
       - 49
@@ -58,7 +58,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a0b38c11
+    name: compass_7a93663b
   pad:
     changed: {}
     default:

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_4725f0ef:
+  bend_euler_2e0a66fe:
     changed:
-      cross_section:
-        function: cross_section
       radius: 10
     default:
       angle: 90
@@ -28,15 +26,14 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_4725f0ef
+    name: bend_euler_2e0a66fe
     radius: 10
     radius_min: 7.061
-  compass_6ffda32f:
+  compass_a0b38c11:
     changed:
       layer:
       - 49
       - 0
-      port_inclusion: 0
       size:
       - 100
       - 100
@@ -61,7 +58,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_6ffda32f
+    name: compass_a0b38c11
   pad:
     changed: {}
     default:
@@ -95,85 +92,8 @@ cells:
     - 100
     - 100
   sample_path_length_matching: {}
-  straight_3bc3129a:
+  straight_1a88079a:
     changed:
-      cross_section:
-        function: cross_section
-      length: 200
-      radius: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 200
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 200
-    module: gdsfactory.components.straight
-    name: straight_3bc3129a
-    width: 0.5
-  straight_7b1e3316:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 580
-      radius: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 580
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 580
-    module: gdsfactory.components.straight
-    name: straight_7b1e3316
-    width: 0.5
-  straight_95cf111d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 340
-      radius: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 340
-      npoints: 2
-      radius: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 340
-    module: gdsfactory.components.straight
-    name: straight_95cf111d
-    width: 0.5
-  straight_99672b3b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 250
       radius: 10
     default:
@@ -193,13 +113,11 @@ cells:
     info_version: 1
     length: 250
     module: gdsfactory.components.straight
-    name: straight_99672b3b
+    name: straight_1a88079a
     width: 0.5
-  straight_ab370e58:
+  straight_730b39a8:
     changed:
-      cross_section:
-        function: cross_section
-      length: 170
+      length: 200
       radius: 10
     default:
       cross_section:
@@ -210,20 +128,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 170
+      length: 200
       npoints: 2
       radius: 10
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 170
+    length: 200
     module: gdsfactory.components.straight
-    name: straight_ab370e58
+    name: straight_730b39a8
     width: 0.5
-  straight_b28806b6:
+  straight_76c7a705:
     changed:
-      cross_section:
-        function: cross_section
       length: 610
       radius: 10
     default:
@@ -243,7 +159,76 @@ cells:
     info_version: 1
     length: 610
     module: gdsfactory.components.straight
-    name: straight_b28806b6
+    name: straight_76c7a705
+    width: 0.5
+  straight_80b7924a:
+    changed:
+      length: 170
+      radius: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 170
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 170
+    module: gdsfactory.components.straight
+    name: straight_80b7924a
+    width: 0.5
+  straight_aa7b6441:
+    changed:
+      length: 340
+      radius: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 340
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 340
+    module: gdsfactory.components.straight
+    name: straight_aa7b6441
+    width: 0.5
+  straight_e3b83c00:
+    changed:
+      length: 580
+      radius: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 580
+      npoints: 2
+      radius: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 580
+    module: gdsfactory.components.straight
+    name: straight_e3b83c00
     width: 0.5
 info:
   name: sample_path_length_matching

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
@@ -92,49 +92,7 @@ cells:
     module: gdsfactory.components.mmi1x2
     name: mmi1x2_52b0d64a
   sample_docstring: {}
-  straight_3aa6a47c:
-    changed:
-      length: 19.99
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 19.99
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 19.99
-    module: gdsfactory.components.straight
-    name: straight_3aa6a47c
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_d0ae2c31:
+  straight_720ba455:
     changed:
       length: 18.75
     default:
@@ -153,7 +111,49 @@ cells:
     info_version: 1
     length: 18.75
     module: gdsfactory.components.straight
-    name: straight_d0ae2c31
+    name: straight_720ba455
+    width: 0.5
+  straight_775184d2:
+    changed:
+      length: 19.99
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 19.99
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 19.99
+    module: gdsfactory.components.straight
+    name: straight_775184d2
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
     width: 0.5
 info:
   name: sample_docstring

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi1x2_28584457:
@@ -94,10 +92,8 @@ cells:
     module: gdsfactory.components.mmi1x2
     name: mmi1x2_52b0d64a
   sample_docstring: {}
-  straight_466a3c74:
+  straight_3aa6a47c:
     changed:
-      cross_section:
-        function: cross_section
       length: 19.99
     default:
       cross_section:
@@ -115,12 +111,10 @@ cells:
     info_version: 1
     length: 19.99
     module: gdsfactory.components.straight
-    name: straight_466a3c74
+    name: straight_3aa6a47c
     width: 0.5
-  straight_5743d35a:
+  straight_c138f2c4:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.01
     default:
       cross_section:
@@ -138,12 +132,10 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_c138f2c4
     width: 0.5
-  straight_b649c633:
+  straight_d0ae2c31:
     changed:
-      cross_section:
-        function: cross_section
       length: 18.75
     default:
       cross_section:
@@ -161,7 +153,7 @@ cells:
     info_version: 1
     length: 18.75
     module: gdsfactory.components.straight
-    name: straight_b649c633
+    name: straight_d0ae2c31
     width: 0.5
 info:
   name: sample_docstring

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
@@ -3,10 +3,8 @@ cells:
     description: just a demo on adding metadata
     polarization: te
     wavelength: 1.55
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -30,7 +28,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi1x2_41793ed4:
@@ -97,56 +95,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2_5ad5950d
-  straight_5743d35a:
+  straight_94fc1711:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_c8d42def:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 79.375
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 79.375
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 79.375
-    module: gdsfactory.components.straight
-    name: straight_c8d42def
-    width: 0.5
-  straight_c96c7cf4:
-    changed:
-      cross_section:
-        function: cross_section
       length: 102.51
     default:
       cross_section:
@@ -164,7 +114,49 @@ cells:
     info_version: 1
     length: 102.51
     module: gdsfactory.components.straight
-    name: straight_c96c7cf4
+    name: straight_94fc1711
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_f5e73eb6:
+    changed:
+      length: 79.375
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 79.375
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 79.375
+    module: gdsfactory.components.straight
+    name: straight_f5e73eb6
     width: 0.5
 info:
   description: just a demo on adding metadata

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
@@ -31,39 +31,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  mmi1x2_41793ed4:
-    changed:
-      length_mmi: 5
-      width_mmi: 4.5
-    default:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5.5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 2.5
-      width_taper: 1
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 4.5
-      width_taper: 1
-      with_cladding_box: true
-    function_name: mmi1x2
-    info_version: 1
-    module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
-  mmi1x2_5ad5950d:
+  mmi1x2_25023716:
     changed:
       length_mmi: 10
       width_mmi: 4.5
@@ -94,8 +62,40 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_5ad5950d
-  straight_94fc1711:
+    name: mmi1x2_25023716
+  mmi1x2_63d4efba:
+    changed:
+      length_mmi: 5
+      width_mmi: 4.5
+    default:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5.5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 2.5
+      width_taper: 1
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 4.5
+      width_taper: 1
+      with_cladding_box: true
+    function_name: mmi1x2
+    info_version: 1
+    module: gdsfactory.components.mmi1x2
+    name: mmi1x2_63d4efba
+  straight_7a57a71b:
     changed:
       length: 102.51
     default:
@@ -114,9 +114,9 @@ cells:
     info_version: 1
     length: 102.51
     module: gdsfactory.components.straight
-    name: straight_94fc1711
+    name: straight_7a57a71b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -135,9 +135,9 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
-  straight_f5e73eb6:
+  straight_e4b574c8:
     changed:
       length: 79.375
     default:
@@ -156,7 +156,7 @@ cells:
     info_version: 1
     length: 79.375
     module: gdsfactory.components.straight
-    name: straight_f5e73eb6
+    name: straight_e4b574c8
     width: 0.5
 info:
   description: just a demo on adding metadata

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
@@ -1,9 +1,7 @@
 cells:
-  bend_euler_93ab05a3:
+  bend_euler_107bf6b2:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -28,9 +26,36 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_93ab05a3
+    name: bend_euler_107bf6b2
     radius: 10
     radius_min: 7.061
+  pad_array:
+    changed: {}
+    default:
+      columns: 6
+      orientation: 270
+      pad:
+        function: pad
+      rows: 1
+      spacing:
+      - 150
+      - 150
+    full:
+      columns: 6
+      orientation: 270
+      pad:
+        function: pad
+      rows: 1
+      spacing:
+      - 150
+      - 150
+    function_name: pad_array
+    info_version: 1
+    module: gdsfactory.components.pad
+    name: pad_array
+    size:
+    - 100
+    - 100
   pad_array_b84950ef:
     changed:
       orientation: 90
@@ -59,165 +84,10 @@ cells:
     size:
     - 100
     - 100
-  pad_array_fe55c938:
-    changed:
-      orientation: 270
-    default:
-      columns: 6
-      orientation: 270
-      pad:
-        function: pad
-      rows: 1
-      spacing:
-      - 150
-      - 150
-    full:
-      columns: 6
-      orientation: 270
-      pad:
-        function: pad
-      rows: 1
-      spacing:
-      - 150
-      - 150
-    function_name: pad_array
-    info_version: 1
-    module: gdsfactory.components.pad
-    name: pad_array_fe55c938
-    size:
-    - 100
-    - 100
   sample_waypoints: {}
-  straight_0e209496:
+  straight_152c11f4:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 140
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 140
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 140
-    module: gdsfactory.components.straight
-    name: straight_0e209496
-    width: 0.5
-  straight_1a997572:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 630
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 630
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 630
-    module: gdsfactory.components.straight
-    name: straight_1a997572
-    width: 0.5
-  straight_27026560:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 290
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 290
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 290
-    module: gdsfactory.components.straight
-    name: straight_27026560
-    width: 0.5
-  straight_61c245c0:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 80
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 80
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 80
-    module: gdsfactory.components.straight
-    name: straight_61c245c0
-    width: 0.5
-  straight_9dca303a:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 590
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 590
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 590
-    module: gdsfactory.components.straight
-    name: straight_9dca303a
-    width: 0.5
-  straight_b169702d:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
       length: 380
     default:
       cross_section:
@@ -236,13 +106,126 @@ cells:
     info_version: 1
     length: 380
     module: gdsfactory.components.straight
-    name: straight_b169702d
+    name: straight_152c11f4
     width: 0.5
-  straight_d04bc13d:
+  straight_1efce1c9:
     changed:
+      auto_widen: false
+      length: 290
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
       auto_widen: false
       cross_section:
         function: cross_section
+      length: 290
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 290
+    module: gdsfactory.components.straight
+    name: straight_1efce1c9
+    width: 0.5
+  straight_2b932af0:
+    changed:
+      auto_widen: false
+      length: 80
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 80
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 80
+    module: gdsfactory.components.straight
+    name: straight_2b932af0
+    width: 0.5
+  straight_a01b1c4b:
+    changed:
+      auto_widen: false
+      length: 140
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 140
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 140
+    module: gdsfactory.components.straight
+    name: straight_a01b1c4b
+    width: 0.5
+  straight_a9485c4a:
+    changed:
+      auto_widen: false
+      length: 590
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 590
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 590
+    module: gdsfactory.components.straight
+    name: straight_a9485c4a
+    width: 0.5
+  straight_b2910871:
+    changed:
+      auto_widen: false
+      length: 630
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 630
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 630
+    module: gdsfactory.components.straight
+    name: straight_b2910871
+    width: 0.5
+  straight_bda70908:
+    changed:
+      auto_widen: false
       length: 440
     default:
       cross_section:
@@ -261,7 +244,7 @@ cells:
     info_version: 1
     length: 440
     module: gdsfactory.components.straight
-    name: straight_d04bc13d
+    name: straight_bda70908
     width: 0.5
 info:
   name: sample_waypoints

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
@@ -1,37 +1,5 @@
 cells:
-  mmi1x2_41793ed4:
-    changed:
-      length_mmi: 5
-      width_mmi: 4.5
-    default:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5.5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 2.5
-      width_taper: 1
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 4.5
-      width_taper: 1
-      with_cladding_box: true
-    function_name: mmi1x2
-    info_version: 1
-    module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
-  mmi1x2_5ad5950d:
+  mmi1x2_25023716:
     changed:
       length_mmi: 10
       width_mmi: 4.5
@@ -62,7 +30,39 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_5ad5950d
+    name: mmi1x2_25023716
+  mmi1x2_63d4efba:
+    changed:
+      length_mmi: 5
+      width_mmi: 4.5
+    default:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5.5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 2.5
+      width_taper: 1
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 4.5
+      width_taper: 1
+      with_cladding_box: true
+    function_name: mmi1x2
+    info_version: 1
+    module: gdsfactory.components.mmi1x2
+    name: mmi1x2_63d4efba
   yaml_anchor: {}
 info:
   name: yaml_anchor

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_0_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_0_.yml
@@ -1,6 +1,6 @@
 cells:
   mirror_port: {}
-  mmi1x2_41793ed4:
+  mmi1x2_63d4efba:
     changed:
       length_mmi: 5
       width_mmi: 4.5
@@ -31,7 +31,7 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
+    name: mmi1x2_63d4efba
 info:
   name: mirror_port
 ports:

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_1_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_1_.yml
@@ -1,6 +1,6 @@
 cells:
   mirror_x: {}
-  mmi1x2_41793ed4:
+  mmi1x2_63d4efba:
     changed:
       length_mmi: 5
       width_mmi: 4.5
@@ -31,7 +31,7 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
+    name: mmi1x2_63d4efba
 info:
   name: mirror_x
 ports:

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_2_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_2_.yml
@@ -1,5 +1,5 @@
 cells:
-  mmi1x2_41793ed4:
+  mmi1x2_63d4efba:
     changed:
       length_mmi: 5
       width_mmi: 4.5
@@ -30,7 +30,7 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
+    name: mmi1x2_63d4efba
   rotation: {}
 info:
   name: rotation

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_3_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_3_.yml
@@ -1,38 +1,6 @@
 cells:
   dxdy: {}
-  mmi1x2_41793ed4:
-    changed:
-      length_mmi: 5
-      width_mmi: 4.5
-    default:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5.5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 2.5
-      width_taper: 1
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      gap_mmi: 0.25
-      length_mmi: 5
-      length_taper: 10
-      taper:
-        function: taper
-      width: 0.5
-      width_mmi: 4.5
-      width_taper: 1
-      with_cladding_box: true
-    function_name: mmi1x2
-    info_version: 1
-    module: gdsfactory.components.mmi1x2
-    name: mmi1x2_41793ed4
-  mmi1x2_5ad5950d:
+  mmi1x2_25023716:
     changed:
       length_mmi: 10
       width_mmi: 4.5
@@ -63,7 +31,39 @@ cells:
     function_name: mmi1x2
     info_version: 1
     module: gdsfactory.components.mmi1x2
-    name: mmi1x2_5ad5950d
+    name: mmi1x2_25023716
+  mmi1x2_63d4efba:
+    changed:
+      length_mmi: 5
+      width_mmi: 4.5
+    default:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5.5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 2.5
+      width_taper: 1
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      gap_mmi: 0.25
+      length_mmi: 5
+      length_taper: 10
+      taper:
+        function: taper
+      width: 0.5
+      width_mmi: 4.5
+      width_taper: 1
+      with_cladding_box: true
+    function_name: mmi1x2
+    info_version: 1
+    module: gdsfactory.components.mmi1x2
+    name: mmi1x2_63d4efba
 info:
   name: dxdy
 ports:

--- a/gdsfactory/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
+++ b/gdsfactory/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
@@ -1,6 +1,6 @@
 cells:
   Unnamed_85f74110: {}
-  compass_b3c54927:
+  compass_ecda870f:
     changed:
       port_type: None
       size:
@@ -27,7 +27,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b3c54927
+    name: compass_ecda870f
 info:
   name: Unnamed_85f74110
 ports:

--- a/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
@@ -1,10 +1,6 @@
 cells:
-  compass_bdc25def:
+  compass_88c59c1f:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 3
       - 10
@@ -29,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_bdc25def
+    name: compass_88c59c1f
   cross:
     changed: {}
     default:
@@ -130,11 +126,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.add_fidutials
     name: pad_array_add_fidutials
-  rectangle_0eb96b44:
+  rectangle_88c59c1f:
     changed:
-      layer:
-      - 1
-      - 0
       size:
       - 3
       - 10
@@ -159,7 +152,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0eb96b44
+    name: rectangle_88c59c1f
 info:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_88c59c1f:
+  compass_bd043ca6:
     changed:
       size:
       - 3
@@ -25,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_88c59c1f
+    name: compass_bd043ca6
   cross:
     changed: {}
     default:
@@ -126,7 +126,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.add_fidutials
     name: pad_array_add_fidutials
-  rectangle_88c59c1f:
+  rectangle_bd043ca6:
     changed:
       size:
       - 3
@@ -152,7 +152,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_88c59c1f
+    name: rectangle_bd043ca6
 info:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_add_frame_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_frame_.yml
@@ -21,34 +21,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.align
     name: add_frame
-  compass_0c2ee789:
-    changed:
-      size:
-      - 44
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 44
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_0c2ee789
-  compass_d40ce24f:
+  compass_b09a8674:
     changed:
       size:
       - 10
@@ -74,8 +47,35 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_d40ce24f
-  rectangle_adb79d85:
+    name: compass_b09a8674
+  compass_b3a87156:
+    changed:
+      size:
+      - 44
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 44
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_b3a87156
+  rectangle_e5e2408e:
     changed:
       centered: true
       size:
@@ -102,8 +102,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_adb79d85
-  rectangle_b6e0d688:
+    name: rectangle_e5e2408e
+  rectangle_e97c2782:
     changed:
       centered: true
       size:
@@ -130,7 +130,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_b6e0d688
+    name: rectangle_e97c2782
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_add_frame_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_frame_.yml
@@ -21,12 +21,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.align
     name: add_frame
-  compass_1634c468:
+  compass_0c2ee789:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 44
       - 10
@@ -51,13 +47,9 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_1634c468
-  compass_eae46794:
+    name: compass_0c2ee789
+  compass_d40ce24f:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 10
       - 34
@@ -82,13 +74,10 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_eae46794
-  rectangle_0b48cd3f:
+    name: compass_d40ce24f
+  rectangle_adb79d85:
     changed:
       centered: true
-      layer:
-      - 1
-      - 0
       size:
       - 10
       - 34
@@ -113,13 +102,10 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0b48cd3f
-  rectangle_95e5d332:
+    name: rectangle_adb79d85
+  rectangle_b6e0d688:
     changed:
       centered: true
-      layer:
-      - 1
-      - 0
       size:
       - 44
       - 10
@@ -144,7 +130,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_95e5d332
+    name: rectangle_b6e0d688
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
@@ -23,12 +23,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.align
     name: align_wafer
-  compass_127270ff:
+  compass_2ffd58c5:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 25
       - 25
@@ -53,75 +49,9 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_127270ff
-  compass_57434a14:
+    name: compass_2ffd58c5
+  compass_529a54df:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 10
-      - 110
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 110
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_57434a14
-  compass_7b7cb819:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 120
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 120
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_7b7cb819
-  compass_a5ee220a:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 10
       - 80
@@ -146,12 +76,63 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a5ee220a
-  cross_62d15a86:
+    name: compass_529a54df
+  compass_f06d5e3f:
     changed:
+      size:
+      - 10
+      - 110
+    default:
       layer:
       - 1
       - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 110
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_f06d5e3f
+  compass_fa7f8ead:
+    changed:
+      size:
+      - 120
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 120
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_fa7f8ead
+  cross_d06bdb06:
+    changed:
       length: 80
       width: 10
     default:
@@ -171,13 +152,10 @@ cells:
     function_name: cross
     info_version: 1
     module: gdsfactory.components.cross
-    name: cross_62d15a86
-  rectangle_4f8a0845:
+    name: cross_d06bdb06
+  rectangle_0c2f16e7:
     changed:
       centered: true
-      layer:
-      - 1
-      - 0
       size:
       - 25
       - 25
@@ -202,12 +180,9 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_4f8a0845
-  rectangle_50ce9eb9:
+    name: rectangle_0c2f16e7
+  rectangle_529a54df:
     changed:
-      layer:
-      - 1
-      - 0
       size:
       - 10
       - 80
@@ -232,44 +207,10 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_50ce9eb9
-  rectangle_81eb1623:
+    name: rectangle_529a54df
+  rectangle_dbc16b81:
     changed:
       centered: true
-      layer:
-      - 1
-      - 0
-      size:
-      - 120
-      - 10
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: true
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 120
-      - 10
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_81eb1623
-  rectangle_8347a242:
-    changed:
-      centered: true
-      layer:
-      - 1
-      - 0
       size:
       - 10
       - 110
@@ -294,7 +235,35 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_8347a242
+    name: rectangle_dbc16b81
+  rectangle_fca0e351:
+    changed:
+      centered: true
+      size:
+      - 120
+      - 10
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: true
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 120
+      - 10
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_fca0e351
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
@@ -23,61 +23,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.align
     name: align_wafer
-  compass_2ffd58c5:
-    changed:
-      size:
-      - 25
-      - 25
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 25
-      - 25
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_2ffd58c5
-  compass_529a54df:
-    changed:
-      size:
-      - 10
-      - 80
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 80
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_529a54df
-  compass_f06d5e3f:
+  compass_0af16c65:
     changed:
       size:
       - 10
@@ -103,8 +49,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f06d5e3f
-  compass_fa7f8ead:
+    name: compass_0af16c65
+  compass_50c46baf:
     changed:
       size:
       - 120
@@ -130,7 +76,61 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_fa7f8ead
+    name: compass_50c46baf
+  compass_9a9bf197:
+    changed:
+      size:
+      - 25
+      - 25
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 25
+      - 25
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_9a9bf197
+  compass_b889b1c6:
+    changed:
+      size:
+      - 10
+      - 80
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 80
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_b889b1c6
   cross_d06bdb06:
     changed:
       length: 80
@@ -153,7 +153,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.cross
     name: cross_d06bdb06
-  rectangle_0c2f16e7:
+  rectangle_3450f4e8:
     changed:
       centered: true
       size:
@@ -180,63 +180,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0c2f16e7
-  rectangle_529a54df:
-    changed:
-      size:
-      - 10
-      - 80
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 10
-      - 80
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_529a54df
-  rectangle_dbc16b81:
-    changed:
-      centered: true
-      size:
-      - 10
-      - 110
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: true
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 10
-      - 110
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_dbc16b81
-  rectangle_fca0e351:
+    name: rectangle_3450f4e8
+  rectangle_5a734268:
     changed:
       centered: true
       size:
@@ -263,7 +208,62 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_fca0e351
+    name: rectangle_5a734268
+  rectangle_b889b1c6:
+    changed:
+      size:
+      - 10
+      - 80
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10
+      - 80
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_b889b1c6
+  rectangle_e6411d33:
+    changed:
+      centered: true
+      size:
+      - 10
+      - 110
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: true
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10
+      - 110
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_e6411d33
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
@@ -67,7 +67,7 @@ cells:
     name: bend_euler_212e6ad7
     radius: 5
     radius_min: 3.53
-  compass_a0b38c11:
+  compass_7a93663b:
     changed:
       layer:
       - 49
@@ -96,7 +96,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a0b38c11
+    name: compass_7a93663b
   pad:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
@@ -37,10 +37,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_with_fanout
     name: array_with_fanout
-  bend_euler_a519ff2d:
+  bend_euler_212e6ad7:
     changed:
-      cross_section:
-        function: cross_section
       radius: 5
     default:
       angle: 90
@@ -66,15 +64,14 @@ cells:
     info_version: 1
     length: 8.318
     module: gdsfactory.components.bend_euler
-    name: bend_euler_a519ff2d
+    name: bend_euler_212e6ad7
     radius: 5
     radius_min: 3.53
-  compass_6ffda32f:
+  compass_a0b38c11:
     changed:
       layer:
       - 49
       - 0
-      port_inclusion: 0
       size:
       - 100
       - 100
@@ -99,7 +96,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_6ffda32f
+    name: compass_a0b38c11
   pad:
     changed: {}
     default:
@@ -132,79 +129,8 @@ cells:
     size:
     - 100
     - 100
-  straight_396b7705:
+  straight_01823ba6:
     changed:
-      cross_section:
-        function: cross_section
-      length: 15
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15
-    module: gdsfactory.components.straight
-    name: straight_396b7705
-    width: 0.5
-  straight_3d24b479:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 340
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 340
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 340
-    module: gdsfactory.components.straight
-    name: straight_3d24b479
-    width: 0.5
-  straight_3fc002c1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 190
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 190
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 190
-    module: gdsfactory.components.straight
-    name: straight_3fc002c1
-    width: 0.5
-  straight_999e033a:
-    changed:
-      cross_section:
-        function: cross_section
       length: 25
     default:
       cross_section:
@@ -222,12 +148,52 @@ cells:
     info_version: 1
     length: 25
     module: gdsfactory.components.straight
-    name: straight_999e033a
+    name: straight_01823ba6
     width: 0.5
-  straight_d9996de2:
+  straight_66e52e36:
     changed:
+      length: 15
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 15
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 15
+    module: gdsfactory.components.straight
+    name: straight_66e52e36
+    width: 0.5
+  straight_a788a46d:
+    changed:
+      length: 340
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 340
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 340
+    module: gdsfactory.components.straight
+    name: straight_a788a46d
+    width: 0.5
+  straight_b24e342f:
+    changed:
       length: 40
     default:
       cross_section:
@@ -245,12 +211,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_e7395bed:
+  straight_b3dac65b:
     changed:
-      cross_section:
-        function: cross_section
       length: 5
     default:
       cross_section:
@@ -268,7 +232,28 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_e7395bed
+    name: straight_b3dac65b
+    width: 0.5
+  straight_e0266eea:
+    changed:
+      length: 190
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 190
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 190
+    module: gdsfactory.components.straight
+    name: straight_e0266eea
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
@@ -83,37 +83,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_280a2d8b
-  compass_6ffda32f:
-    changed:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      size:
-      - 100
-      - 100
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 100
-      - 100
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_6ffda32f
   compass_8e661824:
     changed:
       layer:
@@ -144,6 +113,36 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_8e661824
+  compass_a0b38c11:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 100
+      - 100
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 100
+      - 100
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_a0b38c11
   compass_ef690c07:
     changed:
       layer:

--- a/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
@@ -53,7 +53,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_with_via
     name: array_with_via
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -82,38 +82,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_8e661824
-  compass_a0b38c11:
+    name: compass_0570d255
+  compass_7a93663b:
     changed:
       layer:
       - 49
@@ -142,8 +112,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a0b38c11
-  compass_ef690c07:
+    name: compass_7a93663b
+  compass_8b1f5d7c:
     changed:
       layer:
       - 41
@@ -172,7 +142,37 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ef690c07
+    name: compass_8b1f5d7c
+  compass_aa9c3262:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_aa9c3262
   contact:
     changed: {}
     default:
@@ -261,93 +261,7 @@ cells:
     size:
     - 100
     - 100
-  straight_2fbbd4a9:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 45
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 360
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 45
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 360
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 360
-    module: gdsfactory.components.straight
-    name: straight_2fbbd4a9
-    width: 10
-  straight_5ca1245d:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 45
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 210
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 45
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 210
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 210
-    module: gdsfactory.components.straight
-    name: straight_5ca1245d
-    width: 10
-  straight_9d5a0d1b:
+  straight_783ae0aa:
     changed:
       cross_section:
         function: cross_section
@@ -388,7 +302,93 @@ cells:
     info_version: 1
     length: 60
     module: gdsfactory.components.straight
-    name: straight_9d5a0d1b
+    name: straight_783ae0aa
+    width: 10
+  straight_8b3d6f6b:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 45
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 210
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 45
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 210
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 210
+    module: gdsfactory.components.straight
+    name: straight_8b3d6f6b
+    width: 10
+  straight_b4bf47bb:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 45
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 360
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 45
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 360
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 360
+    module: gdsfactory.components.straight
+    name: straight_b4bf47bb
     width: 10
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_awg_.yml
+++ b/gdsfactory/tests/test_components/test_settings_awg_.yml
@@ -84,343 +84,7 @@ cells:
     name: free_propagation_region_734f1395
     width1: 10
     width2: 20
-  straight_1869a89c:
-    changed:
-      length: 40.834
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.834
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.834
-    module: gdsfactory.components.straight
-    name: straight_1869a89c
-    width: 0.5
-  straight_35bddbaa:
-    changed:
-      length: 23.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 23.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 23.5
-    module: gdsfactory.components.straight
-    name: straight_35bddbaa
-    width: 0.5
-  straight_3c3cbe65:
-    changed:
-      length: 30.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30.01
-    module: gdsfactory.components.straight
-    name: straight_3c3cbe65
-    width: 0.5
-  straight_56794401:
-    changed:
-      length: 25.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 25.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 25.01
-    module: gdsfactory.components.straight
-    name: straight_56794401
-    width: 0.5
-  straight_5832509c:
-    changed:
-      length: 10.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 10.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 10.01
-    module: gdsfactory.components.straight
-    name: straight_5832509c
-    width: 0.5
-  straight_6bc6f3f6:
-    changed:
-      length: 5.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 5.01
-    module: gdsfactory.components.straight
-    name: straight_6bc6f3f6
-    width: 0.5
-  straight_7576fd2a:
-    changed:
-      length: 49.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 49.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 49.5
-    module: gdsfactory.components.straight
-    name: straight_7576fd2a
-    width: 0.5
-  straight_904a156a:
-    changed:
-      length: 19.166
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 19.166
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 19.166
-    module: gdsfactory.components.straight
-    name: straight_904a156a
-    width: 0.5
-  straight_98bc341d:
-    changed:
-      length: 40.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.01
-    module: gdsfactory.components.straight
-    name: straight_98bc341d
-    width: 0.5
-  straight_9d4f36ac:
-    changed:
-      length: 32.166
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 32.166
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 32.166
-    module: gdsfactory.components.straight
-    name: straight_9d4f36ac
-    width: 0.5
-  straight_a9cd772d:
-    changed:
-      length: 14.834
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 14.834
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 14.834
-    module: gdsfactory.components.straight
-    name: straight_a9cd772d
-    width: 0.5
-  straight_b3a0026b:
-    changed:
-      length: 15.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15.01
-    module: gdsfactory.components.straight
-    name: straight_b3a0026b
-    width: 0.5
-  straight_b57d86ce:
-    changed:
-      length: 10.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 10.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 10.5
-    module: gdsfactory.components.straight
-    name: straight_b57d86ce
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c336c571:
-    changed:
-      length: 27.834
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.834
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.834
-    module: gdsfactory.components.straight
-    name: straight_c336c571
-    width: 0.5
-  straight_d0a3ec0c:
-    changed:
-      length: 36.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 36.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 36.5
-    module: gdsfactory.components.straight
-    name: straight_d0a3ec0c
-    width: 0.5
-  straight_de8fe94b:
+  straight_062be35c:
     changed:
       length: 35.01
     default:
@@ -439,9 +103,9 @@ cells:
     info_version: 1
     length: 35.01
     module: gdsfactory.components.straight
-    name: straight_de8fe94b
+    name: straight_062be35c
     width: 0.5
-  straight_f55d0c9d:
+  straight_096b404f:
     changed:
       length: 45.166
     default:
@@ -460,9 +124,9 @@ cells:
     info_version: 1
     length: 45.166
     module: gdsfactory.components.straight
-    name: straight_f55d0c9d
+    name: straight_096b404f
     width: 0.5
-  straight_f77186f5:
+  straight_168c1853:
     changed:
       length: 45.01
     default:
@@ -481,9 +145,51 @@ cells:
     info_version: 1
     length: 45.01
     module: gdsfactory.components.straight
-    name: straight_f77186f5
+    name: straight_168c1853
     width: 0.5
-  straight_f7c51d07:
+  straight_18e5aafd:
+    changed:
+      length: 19.166
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 19.166
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 19.166
+    module: gdsfactory.components.straight
+    name: straight_18e5aafd
+    width: 0.5
+  straight_1ce25ac8:
+    changed:
+      length: 40.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.01
+    module: gdsfactory.components.straight
+    name: straight_1ce25ac8
+    width: 0.5
+  straight_26cdaaa0:
     changed:
       length: 20.01
     default:
@@ -502,7 +208,301 @@ cells:
     info_version: 1
     length: 20.01
     module: gdsfactory.components.straight
-    name: straight_f7c51d07
+    name: straight_26cdaaa0
+    width: 0.5
+  straight_2ed32a7a:
+    changed:
+      length: 14.834
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 14.834
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 14.834
+    module: gdsfactory.components.straight
+    name: straight_2ed32a7a
+    width: 0.5
+  straight_4d60b220:
+    changed:
+      length: 23.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 23.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 23.5
+    module: gdsfactory.components.straight
+    name: straight_4d60b220
+    width: 0.5
+  straight_50e371b3:
+    changed:
+      length: 25.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 25.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 25.01
+    module: gdsfactory.components.straight
+    name: straight_50e371b3
+    width: 0.5
+  straight_79586da1:
+    changed:
+      length: 49.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 49.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 49.5
+    module: gdsfactory.components.straight
+    name: straight_79586da1
+    width: 0.5
+  straight_79cb7d88:
+    changed:
+      length: 30.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 30.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30.01
+    module: gdsfactory.components.straight
+    name: straight_79cb7d88
+    width: 0.5
+  straight_8208bfd9:
+    changed:
+      length: 27.834
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.834
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.834
+    module: gdsfactory.components.straight
+    name: straight_8208bfd9
+    width: 0.5
+  straight_8bb5749e:
+    changed:
+      length: 5.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5.01
+    module: gdsfactory.components.straight
+    name: straight_8bb5749e
+    width: 0.5
+  straight_8d4a59e3:
+    changed:
+      length: 10.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10.01
+    module: gdsfactory.components.straight
+    name: straight_8d4a59e3
+    width: 0.5
+  straight_a0707db0:
+    changed:
+      length: 40.834
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.834
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.834
+    module: gdsfactory.components.straight
+    name: straight_a0707db0
+    width: 0.5
+  straight_a49667fe:
+    changed:
+      length: 10.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10.5
+    module: gdsfactory.components.straight
+    name: straight_a49667fe
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ccf0b03a:
+    changed:
+      length: 36.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 36.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 36.5
+    module: gdsfactory.components.straight
+    name: straight_ccf0b03a
+    width: 0.5
+  straight_da1cb66f:
+    changed:
+      length: 32.166
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 32.166
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 32.166
+    module: gdsfactory.components.straight
+    name: straight_da1cb66f
+    width: 0.5
+  straight_ef475272:
+    changed:
+      length: 15.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 15.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 15.01
+    module: gdsfactory.components.straight
+    name: straight_ef475272
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_awg_.yml
+++ b/gdsfactory/tests/test_components/test_settings_awg_.yml
@@ -21,10 +21,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.awg
     name: awg
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -48,9 +46,24 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
+  free_propagation_region_35b491a8:
+    changed:
+      outputs: 10
+    default:
+      inputs: 1
+    full:
+      inputs: 1
+      outputs: 10
+    function_name: free_propagation_region_input
+    info_version: 1
+    length: 20
+    module: gdsfactory.components.awg
+    name: free_propagation_region_35b491a8
+    width1: 2
+    width2: 20
   free_propagation_region_734f1395:
     changed:
       inputs: 3
@@ -71,49 +84,8 @@ cells:
     name: free_propagation_region_734f1395
     width1: 10
     width2: 20
-  free_propagation_region_ccb25c60:
+  straight_1869a89c:
     changed:
-      inputs: 1
-      outputs: 10
-    default:
-      inputs: 1
-    full:
-      inputs: 1
-      outputs: 10
-    function_name: free_propagation_region_input
-    info_version: 1
-    length: 20
-    module: gdsfactory.components.awg
-    name: free_propagation_region_ccb25c60
-    width1: 2
-    width2: 20
-  straight_15d165a7:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 19.166
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 19.166
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 19.166
-    module: gdsfactory.components.straight
-    name: straight_15d165a7
-    width: 0.5
-  straight_40260575:
-    changed:
-      cross_section:
-        function: cross_section
       length: 40.834
     default:
       cross_section:
@@ -131,242 +103,10 @@ cells:
     info_version: 1
     length: 40.834
     module: gdsfactory.components.straight
-    name: straight_40260575
+    name: straight_1869a89c
     width: 0.5
-  straight_499fba7c:
+  straight_35bddbaa:
     changed:
-      cross_section:
-        function: cross_section
-      length: 45.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.01
-    module: gdsfactory.components.straight
-    name: straight_499fba7c
-    width: 0.5
-  straight_4c049c50:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 45.166
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.166
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.166
-    module: gdsfactory.components.straight
-    name: straight_4c049c50
-    width: 0.5
-  straight_4c511329:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 30.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30.01
-    module: gdsfactory.components.straight
-    name: straight_4c511329
-    width: 0.5
-  straight_5743d35a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_6059d86e:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 36.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 36.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 36.5
-    module: gdsfactory.components.straight
-    name: straight_6059d86e
-    width: 0.5
-  straight_612a36d3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 5.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 5.01
-    module: gdsfactory.components.straight
-    name: straight_612a36d3
-    width: 0.5
-  straight_76407714:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 32.166
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 32.166
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 32.166
-    module: gdsfactory.components.straight
-    name: straight_76407714
-    width: 0.5
-  straight_8fab3d89:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 15.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15.01
-    module: gdsfactory.components.straight
-    name: straight_8fab3d89
-    width: 0.5
-  straight_a3115f75:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 49.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 49.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 49.5
-    module: gdsfactory.components.straight
-    name: straight_a3115f75
-    width: 0.5
-  straight_a81ec5a6:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 14.834
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 14.834
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 14.834
-    module: gdsfactory.components.straight
-    name: straight_a81ec5a6
-    width: 0.5
-  straight_add34fb1:
-    changed:
-      cross_section:
-        function: cross_section
       length: 23.5
     default:
       cross_section:
@@ -384,13 +124,11 @@ cells:
     info_version: 1
     length: 23.5
     module: gdsfactory.components.straight
-    name: straight_add34fb1
+    name: straight_35bddbaa
     width: 0.5
-  straight_b4d579dd:
+  straight_3c3cbe65:
     changed:
-      cross_section:
-        function: cross_section
-      length: 10.5
+      length: 30.01
     default:
       cross_section:
         function: cross_section
@@ -400,65 +138,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10.5
+      length: 30.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10.5
+    length: 30.01
     module: gdsfactory.components.straight
-    name: straight_b4d579dd
+    name: straight_3c3cbe65
     width: 0.5
-  straight_b63cd85d:
+  straight_56794401:
     changed:
-      cross_section:
-        function: cross_section
-      length: 20.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 20.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 20.01
-    module: gdsfactory.components.straight
-    name: straight_b63cd85d
-    width: 0.5
-  straight_b9de6283:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 35.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.01
-    module: gdsfactory.components.straight
-    name: straight_b9de6283
-    width: 0.5
-  straight_cae5b3bf:
-    changed:
-      cross_section:
-        function: cross_section
       length: 25.01
     default:
       cross_section:
@@ -476,35 +166,10 @@ cells:
     info_version: 1
     length: 25.01
     module: gdsfactory.components.straight
-    name: straight_cae5b3bf
+    name: straight_56794401
     width: 0.5
-  straight_e2a1b751:
+  straight_5832509c:
     changed:
-      cross_section:
-        function: cross_section
-      length: 40.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.01
-    module: gdsfactory.components.straight
-    name: straight_e2a1b751
-    width: 0.5
-  straight_f3bc8e92:
-    changed:
-      cross_section:
-        function: cross_section
       length: 10.01
     default:
       cross_section:
@@ -522,12 +187,199 @@ cells:
     info_version: 1
     length: 10.01
     module: gdsfactory.components.straight
-    name: straight_f3bc8e92
+    name: straight_5832509c
     width: 0.5
-  straight_f78c486e:
+  straight_6bc6f3f6:
     changed:
+      length: 5.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5.01
+    module: gdsfactory.components.straight
+    name: straight_6bc6f3f6
+    width: 0.5
+  straight_7576fd2a:
+    changed:
+      length: 49.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 49.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 49.5
+    module: gdsfactory.components.straight
+    name: straight_7576fd2a
+    width: 0.5
+  straight_904a156a:
+    changed:
+      length: 19.166
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 19.166
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 19.166
+    module: gdsfactory.components.straight
+    name: straight_904a156a
+    width: 0.5
+  straight_98bc341d:
+    changed:
+      length: 40.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.01
+    module: gdsfactory.components.straight
+    name: straight_98bc341d
+    width: 0.5
+  straight_9d4f36ac:
+    changed:
+      length: 32.166
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 32.166
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 32.166
+    module: gdsfactory.components.straight
+    name: straight_9d4f36ac
+    width: 0.5
+  straight_a9cd772d:
+    changed:
+      length: 14.834
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 14.834
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 14.834
+    module: gdsfactory.components.straight
+    name: straight_a9cd772d
+    width: 0.5
+  straight_b3a0026b:
+    changed:
+      length: 15.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 15.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 15.01
+    module: gdsfactory.components.straight
+    name: straight_b3a0026b
+    width: 0.5
+  straight_b57d86ce:
+    changed:
+      length: 10.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10.5
+    module: gdsfactory.components.straight
+    name: straight_b57d86ce
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c336c571:
+    changed:
       length: 27.834
     default:
       cross_section:
@@ -545,7 +397,112 @@ cells:
     info_version: 1
     length: 27.834
     module: gdsfactory.components.straight
-    name: straight_f78c486e
+    name: straight_c336c571
+    width: 0.5
+  straight_d0a3ec0c:
+    changed:
+      length: 36.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 36.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 36.5
+    module: gdsfactory.components.straight
+    name: straight_d0a3ec0c
+    width: 0.5
+  straight_de8fe94b:
+    changed:
+      length: 35.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.01
+    module: gdsfactory.components.straight
+    name: straight_de8fe94b
+    width: 0.5
+  straight_f55d0c9d:
+    changed:
+      length: 45.166
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.166
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.166
+    module: gdsfactory.components.straight
+    name: straight_f55d0c9d
+    width: 0.5
+  straight_f77186f5:
+    changed:
+      length: 45.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.01
+    module: gdsfactory.components.straight
+    name: straight_f77186f5
+    width: 0.5
+  straight_f7c51d07:
+    changed:
+      length: 20.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 20.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 20.01
+    module: gdsfactory.components.straight
+    name: straight_f7c51d07
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_port_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_circular_fe5fb2bc:
+  bend_circular_dc86f403:
     changed:
       angle: 180
       cross_section:
@@ -41,39 +41,9 @@ cells:
     info_version: 1
     length: 31.416
     module: gdsfactory.components.bend_circular
-    name: bend_circular_fe5fb2bc
+    name: bend_circular_dc86f403
     radius: 10
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -102,8 +72,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -132,21 +132,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -162,22 +162,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -236,36 +236,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_527cba51:
+  straight_16515acc:
     changed:
       cross_section:
         function: cross_section
@@ -306,34 +281,9 @@ cells:
     info_version: 1
     length: 352
     module: gdsfactory.components.straight
-    name: straight_527cba51
+    name: straight_16515acc
     width: 10
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -356,7 +306,57 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:
@@ -564,7 +564,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.bend_port
     name: straight_heater_metal_u_d78c69b7
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -595,7 +595,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_port_.yml
@@ -177,7 +177,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -185,16 +185,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -246,7 +236,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11

--- a/gdsfactory/tests/test_components/test_settings_bend_s_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_s_.yml
@@ -1,20 +1,7 @@
 cells:
-  bezier_2ee69c51:
+  bezier_55a6d777:
     changed:
-      control_points:
-      - - 0
-        - 0
-      - - 5
-        - 0
-      - - 5
-        - 2
-      - - 10
-        - 2
-      layer:
-      - 1
-      - 0
       npoints: 99
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -63,26 +50,13 @@ cells:
     length: 10.278
     min_bend_radius: 9.959
     module: gdsfactory.components.bezier
-    name: bezier_2ee69c51
+    name: bezier_55a6d777
     start_angle: 0.235
-  bezier_2ee69c51_bend_s:
+  bezier_55a6d777_bend_s:
     changed: {}
     child:
       changed:
-        control_points:
-        - - 0
-          - 0
-        - - 5
-          - 0
-        - - 5
-          - 2
-        - - 10
-          - 2
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -131,7 +105,7 @@ cells:
       length: 10.278
       min_bend_radius: 9.959
       module: gdsfactory.components.bezier
-      name: bezier_2ee69c51
+      name: bezier_55a6d777
       start_angle: 0.235
     default:
       cross_section:
@@ -155,26 +129,13 @@ cells:
     length: 10.278
     min_bend_radius: 9.959
     module: gdsfactory.components.bend_s
-    name: bezier_2ee69c51_bend_s
+    name: bezier_55a6d777_bend_s
     start_angle: 0.235
 info:
   changed: {}
   child:
     changed:
-      control_points:
-      - - 0
-        - 0
-      - - 5
-        - 0
-      - - 5
-        - 2
-      - - 10
-        - 2
-      layer:
-      - 1
-      - 0
       npoints: 99
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -223,7 +184,7 @@ info:
     length: 10.278
     min_bend_radius: 9.959
     module: gdsfactory.components.bezier
-    name: bezier_2ee69c51
+    name: bezier_55a6d777
     start_angle: 0.235
   default:
     cross_section:
@@ -247,7 +208,7 @@ info:
   length: 10.278
   min_bend_radius: 9.959
   module: gdsfactory.components.bend_s
-  name: bezier_2ee69c51_bend_s
+  name: bezier_55a6d777_bend_s
   start_angle: 0.235
 ports:
   o1:

--- a/gdsfactory/tests/test_components/test_settings_bend_straight_bend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_straight_bend_.yml
@@ -1,14 +1,6 @@
 cells:
-  bend_euler_e146b96b:
-    changed:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      with_arc_floorplan: true
-      with_cladding_box: true
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -32,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_e146b96b
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   bend_straight_bend:
@@ -61,11 +53,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.bend_euler
     name: bend_straight_bend
-  straight_457f2252:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 10
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -82,7 +71,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_457f2252
+    name: straight
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cavity_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cavity_.yml
@@ -1,5 +1,5 @@
 cells:
-  coupler_3e9f9e6a:
+  coupler_4e842e54:
     changed:
       gap: 0.2
       length: 0.1
@@ -30,7 +30,7 @@ cells:
     length: 10.319
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
-    name: coupler_3e9f9e6a
+    name: coupler_4e842e54
   dbr:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
@@ -215,18 +215,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.cdsem_all
     name: cdsem_all
-  cdsem_bend180_04367601:
-    changed:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      width: 0.5
+  cdsem_bend180:
+    changed: {}
     default:
       bend90:
         function: bend_circular
@@ -256,60 +246,9 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_04367601
-  cdsem_bend180_123844b1:
+    name: cdsem_bend180
+  cdsem_bend180_26fb3458:
     changed:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      width: 1
-    default:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.5
-    full:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 1
-    function_name: cdsem_bend180
-    info_version: 1
-    module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_123844b1
-  cdsem_bend180_3af2012c:
-    changed:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
       width: 0.6
     default:
       bend90:
@@ -340,18 +279,9 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_3af2012c
-  cdsem_bend180_87e3494a:
+    name: cdsem_bend180_26fb3458
+  cdsem_bend180_2d8c0ba2:
     changed:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
       width: 0.8
     default:
       bend90:
@@ -382,18 +312,42 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_87e3494a
-  cdsem_bend180_9b187b5d:
+    name: cdsem_bend180_2d8c0ba2
+  cdsem_bend180_85e434d4:
     changed:
+      width: 1
+    default:
       bend90:
         function: bend_circular
       cross_section:
         function: cross_section
+      radius: 10
       straight:
         function: straight
       text:
         function: text_rectangular
         size: 1
+      wg_length: 420
+      width: 0.5
+    full:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 1
+    function_name: cdsem_bend180
+    info_version: 1
+    module: gdsfactory.components.cdsem_bend180
+    name: cdsem_bend180_85e434d4
+  cdsem_bend180_8cb34e61:
+    changed:
       width: 0.45
     default:
       bend90:
@@ -424,18 +378,9 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_9b187b5d
-  cdsem_bend180_bdb79983:
+    name: cdsem_bend180_8cb34e61
+  cdsem_bend180_980c4040:
     changed:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
       width: 0.4
     default:
       bend90:
@@ -466,18 +411,9 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_bdb79983
-  cdsem_straight_8cc4f19e:
-    changed:
-      cross_section:
-        function: cross_section
-      widths:
-      - 0.4
-      - 0.45
-      - 0.5
-      - 0.6
-      - 0.8
-      - 1
+    name: cdsem_bend180_980c4040
+  cdsem_straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -511,37 +447,10 @@ cells:
     function_name: cdsem_straight
     info_version: 1
     module: gdsfactory.components.cdsem_straight
-    name: cdsem_straight_8cc4f19e
-  cdsem_straight_density_794e9c51:
+    name: cdsem_straight
+  cdsem_straight_density_ba4fcfbc:
     changed:
-      cross_section:
-        function: cross_section
-      gaps:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      label: DH
-      text:
-        function: text_rectangular
-        size: 1
-      widths:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
+      label: DM
     default:
       cross_section:
         function: cross_section
@@ -576,40 +485,38 @@ cells:
       cross_section:
         function: cross_section
       gaps:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      label: DH
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      label: DM
       length: 420
       text:
         function: text_rectangular
         size: 1
       widths:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
     function_name: cdsem_straight_density
     info_version: 1
     module: gdsfactory.components.cdsem_straight_density
-    name: cdsem_straight_density_794e9c51
-  cdsem_straight_density_add4aba5:
+    name: cdsem_straight_density_ba4fcfbc
+  cdsem_straight_density_d99b7c4f:
     changed:
-      cross_section:
-        function: cross_section
       gaps:
       - 0.27999999999999997
       - 0.27999999999999997
@@ -622,9 +529,6 @@ cells:
       - 0.27999999999999997
       - 0.27999999999999997
       label: DL
-      text:
-        function: text_rectangular
-        size: 1
       widths:
       - 0.27999999999999997
       - 0.27999999999999997
@@ -699,37 +603,32 @@ cells:
     function_name: cdsem_straight_density
     info_version: 1
     module: gdsfactory.components.cdsem_straight_density
-    name: cdsem_straight_density_add4aba5
-  cdsem_straight_density_b5c642fb:
+    name: cdsem_straight_density_d99b7c4f
+  cdsem_straight_density_f819cd92:
     changed:
-      cross_section:
-        function: cross_section
       gaps:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      label: DM
-      text:
-        function: text_rectangular
-        size: 1
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      label: DH
       widths:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
     default:
       cross_section:
         function: cross_section
@@ -764,36 +663,36 @@ cells:
       cross_section:
         function: cross_section
       gaps:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      label: DM
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      label: DH
       length: 420
       text:
         function: text_rectangular
         size: 1
       widths:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
     function_name: cdsem_straight_density
     info_version: 1
     module: gdsfactory.components.cdsem_straight_density
-    name: cdsem_straight_density_b5c642fb
+    name: cdsem_straight_density_f819cd92
   straight_16be8a94:
     changed:
       cross_section:

--- a/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_circular_19695a26:
+  bend_circular_1a34e3d5:
     changed:
       cross_section:
         function: cross_section
@@ -24,63 +24,9 @@ cells:
     info_version: 1
     length: 15.708
     module: gdsfactory.components.bend_circular
-    name: bend_circular_19695a26
+    name: bend_circular_1a34e3d5
     radius: 10
-  bend_circular_2615ff47:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.5
-      radius: 10
-    default:
-      angle: 90
-      cross_section:
-        function: cross_section
-      npoints: 720
-      with_cladding_box: true
-    dy: 10
-    full:
-      angle: 90
-      cross_section:
-        function: cross_section
-        width: 0.5
-      npoints: 720
-      radius: 10
-      with_cladding_box: true
-    function_name: bend_circular
-    info_version: 1
-    length: 15.708
-    module: gdsfactory.components.bend_circular
-    name: bend_circular_2615ff47
-    radius: 10
-  bend_circular_33edc033:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.45
-      radius: 10
-    default:
-      angle: 90
-      cross_section:
-        function: cross_section
-      npoints: 720
-      with_cladding_box: true
-    dy: 10
-    full:
-      angle: 90
-      cross_section:
-        function: cross_section
-        width: 0.45
-      npoints: 720
-      radius: 10
-      with_cladding_box: true
-    function_name: bend_circular
-    info_version: 1
-    length: 15.708
-    module: gdsfactory.components.bend_circular
-    name: bend_circular_33edc033
-    radius: 10
-  bend_circular_6b2670e1:
+  bend_circular_248503c5:
     changed:
       cross_section:
         function: cross_section
@@ -105,9 +51,9 @@ cells:
     info_version: 1
     length: 15.708
     module: gdsfactory.components.bend_circular
-    name: bend_circular_6b2670e1
+    name: bend_circular_248503c5
     radius: 10
-  bend_circular_8ba39115:
+  bend_circular_3e58a271:
     changed:
       cross_section:
         function: cross_section
@@ -132,9 +78,9 @@ cells:
     info_version: 1
     length: 15.708
     module: gdsfactory.components.bend_circular
-    name: bend_circular_8ba39115
+    name: bend_circular_3e58a271
     radius: 10
-  bend_circular_ef9bcc9f:
+  bend_circular_60a5bd35:
     changed:
       cross_section:
         function: cross_section
@@ -159,7 +105,61 @@ cells:
     info_version: 1
     length: 15.708
     module: gdsfactory.components.bend_circular
-    name: bend_circular_ef9bcc9f
+    name: bend_circular_60a5bd35
+    radius: 10
+  bend_circular_8c9e29a8:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.45
+      radius: 10
+    default:
+      angle: 90
+      cross_section:
+        function: cross_section
+      npoints: 720
+      with_cladding_box: true
+    dy: 10
+    full:
+      angle: 90
+      cross_section:
+        function: cross_section
+        width: 0.45
+      npoints: 720
+      radius: 10
+      with_cladding_box: true
+    function_name: bend_circular
+    info_version: 1
+    length: 15.708
+    module: gdsfactory.components.bend_circular
+    name: bend_circular_8c9e29a8
+    radius: 10
+  bend_circular_eecf8d74:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.5
+      radius: 10
+    default:
+      angle: 90
+      cross_section:
+        function: cross_section
+      npoints: 720
+      with_cladding_box: true
+    dy: 10
+    full:
+      angle: 90
+      cross_section:
+        function: cross_section
+        width: 0.5
+      npoints: 720
+      radius: 10
+      with_cladding_box: true
+    function_name: bend_circular
+    info_version: 1
+    length: 15.708
+    module: gdsfactory.components.bend_circular
+    name: bend_circular_eecf8d74
     radius: 10
   cdsem_all:
     changed: {}
@@ -247,72 +247,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
     name: cdsem_bend180
-  cdsem_bend180_26fb3458:
-    changed:
-      width: 0.6
-    default:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.5
-    full:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.6
-    function_name: cdsem_bend180
-    info_version: 1
-    module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_26fb3458
-  cdsem_bend180_2d8c0ba2:
-    changed:
-      width: 0.8
-    default:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.5
-    full:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.8
-    function_name: cdsem_bend180
-    info_version: 1
-    module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_2d8c0ba2
   cdsem_bend180_85e434d4:
     changed:
       width: 1
@@ -346,40 +280,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
     name: cdsem_bend180_85e434d4
-  cdsem_bend180_8cb34e61:
-    changed:
-      width: 0.45
-    default:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.5
-    full:
-      bend90:
-        function: bend_circular
-      cross_section:
-        function: cross_section
-      radius: 10
-      straight:
-        function: straight
-      text:
-        function: text_rectangular
-        size: 1
-      wg_length: 420
-      width: 0.45
-    function_name: cdsem_bend180
-    info_version: 1
-    module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_8cb34e61
-  cdsem_bend180_980c4040:
+  cdsem_bend180_8ab81133:
     changed:
       width: 0.4
     default:
@@ -411,7 +312,106 @@ cells:
     function_name: cdsem_bend180
     info_version: 1
     module: gdsfactory.components.cdsem_bend180
-    name: cdsem_bend180_980c4040
+    name: cdsem_bend180_8ab81133
+  cdsem_bend180_8de26d73:
+    changed:
+      width: 0.8
+    default:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.5
+    full:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.8
+    function_name: cdsem_bend180
+    info_version: 1
+    module: gdsfactory.components.cdsem_bend180
+    name: cdsem_bend180_8de26d73
+  cdsem_bend180_cb4b0fce:
+    changed:
+      width: 0.6
+    default:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.5
+    full:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.6
+    function_name: cdsem_bend180
+    info_version: 1
+    module: gdsfactory.components.cdsem_bend180
+    name: cdsem_bend180_cb4b0fce
+  cdsem_bend180_d1578ff4:
+    changed:
+      width: 0.45
+    default:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.5
+    full:
+      bend90:
+        function: bend_circular
+      cross_section:
+        function: cross_section
+      radius: 10
+      straight:
+        function: straight
+      text:
+        function: text_rectangular
+        size: 1
+      wg_length: 420
+      width: 0.45
+    function_name: cdsem_bend180
+    info_version: 1
+    module: gdsfactory.components.cdsem_bend180
+    name: cdsem_bend180_d1578ff4
   cdsem_straight:
     changed: {}
     default:
@@ -448,6 +448,184 @@ cells:
     info_version: 1
     module: gdsfactory.components.cdsem_straight
     name: cdsem_straight
+  cdsem_straight_density_0bf607b2:
+    changed:
+      gaps:
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      label: DH
+      widths:
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+    default:
+      cross_section:
+        function: cross_section
+      gaps:
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      label: ''
+      length: 420
+      text:
+        function: text_rectangular
+        size: 1
+      widths:
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+    full:
+      cross_section:
+        function: cross_section
+      gaps:
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      label: DH
+      length: 420
+      text:
+        function: text_rectangular
+        size: 1
+      widths:
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+      - 0.32
+    function_name: cdsem_straight_density
+    info_version: 1
+    module: gdsfactory.components.cdsem_straight_density
+    name: cdsem_straight_density_0bf607b2
+  cdsem_straight_density_ab14f3b7:
+    changed:
+      gaps:
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      label: DL
+      widths:
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+    default:
+      cross_section:
+        function: cross_section
+      gaps:
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      label: ''
+      length: 420
+      text:
+        function: text_rectangular
+        size: 1
+      widths:
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+      - 0.3
+    full:
+      cross_section:
+        function: cross_section
+      gaps:
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      label: DL
+      length: 420
+      text:
+        function: text_rectangular
+        size: 1
+      widths:
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+      - 0.27999999999999997
+    function_name: cdsem_straight_density
+    info_version: 1
+    module: gdsfactory.components.cdsem_straight_density
+    name: cdsem_straight_density_ab14f3b7
   cdsem_straight_density_ba4fcfbc:
     changed:
       label: DM
@@ -515,535 +693,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.cdsem_straight_density
     name: cdsem_straight_density_ba4fcfbc
-  cdsem_straight_density_d99b7c4f:
-    changed:
-      gaps:
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      label: DL
-      widths:
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-    default:
-      cross_section:
-        function: cross_section
-      gaps:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      label: ''
-      length: 420
-      text:
-        function: text_rectangular
-        size: 1
-      widths:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-    full:
-      cross_section:
-        function: cross_section
-      gaps:
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      label: DL
-      length: 420
-      text:
-        function: text_rectangular
-        size: 1
-      widths:
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-      - 0.27999999999999997
-    function_name: cdsem_straight_density
-    info_version: 1
-    module: gdsfactory.components.cdsem_straight_density
-    name: cdsem_straight_density_d99b7c4f
-  cdsem_straight_density_f819cd92:
-    changed:
-      gaps:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      label: DH
-      widths:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-    default:
-      cross_section:
-        function: cross_section
-      gaps:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      label: ''
-      length: 420
-      text:
-        function: text_rectangular
-        size: 1
-      widths:
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-      - 0.3
-    full:
-      cross_section:
-        function: cross_section
-      gaps:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      label: DH
-      length: 420
-      text:
-        function: text_rectangular
-        size: 1
-      widths:
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-      - 0.32
-    function_name: cdsem_straight_density
-    info_version: 1
-    module: gdsfactory.components.cdsem_straight_density
-    name: cdsem_straight_density_f819cd92
-  straight_16be8a94:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.5
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.5
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_16be8a94
-    width: 0.5
-  straight_16be8a94_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.5
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.5
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_16be8a94
-    width: 0.5
-  straight_1768a98b:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.27999999999999997
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.27999999999999997
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_1768a98b
-    width: 0.27999999999999997
-  straight_2ec186d7:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.4
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.4
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_2ec186d7
-    width: 0.4
-  straight_2ec186d7_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.4
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.4
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_2ec186d7
-    width: 0.4
-  straight_4d6984e2:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 1
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 1
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_4d6984e2
-    width: 1
-  straight_4d6984e2_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 1
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 1
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_4d6984e2
-    width: 1
-  straight_7cd12c13:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.45
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.45
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_7cd12c13
-    width: 0.45
-  straight_7cd12c13_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.45
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.45
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_7cd12c13
-    width: 0.45
-  straight_84a2ba0c:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.6
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.6
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_84a2ba0c
-    width: 0.6
-  straight_84a2ba0c_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.6
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.6
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_84a2ba0c
-    width: 0.6
-  straight_87ca020c:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.32
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.32
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_87ca020c
-    width: 0.32
-  straight_8eab5a24:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.8
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.8
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_8eab5a24
-    width: 0.8
-  straight_8eab5a24_copy:
-    changed:
-      cross_section:
-        function: cross_section
-        width: 0.8
-      length: 420
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        width: 0.8
-      length: 420
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 420
-    module: gdsfactory.components.straight
-    name: straight_8eab5a24
-    width: 0.8
-  straight_e4677918:
+  straight_11432894:
     changed:
       cross_section:
         function: cross_section
@@ -1066,8 +716,358 @@ cells:
     info_version: 1
     length: 420
     module: gdsfactory.components.straight
-    name: straight_e4677918
+    name: straight_11432894
     width: 0.3
+  straight_2bb41aba:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.32
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.32
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_2bb41aba
+    width: 0.32
+  straight_3d4109cc:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.6
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.6
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_3d4109cc
+    width: 0.6
+  straight_3d4109cc_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.6
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.6
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_3d4109cc
+    width: 0.6
+  straight_64e92065:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 1
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 1
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_64e92065
+    width: 1
+  straight_64e92065_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 1
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 1
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_64e92065
+    width: 1
+  straight_693096cd:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.5
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.5
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_693096cd
+    width: 0.5
+  straight_693096cd_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.5
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.5
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_693096cd
+    width: 0.5
+  straight_797e7b92:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.27999999999999997
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.27999999999999997
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_797e7b92
+    width: 0.27999999999999997
+  straight_abddf429:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.4
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.4
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_abddf429
+    width: 0.4
+  straight_abddf429_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.4
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.4
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_abddf429
+    width: 0.4
+  straight_f3c51b31:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.8
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.8
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_f3c51b31
+    width: 0.8
+  straight_f3c51b31_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.8
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.8
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_f3c51b31
+    width: 0.8
+  straight_f6ae9531:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.45
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.45
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_f6ae9531
+    width: 0.45
+  straight_f6ae9531_copy:
+    changed:
+      cross_section:
+        function: cross_section
+        width: 0.45
+      length: 420
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        width: 0.45
+      length: 420
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 420
+    module: gdsfactory.components.straight
+    name: straight_f6ae9531
+    width: 0.45
   text_rectangular_0890d8b4:
     changed:
       size: 1

--- a/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
+++ b/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
@@ -67,8 +67,7 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45:
-        function: crossing45
+      crossing45: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
@@ -155,8 +154,7 @@ info:
       function: crossing45
     direction: top
   full:
-    crossing45:
-      function: crossing45
+    crossing45: crossing45
     direction: top
   function_name: compensation_path
   info_version: 1

--- a/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
+++ b/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
@@ -67,7 +67,8 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45: crossing45
+      crossing45:
+        function: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
@@ -154,7 +155,8 @@ info:
       function: crossing45
     direction: top
   full:
-    crossing45: crossing45
+    crossing45:
+      function: crossing45
     direction: top
   function_name: compensation_path
   info_version: 1

--- a/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
+++ b/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
@@ -1,5 +1,5 @@
 cells:
-  bezier_87e8511e:
+  bezier_328fe8a5:
     changed:
       control_points:
       - - 0
@@ -58,7 +58,7 @@ cells:
     length: 42.087
     min_bend_radius: 18.226
     module: gdsfactory.components.bezier
-    name: bezier_87e8511e
+    name: bezier_328fe8a5
     start_angle: 0.301
   compensation_path:
     changed: {}
@@ -67,7 +67,8 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45: crossing45
+      crossing45:
+        function: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
@@ -133,7 +134,7 @@ cells:
       length: 42.087
       min_bend_radius: 18.226
       module: gdsfactory.components.bezier
-      name: bezier_87e8511e
+      name: bezier_328fe8a5
       start_angle: 0.301
   crossing:
     changed: {}
@@ -154,7 +155,8 @@ info:
       function: crossing45
     direction: top
   full:
-    crossing45: crossing45
+    crossing45:
+      function: crossing45
     direction: top
   function_name: compensation_path
   info_version: 1
@@ -220,7 +222,7 @@ info:
     length: 42.087
     min_bend_radius: 18.226
     module: gdsfactory.components.bezier
-    name: bezier_87e8511e
+    name: bezier_328fe8a5
     start_angle: 0.301
 ports:
   o1:

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -1,72 +1,4 @@
 cells:
-  bezier_01cb3c8e:
-    changed:
-      control_points:
-      - - 0
-        - 0
-      - - 20
-        - 0
-      - - 20
-        - 17.5
-      - - 40
-        - 17.5
-      end_angle: 0
-      layer:
-      - 1
-      - 0
-      npoints: 101
-      start_angle: 0
-      width: 0.5
-    default:
-      control_points:
-      - - 0
-        - 0
-      - - 5
-        - 0
-      - - 5
-        - 2
-      - - 10
-        - 2
-      end_angle: null
-      grid: 0.001
-      layer:
-      - 1
-      - 0
-      name: null
-      npoints: 201
-      spike_length: 0
-      start_angle: null
-      width: 0.5
-      with_manhattan_facing_angles: true
-    end_angle: 0.503
-    full:
-      control_points:
-      - - 0
-        - 0
-      - - 20
-        - 0
-      - - 20
-        - 17.5
-      - - 40
-        - 17.5
-      end_angle: 0
-      grid: 0.001
-      layer:
-      - 1
-      - 0
-      name: null
-      npoints: 101
-      spike_length: 0
-      start_angle: 0
-      width: 0.5
-      with_manhattan_facing_angles: true
-    function_name: bezier
-    info_version: 1
-    length: 44.891
-    min_bend_radius: 22.662
-    module: gdsfactory.components.bezier
-    name: bezier_01cb3c8e
-    start_angle: 0.503
   bezier_87e8511e:
     changed:
       control_points:
@@ -128,21 +60,84 @@ cells:
     module: gdsfactory.components.bezier
     name: bezier_87e8511e
     start_angle: 0.301
-  compensation_path_b9f50572:
+  bezier_d7e697a9:
     changed:
-      crossing45: crossing45_f9b93bcb
+      control_points:
+      - - 0
+        - 0
+      - - 20
+        - 0
+      - - 20
+        - 17.5
+      - - 40
+        - 17.5
+      end_angle: 0
+      npoints: 101
+      start_angle: 0
+    default:
+      control_points:
+      - - 0
+        - 0
+      - - 5
+        - 0
+      - - 5
+        - 2
+      - - 10
+        - 2
+      end_angle: null
+      grid: 0.001
+      layer:
+      - 1
+      - 0
+      name: null
+      npoints: 201
+      spike_length: 0
+      start_angle: null
+      width: 0.5
+      with_manhattan_facing_angles: true
+    end_angle: 0.503
+    full:
+      control_points:
+      - - 0
+        - 0
+      - - 20
+        - 0
+      - - 20
+        - 17.5
+      - - 40
+        - 17.5
+      end_angle: 0
+      grid: 0.001
+      layer:
+      - 1
+      - 0
+      name: null
+      npoints: 101
+      spike_length: 0
+      start_angle: 0
+      width: 0.5
+      with_manhattan_facing_angles: true
+    function_name: bezier
+    info_version: 1
+    length: 44.891
+    min_bend_radius: 22.662
+    module: gdsfactory.components.bezier
+    name: bezier_d7e697a9
+    start_angle: 0.503
+  compensation_path:
+    changed: {}
     default:
       crossing45:
         function: crossing45
       direction: top
     full:
-      crossing45: crossing45_f9b93bcb
+      crossing45: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
     min_bend_radius: 18.226
     module: gdsfactory.components.crossing_waveguide
-    name: compensation_path_b9f50572
+    name: compensation_path
     sbend:
       changed:
         control_points:
@@ -207,15 +202,13 @@ cells:
   component_lattice:
     changed: {}
     default:
-      components: null
       grid_per_unit: 1000
       lattice: "\n        C-X\n        CXX\n        CXX\n        C-X\n        "
-      name: lattice
+      symbol_to_component: null
     full:
-      components: null
       grid_per_unit: 1000
       lattice: "\n        C-X\n        CXX\n        CXX\n        C-X\n        "
-      name: lattice
+      symbol_to_component: null
     function_name: component_lattice
     info_version: 1
     module: gdsfactory.components.component_lattice
@@ -321,10 +314,9 @@ cells:
     info_version: 1
     module: gdsfactory.components.crossing_waveguide
     name: crossing
-  crossing45_f9b93bcb:
+  crossing45:
     bezier_length: 42.085
-    changed:
-      port_spacing: 40
+    changed: {}
     crossing:
       changed: {}
       default:
@@ -355,19 +347,17 @@ cells:
     info_version: 1
     min_bend_radius: 44.312
     module: gdsfactory.components.crossing_waveguide
-    name: crossing45_f9b93bcb
+    name: crossing45
 info:
   changed: {}
   default:
-    components: null
     grid_per_unit: 1000
     lattice: "\n        C-X\n        CXX\n        CXX\n        C-X\n        "
-    name: lattice
+    symbol_to_component: null
   full:
-    components: null
     grid_per_unit: 1000
     lattice: "\n        C-X\n        CXX\n        CXX\n        C-X\n        "
-    name: lattice
+    symbol_to_component: null
   function_name: component_lattice
   info_version: 1
   module: gdsfactory.components.component_lattice

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -1,5 +1,5 @@
 cells:
-  bezier_87e8511e:
+  bezier_328fe8a5:
     changed:
       control_points:
       - - 0
@@ -58,9 +58,9 @@ cells:
     length: 42.087
     min_bend_radius: 18.226
     module: gdsfactory.components.bezier
-    name: bezier_87e8511e
+    name: bezier_328fe8a5
     start_angle: 0.301
-  bezier_d7e697a9:
+  bezier_540d75dd:
     changed:
       control_points:
       - - 0
@@ -122,10 +122,11 @@ cells:
     length: 44.891
     min_bend_radius: 22.662
     module: gdsfactory.components.bezier
-    name: bezier_d7e697a9
+    name: bezier_540d75dd
     start_angle: 0.503
-  compensation_path:
-    changed: {}
+  compensation_path_bf5c418b:
+    changed:
+      crossing45: crossing45
     default:
       crossing45:
         function: crossing45
@@ -137,7 +138,7 @@ cells:
     info_version: 1
     min_bend_radius: 18.226
     module: gdsfactory.components.crossing_waveguide
-    name: compensation_path
+    name: compensation_path_bf5c418b
     sbend:
       changed:
         control_points:
@@ -197,7 +198,7 @@ cells:
       length: 42.087
       min_bend_radius: 18.226
       module: gdsfactory.components.bezier
-      name: bezier_87e8511e
+      name: bezier_328fe8a5
       start_angle: 0.301
   component_lattice:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -131,7 +131,8 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45: crossing45
+      crossing45:
+        function: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
@@ -317,18 +318,6 @@ cells:
   crossing45:
     bezier_length: 42.085
     changed: {}
-    crossing:
-      changed: {}
-      default:
-        arm:
-          function: crossing_arm
-      full:
-        arm:
-          function: crossing_arm
-      function_name: crossing
-      info_version: 1
-      module: gdsfactory.components.crossing_waveguide
-      name: crossing
     default:
       alpha: 0.08
       crossing:

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -131,8 +131,7 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45:
-        function: crossing45
+      crossing45: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1
@@ -414,7 +413,7 @@ ports:
     - 0
     midpoint:
     - 280
-    - -40
+    - 0
     name: '4'
     orientation: 0
     port_type: optical
@@ -425,7 +424,7 @@ ports:
     - 0
     midpoint:
     - 280
-    - 0
+    - -40
     name: '5'
     orientation: 0
     port_type: optical
@@ -436,7 +435,7 @@ ports:
     - 0
     midpoint:
     - 280
-    - -120
+    - -80
     name: '6'
     orientation: 0
     port_type: optical
@@ -447,7 +446,7 @@ ports:
     - 0
     midpoint:
     - 280
-    - -80
+    - -120
     name: '7'
     orientation: 0
     port_type: optical

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -363,91 +363,91 @@ info:
   module: gdsfactory.components.component_lattice
   name: component_lattice
 ports:
-  '0':
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - 0
-    - -40
-    name: '0'
-    orientation: 180
-    port_type: optical
-    width: 0.5
-  '1':
-    layer:
-    - 1
-    - 0
-    midpoint:
-    - 0
-    - 0
-    name: '1'
-    orientation: 180
-    port_type: optical
-    width: 0.5
-  '2':
+  o1:
     layer:
     - 1
     - 0
     midpoint:
     - 0
     - -120
-    name: '2'
+    name: o1
     orientation: 180
     port_type: optical
     width: 0.5
-  '3':
+  o2:
     layer:
     - 1
     - 0
     midpoint:
     - 0
     - -80
-    name: '3'
+    name: o2
     orientation: 180
     port_type: optical
     width: 0.5
-  '4':
+  o3:
+    layer:
+    - 1
+    - 0
+    midpoint:
+    - 0
+    - -40
+    name: o3
+    orientation: 180
+    port_type: optical
+    width: 0.5
+  o4:
+    layer:
+    - 1
+    - 0
+    midpoint:
+    - 0
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    width: 0.5
+  o5:
     layer:
     - 1
     - 0
     midpoint:
     - 280
     - 0
-    name: '4'
+    name: o5
     orientation: 0
     port_type: optical
     width: 0.5
-  '5':
+  o6:
     layer:
     - 1
     - 0
     midpoint:
     - 280
     - -40
-    name: '5'
+    name: o6
     orientation: 0
     port_type: optical
     width: 0.5
-  '6':
+  o7:
     layer:
     - 1
     - 0
     midpoint:
     - 280
     - -80
-    name: '6'
+    name: o7
     orientation: 0
     port_type: optical
     width: 0.5
-  '7':
+  o8:
     layer:
     - 1
     - 0
     midpoint:
     - 280
     - -120
-    name: '7'
+    name: o8
     orientation: 0
     port_type: optical
     width: 0.5

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -131,7 +131,8 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45: crossing45
+      crossing45:
+        function: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -131,8 +131,7 @@ cells:
         function: crossing45
       direction: top
     full:
-      crossing45:
-        function: crossing45
+      crossing45: crossing45
       direction: top
     function_name: compensation_path
     info_version: 1

--- a/gdsfactory/tests/test_components/test_settings_contact_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -28,38 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_8e661824
-  compass_ef690c07:
+    name: compass_0570d255
+  compass_8b1f5d7c:
     changed:
       layer:
       - 41
@@ -88,7 +58,37 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ef690c07
+    name: compass_8b1f5d7c
+  compass_aa9c3262:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_aa9c3262
   contact:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_contact_heater_m3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_heater_m3_.yml
@@ -89,7 +89,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_8e661824
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -97,16 +97,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -158,7 +148,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -170,16 +160,6 @@ info:
     - - 45
       - 0
     - - 49
-      - 0
-    vias:
-    - enclosure: 2
-      function: via
-      layer:
-      - 44
-      - 0
-    - function: via
-      layer:
-      - 43
       - 0
   default:
     layer_port: null
@@ -231,7 +211,7 @@ info:
   - 49
   - 0
   module: gdsfactory.components.contact
-  name: contact_46068602
+  name: contact_f7ba3155
   size:
   - 11
   - 11

--- a/gdsfactory/tests/test_components/test_settings_contact_heater_m3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_heater_m3_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -58,8 +28,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -88,8 +88,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  contact_f7ba3155:
+    name: compass_aa9c3262
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -148,7 +148,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -211,7 +211,7 @@ info:
   - 49
   - 0
   module: gdsfactory.components.contact
-  name: contact_f7ba3155
+  name: contact_02e7e014
   size:
   - 11
   - 11

--- a/gdsfactory/tests/test_components/test_settings_contact_slab_m3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_slab_m3_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -28,38 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_8e661824
-  compass_e24a4316:
+    name: compass_0570d255
+  compass_09625bb3:
     changed:
       layer:
       - 3
@@ -88,8 +58,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_e24a4316
-  compass_ef690c07:
+    name: compass_09625bb3
+  compass_8b1f5d7c:
     changed:
       layer:
       - 41
@@ -118,8 +88,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ef690c07
-  contact_339a6fb6:
+    name: compass_8b1f5d7c
+  compass_aa9c3262:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_aa9c3262
+  contact_329ccb76:
     changed:
       layers:
       - - 3
@@ -200,7 +200,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_339a6fb6
+    name: contact_329ccb76
     size:
     - 11
     - 11
@@ -285,7 +285,7 @@ info:
   - 49
   - 0
   module: gdsfactory.components.contact
-  name: contact_339a6fb6
+  name: contact_329ccb76
   size:
   - 11
   - 11

--- a/gdsfactory/tests/test_components/test_settings_contact_slot_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_slot_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_225d333d:
+  compass_2cea9a79:
     changed:
       layer:
       - 45
@@ -28,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_225d333d
-  compass_ef690c07:
+    name: compass_2cea9a79
+  compass_8b1f5d7c:
     changed:
       layer:
       - 41
@@ -58,7 +58,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ef690c07
+    name: compass_8b1f5d7c
   contact_slot:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_contact_slot_m1_m2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_slot_m1_m2_.yml
@@ -59,19 +59,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_ef690c07
-  contact_slot_9a3dc57d:
-    changed:
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      via:
-        enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
+  contact_slot:
+    changed: {}
     default:
       enclosure: 1
       layer_offsets:
@@ -123,23 +112,12 @@ cells:
     function_name: contact_slot
     info_version: 1
     module: gdsfactory.components.contact_slot
-    name: contact_slot_9a3dc57d
+    name: contact_slot
     size:
     - 11
     - 11
 info:
-  changed:
-    layers:
-    - - 41
-      - 0
-    - - 45
-      - 0
-    via:
-      enclosure: 2
-      function: via
-      layer:
-      - 44
-      - 0
+  changed: {}
   default:
     enclosure: 1
     layer_offsets:
@@ -191,7 +169,7 @@ info:
   function_name: contact_slot
   info_version: 1
   module: gdsfactory.components.contact_slot
-  name: contact_slot_9a3dc57d
+  name: contact_slot
   size:
   - 11
   - 11

--- a/gdsfactory/tests/test_components/test_settings_contact_slot_m1_m2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_contact_slot_m1_m2_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_225d333d:
+  compass_2cea9a79:
     changed:
       layer:
       - 45
@@ -28,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_225d333d
-  compass_ef690c07:
+    name: compass_2cea9a79
+  compass_8b1f5d7c:
     changed:
       layer:
       - 41
@@ -58,7 +58,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ef690c07
+    name: compass_8b1f5d7c
   contact_slot:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
@@ -1,41 +1,6 @@
 cells:
-  compass_2cd8b8ea:
+  compass_88c59c1f:
     changed:
-      layer:
-      - 2
-      - 0
-      port_type: electrical
-      size:
-      - 3
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 2
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 3
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_2cd8b8ea
-  compass_bdc25def:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 3
       - 10
@@ -60,7 +25,57 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_bdc25def
+    name: compass_88c59c1f
+  compass_fe969b88:
+    changed:
+      layer:
+      - 2
+      - 0
+      size:
+      - 3
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 2
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 3
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_fe969b88
+  cross:
+    changed: {}
+    default:
+      layer:
+      - 1
+      - 0
+      length: 10
+      port_type: null
+      width: 3
+    full:
+      layer:
+      - 1
+      - 0
+      length: 10
+      port_type: null
+      width: 3
+    function_name: cross
+    info_version: 1
+    module: gdsfactory.components.cross
+    name: cross
   cross_0d76638b:
     changed:
       layer:
@@ -129,34 +144,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.copy_layers
     name: cross_0d76638b_copy_layers
-  cross_8e0fe979:
+  rectangle_88c59c1f:
     changed:
-      layer:
-      - 1
-      - 0
-    default:
-      layer:
-      - 1
-      - 0
-      length: 10
-      port_type: null
-      width: 3
-    full:
-      layer:
-      - 1
-      - 0
-      length: 10
-      port_type: null
-      width: 3
-    function_name: cross
-    info_version: 1
-    module: gdsfactory.components.cross
-    name: cross_8e0fe979
-  rectangle_0eb96b44:
-    changed:
-      layer:
-      - 1
-      - 0
       size:
       - 3
       - 10
@@ -181,7 +170,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0eb96b44
+    name: rectangle_88c59c1f
   rectangle_fe969b88:
     changed:
       layer:

--- a/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
@@ -1,32 +1,5 @@
 cells:
-  compass_88c59c1f:
-    changed:
-      size:
-      - 3
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 3
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_88c59c1f
-  compass_fe969b88:
+  compass_2a00f02d:
     changed:
       layer:
       - 2
@@ -55,7 +28,34 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_fe969b88
+    name: compass_2a00f02d
+  compass_bd043ca6:
+    changed:
+      size:
+      - 3
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 3
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_bd043ca6
   cross:
     changed: {}
     default:
@@ -76,7 +76,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.cross
     name: cross
-  cross_0d76638b:
+  cross_2976c617:
     changed:
       layer:
       - 2
@@ -98,8 +98,8 @@ cells:
     function_name: cross
     info_version: 1
     module: gdsfactory.components.cross
-    name: cross_0d76638b
-  cross_0d76638b_copy_layers:
+    name: cross_2976c617
+  cross_2976c617_copy_layers:
     changed: {}
     child:
       changed:
@@ -123,7 +123,7 @@ cells:
       function_name: cross
       info_version: 1
       module: gdsfactory.components.cross
-      name: cross_0d76638b
+      name: cross_2976c617
     default:
       factory:
         function: cross
@@ -143,35 +143,8 @@ cells:
     function_name: copy_layers
     info_version: 1
     module: gdsfactory.components.copy_layers
-    name: cross_0d76638b_copy_layers
-  rectangle_88c59c1f:
-    changed:
-      size:
-      - 3
-      - 10
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 3
-      - 10
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_88c59c1f
-  rectangle_fe969b88:
+    name: cross_2976c617_copy_layers
+  rectangle_2a00f02d:
     changed:
       layer:
       - 2
@@ -200,7 +173,34 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_fe969b88
+    name: rectangle_2a00f02d
+  rectangle_bd043ca6:
+    changed:
+      size:
+      - 3
+      - 10
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 3
+      - 10
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_bd043ca6
 info:
   changed: {}
   child:
@@ -225,7 +225,7 @@ info:
     function_name: cross
     info_version: 1
     module: gdsfactory.components.cross
-    name: cross_0d76638b
+    name: cross_2976c617
   default:
     factory:
       function: cross
@@ -245,6 +245,6 @@ info:
   function_name: copy_layers
   info_version: 1
   module: gdsfactory.components.copy_layers
-  name: cross_0d76638b_copy_layers
+  name: cross_2976c617_copy_layers
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_coupler90circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler90circular_.yml
@@ -1,5 +1,5 @@
 cells:
-  coupler90_a71eeef5:
+  coupler90_528aa9f7:
     changed:
       bend:
         function: bend_circular
@@ -22,7 +22,7 @@ cells:
     function_name: coupler90
     info_version: 1
     module: gdsfactory.components.coupler90
-    name: coupler90_a71eeef5
+    name: coupler90_528aa9f7
 info:
   changed:
     bend:
@@ -46,7 +46,7 @@ info:
   function_name: coupler90
   info_version: 1
   module: gdsfactory.components.coupler90
-  name: coupler90_a71eeef5
+  name: coupler90_528aa9f7
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_coupler_straight_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_straight_.yml
@@ -15,9 +15,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.coupler_straight
     name: coupler_straight
-  straight_5b6c3269:
-    changed:
-      length: 10
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -34,7 +33,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_5b6c3269
+    name: straight
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cross_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cross_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_88c59c1f:
+  compass_bd043ca6:
     changed:
       size:
       - 3
@@ -25,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_88c59c1f
+    name: compass_bd043ca6
   cross:
     changed: {}
     default:
@@ -46,7 +46,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.cross
     name: cross
-  rectangle_88c59c1f:
+  rectangle_bd043ca6:
     changed:
       size:
       - 3
@@ -72,7 +72,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_88c59c1f
+    name: rectangle_bd043ca6
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_cross_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cross_.yml
@@ -1,10 +1,6 @@
 cells:
-  compass_bdc25def:
+  compass_88c59c1f:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 3
       - 10
@@ -29,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_bdc25def
+    name: compass_88c59c1f
   cross:
     changed: {}
     default:
@@ -50,11 +46,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.cross
     name: cross
-  rectangle_0eb96b44:
+  rectangle_88c59c1f:
     changed:
-      layer:
-      - 1
-      - 0
       size:
       - 3
       - 10
@@ -79,7 +72,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0eb96b44
+    name: rectangle_88c59c1f
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_crossing45_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing45_.yml
@@ -2,18 +2,6 @@ cells:
   crossing45:
     bezier_length: 42.085
     changed: {}
-    crossing:
-      changed: {}
-      default:
-        arm:
-          function: crossing_arm
-      full:
-        arm:
-          function: crossing_arm
-      function_name: crossing
-      info_version: 1
-      module: gdsfactory.components.crossing_waveguide
-      name: crossing
     default:
       alpha: 0.08
       crossing:
@@ -36,18 +24,6 @@ cells:
 info:
   bezier_length: 42.085
   changed: {}
-  crossing:
-    changed: {}
-    default:
-      arm:
-        function: crossing_arm
-    full:
-      arm:
-        function: crossing_arm
-    function_name: crossing
-    info_version: 1
-    module: gdsfactory.components.crossing_waveguide
-    name: crossing
   default:
     alpha: 0.08
     crossing:

--- a/gdsfactory/tests/test_components/test_settings_crossing_arm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing_arm_.yml
@@ -33,7 +33,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.crossing_waveguide
     name: crossing_arm
-  ellipse_0ee24967:
+  ellipse_2698e856:
     changed:
       layer:
       - 2
@@ -60,7 +60,7 @@ cells:
     function_name: ellipse
     info_version: 1
     module: gdsfactory.components.ellipse
-    name: ellipse_0ee24967
+    name: ellipse_2698e856
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend180_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend180_.yml
@@ -55,30 +55,7 @@ cells:
     module: gdsfactory.components.cutback_bend
     n_bends: 82
     name: cutback_bend180
-  straight_03933fc3:
-    changed:
-      length: 40.656
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.656
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.656
-    module: gdsfactory.components.straight
-    name: straight_03933fc3
-    width: 0.5
-  straight_ffad5cea:
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -99,7 +76,30 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
+    width: 0.5
+  straight_a8effbbc:
+    changed:
+      length: 40.656
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.656
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.656
+    module: gdsfactory.components.straight
+    name: straight_a8effbbc
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend180circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend180circular_.yml
@@ -21,7 +21,7 @@ cells:
     module: gdsfactory.components.bend_circular
     name: bend_circular_8d359e58
     radius: 10
-  cutback_bend180_f50204c2:
+  cutback_bend180_e755f4fb:
     changed:
       bend180:
         angle: 180
@@ -50,8 +50,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.cutback_bend
     n_bends: 82
-    name: cutback_bend180_f50204c2
-  straight_efab87af:
+    name: cutback_bend180_e755f4fb
+  straight_343fa9f5:
     changed:
       length: 28.5
       width: 0.5
@@ -72,9 +72,9 @@ cells:
     info_version: 1
     length: 28.5
     module: gdsfactory.components.straight
-    name: straight_efab87af
+    name: straight_343fa9f5
     width: 0.5
-  straight_ffad5cea:
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -95,7 +95,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
     width: 0.5
 info:
   changed:
@@ -126,7 +126,7 @@ info:
   info_version: 1
   module: gdsfactory.components.cutback_bend
   n_bends: 82
-  name: cutback_bend180_f50204c2
+  name: cutback_bend180_e755f4fb
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend90_.yml
@@ -52,30 +52,7 @@ cells:
     module: gdsfactory.components.cutback_bend
     n_bends: 144
     name: cutback_bend90
-  straight_49d3caf3:
-    changed:
-      length: 30
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_49d3caf3
-    width: 0.5
-  straight_ffad5cea:
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -96,7 +73,30 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
+    width: 0.5
+  straight_b49b5ec1:
+    changed:
+      length: 30
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 30
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_b49b5ec1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend90circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend90circular_.yml
@@ -20,7 +20,7 @@ cells:
     module: gdsfactory.components.bend_circular
     name: bend_circular
     radius: 10
-  cutback_bend90_fd4656cd:
+  cutback_bend90_d1ad1beb:
     changed:
       bend90:
         function: bend_circular
@@ -46,31 +46,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.cutback_bend
     n_bends: 144
-    name: cutback_bend90_fd4656cd
-  straight_49d3caf3:
-    changed:
-      length: 30
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_49d3caf3
-    width: 0.5
-  straight_ffad5cea:
+    name: cutback_bend90_d1ad1beb
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -91,7 +68,30 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
+    width: 0.5
+  straight_b49b5ec1:
+    changed:
+      length: 30
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 30
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_b49b5ec1
     width: 0.5
 info:
   changed:
@@ -119,7 +119,7 @@ info:
   info_version: 1
   module: gdsfactory.components.cutback_bend
   n_bends: 144
-  name: cutback_bend90_fd4656cd
+  name: cutback_bend90_d1ad1beb
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend_.yml
@@ -50,7 +50,7 @@ cells:
     module: gdsfactory.components.cutback_bend
     n_bends: 68
     name: cutback_bend
-  straight_ffad5cea:
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -71,7 +71,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
@@ -30,12 +30,12 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_2956f7b0:
+  component_sequence_09c12bb3:
     changed:
       sequence: ABABABABDABABABABCABABABABDABABABABCABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
         '-':
-        - straight_5b6c3269
+        - straight
         - o1
         - o2
         A:
@@ -55,7 +55,7 @@ cells:
         - o1
         - o2
         _:
-        - straight_5b6c3269
+        - straight
         - o2
         - o1
     default:
@@ -71,7 +71,7 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_5b6c3269
+        - straight
         - o1
         - o2
         A:
@@ -91,16 +91,15 @@ cells:
         - o1
         - o2
         _:
-        - straight_5b6c3269
+        - straight
         - o2
         - o1
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_2956f7b0
-  straight_5b6c3269:
-    changed:
-      length: 10
+    name: component_sequence_09c12bb3
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -117,7 +116,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_5b6c3269
+    name: straight
     width: 0.5
   taper_0p5_to_3_l36:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
@@ -30,7 +30,7 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_b82e6c6d:
+  component_sequence_9646673c:
     changed:
       sequence: ABABABABDABABABABCABABABABDABABABABCABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
@@ -97,7 +97,7 @@ cells:
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_b82e6c6d
+    name: component_sequence_9646673c
   straight:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
@@ -30,7 +30,7 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_09c12bb3:
+  component_sequence_b82e6c6d:
     changed:
       sequence: ABABABABDABABABABCABABABABDABABABABCABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
@@ -39,11 +39,11 @@ cells:
         - o1
         - o2
         A:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o1
         - o2
         B:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o2
         - o1
         C:
@@ -75,11 +75,11 @@ cells:
         - o1
         - o2
         A:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o1
         - o2
         B:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o2
         - o1
         C:
@@ -97,7 +97,7 @@ cells:
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_09c12bb3
+    name: component_sequence_b82e6c6d
   straight:
     changed: {}
     default:
@@ -118,24 +118,56 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  taper_0p5_to_3_l36:
+  taper_from_csv:
     changed: {}
-    default: {}
-    full: {}
-    function_name: taper_0p5_to_3_l36
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_0p5_to_3_l36
-  taper_0p5_to_3_l36_cutb_d84cedbf:
+    name: taper_from_csv
+  taper_from_csv_cutback_component:
     changed: {}
     child:
       changed: {}
-      default: {}
-      full: {}
-      function_name: taper_0p5_to_3_l36
+      default:
+        cladding_offset: 3
+        filepath: taper_strip_0p5_3_36.csv
+        layer:
+        - 1
+        - 0
+        layer_cladding:
+        - 111
+        - 0
+      full:
+        cladding_offset: 3
+        filepath: taper_strip_0p5_3_36.csv
+        layer:
+        - 1
+        - 0
+        layer_cladding:
+        - 111
+        - 0
+      function_name: taper_from_csv
       info_version: 1
       module: gdsfactory.components.taper_from_csv
-      name: taper_0p5_to_3_l36
+      name: taper_from_csv
     components: 88
     default:
       bend180:
@@ -143,7 +175,8 @@ cells:
         function: bend_euler
       cols: 4
       component:
-        function: taper_0p5_to_3_l36
+        filepath: taper_strip_0p5_3_36.csv
+        function: taper_from_csv
       mirror: false
       port1: o1
       port2: o2
@@ -158,7 +191,8 @@ cells:
         function: bend_euler
       cols: 4
       component:
-        function: taper_0p5_to_3_l36
+        filepath: taper_strip_0p5_3_36.csv
+        function: taper_from_csv
       mirror: false
       port1: o1
       port2: o2
@@ -170,17 +204,33 @@ cells:
     function_name: cutback_component
     info_version: 1
     module: gdsfactory.components.cutback_component
-    name: taper_0p5_to_3_l36_cutb_d84cedbf
+    name: taper_from_csv_cutback_component
 info:
   changed: {}
   child:
     changed: {}
-    default: {}
-    full: {}
-    function_name: taper_0p5_to_3_l36
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_0p5_to_3_l36
+    name: taper_from_csv
   components: 88
   default:
     bend180:
@@ -188,7 +238,8 @@ info:
       function: bend_euler
     cols: 4
     component:
-      function: taper_0p5_to_3_l36
+      filepath: taper_strip_0p5_3_36.csv
+      function: taper_from_csv
     mirror: false
     port1: o1
     port2: o2
@@ -203,7 +254,8 @@ info:
       function: bend_euler
     cols: 4
     component:
-      function: taper_0p5_to_3_l36
+      filepath: taper_strip_0p5_3_36.csv
+      function: taper_from_csv
     mirror: false
     port1: o1
     port2: o2
@@ -215,7 +267,7 @@ info:
   function_name: cutback_component
   info_version: 1
   module: gdsfactory.components.cutback_component
-  name: taper_0p5_to_3_l36_cutb_d84cedbf
+  name: taper_from_csv_cutback_component
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
@@ -30,7 +30,7 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_fecfde12:
+  component_sequence_22355b45:
     changed:
       sequence: ABABABABCABABABABDABABABABCABABABABDABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
@@ -97,7 +97,7 @@ cells:
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_fecfde12
+    name: component_sequence_22355b45
   straight:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
@@ -30,7 +30,7 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_d377cad6:
+  component_sequence_fecfde12:
     changed:
       sequence: ABABABABCABABABABDABABABABCABABABABDABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
@@ -39,11 +39,11 @@ cells:
         - o1
         - o2
         A:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o1
         - o2
         B:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o2
         - o1
         C:
@@ -75,11 +75,11 @@ cells:
         - o1
         - o2
         A:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o1
         - o2
         B:
-        - taper_0p5_to_3_l36
+        - taper_from_csv
         - o2
         - o1
         C:
@@ -97,7 +97,7 @@ cells:
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_d377cad6
+    name: component_sequence_fecfde12
   straight:
     changed: {}
     default:
@@ -118,25 +118,57 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  taper_0p5_to_3_l36:
+  taper_from_csv:
     changed: {}
-    default: {}
-    full: {}
-    function_name: taper_0p5_to_3_l36
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_0p5_to_3_l36
-  taper_0p5_to_3_l36_cutb_8d365e01:
+    name: taper_from_csv
+  taper_from_csv_cutback__5abf47c8:
     changed:
       mirror: true
     child:
       changed: {}
-      default: {}
-      full: {}
-      function_name: taper_0p5_to_3_l36
+      default:
+        cladding_offset: 3
+        filepath: taper_strip_0p5_3_36.csv
+        layer:
+        - 1
+        - 0
+        layer_cladding:
+        - 111
+        - 0
+      full:
+        cladding_offset: 3
+        filepath: taper_strip_0p5_3_36.csv
+        layer:
+        - 1
+        - 0
+        layer_cladding:
+        - 111
+        - 0
+      function_name: taper_from_csv
       info_version: 1
       module: gdsfactory.components.taper_from_csv
-      name: taper_0p5_to_3_l36
+      name: taper_from_csv
     components: 88
     default:
       bend180:
@@ -144,7 +176,8 @@ cells:
         function: bend_euler
       cols: 4
       component:
-        function: taper_0p5_to_3_l36
+        filepath: taper_strip_0p5_3_36.csv
+        function: taper_from_csv
       mirror: false
       port1: o1
       port2: o2
@@ -159,7 +192,8 @@ cells:
         function: bend_euler
       cols: 4
       component:
-        function: taper_0p5_to_3_l36
+        filepath: taper_strip_0p5_3_36.csv
+        function: taper_from_csv
       mirror: true
       port1: o1
       port2: o2
@@ -171,18 +205,34 @@ cells:
     function_name: cutback_component
     info_version: 1
     module: gdsfactory.components.cutback_component
-    name: taper_0p5_to_3_l36_cutb_8d365e01
+    name: taper_from_csv_cutback__5abf47c8
 info:
   changed:
     mirror: true
   child:
     changed: {}
-    default: {}
-    full: {}
-    function_name: taper_0p5_to_3_l36
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_0p5_to_3_l36
+    name: taper_from_csv
   components: 88
   default:
     bend180:
@@ -190,7 +240,8 @@ info:
       function: bend_euler
     cols: 4
     component:
-      function: taper_0p5_to_3_l36
+      filepath: taper_strip_0p5_3_36.csv
+      function: taper_from_csv
     mirror: false
     port1: o1
     port2: o2
@@ -205,7 +256,8 @@ info:
       function: bend_euler
     cols: 4
     component:
-      function: taper_0p5_to_3_l36
+      filepath: taper_strip_0p5_3_36.csv
+      function: taper_from_csv
     mirror: true
     port1: o1
     port2: o2
@@ -217,7 +269,7 @@ info:
   function_name: cutback_component
   info_version: 1
   module: gdsfactory.components.cutback_component
-  name: taper_0p5_to_3_l36_cutb_8d365e01
+  name: taper_from_csv_cutback__5abf47c8
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
@@ -30,12 +30,12 @@ cells:
     name: bend_euler_3cfca9b9
     radius: 5
     radius_min: 4.543
-  component_sequence_c72a7644:
+  component_sequence_d377cad6:
     changed:
       sequence: ABABABABCABABABABDABABABABCABABABABDABABABAB-_ABABABABCABABABABDABABABABCABABABABDABABABAB
       symbol_to_component:
         '-':
-        - straight_5b6c3269
+        - straight
         - o1
         - o2
         A:
@@ -55,7 +55,7 @@ cells:
         - o1
         - o2
         _:
-        - straight_5b6c3269
+        - straight
         - o2
         - o1
     default:
@@ -71,7 +71,7 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_5b6c3269
+        - straight
         - o1
         - o2
         A:
@@ -91,16 +91,15 @@ cells:
         - o1
         - o2
         _:
-        - straight_5b6c3269
+        - straight
         - o2
         - o1
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_c72a7644
-  straight_5b6c3269:
-    changed:
-      length: 10
+    name: component_sequence_d377cad6
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -117,7 +116,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_5b6c3269
+    name: straight
     width: 0.5
   taper_0p5_to_3_l36:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
@@ -52,7 +52,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.delay_snake2
     name: delay_snake2
-  straight_65092a02:
+  straight_cffd869c:
     changed:
       length: 504.788
     default:
@@ -71,7 +71,7 @@ cells:
     info_version: 1
     length: 504.788
     module: gdsfactory.components.straight
-    name: straight_65092a02
+    name: straight_cffd869c
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
@@ -1,9 +1,7 @@
 cells:
-  bend_euler_d80b08de:
+  bend_euler_8d359e58:
     changed:
       angle: 180
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -27,7 +25,7 @@ cells:
     info_version: 1
     length: 42.818
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d80b08de
+    name: bend_euler_8d359e58
     radius: 10
     radius_min: 9.086
   delay_snake2:
@@ -54,10 +52,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.delay_snake2
     name: delay_snake2
-  straight_73b2527a:
+  straight_65092a02:
     changed:
-      cross_section:
-        function: cross_section
       length: 504.788
     default:
       cross_section:
@@ -75,7 +71,7 @@ cells:
     info_version: 1
     length: 504.788
     module: gdsfactory.components.straight
-    name: straight_73b2527a
+    name: straight_65092a02
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
@@ -73,7 +73,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_392568a6
     width: 0.5
-  straight_65092a02:
+  straight_cffd869c:
     changed:
       length: 504.788
     default:
@@ -92,7 +92,7 @@ cells:
     info_version: 1
     length: 504.788
     module: gdsfactory.components.straight
-    name: straight_65092a02
+    name: straight_cffd869c
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
@@ -1,9 +1,7 @@
 cells:
-  bend_euler_d80b08de:
+  bend_euler_8d359e58:
     changed:
       angle: 180
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -27,7 +25,7 @@ cells:
     info_version: 1
     length: 42.818
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d80b08de
+    name: bend_euler_8d359e58
     radius: 10
     radius_min: 9.086
   delay_snake3:
@@ -54,33 +52,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.delay_snake3
     name: delay_snake3
-  straight_73b2527a:
+  straight_392568a6:
     changed:
-      cross_section:
-        function: cross_section
-      length: 504.788
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 504.788
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 504.788
-    module: gdsfactory.components.straight
-    name: straight_73b2527a
-    width: 0.5
-  straight_80d6c653:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0
     default:
       cross_section:
@@ -98,7 +71,28 @@ cells:
     info_version: 1
     length: 0
     module: gdsfactory.components.straight
-    name: straight_80d6c653
+    name: straight_392568a6
+    width: 0.5
+  straight_65092a02:
+    changed:
+      length: 504.788
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 504.788
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 504.788
+    module: gdsfactory.components.straight
+    name: straight_65092a02
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_a96febb9:
+  bend_euler_d6e1c0cf:
     changed:
       width: 0.5
     default:
@@ -26,7 +26,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_a96febb9
+    name: bend_euler_d6e1c0cf
     radius: 10
     radius_min: 7.061
   delay_snake:
@@ -61,7 +61,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.delay_snake
     name: delay_snake
-  straight_17e6c646:
+  straight_18f1d09c:
     changed:
       length: 0.1
       width_wide: 2
@@ -82,32 +82,9 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_17e6c646
+    name: straight_18f1d09c
     width: 0.5
-  straight_30094218:
-    changed:
-      length: 293.394
-      width_wide: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 293.394
-      npoints: 2
-      width_wide: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 293.394
-    module: gdsfactory.components.straight
-    name: straight_30094218
-    width: 0.5
-  straight_699bdae3:
+  straight_26ad0fe3:
     changed:
       length: 298.394
       width_wide: 2
@@ -128,9 +105,9 @@ cells:
     info_version: 1
     length: 298.394
     module: gdsfactory.components.straight
-    name: straight_699bdae3
+    name: straight_26ad0fe3
     width: 0.5
-  straight_dd058ba5:
+  straight_cfb2591e:
     changed:
       length: 288.394
       width_wide: 2
@@ -151,7 +128,30 @@ cells:
     info_version: 1
     length: 288.394
     module: gdsfactory.components.straight
-    name: straight_dd058ba5
+    name: straight_cfb2591e
+    width: 0.5
+  straight_e7f38533:
+    changed:
+      length: 293.394
+      width_wide: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 293.394
+      npoints: 2
+      width_wide: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 293.394
+    module: gdsfactory.components.straight
+    name: straight_e7f38533
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
@@ -61,60 +61,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.delay_snake
     name: delay_snake
-  straight_0bb8b569:
+  straight_17e6c646:
     changed:
-      cross_section:
-        function: cross_section
-      length: 293.394
-      width_wide: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 293.394
-      npoints: 2
-      width_wide: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 293.394
-    module: gdsfactory.components.straight
-    name: straight_0bb8b569
-    width: 0.5
-  straight_4cf66f33:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 298.394
-      width_wide: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 298.394
-      npoints: 2
-      width_wide: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 298.394
-    module: gdsfactory.components.straight
-    name: straight_4cf66f33
-    width: 0.5
-  straight_5617416a:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.1
       width_wide: 2
     default:
@@ -134,12 +82,56 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_5617416a
+    name: straight_17e6c646
     width: 0.5
-  straight_7b4f04d9:
+  straight_30094218:
     changed:
+      length: 293.394
+      width_wide: 2
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 293.394
+      npoints: 2
+      width_wide: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 293.394
+    module: gdsfactory.components.straight
+    name: straight_30094218
+    width: 0.5
+  straight_699bdae3:
+    changed:
+      length: 298.394
+      width_wide: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 298.394
+      npoints: 2
+      width_wide: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 298.394
+    module: gdsfactory.components.straight
+    name: straight_699bdae3
+    width: 0.5
+  straight_dd058ba5:
+    changed:
       length: 288.394
       width_wide: 2
     default:
@@ -159,7 +151,7 @@ cells:
     info_version: 1
     length: 288.394
     module: gdsfactory.components.straight
-    name: straight_7b4f04d9
+    name: straight_dd058ba5
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
+++ b/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_93ceba3b:
+  compass_30e133a7:
     changed:
       layer:
       - 100
@@ -28,7 +28,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_93ceba3b
+    name: compass_30e133a7
   dicing_lane:
     changed: {}
     default:
@@ -61,7 +61,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.dicing_lane
     name: dicing_lane
-  rectangle_93ceba3b:
+  rectangle_30e133a7:
     changed:
       layer:
       - 100
@@ -90,8 +90,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_93ceba3b
-  triangle_0196de93:
+    name: rectangle_30e133a7
+  triangle_335b4d41:
     changed:
       layer:
       - 49
@@ -116,7 +116,7 @@ cells:
     function_name: triangle
     info_version: 1
     module: gdsfactory.components.triangle
-    name: triangle_0196de93
+    name: triangle_335b4d41
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
+++ b/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
@@ -1,10 +1,9 @@
 cells:
-  compass_f4e2fd7c:
+  compass_93ceba3b:
     changed:
       layer:
       - 100
       - 0
-      port_type: electrical
       size:
       - 50
       - 300
@@ -29,7 +28,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f4e2fd7c
+    name: compass_93ceba3b
   dicing_lane:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_die_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_.yml
@@ -39,7 +39,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.die
     name: die
-  text_cc38bd78:
+  text_3ca55ae2:
     changed:
       layer:
       - 99
@@ -69,7 +69,7 @@ cells:
     function_name: text
     info_version: 1
     module: gdsfactory.components.text
-    name: text_cc38bd78
+    name: text_3ca55ae2
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
@@ -1,10 +1,6 @@
 cells:
-  compass_85d33a91:
+  compass_6df08d23:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 1300
       - 2600
@@ -29,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_85d33a91
+    name: compass_6df08d23
   rectangle_6df08d23:
     changed:
       size:

--- a/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_6df08d23:
+  compass_5992b8ec:
     changed:
       size:
       - 1300
@@ -25,8 +25,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_6df08d23
-  rectangle_6df08d23:
+    name: compass_5992b8ec
+  rectangle_5992b8ec:
     changed:
       size:
       - 1300
@@ -52,8 +52,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_6df08d23
-  rectangle_6df08d23_die_bbox:
+    name: rectangle_5992b8ec
+  rectangle_5992b8ec_die_bbox:
     changed: {}
     child:
       changed:
@@ -81,7 +81,7 @@ cells:
       function_name: rectangle
       info_version: 1
       module: gdsfactory.components.rectangle
-      name: rectangle_6df08d23
+      name: rectangle_5992b8ec
     default:
       component:
         function: rectangle
@@ -115,7 +115,7 @@ cells:
     function_name: die_bbox
     info_version: 1
     module: gdsfactory.components.die_bbox
-    name: rectangle_6df08d23_die_bbox
+    name: rectangle_5992b8ec_die_bbox
 info:
   changed: {}
   child:
@@ -144,7 +144,7 @@ info:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_6df08d23
+    name: rectangle_5992b8ec
   default:
     component:
       function: rectangle
@@ -178,6 +178,6 @@ info:
   function_name: die_bbox
   info_version: 1
   module: gdsfactory.components.die_bbox
-  name: rectangle_6df08d23_die_bbox
+  name: rectangle_5992b8ec_die_bbox
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_fiber_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_.yml
@@ -18,7 +18,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_212e6ad7
-  circle_e248ff5e:
+  circle_26bb5ae5:
     changed:
       layer:
       - 111
@@ -39,7 +39,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_e248ff5e
+    name: circle_26bb5ae5
   fiber:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_fiber_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_.yml
@@ -1,9 +1,6 @@
 cells:
-  circle_72737e6a:
+  circle_212e6ad7:
     changed:
-      layer:
-      - 1
-      - 0
       radius: 5
     default:
       angle_resolution: 2.5
@@ -20,7 +17,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_72737e6a
+    name: circle_212e6ad7
   circle_e248ff5e:
     changed:
       layer:

--- a/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
@@ -18,7 +18,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_212e6ad7
-  circle_e248ff5e:
+  circle_26bb5ae5:
     changed:
       layer:
       - 111
@@ -39,7 +39,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_e248ff5e
+    name: circle_26bb5ae5
   fiber_array:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
@@ -1,9 +1,6 @@
 cells:
-  circle_72737e6a:
+  circle_212e6ad7:
     changed:
-      layer:
-      - 1
-      - 0
       radius: 5
     default:
       angle_resolution: 2.5
@@ -20,7 +17,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_72737e6a
+    name: circle_212e6ad7
   circle_e248ff5e:
     changed:
       layer:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_array_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_array:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_circular:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_arbitrary_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_circula_bc2655da:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_elliptical:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_4a0b5da2:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_9d85a0c6:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_elliptical:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_b1a123ab:
+  circle_c1ca507f:
     changed:
       layer:
       - 204
@@ -20,8 +20,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_b1a123ab
-  grating_coupler_ellipti_6c2ddb68:
+    name: circle_c1ca507f
+  grating_coupler_ellipti_2e0a058f:
     changed:
       fiber_marker_layer:
       - 204
@@ -85,7 +85,7 @@ cells:
     function_name: grating_coupler_elliptical
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical
-    name: grating_coupler_ellipti_6c2ddb68
+    name: grating_coupler_ellipti_2e0a058f
     polarization: tm
     wavelength: 1.554
 info:
@@ -152,7 +152,7 @@ info:
   function_name: grating_coupler_elliptical
   info_version: 1
   module: gdsfactory.components.grating_coupler_elliptical
-  name: grating_coupler_ellipti_6c2ddb68
+  name: grating_coupler_ellipti_2e0a058f
   polarization: tm
   wavelength: 1.554
 ports:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_7935cab4:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -222,9 +222,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_52c0fe19
     width: 0.5
-  straight_5656be49:
+  straight_77cb16b3:
     changed:
-      length: 43.5
+      length: 40.081
     default:
       cross_section:
         function: cross_section
@@ -234,14 +234,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 43.5
+      length: 40.081
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 43.5
+    length: 40.081
     module: gdsfactory.components.straight
-    name: straight_5656be49
+    name: straight_77cb16b3
     width: 0.5
   straight_855f95b0:
     changed:
@@ -263,27 +263,6 @@ cells:
     length: 361
     module: gdsfactory.components.straight
     name: straight_855f95b0
-    width: 0.5
-  straight_9bf8b352:
-    changed:
-      length: 40.081
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.081
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.081
-    module: gdsfactory.components.straight
-    name: straight_9bf8b352
     width: 0.5
   straight_a065fbc7:
     changed:
@@ -347,6 +326,27 @@ cells:
     length: 5
     module: gdsfactory.components.straight
     name: straight_b3dac65b
+    width: 0.5
+  straight_b81889b2:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_b81889b2
     width: 0.5
   straight_c2717bb1:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,7 +103,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -128,12 +125,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
     name: grating_coupler_loss_fi_da445079
-  loss_deembedding_ch12_3_f58810dc:
-    changed:
-      grating_coupler:
-        function: grating_coupler_elliptical_trenches
-        polarization: te
-        taper_angle: 35
+  loss_deembedding_ch12_34:
+    changed: {}
     default:
       grating_coupler:
         function: grating_coupler_elliptical_trenches
@@ -155,13 +148,9 @@ cells:
     function_name: loss_deembedding_ch12_34
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
-    name: loss_deembedding_ch12_3_f58810dc
-  loss_deembedding_ch13_2_f2b3e660:
-    changed:
-      grating_coupler:
-        function: grating_coupler_elliptical_trenches
-        polarization: te
-        taper_angle: 35
+    name: loss_deembedding_ch12_34
+  loss_deembedding_ch13_24:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -187,13 +176,9 @@ cells:
     function_name: loss_deembedding_ch13_24
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
-    name: loss_deembedding_ch13_2_f2b3e660
-  loss_deembedding_ch14_2_d4576d20:
-    changed:
-      grating_coupler:
-        function: grating_coupler_elliptical_trenches
-        polarization: te
-        taper_angle: 35
+    name: loss_deembedding_ch13_24
+  loss_deembedding_ch14_23:
+    changed: {}
     default:
       grating_coupler:
         function: grating_coupler_elliptical_trenches
@@ -215,80 +200,9 @@ cells:
     function_name: loss_deembedding_ch14_23
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
-    name: loss_deembedding_ch14_2_d4576d20
-  straight_06b7497a:
+    name: loss_deembedding_ch14_23
+  straight_52c0fe19:
     changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_06b7497a
-    width: 0.5
-  straight_40ffb32d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 40.081
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.081
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.081
-    module: gdsfactory.components.straight
-    name: straight_40ffb32d
-    width: 0.5
-  straight_93f9bbf9:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_93f9bbf9
-    width: 0.5
-  straight_c4828fc0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 234
     default:
       cross_section:
@@ -306,12 +220,31 @@ cells:
     info_version: 1
     length: 234
     module: gdsfactory.components.straight
-    name: straight_c4828fc0
+    name: straight_52c0fe19
     width: 0.5
-  straight_c812ca36:
+  straight_5656be49:
     changed:
+      length: 43.5
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_855f95b0:
+    changed:
       length: 361
     default:
       cross_section:
@@ -329,12 +262,52 @@ cells:
     info_version: 1
     length: 361
     module: gdsfactory.components.straight
-    name: straight_c812ca36
+    name: straight_855f95b0
     width: 0.5
-  straight_d9996de2:
+  straight_9bf8b352:
     changed:
+      length: 40.081
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.081
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.081
+    module: gdsfactory.components.straight
+    name: straight_9bf8b352
+    width: 0.5
+  straight_a065fbc7:
+    changed:
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_a065fbc7
+    width: 0.5
+  straight_b24e342f:
+    changed:
       length: 40
     default:
       cross_section:
@@ -352,12 +325,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_e7395bed:
+  straight_b3dac65b:
     changed:
-      cross_section:
-        function: cross_section
       length: 5
     default:
       cross_section:
@@ -375,12 +346,10 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_e7395bed
+    name: straight_b3dac65b
     width: 0.5
-  straight_f031ecb0:
+  straight_c2717bb1:
     changed:
-      cross_section:
-        function: cross_section
       length: 107
     default:
       cross_section:
@@ -398,7 +367,7 @@ cells:
     info_version: 1
     length: 107
     module: gdsfactory.components.straight
-    name: straight_f031ecb0
+    name: straight_c2717bb1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,7 +103,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -134,10 +131,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
     name: grating_coupler_loss_fiber_array
-  straight_d9996de2:
+  straight_b24e342f:
     changed:
-      cross_section:
-        function: cross_section
       length: 40
     default:
       cross_section:
@@ -155,12 +150,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_f031ecb0:
+  straight_c2717bb1:
     changed:
-      cross_section:
-        function: cross_section
       length: 107
     default:
       cross_section:
@@ -178,7 +171,7 @@ cells:
     info_version: 1
     length: 107
     module: gdsfactory.components.straight
-    name: straight_f031ecb0
+    name: straight_c2717bb1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_1460ca4e:
     changed: {}
     child:
@@ -177,29 +177,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_3e20c129:
-    changed:
-      auto_widen: false
-      length: 91.4
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 91.4
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 91.4
-    module: gdsfactory.components.straight
-    name: straight_3e20c129
-    width: 0.5
   straight_add_fiber_sing_20d1f7a6:
     changed:
       component: straight
@@ -310,6 +287,29 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_fiber_single
     name: straight_add_fiber_sing_20d1f7a6
+  straight_b81edde8:
+    changed:
+      auto_widen: false
+      length: 91.4
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 91.4
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 91.4
+    module: gdsfactory.components.straight
+    name: straight_b81edde8
+    width: 0.5
   straight_move_5f0356c3:
     changed:
       component: straight

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
@@ -21,11 +21,10 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_6e4a1333:
+  grating_coupler_ellipti_1460ca4e:
     changed: {}
     child:
       changed:
-        polarization: te
         taper_angle: 35
       default:
         end_straight_length: 0.2
@@ -78,7 +77,7 @@ cells:
       function_name: grating_coupler_elliptical_trenches
       info_version: 1
       module: gdsfactory.components.grating_coupler_elliptical_trenches
-      name: grating_coupler_ellipti_b632d295
+      name: grating_coupler_ellipti_db285fcb
       period: 0.6759999999999999
       polarization: te
       wavelength: 1.53
@@ -99,10 +98,9 @@ cells:
     function_name: grating_coupler_loss_fiber_single
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss_fiber_single
-    name: grating_coupler_ellipti_6e4a1333
-  grating_coupler_ellipti_b632d295:
+    name: grating_coupler_ellipti_1460ca4e
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -155,14 +153,12 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
-  straight_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -179,26 +175,42 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_1da190e0
+    name: straight
     width: 0.5
-  straight_1da190e0_add_f_feca92a5:
+  straight_3e20c129:
     changed:
-      component: straight_1da190e0
-      component_name: grating_coupler_ellipti_b632d295
+      auto_widen: false
+      length: 91.4
+    default:
       cross_section:
         function: cross_section
-      grating_coupler: grating_coupler_ellipti_b632d295
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 91.4
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 91.4
+    module: gdsfactory.components.straight
+    name: straight_3e20c129
+    width: 0.5
+  straight_add_fiber_sing_20d1f7a6:
+    changed:
+      component: straight
+      component_name: grating_coupler_ellipti_db285fcb
+      grating_coupler: grating_coupler_ellipti_db285fcb
       with_loopback: false
     child:
       changed:
-        component: straight_1da190e0
-        origin:
-        - 0
-        - 0
+        component: straight
       child:
-        changed:
-          cross_section:
-            function: cross_section
+        changed: {}
         default:
           cross_section:
             function: cross_section
@@ -215,7 +227,7 @@ cells:
         info_version: 1
         length: 10
         module: gdsfactory.components.straight
-        name: straight_1da190e0
+        name: straight
         width: 0.5
       default:
         axis: null
@@ -225,7 +237,7 @@ cells:
         - 0
       full:
         axis: null
-        component: straight_1da190e0
+        component: straight
         destination: null
         origin:
         - 0
@@ -233,7 +245,7 @@ cells:
       function_name: move
       info_version: 1
       module: gdsfactory.functions
-      name: straight_1da190e0_move_bb3832a3
+      name: straight_move_5f0356c3
     default:
       bend:
         function: bend_circular
@@ -268,8 +280,8 @@ cells:
     full:
       bend:
         function: bend_circular
-      component: straight_1da190e0
-      component_name: grating_coupler_ellipti_b632d295
+      component: straight
+      component_name: grating_coupler_ellipti_db285fcb
       cross_section:
         function: cross_section
       fiber_spacing: 50
@@ -278,7 +290,7 @@ cells:
         function: get_input_label_text
       get_input_label_text_loopback_function:
         function: get_input_label_text_loopback
-      grating_coupler: grating_coupler_ellipti_b632d295
+      grating_coupler: grating_coupler_ellipti_db285fcb
       layer_label:
       - 201
       - 0
@@ -297,17 +309,12 @@ cells:
     function_name: add_fiber_single
     info_version: 1
     module: gdsfactory.routing.add_fiber_single
-    name: straight_1da190e0_add_f_feca92a5
-  straight_1da190e0_move_bb3832a3:
+    name: straight_add_fiber_sing_20d1f7a6
+  straight_move_5f0356c3:
     changed:
-      component: straight_1da190e0
-      origin:
-      - 0
-      - 0
+      component: straight
     child:
-      changed:
-        cross_section:
-          function: cross_section
+      changed: {}
       default:
         cross_section:
           function: cross_section
@@ -324,7 +331,7 @@ cells:
       info_version: 1
       length: 10
       module: gdsfactory.components.straight
-      name: straight_1da190e0
+      name: straight
       width: 0.5
     default:
       axis: null
@@ -334,7 +341,7 @@ cells:
       - 0
     full:
       axis: null
-      component: straight_1da190e0
+      component: straight
       destination: null
       origin:
       - 0
@@ -342,37 +349,11 @@ cells:
     function_name: move
     info_version: 1
     module: gdsfactory.functions
-    name: straight_1da190e0_move_bb3832a3
-  straight_681f557c:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 91.4
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 91.4
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 91.4
-    module: gdsfactory.components.straight
-    name: straight_681f557c
-    width: 0.5
+    name: straight_move_5f0356c3
 info:
   changed: {}
   child:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -425,7 +406,7 @@ info:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -446,6 +427,6 @@ info:
   function_name: grating_coupler_loss_fiber_single
   info_version: 1
   module: gdsfactory.components.grating_coupler_loss_fiber_single
-  name: grating_coupler_ellipti_6e4a1333
+  name: grating_coupler_ellipti_1460ca4e
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_b2b84254:
+  compass_cd59cd6b:
     changed:
       port_type: null
       size:
@@ -26,7 +26,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b2b84254
+    name: compass_cd59cd6b
   grating_coupler_rectangular:
     changed: {}
     default:
@@ -73,7 +73,7 @@ cells:
     name: grating_coupler_rectangular
     polarization: te
     wavelength: 1.55
-  rectangle_b2b84254:
+  rectangle_cd59cd6b:
     changed:
       port_type: null
       size:
@@ -100,8 +100,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_b2b84254
-  taper_2427f3be:
+    name: rectangle_cd59cd6b
+  taper_395da726:
     changed:
       layer:
       - 1
@@ -131,7 +131,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_2427f3be
+    name: taper_395da726
     width1: 0.5
     width2: 11
 info:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
@@ -1,9 +1,6 @@
 cells:
-  compass_fa26bb75:
+  compass_b2b84254:
     changed:
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 0.375
@@ -29,7 +26,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_fa26bb75
+    name: compass_b2b84254
   grating_coupler_rectangular:
     changed: {}
     default:
@@ -76,11 +73,8 @@ cells:
     name: grating_coupler_rectangular
     polarization: te
     wavelength: 1.55
-  rectangle_fa26bb75:
+  rectangle_b2b84254:
     changed:
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 0.375
@@ -106,14 +100,13 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_fa26bb75
-  taper_211ef0b5:
+    name: rectangle_b2b84254
+  taper_2427f3be:
     changed:
       layer:
       - 1
       - 0
       length: 150
-      width1: 0.5
       width2: 11
     default:
       cross_section:
@@ -138,7 +131,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_211ef0b5
+    name: taper_2427f3be
     width1: 0.5
     width2: 11
 info:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_d53556e1:
+  compass_cbfd9735:
     changed:
       port_type: null
       size:
@@ -26,7 +26,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_d53556e1
+    name: compass_cbfd9735
   grating_coupler_rectang_0b571e8d:
     changed: {}
     default:
@@ -113,7 +113,7 @@ cells:
     name: grating_coupler_rectang_0b571e8d
     polarization: te
     wavelength: 1.55
-  rectangle_c4cbcb00:
+  rectangle_cdffebea:
     changed:
       centered: true
       port_type: null
@@ -141,8 +141,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_c4cbcb00
-  taper_2427f3be:
+    name: rectangle_cdffebea
+  taper_395da726:
     changed:
       layer:
       - 1
@@ -172,7 +172,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_2427f3be
+    name: taper_395da726
     width1: 0.5
     width2: 11
 info:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
@@ -1,9 +1,6 @@
 cells:
-  compass_ae46bf3c:
+  compass_d53556e1:
     changed:
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 0.5
@@ -29,7 +26,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ae46bf3c
+    name: compass_d53556e1
   grating_coupler_rectang_0b571e8d:
     changed: {}
     default:
@@ -116,12 +113,9 @@ cells:
     name: grating_coupler_rectang_0b571e8d
     polarization: te
     wavelength: 1.55
-  rectangle_14fb5f60:
+  rectangle_c4cbcb00:
     changed:
       centered: true
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 0.5
@@ -147,14 +141,13 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_14fb5f60
-  taper_211ef0b5:
+    name: rectangle_c4cbcb00
+  taper_2427f3be:
     changed:
       layer:
       - 1
       - 0
       length: 150
-      width1: 0.5
       width2: 11
     default:
       cross_section:
@@ -179,7 +172,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_211ef0b5
+    name: taper_2427f3be
     width1: 0.5
     width2: 11
 info:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
@@ -30,11 +30,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_14a57bc5
-  compass_ae46bf3c:
+  compass_d53556e1:
     changed:
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 0.5
@@ -60,7 +57,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ae46bf3c
+    name: compass_d53556e1
   grating_coupler_rectang_c148e9a3:
     changed: {}
     default:
@@ -149,38 +146,6 @@ cells:
     name: grating_coupler_rectang_c148e9a3
     polarization: te
     wavelength: 1.55
-  rectangle_14fb5f60:
-    changed:
-      centered: true
-      layer:
-      - 1
-      - 0
-      port_type: null
-      size:
-      - 0.5
-      - 11
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: true
-      layer:
-      - 1
-      - 0
-      port_type: null
-      size:
-      - 0.5
-      - 11
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_14fb5f60
   rectangle_a3e44e0a:
     changed:
       centered: true
@@ -213,14 +178,42 @@ cells:
     info_version: 1
     module: gdsfactory.components.rectangle
     name: rectangle_a3e44e0a
-  taper_strip_to_ridge_2502810c:
+  rectangle_c4cbcb00:
+    changed:
+      centered: true
+      port_type: null
+      size:
+      - 0.5
+      - 11
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: true
+      layer:
+      - 1
+      - 0
+      port_type: null
+      size:
+      - 0.5
+      - 11
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_c4cbcb00
+  taper_strip_to_ridge_f04fdfe4:
     changed:
       layer_slab:
       - 2
       - 0
       length: 150
       w_slab2: 15
-      width1: 0.5
       width2: 11
     default:
       cladding_offset: 3
@@ -258,7 +251,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_strip_to_ridge_2502810c
+    name: taper_strip_to_ridge_f04fdfe4
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
@@ -1,5 +1,33 @@
 cells:
-  compass_14a57bc5:
+  compass_cbfd9735:
+    changed:
+      port_type: null
+      size:
+      - 0.5
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: null
+      size:
+      - 0.5
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_cbfd9735
+  compass_e8e54b6a:
     changed:
       layer:
       - 2
@@ -29,35 +57,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_14a57bc5
-  compass_d53556e1:
-    changed:
-      port_type: null
-      size:
-      - 0.5
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: null
-      size:
-      - 0.5
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_d53556e1
+    name: compass_e8e54b6a
   grating_coupler_rectang_c148e9a3:
     changed: {}
     default:
@@ -146,7 +146,7 @@ cells:
     name: grating_coupler_rectang_c148e9a3
     polarization: te
     wavelength: 1.55
-  rectangle_a3e44e0a:
+  rectangle_8df7b4c8:
     changed:
       centered: true
       layer:
@@ -177,8 +177,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_a3e44e0a
-  rectangle_c4cbcb00:
+    name: rectangle_8df7b4c8
+  rectangle_cdffebea:
     changed:
       centered: true
       port_type: null
@@ -206,8 +206,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_c4cbcb00
-  taper_strip_to_ridge_f04fdfe4:
+    name: rectangle_cdffebea
+  taper_strip_to_ridge_a9110a8e:
     changed:
       layer_slab:
       - 2
@@ -251,7 +251,7 @@ cells:
     info_version: 1
     length: 150
     module: gdsfactory.components.taper
-    name: taper_strip_to_ridge_f04fdfe4
+    name: taper_strip_to_ridge_a9110a8e
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
@@ -21,9 +21,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -76,13 +75,12 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
 info:
   changed:
-    polarization: te
     taper_angle: 35
   default:
     end_straight_length: 0.2
@@ -135,7 +133,7 @@ info:
   function_name: grating_coupler_elliptical_trenches
   info_version: 1
   module: gdsfactory.components.grating_coupler_elliptical_trenches
-  name: grating_coupler_ellipti_b632d295
+  name: grating_coupler_ellipti_db285fcb
   period: 0.6759999999999999
   polarization: te
   wavelength: 1.53

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -20,7 +20,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tm_.yml
@@ -1,5 +1,5 @@
 cells:
-  circle_b1a123ab:
+  circle_c1ca507f:
     changed:
       layer:
       - 204
@@ -20,8 +20,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_b1a123ab
-  grating_coupler_ellipti_e0b1bd5d:
+    name: circle_c1ca507f
+  grating_coupler_ellipti_2b07d8fa:
     changed:
       fiber_marker_layer:
       - 204
@@ -80,7 +80,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_e0b1bd5d
+    name: grating_coupler_ellipti_2b07d8fa
     period: 1.072
     polarization: tm
     wavelength: 1.53
@@ -143,7 +143,7 @@ info:
   function_name: grating_coupler_elliptical_trenches
   info_version: 1
   module: gdsfactory.components.grating_coupler_elliptical_trenches
-  name: grating_coupler_ellipti_e0b1bd5d
+  name: grating_coupler_ellipti_2b07d8fa
   period: 1.072
   polarization: tm
   wavelength: 1.53

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -129,56 +127,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_09267a6d:
+  straight_44b2bce1:
     changed:
-      cross_section:
-        function: cross_section
-      length: 429.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 429.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 429.5
-    module: gdsfactory.components.straight
-    name: straight_09267a6d
-    width: 0.5
-  straight_2480e476:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 24.2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 24.2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 24.2
-    module: gdsfactory.components.straight
-    name: straight_2480e476
-    width: 0.5
-  straight_2ac686be:
-    changed:
-      cross_section:
-        function: cross_section
       length: 33.2
     default:
       cross_section:
@@ -196,13 +146,11 @@ cells:
     info_version: 1
     length: 33.2
     module: gdsfactory.components.straight
-    name: straight_2ac686be
+    name: straight_44b2bce1
     width: 0.5
-  straight_35279b0d:
+  straight_95606a4f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 175.5
+      length: 429.5
     default:
       cross_section:
         function: cross_section
@@ -212,20 +160,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 175.5
+      length: 429.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 175.5
+    length: 429.5
     module: gdsfactory.components.straight
-    name: straight_35279b0d
+    name: straight_95606a4f
     width: 0.5
-  straight_8535e376:
+  straight_99a23ec3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 48.5
+      length: 37.7
     default:
       cross_section:
         function: cross_section
@@ -235,65 +181,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 48.5
+      length: 37.7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 48.5
+    length: 37.7
     module: gdsfactory.components.straight
-    name: straight_8535e376
+    name: straight_99a23ec3
     width: 0.5
-  straight_aa45e1cb:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 302.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 302.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 302.5
-    module: gdsfactory.components.straight
-    name: straight_aa45e1cb
-    width: 0.5
-  straight_aea980a7:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 28.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 28.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 28.7
-    module: gdsfactory.components.straight
-    name: straight_aea980a7
-    width: 0.5
-  straight_array_e79eb4c6:
-    changed:
-      n: 4
-      spacing: 4
+  straight_array:
+    changed: {}
     default:
       n: 4
       spacing: 4
@@ -307,13 +205,11 @@ cells:
     function_name: straight_array
     info_version: 1
     module: gdsfactory.components.straight_array
-    name: straight_array_e79eb4c6
-  straight_array_e79eb4c6_be2a1404:
+    name: straight_array
+  straight_array_grating__b29c362b:
     changed: {}
     child:
-      changed:
-        n: 4
-        spacing: 4
+      changed: {}
       default:
         n: 4
         spacing: 4
@@ -327,7 +223,7 @@ cells:
       function_name: straight_array
       info_version: 1
       module: gdsfactory.components.straight_array
-      name: straight_array_e79eb4c6
+      name: straight_array
     default:
       bend:
         function: bend_euler
@@ -355,12 +251,10 @@ cells:
     function_name: grating_coupler_tree
     info_version: 1
     module: gdsfactory.components.grating_coupler_tree
-    name: straight_array_e79eb4c6_be2a1404
-  straight_d9504b06:
+    name: straight_array_grating__b29c362b
+  straight_b4effb5f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 37.7
+      length: 175.5
     default:
       cross_section:
         function: cross_section
@@ -370,21 +264,103 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 37.7
+      length: 175.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 37.7
+    length: 175.5
     module: gdsfactory.components.straight
-    name: straight_d9504b06
+    name: straight_b4effb5f
+    width: 0.5
+  straight_cc0823b7:
+    changed:
+      length: 48.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 48.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 48.5
+    module: gdsfactory.components.straight
+    name: straight_cc0823b7
+    width: 0.5
+  straight_e603b0ba:
+    changed:
+      length: 302.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 302.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 302.5
+    module: gdsfactory.components.straight
+    name: straight_e603b0ba
+    width: 0.5
+  straight_e8a58398:
+    changed:
+      length: 24.2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 24.2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 24.2
+    module: gdsfactory.components.straight
+    name: straight_e8a58398
+    width: 0.5
+  straight_edcc8194:
+    changed:
+      length: 28.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 28.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 28.7
+    module: gdsfactory.components.straight
+    name: straight_edcc8194
     width: 0.5
 info:
   changed: {}
   child:
-    changed:
-      n: 4
-      spacing: 4
+    changed: {}
     default:
       n: 4
       spacing: 4
@@ -398,7 +374,7 @@ info:
     function_name: straight_array
     info_version: 1
     module: gdsfactory.components.straight_array
-    name: straight_array_e79eb4c6
+    name: straight_array
   default:
     bend:
       function: bend_euler
@@ -426,7 +402,7 @@ info:
   function_name: grating_coupler_tree
   info_version: 1
   module: gdsfactory.components.grating_coupler_tree
-  name: straight_array_e79eb4c6_be2a1404
+  name: straight_array_grating__b29c362b
 ports:
   vertical_te_00:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_elliptical:
     changed: {}
     default:
@@ -127,7 +127,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_44b2bce1:
+  straight_3c29ca61:
     changed:
       length: 33.2
     default:
@@ -146,11 +146,11 @@ cells:
     info_version: 1
     length: 33.2
     module: gdsfactory.components.straight
-    name: straight_44b2bce1
+    name: straight_3c29ca61
     width: 0.5
-  straight_95606a4f:
+  straight_5668d044:
     changed:
-      length: 429.5
+      length: 302.5
     default:
       cross_section:
         function: cross_section
@@ -160,35 +160,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 429.5
+      length: 302.5
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 429.5
+    length: 302.5
     module: gdsfactory.components.straight
-    name: straight_95606a4f
-    width: 0.5
-  straight_99a23ec3:
-    changed:
-      length: 37.7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 37.7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 37.7
-    module: gdsfactory.components.straight
-    name: straight_99a23ec3
+    name: straight_5668d044
     width: 0.5
   straight_array:
     changed: {}
@@ -252,70 +231,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_tree
     name: straight_array_grating__b29c362b
-  straight_b4effb5f:
-    changed:
-      length: 175.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 175.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 175.5
-    module: gdsfactory.components.straight
-    name: straight_b4effb5f
-    width: 0.5
-  straight_cc0823b7:
-    changed:
-      length: 48.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 48.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 48.5
-    module: gdsfactory.components.straight
-    name: straight_cc0823b7
-    width: 0.5
-  straight_e603b0ba:
-    changed:
-      length: 302.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 302.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 302.5
-    module: gdsfactory.components.straight
-    name: straight_e603b0ba
-    width: 0.5
-  straight_e8a58398:
+  straight_c382e097:
     changed:
       length: 24.2
     default:
@@ -334,9 +250,30 @@ cells:
     info_version: 1
     length: 24.2
     module: gdsfactory.components.straight
-    name: straight_e8a58398
+    name: straight_c382e097
     width: 0.5
-  straight_edcc8194:
+  straight_d54c3d92:
+    changed:
+      length: 48.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 48.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 48.5
+    module: gdsfactory.components.straight
+    name: straight_d54c3d92
+    width: 0.5
+  straight_e02c5b3b:
     changed:
       length: 28.7
     default:
@@ -355,7 +292,70 @@ cells:
     info_version: 1
     length: 28.7
     module: gdsfactory.components.straight
-    name: straight_edcc8194
+    name: straight_e02c5b3b
+    width: 0.5
+  straight_e34a4c34:
+    changed:
+      length: 429.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 429.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 429.5
+    module: gdsfactory.components.straight
+    name: straight_e34a4c34
+    width: 0.5
+  straight_e413e993:
+    changed:
+      length: 37.7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 37.7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 37.7
+    module: gdsfactory.components.straight
+    name: straight_e413e993
+    width: 0.5
+  straight_e5eea821:
+    changed:
+      length: 175.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 175.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 175.5
+    module: gdsfactory.components.straight
+    name: straight_e5eea821
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
@@ -1,41 +1,9 @@
 cells:
-  compass_205010ac:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 2
-      - 5
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 2
-      - 5
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_205010ac
-  compass_c14e0736:
+  compass_229ba6f2:
     changed:
       layer:
       - 2
       - 0
-      port_type: electrical
       size:
       - 2
       - 5
@@ -60,7 +28,34 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c14e0736
+    name: compass_229ba6f2
+  compass_408b547b:
+    changed:
+      size:
+      - 2
+      - 5
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 2
+      - 5
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_408b547b
   litho_calipers:
     changed: {}
     default:
@@ -125,11 +120,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.rectangle
     name: rectangle_229ba6f2
-  rectangle_92db19f8:
+  rectangle_408b547b:
     changed:
-      layer:
-      - 1
-      - 0
       size:
       - 2
       - 5
@@ -154,7 +146,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_92db19f8
+    name: rectangle_408b547b
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_229ba6f2:
+  compass_0d5fe397:
     changed:
       layer:
       - 2
@@ -28,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_229ba6f2
-  compass_408b547b:
+    name: compass_0d5fe397
+  compass_b841579c:
     changed:
       size:
       - 2
@@ -55,7 +55,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_408b547b
+    name: compass_b841579c
   litho_calipers:
     changed: {}
     default:
@@ -90,7 +90,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.litho_calipers
     name: litho_calipers
-  rectangle_229ba6f2:
+  rectangle_0d5fe397:
     changed:
       layer:
       - 2
@@ -119,8 +119,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_229ba6f2
-  rectangle_408b547b:
+    name: rectangle_0d5fe397
+  rectangle_b841579c:
     changed:
       size:
       - 2
@@ -146,7 +146,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_408b547b
+    name: rectangle_b841579c
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
@@ -1,5 +1,32 @@
 cells:
-  compass_343ff3fe:
+  compass_102e71e5:
+    changed:
+      size:
+      - 4
+      - 50
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 50
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_102e71e5
+  compass_7e8c907a:
     changed:
       size:
       - 16
@@ -25,11 +52,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_343ff3fe
-  compass_5dbd19b0:
+    name: compass_7e8c907a
+  compass_96ab200c:
     changed:
       size:
-      - 4
+      - 2
       - 50
     default:
       layer:
@@ -47,67 +74,13 @@ cells:
       port_inclusion: 0
       port_type: electrical
       size:
-      - 4
-      - 50
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_5dbd19b0
-  compass_689ac5ed:
-    changed:
-      size:
-      - 1
-      - 50
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
       - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 1
       - 50
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_689ac5ed
-  compass_86a8dcf6:
-    changed:
-      size:
-      - 10
-      - 50
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 50
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_86a8dcf6
-  compass_aa265452:
+    name: compass_96ab200c
+  compass_9edff4b5:
     changed:
       size:
       - 8
@@ -133,11 +106,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_aa265452
-  compass_b7fab762:
+    name: compass_9edff4b5
+  compass_b0a9db07:
     changed:
       size:
-      - 2
+      - 10
       - 50
     default:
       layer:
@@ -155,12 +128,39 @@ cells:
       port_inclusion: 0
       port_type: electrical
       size:
-      - 2
+      - 10
       - 50
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b7fab762
+    name: compass_b0a9db07
+  compass_fd06ce5b:
+    changed:
+      size:
+      - 1
+      - 50
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 1
+      - 50
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_fd06ce5b
   litho_steps:
     changed: {}
     default:
@@ -191,7 +191,34 @@ cells:
     info_version: 1
     module: gdsfactory.components.litho_steps
     name: litho_steps
-  rectangle_343ff3fe:
+  rectangle_102e71e5:
+    changed:
+      size:
+      - 4
+      - 50
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 50
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_102e71e5
+  rectangle_7e8c907a:
     changed:
       size:
       - 16
@@ -217,11 +244,11 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_343ff3fe
-  rectangle_5dbd19b0:
+    name: rectangle_7e8c907a
+  rectangle_96ab200c:
     changed:
       size:
-      - 4
+      - 2
       - 50
     default:
       centered: false
@@ -239,67 +266,13 @@ cells:
       - 0
       port_type: electrical
       size:
-      - 4
-      - 50
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_5dbd19b0
-  rectangle_689ac5ed:
-    changed:
-      size:
-      - 1
-      - 50
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
       - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 1
       - 50
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_689ac5ed
-  rectangle_86a8dcf6:
-    changed:
-      size:
-      - 10
-      - 50
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 10
-      - 50
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_86a8dcf6
-  rectangle_aa265452:
+    name: rectangle_96ab200c
+  rectangle_9edff4b5:
     changed:
       size:
       - 8
@@ -325,11 +298,11 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_aa265452
-  rectangle_b7fab762:
+    name: rectangle_9edff4b5
+  rectangle_b0a9db07:
     changed:
       size:
-      - 2
+      - 10
       - 50
     default:
       centered: false
@@ -347,13 +320,40 @@ cells:
       - 0
       port_type: electrical
       size:
-      - 2
+      - 10
       - 50
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_b7fab762
-  text_7ec79399:
+    name: rectangle_b0a9db07
+  rectangle_fd06ce5b:
+    changed:
+      size:
+      - 1
+      - 50
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 1
+      - 50
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_fd06ce5b
+  text_2a934bd1:
     changed:
       justify: center
       layer:
@@ -384,7 +384,7 @@ cells:
     function_name: text
     info_version: 1
     module: gdsfactory.components.text
-    name: text_7ec79399
+    name: text_2a934bd1
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
@@ -1,41 +1,6 @@
 cells:
-  compass_21e79cb0:
+  compass_343ff3fe:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 50
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 50
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_21e79cb0
-  compass_5f6dbeb7:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 16
       - 50
@@ -60,15 +25,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_5f6dbeb7
-  compass_a6b95cbc:
+    name: compass_343ff3fe
+  compass_5dbd19b0:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
-      - 2
+      - 4
       - 50
     default:
       layer:
@@ -86,18 +47,41 @@ cells:
       port_inclusion: 0
       port_type: electrical
       size:
-      - 2
+      - 4
       - 50
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a6b95cbc
-  compass_ac678056:
+    name: compass_5dbd19b0
+  compass_689ac5ed:
     changed:
+      size:
+      - 1
+      - 50
+    default:
       layer:
       - 1
       - 0
+      port_inclusion: 0
       port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 1
+      - 50
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_689ac5ed
+  compass_86a8dcf6:
+    changed:
       size:
       - 10
       - 50
@@ -122,44 +106,9 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ac678056
-  compass_e3cae1be:
+    name: compass_86a8dcf6
+  compass_aa265452:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 1
-      - 50
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 1
-      - 50
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_e3cae1be
-  compass_e92cd6ce:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 8
       - 50
@@ -184,7 +133,34 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_e92cd6ce
+    name: compass_aa265452
+  compass_b7fab762:
+    changed:
+      size:
+      - 2
+      - 50
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 2
+      - 50
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_b7fab762
   litho_steps:
     changed: {}
     default:
@@ -215,71 +191,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.litho_steps
     name: litho_steps
-  rectangle_2f00fe9d:
+  rectangle_343ff3fe:
     changed:
-      layer:
-      - 1
-      - 0
-      size:
-      - 10
-      - 50
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 10
-      - 50
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_2f00fe9d
-  rectangle_4f322ec0:
-    changed:
-      layer:
-      - 1
-      - 0
-      size:
-      - 4
-      - 50
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 50
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_4f322ec0
-  rectangle_84f59762:
-    changed:
-      layer:
-      - 1
-      - 0
       size:
       - 16
       - 50
@@ -304,12 +217,90 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_84f59762
-  rectangle_9aa64122:
+    name: rectangle_343ff3fe
+  rectangle_5dbd19b0:
     changed:
+      size:
+      - 4
+      - 50
+    default:
+      centered: false
       layer:
       - 1
       - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 50
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_5dbd19b0
+  rectangle_689ac5ed:
+    changed:
+      size:
+      - 1
+      - 50
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 1
+      - 50
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_689ac5ed
+  rectangle_86a8dcf6:
+    changed:
+      size:
+      - 10
+      - 50
+    default:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      centered: false
+      layer:
+      - 1
+      - 0
+      port_type: electrical
+      size:
+      - 10
+      - 50
+    function_name: rectangle
+    info_version: 1
+    module: gdsfactory.components.rectangle
+    name: rectangle_86a8dcf6
+  rectangle_aa265452:
+    changed:
       size:
       - 8
       - 50
@@ -334,42 +325,9 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_9aa64122
-  rectangle_b6ed30a7:
+    name: rectangle_aa265452
+  rectangle_b7fab762:
     changed:
-      layer:
-      - 1
-      - 0
-      size:
-      - 1
-      - 50
-    default:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      centered: false
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 1
-      - 50
-    function_name: rectangle
-    info_version: 1
-    module: gdsfactory.components.rectangle
-    name: rectangle_b6ed30a7
-  rectangle_f8092a8c:
-    changed:
-      layer:
-      - 1
-      - 0
       size:
       - 2
       - 50
@@ -394,7 +352,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_f8092a8c
+    name: rectangle_b7fab762
   text_7ec79399:
     changed:
       justify: center

--- a/gdsfactory/tests/test_components/test_settings_logo_.yml
+++ b/gdsfactory/tests/test_components/test_settings_logo_.yml
@@ -9,291 +9,11 @@ cells:
     info_version: 1
     module: gdsfactory.components.logo
     name: logo
-  text_0f9ea51c:
-    changed:
-      layer:
-      - 4
-      - 0
-      size: 10
-      text: F
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 4
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: F
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_0f9ea51c
-  text_19d0c9ec:
-    changed:
-      layer:
-      - 9
-      - 0
-      size: 10
-      text: R
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 9
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: R
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_19d0c9ec
-  text_3c548262:
-    changed:
-      layer:
-      - 10
-      - 0
-      size: 10
-      text: Y
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 10
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: Y
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_3c548262
-  text_6619dbe6:
-    changed:
-      layer:
-      - 6
-      - 0
-      size: 10
-      text: C
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 6
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: C
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_6619dbe6
-  text_972f5232:
-    changed:
-      layer:
-      - 5
-      - 0
-      size: 10
-      text: A
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 5
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: A
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_972f5232
-  text_9c978283:
-    changed:
-      layer:
-      - 2
-      - 0
-      size: 10
-      text: D
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 2
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: D
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_9c978283
-  text_c5bdb23c:
-    changed:
-      layer:
-      - 8
-      - 0
-      size: 10
-      text: O
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 8
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: O
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_c5bdb23c
-  text_eaa6de8d:
-    changed:
-      layer:
-      - 7
-      - 0
-      size: 10
-      text: T
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 7
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: T
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_eaa6de8d
-  text_ecd14e34:
-    changed:
-      layer:
-      - 3
-      - 0
-      size: 10
-      text: S
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 3
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: S
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_ecd14e34
-  text_f8200b73:
+  text_0d94c7f8:
     changed:
       layer:
       - 1
       - 0
-      size: 10
       text: G
     default:
       justify: left
@@ -318,7 +38,277 @@ cells:
     function_name: text
     info_version: 1
     module: gdsfactory.components.text
-    name: text_f8200b73
+    name: text_0d94c7f8
+  text_15388a31:
+    changed:
+      layer:
+      - 10
+      - 0
+      text: Y
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 10
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: Y
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_15388a31
+  text_22a8998c:
+    changed:
+      layer:
+      - 9
+      - 0
+      text: R
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 9
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: R
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_22a8998c
+  text_2f90f9a7:
+    changed:
+      layer:
+      - 2
+      - 0
+      text: D
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 2
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: D
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_2f90f9a7
+  text_63d54d56:
+    changed:
+      layer:
+      - 5
+      - 0
+      text: A
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 5
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: A
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_63d54d56
+  text_6a170f7a:
+    changed:
+      layer:
+      - 8
+      - 0
+      text: O
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 8
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: O
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_6a170f7a
+  text_6a8cb5f0:
+    changed:
+      layer:
+      - 6
+      - 0
+      text: C
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 6
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: C
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_6a8cb5f0
+  text_8a6e7873:
+    changed:
+      layer:
+      - 7
+      - 0
+      text: T
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 7
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: T
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_8a6e7873
+  text_e24958e7:
+    changed:
+      layer:
+      - 3
+      - 0
+      text: S
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 3
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: S
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_e24958e7
+  text_e7d1f443:
+    changed:
+      layer:
+      - 4
+      - 0
+      text: F
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 4
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: F
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_e7d1f443
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_logo_.yml
+++ b/gdsfactory/tests/test_components/test_settings_logo_.yml
@@ -9,277 +9,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.logo
     name: logo
-  text_0d94c7f8:
-    changed:
-      layer:
-      - 1
-      - 0
-      text: G
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 1
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: G
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_0d94c7f8
-  text_15388a31:
-    changed:
-      layer:
-      - 10
-      - 0
-      text: Y
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 10
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: Y
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_15388a31
-  text_22a8998c:
-    changed:
-      layer:
-      - 9
-      - 0
-      text: R
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 9
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: R
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_22a8998c
-  text_2f90f9a7:
-    changed:
-      layer:
-      - 2
-      - 0
-      text: D
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 2
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: D
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_2f90f9a7
-  text_63d54d56:
-    changed:
-      layer:
-      - 5
-      - 0
-      text: A
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 5
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: A
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_63d54d56
-  text_6a170f7a:
-    changed:
-      layer:
-      - 8
-      - 0
-      text: O
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 8
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: O
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_6a170f7a
-  text_6a8cb5f0:
-    changed:
-      layer:
-      - 6
-      - 0
-      text: C
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 6
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: C
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_6a8cb5f0
-  text_8a6e7873:
-    changed:
-      layer:
-      - 7
-      - 0
-      text: T
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 7
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: T
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_8a6e7873
-  text_e24958e7:
-    changed:
-      layer:
-      - 3
-      - 0
-      text: S
-    default:
-      justify: left
-      layer:
-      - 66
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: abcd
-    full:
-      justify: left
-      layer:
-      - 3
-      - 0
-      position:
-      - 0
-      - 0
-      size: 10
-      text: S
-    function_name: text
-    info_version: 1
-    module: gdsfactory.components.text
-    name: text_e24958e7
-  text_e7d1f443:
+  text_26234d59:
     changed:
       layer:
       - 4
@@ -308,7 +38,277 @@ cells:
     function_name: text
     info_version: 1
     module: gdsfactory.components.text
-    name: text_e7d1f443
+    name: text_26234d59
+  text_38c6d574:
+    changed:
+      layer:
+      - 10
+      - 0
+      text: Y
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 10
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: Y
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_38c6d574
+  text_43ffc5bd:
+    changed:
+      layer:
+      - 2
+      - 0
+      text: D
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 2
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: D
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_43ffc5bd
+  text_4a943c7d:
+    changed:
+      layer:
+      - 6
+      - 0
+      text: C
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 6
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: C
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_4a943c7d
+  text_540e717d:
+    changed:
+      layer:
+      - 3
+      - 0
+      text: S
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 3
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: S
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_540e717d
+  text_6382d892:
+    changed:
+      layer:
+      - 8
+      - 0
+      text: O
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 8
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: O
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_6382d892
+  text_a9150991:
+    changed:
+      layer:
+      - 1
+      - 0
+      text: G
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 1
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: G
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_a9150991
+  text_b6218e72:
+    changed:
+      layer:
+      - 5
+      - 0
+      text: A
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 5
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: A
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_b6218e72
+  text_cbcdd3d5:
+    changed:
+      layer:
+      - 9
+      - 0
+      text: R
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 9
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: R
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_cbcdd3d5
+  text_cf534270:
+    changed:
+      layer:
+      - 7
+      - 0
+      text: T
+    default:
+      justify: left
+      layer:
+      - 66
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+    full:
+      justify: left
+      layer:
+      - 7
+      - 0
+      position:
+      - 0
+      - 0
+      size: 10
+      text: T
+    function_name: text
+    info_version: 1
+    module: gdsfactory.components.text
+    name: text_cf534270
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
@@ -43,7 +43,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.loop_mirror
     name: loop_mirror
-  straight_2ad9f88b:
+  straight_46e50542:
     changed:
       length: 1.26
     default:
@@ -62,9 +62,9 @@ cells:
     info_version: 1
     length: 1.26
     module: gdsfactory.components.straight
-    name: straight_2ad9f88b
+    name: straight_46e50542
     width: 0.5
-  straight_51104ba3:
+  straight_9bfabe31:
     changed:
       length: 20.02
     default:
@@ -83,9 +83,9 @@ cells:
     info_version: 1
     length: 20.02
     module: gdsfactory.components.straight
-    name: straight_51104ba3
+    name: straight_9bfabe31
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -104,7 +104,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
@@ -43,56 +43,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.loop_mirror
     name: loop_mirror
-  straight_5743d35a:
+  straight_2ad9f88b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_a8788986:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 20.02
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 20.02
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 20.02
-    module: gdsfactory.components.straight
-    name: straight_a8788986
-    width: 0.5
-  straight_c8e6739e:
-    changed:
-      cross_section:
-        function: cross_section
       length: 1.26
     default:
       cross_section:
@@ -110,7 +62,49 @@ cells:
     info_version: 1
     length: 1.26
     module: gdsfactory.components.straight
-    name: straight_c8e6739e
+    name: straight_2ad9f88b
+    width: 0.5
+  straight_51104ba3:
+    changed:
+      length: 20.02
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 20.02
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 20.02
+    module: gdsfactory.components.straight
+    name: straight_51104ba3
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,7 +103,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -134,10 +131,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
     name: loss_deembedding_ch12_34
-  straight_d9996de2:
+  straight_b24e342f:
     changed:
-      cross_section:
-        function: cross_section
       length: 40
     default:
       cross_section:
@@ -155,12 +150,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_f031ecb0:
+  straight_c2717bb1:
     changed:
-      cross_section:
-        function: cross_section
       length: 107
     default:
       cross_section:
@@ -178,7 +171,7 @@ cells:
     info_version: 1
     length: 107
     module: gdsfactory.components.straight
-    name: straight_f031ecb0
+    name: straight_c2717bb1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35
@@ -156,28 +156,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_52c0fe19
     width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_9bf8b352:
+  straight_77cb16b3:
     changed:
       length: 40.081
     default:
@@ -196,7 +175,7 @@ cells:
     info_version: 1
     length: 40.081
     module: gdsfactory.components.straight
-    name: straight_9bf8b352
+    name: straight_77cb16b3
     width: 0.5
   straight_b24e342f:
     changed:
@@ -239,6 +218,27 @@ cells:
     length: 5
     module: gdsfactory.components.straight
     name: straight_b3dac65b
+    width: 0.5
+  straight_b81889b2:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_b81889b2
     width: 0.5
   straight_c2717bb1:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,7 +103,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -138,56 +135,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
     name: loss_deembedding_ch13_24
-  straight_06b7497a:
+  straight_52c0fe19:
     changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_06b7497a
-    width: 0.5
-  straight_40ffb32d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 40.081
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40.081
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40.081
-    module: gdsfactory.components.straight
-    name: straight_40ffb32d
-    width: 0.5
-  straight_c4828fc0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 234
     default:
       cross_section:
@@ -205,12 +154,52 @@ cells:
     info_version: 1
     length: 234
     module: gdsfactory.components.straight
-    name: straight_c4828fc0
+    name: straight_52c0fe19
     width: 0.5
-  straight_d9996de2:
+  straight_5656be49:
     changed:
+      length: 43.5
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_9bf8b352:
+    changed:
+      length: 40.081
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40.081
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40.081
+    module: gdsfactory.components.straight
+    name: straight_9bf8b352
+    width: 0.5
+  straight_b24e342f:
+    changed:
       length: 40
     default:
       cross_section:
@@ -228,12 +217,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_e7395bed:
+  straight_b3dac65b:
     changed:
-      cross_section:
-        function: cross_section
       length: 5
     default:
       cross_section:
@@ -251,12 +238,10 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_e7395bed
+    name: straight_b3dac65b
     width: 0.5
-  straight_f031ecb0:
+  straight_c2717bb1:
     changed:
-      cross_section:
-        function: cross_section
       length: 107
     default:
       cross_section:
@@ -274,7 +259,7 @@ cells:
     info_version: 1
     length: 107
     module: gdsfactory.components.straight
-    name: straight_f031ecb0
+    name: straight_c2717bb1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,7 +48,7 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
+    name: circle_925ccccf
   grating_coupler_ellipti_db285fcb:
     changed:
       taper_angle: 35

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -51,9 +49,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.circle
     name: circle_602e85fd
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -106,7 +103,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -134,33 +131,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.grating_coupler_loss
     name: loss_deembedding_ch14_23
-  straight_93f9bbf9:
+  straight_855f95b0:
     changed:
-      cross_section:
-        function: cross_section
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_93f9bbf9
-    width: 0.5
-  straight_c812ca36:
-    changed:
-      cross_section:
-        function: cross_section
       length: 361
     default:
       cross_section:
@@ -178,12 +150,31 @@ cells:
     info_version: 1
     length: 361
     module: gdsfactory.components.straight
-    name: straight_c812ca36
+    name: straight_855f95b0
     width: 0.5
-  straight_d9996de2:
+  straight_a065fbc7:
     changed:
+      length: 30
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_a065fbc7
+    width: 0.5
+  straight_b24e342f:
+    changed:
       length: 40
     default:
       cross_section:
@@ -201,12 +192,10 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
     width: 0.5
-  straight_f031ecb0:
+  straight_c2717bb1:
     changed:
-      cross_section:
-        function: cross_section
       length: 107
     default:
       cross_section:
@@ -224,7 +213,7 @@ cells:
     info_version: 1
     length: 107
     module: gdsfactory.components.straight
-    name: straight_f031ecb0
+    name: straight_c2717bb1
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
@@ -85,7 +85,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_4b5b1125:
+  mzi_a62d3423:
     changed:
       combiner:
         function: mmi2x2
@@ -139,8 +139,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_4b5b1125
-  straight_76a4ed9f:
+    name: mzi_a62d3423
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -159,9 +159,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -180,7 +180,7 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
   straight_a4be237b:
     changed:
@@ -203,7 +203,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -222,7 +222,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -299,7 +299,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_4b5b1125
+  name: mzi_a62d3423
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi1x2:
@@ -142,33 +140,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi_4b5b1125
-  straight_15a9c8d1:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -186,12 +159,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_528b9164:
+  straight_8c093820:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.1
     default:
       cross_section:
@@ -209,35 +180,10 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_528b9164
+    name: straight_8c093820
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -255,7 +201,49 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi2x2:
@@ -116,33 +114,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi_86aea49b
-  straight_15a9c8d1:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -160,12 +133,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_528b9164:
+  straight_8c093820:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.1
     default:
       cross_section:
@@ -183,35 +154,10 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_528b9164
+    name: straight_8c093820
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -229,7 +175,49 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
@@ -55,7 +55,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_86aea49b:
+  mzi_d46c281f:
     changed:
       combiner:
         function: mmi2x2
@@ -113,8 +113,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_86aea49b
-  straight_76a4ed9f:
+    name: mzi_d46c281f
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -133,9 +133,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -154,7 +154,7 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
   straight_a4be237b:
     changed:
@@ -177,7 +177,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -196,7 +196,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -277,7 +277,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_86aea49b
+  name: mzi_d46c281f
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_mzi_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_.yml
@@ -107,7 +107,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi
-  straight_76a4ed9f:
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -126,9 +126,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -147,7 +147,7 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
   straight_a4be237b:
     changed:
@@ -170,7 +170,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -189,7 +189,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi1x2:
@@ -109,33 +107,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi
-  straight_15a9c8d1:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -153,12 +126,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_528b9164:
+  straight_8c093820:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.1
     default:
       cross_section:
@@ -176,35 +147,10 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_528b9164
+    name: straight_8c093820
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -222,7 +168,49 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
@@ -57,7 +57,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
-  mzi_arm_bc203dcc:
+  mzi_arm_1256dbdd:
     changed:
       length_y_left: 5.8
       length_y_right: 5.8
@@ -92,8 +92,8 @@ cells:
     length_x: 0.1
     length_xsize: 0.1
     module: gdsfactory.components.mzi_arm
-    name: mzi_arm_bc203dcc
-  mzi_arm_f84ea993:
+    name: mzi_arm_1256dbdd
+  mzi_arm_a74c0db8:
     changed:
       straight_x:
         function: straight
@@ -126,7 +126,7 @@ cells:
     length_x: 0.1
     length_xsize: 0.1
     module: gdsfactory.components.mzi_arm
-    name: mzi_arm_f84ea993
+    name: mzi_arm_a74c0db8
   mzi_arms:
     changed: {}
     default:
@@ -165,7 +165,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi_arms
     name: mzi_arms
-  straight_10336aac:
+  straight_38ffaba0:
     changed:
       length: 5.8
     default:
@@ -184,9 +184,9 @@ cells:
     info_version: 1
     length: 5.8
     module: gdsfactory.components.straight
-    name: straight_10336aac
+    name: straight_38ffaba0
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -205,9 +205,9 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
-  straight_b75caec8:
+  straight_e3da20dd:
     changed:
       length: 0.8
     default:
@@ -226,7 +226,7 @@ cells:
     info_version: 1
     length: 0.8
     module: gdsfactory.components.straight
-    name: straight_b75caec8
+    name: straight_e3da20dd
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
@@ -57,50 +57,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
-  mzi_arm_74064cef:
+  mzi_arm_bc203dcc:
     changed:
-      bend:
-        function: bend_euler
-      length_x: 0.1
-      length_y_left: 0.8
-      length_y_right: 0.8
-      straight_x:
-        function: straight
-      straight_y:
-        function: straight
-    default:
-      bend:
-        function: bend_euler
-      length_x: 0.1
-      length_y_left: 0.8
-      length_y_right: 0.8
-      straight:
-        function: straight
-      straight_x: null
-      straight_y: null
-    full:
-      bend:
-        function: bend_euler
-      length_x: 0.1
-      length_y_left: 0.8
-      length_y_right: 0.8
-      straight:
-        function: straight
-      straight_x:
-        function: straight
-      straight_y:
-        function: straight
-    function_name: mzi_arm
-    info_version: 1
-    length_x: 0.1
-    length_xsize: 0.1
-    module: gdsfactory.components.mzi_arm
-    name: mzi_arm_74064cef
-  mzi_arm_f85ac2e9:
-    changed:
-      bend:
-        function: bend_euler
-      length_x: 0.1
       length_y_left: 5.8
       length_y_right: 5.8
       straight_x:
@@ -134,7 +92,41 @@ cells:
     length_x: 0.1
     length_xsize: 0.1
     module: gdsfactory.components.mzi_arm
-    name: mzi_arm_f85ac2e9
+    name: mzi_arm_bc203dcc
+  mzi_arm_f84ea993:
+    changed:
+      straight_x:
+        function: straight
+      straight_y:
+        function: straight
+    default:
+      bend:
+        function: bend_euler
+      length_x: 0.1
+      length_y_left: 0.8
+      length_y_right: 0.8
+      straight:
+        function: straight
+      straight_x: null
+      straight_y: null
+    full:
+      bend:
+        function: bend_euler
+      length_x: 0.1
+      length_y_left: 0.8
+      length_y_right: 0.8
+      straight:
+        function: straight
+      straight_x:
+        function: straight
+      straight_y:
+        function: straight
+    function_name: mzi_arm
+    info_version: 1
+    length_x: 0.1
+    length_xsize: 0.1
+    module: gdsfactory.components.mzi_arm
+    name: mzi_arm_f84ea993
   mzi_arms:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
@@ -57,7 +57,7 @@ cells:
     min_bend_radius: 9.451
     module: gdsfactory.components.coupler
     name: coupler
-  mzi_f7725ac0:
+  mzi_1fc24805:
     changed:
       combiner:
         function: coupler
@@ -115,8 +115,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_f7725ac0
-  straight_76a4ed9f:
+    name: mzi_1fc24805
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -135,9 +135,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -156,7 +156,7 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
   straight_a4be237b:
     changed:
@@ -179,7 +179,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -198,7 +198,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -279,7 +279,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_f7725ac0
+  name: mzi_1fc24805
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   coupler:
@@ -118,33 +116,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi_f7725ac0
-  straight_15a9c8d1:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -162,12 +135,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_528b9164:
+  straight_8c093820:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.1
     default:
       cross_section:
@@ -185,35 +156,10 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_528b9164
+    name: straight_8c093820
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -231,7 +177,49 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
@@ -27,7 +27,38 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  coupler_02a30dd4:
+  coupler_13a9f38a:
+    changed:
+      gap: 0.3
+    default:
+      coupler_straight:
+        function: coupler_straight
+      coupler_symmetric:
+        function: coupler_symmetric
+      cross_section:
+        function: cross_section
+      dx: 10
+      dy: 5
+      gap: 0.236
+      length: 20
+    full:
+      coupler_straight:
+        function: coupler_straight
+      coupler_symmetric:
+        function: coupler_symmetric
+      cross_section:
+        function: cross_section
+      dx: 10
+      dy: 5
+      gap: 0.3
+      length: 20
+    function_name: coupler
+    info_version: 1
+    length: 10.305
+    min_bend_radius: 9.568
+    module: gdsfactory.components.coupler
+    name: coupler_13a9f38a
+  coupler_464e3181:
     changed:
       gap: 0.2
       length: 10
@@ -58,39 +89,8 @@ cells:
     length: 10.319
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
-    name: coupler_02a30dd4
-  coupler_137172d8:
-    changed:
-      gap: 0.3
-    default:
-      coupler_straight:
-        function: coupler_straight
-      coupler_symmetric:
-        function: coupler_symmetric
-      cross_section:
-        function: cross_section
-      dx: 10
-      dy: 5
-      gap: 0.236
-      length: 20
-    full:
-      coupler_straight:
-        function: coupler_straight
-      coupler_symmetric:
-        function: coupler_symmetric
-      cross_section:
-        function: cross_section
-      dx: 10
-      dy: 5
-      gap: 0.3
-      length: 20
-    function_name: coupler
-    info_version: 1
-    length: 10.305
-    min_bend_radius: 9.568
-    module: gdsfactory.components.coupler
-    name: coupler_137172d8
-  mzi_46538a5e:
+    name: coupler_464e3181
+  mzi_06d9b324:
     changed:
       combiner:
         function: coupler
@@ -156,7 +156,7 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_46538a5e
+    name: mzi_06d9b324
   mzi_lattice:
     changed: {}
     default:
@@ -205,7 +205,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi_lattice
     name: mzi_lattice
-  straight_76a4ed9f:
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -224,9 +224,9 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
-  straight_8c093820:
+  straight_6870e926:
     changed:
       length: 0.1
     default:
@@ -245,9 +245,9 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_8c093820
+    name: straight_6870e926
     width: 0.5
-  straight_9a224667:
+  straight_7507751b:
     changed:
       length: 1.95
     default:
@@ -266,7 +266,28 @@ cells:
     info_version: 1
     length: 1.95
     module: gdsfactory.components.straight
-    name: straight_9a224667
+    name: straight_7507751b
+    width: 0.5
+  straight_a19a2684:
+    changed:
+      length: 7.05
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7.05
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7.05
+    module: gdsfactory.components.straight
+    name: straight_a19a2684
     width: 0.5
   straight_a4be237b:
     changed:
@@ -289,28 +310,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c00fd70e:
-    changed:
-      length: 7.05
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7.05
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7.05
-    module: gdsfactory.components.straight
-    name: straight_c00fd70e
-    width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -329,7 +329,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   coupler_02a30dd4:
@@ -61,10 +59,9 @@ cells:
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
     name: coupler_02a30dd4
-  coupler_676c6f34:
+  coupler_137172d8:
     changed:
       gap: 0.3
-      length: 20
     default:
       coupler_straight:
         function: coupler_straight
@@ -92,14 +89,13 @@ cells:
     length: 10.305
     min_bend_radius: 9.568
     module: gdsfactory.components.coupler
-    name: coupler_676c6f34
-  mzi_e111f24f:
+    name: coupler_137172d8
+  mzi_46538a5e:
     changed:
       combiner:
         function: coupler
         gap: 0.3
         length: 20
-      delta_length: 10
       port_e0_combiner: o4
       port_e0_splitter: o4
       port_e1_combiner: o3
@@ -108,7 +104,6 @@ cells:
         function: coupler
         gap: 0.2
         length: 10
-      with_splitter: true
     default:
       bend:
         function: bend_euler
@@ -161,7 +156,7 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_e111f24f
+    name: mzi_46538a5e
   mzi_lattice:
     changed: {}
     default:
@@ -210,33 +205,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi_lattice
     name: mzi_lattice
-  straight_15a9c8d1:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -254,12 +224,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_528b9164:
+  straight_8c093820:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.1
     default:
       cross_section:
@@ -277,35 +245,10 @@ cells:
     info_version: 1
     length: 0.1
     module: gdsfactory.components.straight
-    name: straight_528b9164
+    name: straight_8c093820
     width: 0.5
-  straight_5743d35a:
+  straight_9a224667:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_7aeeee83:
-    changed:
-      cross_section:
-        function: cross_section
       length: 1.95
     default:
       cross_section:
@@ -323,35 +266,10 @@ cells:
     info_version: 1
     length: 1.95
     module: gdsfactory.components.straight
-    name: straight_7aeeee83
+    name: straight_9a224667
     width: 0.5
-  straight_b3b360a7:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7.05
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7.05
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7.05
-    module: gdsfactory.components.straight
-    name: straight_b3b360a7
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -369,7 +287,70 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c00fd70e:
+    changed:
+      length: 7.05
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7.05
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7.05
+    module: gdsfactory.components.straight
+    name: straight_c00fd70e
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
@@ -1,10 +1,9 @@
 cells:
-  array_5a86ab1d:
+  array_cec1afb6:
     changed:
       columns: 3
       component:
         function: pad
-      rows: 1
     default:
       columns: 6
       component:
@@ -24,11 +23,9 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_5a86ab1d
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+    name: array_cec1afb6
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -52,7 +49,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -189,7 +186,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_3877d0c1
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -197,16 +194,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -258,7 +245,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -292,10 +279,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
-  mzi_8a744511:
+  mzi_bf970450:
     changed:
-      cross_section:
-        function: cross_section
       delta_length: 40
       length_x: 500
       length_y: 40
@@ -356,7 +341,7 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_8a744511
+    name: mzi_bf970450
   mzi_pads_center:
     changed: {}
     default:
@@ -486,6 +471,27 @@ cells:
     module: gdsfactory.components.straight
     name: straight_07d3e839
     width: 10
+  straight_0ab61481:
+    changed:
+      length: 60
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 60
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 60
+    module: gdsfactory.components.straight
+    name: straight_0ab61481
+    width: 0.5
   straight_1c370017:
     changed:
       cross_section:
@@ -646,52 +652,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight_3cb86ecd
     width: 10
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_4e82411b
-    width: 0.5
-  straight_5743d35a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
   straight_66f22399:
     changed:
       cross_section:
@@ -737,6 +697,27 @@ cells:
     module: gdsfactory.components.straight
     name: straight_66f22399
     width: 10
+  straight_76a4ed9f:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_76a4ed9f
+    width: 0.5
   straight_87864950:
     changed:
       cross_section:
@@ -807,10 +788,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_d9996de2:
+  straight_b24e342f:
     changed:
-      cross_section:
-        function: cross_section
       length: 40
     default:
       cross_section:
@@ -828,7 +807,28 @@ cells:
     info_version: 1
     length: 40
     module: gdsfactory.components.straight
-    name: straight_d9996de2
+    name: straight_b24e342f
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
     width: 0.5
   straight_e16afc87:
     changed:
@@ -899,29 +899,6 @@ cells:
     length: 6
     module: gdsfactory.components.straight
     name: straight_e3f148d8
-    width: 0.5
-  straight_f2df738b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 60
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 60
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 60
-    module: gdsfactory.components.straight
-    name: straight_f2df738b
     width: 0.5
   straight_heater_metal_u_8181cc49:
     changed:
@@ -1034,20 +1011,8 @@ cells:
     name: taper_ea91ec9c
     width1: 11
     width2: 2.5
-  wire_corner_f2c7ca05:
+  wire_corner_f7779321:
     changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
       width: 10
     default:
       cross_section:
@@ -1080,7 +1045,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.wire
-    name: wire_corner_f2c7ca05
+    name: wire_corner_f7779321
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
@@ -1,5 +1,5 @@
 cells:
-  array_cec1afb6:
+  array_cbdb029c:
     changed:
       columns: 3
       component:
@@ -23,7 +23,7 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_cec1afb6
+    name: array_cbdb029c
   bend_euler:
     changed: {}
     default:
@@ -52,37 +52,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -111,8 +81,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -141,21 +141,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_3877d0c1:
+    name: compass_aa9c3262
+  component_sequence_860f07fe:
     changed:
       sequence: -UHUHUHUHUHUHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -171,22 +171,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_3877d0c1
-  contact_f7ba3155:
+    name: component_sequence_860f07fe
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -245,7 +245,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -279,7 +279,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
-  mzi_bf970450:
+  mzi_77fca63c:
     changed:
       delta_length: 40
       length_x: 500
@@ -341,7 +341,7 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_bf970450
+    name: mzi_77fca63c
   mzi_pads_center:
     changed: {}
     default:
@@ -426,51 +426,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi_pads_center
     name: mzi_pads_center
-  straight_07d3e839:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 71.05
-      width: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 71.05
-      npoints: 2
-      width: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 71.05
-    module: gdsfactory.components.straight
-    name: straight_07d3e839
-    width: 10
   straight_0ab61481:
     changed:
       length: 60
@@ -492,7 +447,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_0ab61481
     width: 0.5
-  straight_1c370017:
+  straight_3b2fadb2:
     changed:
       cross_section:
         function: cross_section
@@ -535,240 +490,14 @@ cells:
     info_version: 1
     length: 70.95
     module: gdsfactory.components.straight
-    name: straight_1c370017
+    name: straight_3b2fadb2
     width: 10
-  straight_32174f25:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_37398ab6:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 266.05
-      width: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 266.05
-      npoints: 2
-      width: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 266.05
-    module: gdsfactory.components.straight
-    name: straight_37398ab6
-    width: 10
-  straight_3cb86ecd:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 5
-      width: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 5
-      npoints: 2
-      width: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.straight
-    name: straight_3cb86ecd
-    width: 10
-  straight_66f22399:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 265.95
-      width: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 265.95
-      npoints: 2
-      width: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 265.95
-    module: gdsfactory.components.straight
-    name: straight_66f22399
-    width: 10
-  straight_76a4ed9f:
-    changed:
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_76a4ed9f
-    width: 0.5
-  straight_87864950:
-    changed:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 60.625
-      width: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-        layer:
-        - 49
-        - 0
-        port_names:
-        - e1
-        - e2
-        port_types:
-        - electrical
-        - electrical
-        width: 10
-      length: 60.625
-      npoints: 2
-      width: 10
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 60.625
-    module: gdsfactory.components.straight
-    name: straight_87864950
-    width: 10
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
+      length: 6
     default:
       cross_section:
         function: cross_section
@@ -779,58 +508,16 @@ cells:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 16
+      length: 6
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 16
+    length: 6
     module: gdsfactory.components.straight
-    name: straight_b0b74a72
+    name: straight_3fe7bc16
     width: 0.5
-  straight_b24e342f:
-    changed:
-      length: 40
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40
-    module: gdsfactory.components.straight
-    name: straight_b24e342f
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_e16afc87:
+  straight_45f7acc9:
     changed:
       cross_section:
         function: cross_section
@@ -873,14 +560,80 @@ cells:
     info_version: 1
     length: 0.625
     module: gdsfactory.components.straight
-    name: straight_e16afc87
+    name: straight_45f7acc9
     width: 10
-  straight_e3f148d8:
+  straight_5b70f7d2:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_5b70f7d2
+    width: 0.5
+  straight_941903c2:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 60.625
+      width: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 60.625
+      npoints: 2
+      width: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 60.625
+    module: gdsfactory.components.straight
+    name: straight_941903c2
+    width: 10
+  straight_9496f45c:
     changed:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 6
+      length: 30
     default:
       cross_section:
         function: cross_section
@@ -891,15 +644,262 @@ cells:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 6
+      length: 30
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 6
+    length: 30
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_9496f45c
     width: 0.5
+  straight_9733aec0:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 5
+      width: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 5
+      npoints: 2
+      width: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.straight
+    name: straight_9733aec0
+    width: 10
+  straight_a38d7cdd:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 71.05
+      width: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 71.05
+      npoints: 2
+      width: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 71.05
+    module: gdsfactory.components.straight
+    name: straight_a38d7cdd
+    width: 10
+  straight_b24e342f:
+    changed:
+      length: 40
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40
+    module: gdsfactory.components.straight
+    name: straight_b24e342f
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_d75242c4:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 265.95
+      width: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 265.95
+      npoints: 2
+      width: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 265.95
+    module: gdsfactory.components.straight
+    name: straight_d75242c4
+    width: 10
+  straight_e60eb625:
+    changed:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 266.05
+      width: 10
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+        layer:
+        - 49
+        - 0
+        port_names:
+        - e1
+        - e2
+        port_types:
+        - electrical
+        - electrical
+        width: 10
+      length: 266.05
+      npoints: 2
+      width: 10
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 266.05
+    module: gdsfactory.components.straight
+    name: straight_e60eb625
+    width: 10
   straight_heater_metal_u_8181cc49:
     changed:
       length: 500
@@ -977,7 +977,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_8181cc49
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -1008,7 +1008,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
   wire_corner_f7779321:

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
@@ -128,7 +128,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_76a4ed9f:
+  straight_5b70f7d2:
     changed:
       length: 0.09
     default:
@@ -147,7 +147,7 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_76a4ed9f
+    name: straight_5b70f7d2
     width: 0.5
   straight_a4be237b:
     changed:
@@ -170,7 +170,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -189,7 +189,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   mmi1x2:
@@ -110,33 +108,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi_442cfd4a
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -153,12 +126,10 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_1da190e0
+    name: straight
     width: 0.5
-  straight_4e82411b:
+  straight_76a4ed9f:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.09
     default:
       cross_section:
@@ -176,35 +147,10 @@ cells:
     info_version: 1
     length: 0.09
     module: gdsfactory.components.straight
-    name: straight_4e82411b
+    name: straight_76a4ed9f
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
       length: 7
     default:
       cross_section:
@@ -222,7 +168,49 @@ cells:
     info_version: 1
     length: 7
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_a4be237b
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
 info:
   changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -322,33 +310,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzi
     name: mzi_f431cc99
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -365,7 +328,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_1da190e0
+    name: straight
     width: 0.5
   straight_32174f25:
     changed:
@@ -392,56 +355,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_4e82411b:
+  straight_37d9ef2b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_4e82411b
-    width: 0.5
-  straight_5743d35a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_814d0e25:
-    changed:
-      cross_section:
-        function: cross_section
       length: 310.09
     default:
       cross_section:
@@ -459,7 +374,49 @@ cells:
     info_version: 1
     length: 310.09
     module: gdsfactory.components.straight
-    name: straight_814d0e25
+    name: straight_37d9ef2b
+    width: 0.5
+  straight_76a4ed9f:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_76a4ed9f
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -486,11 +443,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_cd61840b:
+  straight_c138f2c4:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 0.01
     default:
       cross_section:
         function: cross_section
@@ -500,14 +455,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 0.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 0.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c138f2c4
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -533,6 +488,27 @@ cells:
     length: 6
     module: gdsfactory.components.straight
     name: straight_e3f148d8
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -254,7 +254,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi1x2
     name: mmi1x2
-  mzi_f431cc99:
+  mzi_daa25958:
     changed:
       length_x: null
       straight_x_top:
@@ -309,7 +309,7 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_f431cc99
+    name: mzi_daa25958
   straight:
     changed: {}
     default:
@@ -330,141 +330,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_37d9ef2b:
-    changed:
-      length: 310.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 310.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 310.09
-    module: gdsfactory.components.straight
-    name: straight_37d9ef2b
-    width: 0.5
-  straight_76a4ed9f:
-    changed:
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_76a4ed9f
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -487,7 +353,141 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5b70f7d2:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_5b70f7d2
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_98977119:
+    changed:
+      length: 310.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 310.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 310.09
+    module: gdsfactory.components.straight
+    name: straight_98977119
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -586,7 +586,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -617,7 +617,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
@@ -675,7 +675,7 @@ info:
   function_name: mzi
   info_version: 1
   module: gdsfactory.components.mzi
-  name: mzi_f431cc99
+  name: mzi_daa25958
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_mzit_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_.yml
@@ -1,37 +1,5 @@
 cells:
-  bend_euler_7f403255:
-    changed:
-      radius: 10
-      width: 0.55
-    default:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      with_arc_floorplan: true
-      with_cladding_box: true
-    dy: 10
-    full:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      radius: 10
-      width: 0.55
-      with_arc_floorplan: true
-      with_cladding_box: true
-    function_name: bend_euler
-    info_version: 1
-    length: 16.637
-    module: gdsfactory.components.bend_euler
-    name: bend_euler_7f403255
-    radius: 10
-    radius_min: 7.061
-  bend_euler_d48fbab9:
+  bend_euler_4320041f:
     changed:
       radius: 10
       width: 0.45
@@ -60,43 +28,42 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d48fbab9
+    name: bend_euler_4320041f
     radius: 10
     radius_min: 7.061
-  coupler_8eaa93fc:
+  bend_euler_d805decb:
     changed:
-      dy: 2
-      gap: 0.3
-      length: 10
+      radius: 10
+      width: 0.55
     default:
-      coupler_straight:
-        function: coupler_straight
-      coupler_symmetric:
-        function: coupler_symmetric
+      angle: 90
       cross_section:
         function: cross_section
-      dx: 10
-      dy: 5
-      gap: 0.236
-      length: 20
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      with_arc_floorplan: true
+      with_cladding_box: true
+    dy: 10
     full:
-      coupler_straight:
-        function: coupler_straight
-      coupler_symmetric:
-        function: coupler_symmetric
+      angle: 90
       cross_section:
         function: cross_section
-      dx: 10
-      dy: 2
-      gap: 0.3
-      length: 10
-    function_name: coupler
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      radius: 10
+      width: 0.55
+      with_arc_floorplan: true
+      with_cladding_box: true
+    function_name: bend_euler
     info_version: 1
-    length: 10.026
-    min_bend_radius: 30.486
-    module: gdsfactory.components.coupler
-    name: coupler_8eaa93fc
-  coupler_cb43455d:
+    length: 16.637
+    module: gdsfactory.components.bend_euler
+    name: bend_euler_d805decb
+    radius: 10
+    radius_min: 7.061
+  coupler_35cf121f:
     changed:
       dy: 2
       gap: 0.2
@@ -128,7 +95,40 @@ cells:
     length: 10.03
     min_bend_radius: 28.187
     module: gdsfactory.components.coupler
-    name: coupler_cb43455d
+    name: coupler_35cf121f
+  coupler_a95c47ae:
+    changed:
+      dy: 2
+      gap: 0.3
+      length: 10
+    default:
+      coupler_straight:
+        function: coupler_straight
+      coupler_symmetric:
+        function: coupler_symmetric
+      cross_section:
+        function: cross_section
+      dx: 10
+      dy: 5
+      gap: 0.236
+      length: 20
+    full:
+      coupler_straight:
+        function: coupler_straight
+      coupler_symmetric:
+        function: coupler_symmetric
+      cross_section:
+        function: cross_section
+      dx: 10
+      dy: 2
+      gap: 0.3
+      length: 10
+    function_name: coupler
+    info_version: 1
+    length: 10.026
+    min_bend_radius: 30.486
+    module: gdsfactory.components.coupler
+    name: coupler_a95c47ae
   mzit:
     changed: {}
     default:
@@ -181,7 +181,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzit
     name: mzit
-  straight_0832c2df:
+  straight_214611f8:
     changed:
       length: 1
       width: 0.55
@@ -202,9 +202,32 @@ cells:
     info_version: 1
     length: 1
     module: gdsfactory.components.straight
-    name: straight_0832c2df
+    name: straight_214611f8
     width: 0.55
-  straight_325d35db:
+  straight_558b3f05:
+    changed:
+      length: 1
+      width: 0.45
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 1
+      npoints: 2
+      width: 0.45
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 1
+    module: gdsfactory.components.straight
+    name: straight_558b3f05
+    width: 0.45
+  straight_714c2263:
     changed:
       length: 4
       width: 0.55
@@ -225,32 +248,9 @@ cells:
     info_version: 1
     length: 4
     module: gdsfactory.components.straight
-    name: straight_325d35db
+    name: straight_714c2263
     width: 0.55
-  straight_dab38390:
-    changed:
-      length: 1
-      width: 0.45
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 1
-      npoints: 2
-      width: 0.45
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 1
-    module: gdsfactory.components.straight
-    name: straight_dab38390
-    width: 0.45
-  straight_e8243227:
+  straight_e1606af8:
     changed:
       length: 3
       width: 0.55
@@ -271,13 +271,12 @@ cells:
     info_version: 1
     length: 3
     module: gdsfactory.components.straight
-    name: straight_e8243227
+    name: straight_e1606af8
     width: 0.55
-  taper_5ef18b11:
+  taper_1f59777d:
     changed:
       length: 5
-      width1: 0.45
-      width2: 0.55
+      width2: 0.45
     default:
       cross_section:
         function: cross_section
@@ -291,17 +290,17 @@ cells:
         function: cross_section
       length: 5
       port: null
-      width1: 0.45
-      width2: 0.55
+      width1: 0.5
+      width2: 0.45
       with_cladding_box: true
     function_name: taper
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_5ef18b11
-    width1: 0.45
-    width2: 0.55
-  taper_85794c73:
+    name: taper_1f59777d
+    width1: 0.5
+    width2: 0.45
+  taper_5f48a32e:
     changed:
       length: 5
       width1: 0.55
@@ -326,37 +325,10 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_85794c73
+    name: taper_5f48a32e
     width1: 0.55
     width2: 0.45
-  taper_8a817cb1:
-    changed:
-      length: 5
-      width2: 0.55
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_8a817cb1
-    width1: 0.5
-    width2: 0.55
-  taper_95acb109:
+  taper_64468ccd:
     changed:
       length: 5
       width1: 0.55
@@ -381,13 +353,13 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_95acb109
+    name: taper_64468ccd
     width1: 0.55
     width2: 0.5
-  taper_c63e501a:
+  taper_66f9ba3d:
     changed:
       length: 5
-      width2: 0.45
+      width2: 0.55
     default:
       cross_section:
         function: cross_section
@@ -402,16 +374,44 @@ cells:
       length: 5
       port: null
       width1: 0.5
-      width2: 0.45
+      width2: 0.55
       with_cladding_box: true
     function_name: taper
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_c63e501a
+    name: taper_66f9ba3d
     width1: 0.5
-    width2: 0.45
-  taper_feb4a44d:
+    width2: 0.55
+  taper_a8f0c5a3:
+    changed:
+      length: 5
+      width1: 0.45
+      width2: 0.55
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.45
+      width2: 0.55
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_a8f0c5a3
+    width1: 0.45
+    width2: 0.55
+  taper_e53c3c15:
     changed:
       length: 5
       width1: 0.45
@@ -436,7 +436,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_feb4a44d
+    name: taper_e53c3c15
     width1: 0.45
     width2: 0.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_mzit_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_.yml
@@ -273,62 +273,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e8243227
     width: 0.55
-  taper_35742b85:
-    changed:
-      length: 5
-      width1: 0.5
-      width2: 0.45
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.45
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_35742b85
-    width1: 0.5
-    width2: 0.45
-  taper_497b9706:
-    changed:
-      length: 5
-      width1: 0.5
-      width2: 0.55
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_497b9706
-    width1: 0.5
-    width2: 0.55
   taper_5ef18b11:
     changed:
       length: 5
@@ -385,6 +329,33 @@ cells:
     name: taper_85794c73
     width1: 0.55
     width2: 0.45
+  taper_8a817cb1:
+    changed:
+      length: 5
+      width2: 0.55
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.55
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_8a817cb1
+    width1: 0.5
+    width2: 0.55
   taper_95acb109:
     changed:
       length: 5
@@ -413,6 +384,33 @@ cells:
     name: taper_95acb109
     width1: 0.55
     width2: 0.5
+  taper_c63e501a:
+    changed:
+      length: 5
+      width2: 0.45
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.45
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_c63e501a
+    width1: 0.5
+    width2: 0.45
   taper_feb4a44d:
     changed:
       length: 5

--- a/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
@@ -63,11 +63,10 @@ cells:
     name: bend_euler_d48fbab9
     radius: 10
     radius_min: 7.061
-  coupler_c4c18dc8:
+  coupler_cbfe64dc:
     changed:
       dy: 2
       gap: 0.3
-      length: 20
     default:
       coupler_straight:
         function: coupler_straight
@@ -95,7 +94,7 @@ cells:
     length: 10.026
     min_bend_radius: 30.486
     module: gdsfactory.components.coupler
-    name: coupler_c4c18dc8
+    name: coupler_cbfe64dc
   coupler_cf85be80:
     changed:
       dy: 2
@@ -129,13 +128,10 @@ cells:
     min_bend_radius: 28.187
     module: gdsfactory.components.coupler
     name: coupler_cf85be80
-  mzit_f7e2e81d:
+  mzit_5c28f5cb:
     changed:
-      coupler_gap1: 0.2
-      coupler_gap2: 0.3
       coupler_length1: 10
       coupler_length2: 20
-      delta_length: 10
     default:
       Ls: 1
       bend90:
@@ -185,7 +181,7 @@ cells:
     function_name: mzit
     info_version: 1
     module: gdsfactory.components.mzit
-    name: mzit_f7e2e81d
+    name: mzit_5c28f5cb
   mzit_lattice:
     changed: {}
     default:
@@ -306,62 +302,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e8243227
     width: 0.55
-  taper_35742b85:
-    changed:
-      length: 5
-      width1: 0.5
-      width2: 0.45
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.45
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_35742b85
-    width1: 0.5
-    width2: 0.45
-  taper_497b9706:
-    changed:
-      length: 5
-      width1: 0.5
-      width2: 0.55
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_497b9706
-    width1: 0.5
-    width2: 0.55
   taper_5ef18b11:
     changed:
       length: 5
@@ -418,6 +358,33 @@ cells:
     name: taper_85794c73
     width1: 0.55
     width2: 0.45
+  taper_8a817cb1:
+    changed:
+      length: 5
+      width2: 0.55
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.55
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_8a817cb1
+    width1: 0.5
+    width2: 0.55
   taper_95acb109:
     changed:
       length: 5
@@ -446,6 +413,33 @@ cells:
     name: taper_95acb109
     width1: 0.55
     width2: 0.5
+  taper_c63e501a:
+    changed:
+      length: 5
+      width2: 0.45
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.45
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_c63e501a
+    width1: 0.5
+    width2: 0.45
   taper_feb4a44d:
     changed:
       length: 5

--- a/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
@@ -1,37 +1,5 @@
 cells:
-  bend_euler_7f403255:
-    changed:
-      radius: 10
-      width: 0.55
-    default:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      with_arc_floorplan: true
-      with_cladding_box: true
-    dy: 10
-    full:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      radius: 10
-      width: 0.55
-      with_arc_floorplan: true
-      with_cladding_box: true
-    function_name: bend_euler
-    info_version: 1
-    length: 16.637
-    module: gdsfactory.components.bend_euler
-    name: bend_euler_7f403255
-    radius: 10
-    radius_min: 7.061
-  bend_euler_d48fbab9:
+  bend_euler_4320041f:
     changed:
       radius: 10
       width: 0.45
@@ -60,10 +28,42 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d48fbab9
+    name: bend_euler_4320041f
     radius: 10
     radius_min: 7.061
-  coupler_cbfe64dc:
+  bend_euler_d805decb:
+    changed:
+      radius: 10
+      width: 0.55
+    default:
+      angle: 90
+      cross_section:
+        function: cross_section
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      with_arc_floorplan: true
+      with_cladding_box: true
+    dy: 10
+    full:
+      angle: 90
+      cross_section:
+        function: cross_section
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      radius: 10
+      width: 0.55
+      with_arc_floorplan: true
+      with_cladding_box: true
+    function_name: bend_euler
+    info_version: 1
+    length: 16.637
+    module: gdsfactory.components.bend_euler
+    name: bend_euler_d805decb
+    radius: 10
+    radius_min: 7.061
+  coupler_355fc964:
     changed:
       dy: 2
       gap: 0.3
@@ -94,8 +94,8 @@ cells:
     length: 10.026
     min_bend_radius: 30.486
     module: gdsfactory.components.coupler
-    name: coupler_cbfe64dc
-  coupler_cf85be80:
+    name: coupler_355fc964
+  coupler_af748ab0:
     changed:
       dy: 2
       gap: 0.2
@@ -127,7 +127,7 @@ cells:
     length: 10.03
     min_bend_radius: 28.187
     module: gdsfactory.components.coupler
-    name: coupler_cf85be80
+    name: coupler_af748ab0
   mzit_5c28f5cb:
     changed:
       coupler_length1: 10
@@ -210,7 +210,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mzit_lattice
     name: mzit_lattice
-  straight_0832c2df:
+  straight_214611f8:
     changed:
       length: 1
       width: 0.55
@@ -231,9 +231,32 @@ cells:
     info_version: 1
     length: 1
     module: gdsfactory.components.straight
-    name: straight_0832c2df
+    name: straight_214611f8
     width: 0.55
-  straight_325d35db:
+  straight_558b3f05:
+    changed:
+      length: 1
+      width: 0.45
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 1
+      npoints: 2
+      width: 0.45
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 1
+    module: gdsfactory.components.straight
+    name: straight_558b3f05
+    width: 0.45
+  straight_714c2263:
     changed:
       length: 4
       width: 0.55
@@ -254,32 +277,9 @@ cells:
     info_version: 1
     length: 4
     module: gdsfactory.components.straight
-    name: straight_325d35db
+    name: straight_714c2263
     width: 0.55
-  straight_dab38390:
-    changed:
-      length: 1
-      width: 0.45
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 1
-      npoints: 2
-      width: 0.45
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 1
-    module: gdsfactory.components.straight
-    name: straight_dab38390
-    width: 0.45
-  straight_e8243227:
+  straight_e1606af8:
     changed:
       length: 3
       width: 0.55
@@ -300,13 +300,12 @@ cells:
     info_version: 1
     length: 3
     module: gdsfactory.components.straight
-    name: straight_e8243227
+    name: straight_e1606af8
     width: 0.55
-  taper_5ef18b11:
+  taper_1f59777d:
     changed:
       length: 5
-      width1: 0.45
-      width2: 0.55
+      width2: 0.45
     default:
       cross_section:
         function: cross_section
@@ -320,17 +319,17 @@ cells:
         function: cross_section
       length: 5
       port: null
-      width1: 0.45
-      width2: 0.55
+      width1: 0.5
+      width2: 0.45
       with_cladding_box: true
     function_name: taper
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_5ef18b11
-    width1: 0.45
-    width2: 0.55
-  taper_85794c73:
+    name: taper_1f59777d
+    width1: 0.5
+    width2: 0.45
+  taper_5f48a32e:
     changed:
       length: 5
       width1: 0.55
@@ -355,37 +354,10 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_85794c73
+    name: taper_5f48a32e
     width1: 0.55
     width2: 0.45
-  taper_8a817cb1:
-    changed:
-      length: 5
-      width2: 0.55
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      port: null
-      width1: 0.5
-      width2: null
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
-    function_name: taper
-    info_version: 1
-    length: 5
-    module: gdsfactory.components.taper
-    name: taper_8a817cb1
-    width1: 0.5
-    width2: 0.55
-  taper_95acb109:
+  taper_64468ccd:
     changed:
       length: 5
       width1: 0.55
@@ -410,13 +382,13 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_95acb109
+    name: taper_64468ccd
     width1: 0.55
     width2: 0.5
-  taper_c63e501a:
+  taper_66f9ba3d:
     changed:
       length: 5
-      width2: 0.45
+      width2: 0.55
     default:
       cross_section:
         function: cross_section
@@ -431,16 +403,44 @@ cells:
       length: 5
       port: null
       width1: 0.5
-      width2: 0.45
+      width2: 0.55
       with_cladding_box: true
     function_name: taper
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_c63e501a
+    name: taper_66f9ba3d
     width1: 0.5
-    width2: 0.45
-  taper_feb4a44d:
+    width2: 0.55
+  taper_a8f0c5a3:
+    changed:
+      length: 5
+      width1: 0.45
+      width2: 0.55
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      port: null
+      width1: 0.5
+      width2: null
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.45
+      width2: 0.55
+      with_cladding_box: true
+    function_name: taper
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.taper
+    name: taper_a8f0c5a3
+    width1: 0.45
+    width2: 0.55
+  taper_e53c3c15:
     changed:
       length: 5
       width1: 0.45
@@ -465,7 +465,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_feb4a44d
+    name: taper_e53c3c15
     width1: 0.45
     width2: 0.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_nxn_.yml
+++ b/gdsfactory/tests/test_components/test_settings_nxn_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_c614e90d:
+  compass_011cc456:
     changed:
       size:
       - 8
@@ -25,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c614e90d
+    name: compass_011cc456
   nxn:
     changed: {}
     default:
@@ -56,7 +56,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.nxn
     name: nxn
-  rectangle_c614e90d:
+  rectangle_011cc456:
     changed:
       size:
       - 8
@@ -82,7 +82,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_c614e90d
+    name: rectangle_011cc456
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_nxn_.yml
+++ b/gdsfactory/tests/test_components/test_settings_nxn_.yml
@@ -1,10 +1,6 @@
 cells:
-  compass_f2a0af54:
+  compass_c614e90d:
     changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
       size:
       - 8
       - 8
@@ -29,7 +25,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f2a0af54
+    name: compass_c614e90d
   nxn:
     changed: {}
     default:
@@ -60,11 +56,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.nxn
     name: nxn
-  rectangle_48d69079:
+  rectangle_c614e90d:
     changed:
-      layer:
-      - 1
-      - 0
       size:
       - 8
       - 8
@@ -89,7 +82,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_48d69079
+    name: rectangle_c614e90d
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_pad_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_.yml
@@ -1,10 +1,9 @@
 cells:
-  compass_6ffda32f:
+  compass_a0b38c11:
     changed:
       layer:
       - 49
       - 0
-      port_inclusion: 0
       size:
       - 100
       - 100
@@ -29,7 +28,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_6ffda32f
+    name: compass_a0b38c11
   pad:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_pad_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_a0b38c11:
+  compass_7a93663b:
     changed:
       layer:
       - 49
@@ -28,7 +28,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a0b38c11
+    name: compass_7a93663b
   pad:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
@@ -1,5 +1,5 @@
 cells:
-  array_dacd7306:
+  array_e601a645:
     changed:
       columns: 1
       component: pad
@@ -25,8 +25,8 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_dacd7306
-  compass_53d34c22:
+    name: array_e601a645
+  compass_a76759a7:
     changed:
       layer:
       - 49
@@ -55,7 +55,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_53d34c22
+    name: compass_a76759a7
   pad_gsg_short_a5a92d3b:
     changed:
       short: false
@@ -97,7 +97,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.pad_gsg
     name: pad_gsg_short_a5a92d3b
-  rectangle_53d34c22:
+  rectangle_a76759a7:
     changed:
       layer:
       - 49
@@ -126,58 +126,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_53d34c22
-  route_quad_6af5ef5d:
-    changed:
-      layer:
-      - 49
-      - 0
-      port1: e3
-      port2: e1_2_1
-    default:
-      layer:
-      - 31
-      - 0
-      width1: null
-      width2: null
-    full:
-      layer:
-      - 49
-      - 0
-      port1: e3
-      port2: e1_2_1
-      width1: null
-      width2: null
-    function_name: route_quad
-    info_version: 1
-    module: gdsfactory.routing.route_quad
-    name: route_quad_6af5ef5d
-  route_quad_6fe3da35:
-    changed:
-      layer:
-      - 49
-      - 0
-      port1: e2
-      port2: e1_3_1
-    default:
-      layer:
-      - 31
-      - 0
-      width1: null
-      width2: null
-    full:
-      layer:
-      - 49
-      - 0
-      port1: e2
-      port2: e1_3_1
-      width1: null
-      width2: null
-    function_name: route_quad
-    info_version: 1
-    module: gdsfactory.routing.route_quad
-    name: route_quad_6fe3da35
-  route_quad_98332987:
+    name: rectangle_a76759a7
+  route_quad_3bbd1238:
     changed:
       layer:
       - 49
@@ -201,7 +151,57 @@ cells:
     function_name: route_quad
     info_version: 1
     module: gdsfactory.routing.route_quad
-    name: route_quad_98332987
+    name: route_quad_3bbd1238
+  route_quad_c109855f:
+    changed:
+      layer:
+      - 49
+      - 0
+      port1: e2
+      port2: e1_3_1
+    default:
+      layer:
+      - 31
+      - 0
+      width1: null
+      width2: null
+    full:
+      layer:
+      - 49
+      - 0
+      port1: e2
+      port2: e1_3_1
+      width1: null
+      width2: null
+    function_name: route_quad
+    info_version: 1
+    module: gdsfactory.routing.route_quad
+    name: route_quad_c109855f
+  route_quad_f132c2d2:
+    changed:
+      layer:
+      - 49
+      - 0
+      port1: e3
+      port2: e1_2_1
+    default:
+      layer:
+      - 31
+      - 0
+      width1: null
+      width2: null
+    full:
+      layer:
+      - 49
+      - 0
+      port1: e3
+      port2: e1_2_1
+      width1: null
+      width2: null
+    function_name: route_quad
+    info_version: 1
+    module: gdsfactory.routing.route_quad
+    name: route_quad_f132c2d2
 info:
   changed:
     short: false

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
@@ -26,12 +26,11 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_component
     name: array_dacd7306
-  compass_83a2e6d6:
+  compass_53d34c22:
     changed:
       layer:
       - 49
       - 0
-      port_type: electrical
       size:
       - 22
       - 7
@@ -56,7 +55,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_83a2e6d6
+    name: compass_53d34c22
   pad_gsg_short_a5a92d3b:
     changed:
       short: false

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
@@ -26,12 +26,11 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_component
     name: array_dacd7306
-  compass_83a2e6d6:
+  compass_53d34c22:
     changed:
       layer:
       - 49
       - 0
-      port_type: electrical
       size:
       - 22
       - 7
@@ -56,7 +55,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_83a2e6d6
+    name: compass_53d34c22
   pad_gsg_short:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
@@ -1,5 +1,5 @@
 cells:
-  array_dacd7306:
+  array_e601a645:
     changed:
       columns: 1
       component: pad
@@ -25,8 +25,8 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_dacd7306
-  compass_53d34c22:
+    name: array_e601a645
+  compass_a76759a7:
     changed:
       layer:
       - 49
@@ -55,7 +55,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_53d34c22
+    name: compass_a76759a7
   pad_gsg_short:
     changed: {}
     default:
@@ -96,7 +96,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.pad_gsg
     name: pad_gsg_short
-  rectangle_53d34c22:
+  rectangle_a76759a7:
     changed:
       layer:
       - 49
@@ -125,58 +125,8 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_53d34c22
-  route_quad_6af5ef5d:
-    changed:
-      layer:
-      - 49
-      - 0
-      port1: e3
-      port2: e1_2_1
-    default:
-      layer:
-      - 31
-      - 0
-      width1: null
-      width2: null
-    full:
-      layer:
-      - 49
-      - 0
-      port1: e3
-      port2: e1_2_1
-      width1: null
-      width2: null
-    function_name: route_quad
-    info_version: 1
-    module: gdsfactory.routing.route_quad
-    name: route_quad_6af5ef5d
-  route_quad_6fe3da35:
-    changed:
-      layer:
-      - 49
-      - 0
-      port1: e2
-      port2: e1_3_1
-    default:
-      layer:
-      - 31
-      - 0
-      width1: null
-      width2: null
-    full:
-      layer:
-      - 49
-      - 0
-      port1: e2
-      port2: e1_3_1
-      width1: null
-      width2: null
-    function_name: route_quad
-    info_version: 1
-    module: gdsfactory.routing.route_quad
-    name: route_quad_6fe3da35
-  route_quad_98332987:
+    name: rectangle_a76759a7
+  route_quad_3bbd1238:
     changed:
       layer:
       - 49
@@ -200,7 +150,57 @@ cells:
     function_name: route_quad
     info_version: 1
     module: gdsfactory.routing.route_quad
-    name: route_quad_98332987
+    name: route_quad_3bbd1238
+  route_quad_c109855f:
+    changed:
+      layer:
+      - 49
+      - 0
+      port1: e2
+      port2: e1_3_1
+    default:
+      layer:
+      - 31
+      - 0
+      width1: null
+      width2: null
+    full:
+      layer:
+      - 49
+      - 0
+      port1: e2
+      port2: e1_3_1
+      width1: null
+      width2: null
+    function_name: route_quad
+    info_version: 1
+    module: gdsfactory.routing.route_quad
+    name: route_quad_c109855f
+  route_quad_f132c2d2:
+    changed:
+      layer:
+      - 49
+      - 0
+      port1: e3
+      port2: e1_2_1
+    default:
+      layer:
+      - 31
+      - 0
+      width1: null
+      width2: null
+    full:
+      layer:
+      - 49
+      - 0
+      port1: e3
+      port2: e1_2_1
+      width1: null
+      width2: null
+    function_name: route_quad
+    info_version: 1
+    module: gdsfactory.routing.route_quad
+    name: route_quad_f132c2d2
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
@@ -1,41 +1,9 @@
 cells:
-  compass_6ffda32f:
+  compass_988ea7ee:
     changed:
       layer:
       - 49
       - 0
-      port_inclusion: 0
-      size:
-      - 100
-      - 100
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 100
-      - 100
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_6ffda32f
-  compass_b0af43a3:
-    changed:
-      layer:
-      - 49
-      - 0
-      port_type: electrical
       size:
       - 1050
       - 10
@@ -60,7 +28,37 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b0af43a3
+    name: compass_988ea7ee
+  compass_a0b38c11:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 100
+      - 100
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 100
+      - 100
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_a0b38c11
   pad:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
@@ -1,5 +1,5 @@
 cells:
-  compass_988ea7ee:
+  compass_59dfb1fe:
     changed:
       layer:
       - 49
@@ -28,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_988ea7ee
-  compass_a0b38c11:
+    name: compass_59dfb1fe
+  compass_7a93663b:
     changed:
       layer:
       - 49
@@ -58,7 +58,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_a0b38c11
+    name: compass_7a93663b
   pad:
     changed: {}
     default:
@@ -115,7 +115,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.pads_shorted
     name: pads_shorted
-  rectangle_0fa1e1c2:
+  rectangle_066887ad:
     changed:
       centered: true
       layer:
@@ -145,7 +145,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_0fa1e1c2
+    name: rectangle_066887ad
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_rectangle_.yml
+++ b/gdsfactory/tests/test_components/test_settings_rectangle_.yml
@@ -1,13 +1,6 @@
 cells:
-  compass_896ae020:
-    changed:
-      layer:
-      - 1
-      - 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
+  compass:
+    changed: {}
     default:
       layer:
       - 1
@@ -29,7 +22,7 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_896ae020
+    name: compass
   rectangle:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
+++ b/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
@@ -26,11 +26,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_component
     name: array_05d1b8c2
-  compass_ad4aadff:
+  compass_9714634f:
     changed:
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 100
@@ -56,13 +53,9 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ad4aadff
-  rectangle_2fbcbfd8:
+    name: compass_9714634f
+  rectangle_9714634f:
     changed:
-      centered: false
-      layer:
-      - 1
-      - 0
       port_type: null
       size:
       - 100
@@ -88,7 +81,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_2fbcbfd8
+    name: rectangle_9714634f
   rectangle_with_slits:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
+++ b/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
@@ -1,8 +1,8 @@
 cells:
-  array_05d1b8c2:
+  array_2030fc32:
     changed:
       columns: 4
-      component: rectangle_dc798a8d
+      component: rectangle_b3809cf3
       rows: 9
       spacing:
       - 20
@@ -17,7 +17,7 @@ cells:
       - 150
     full:
       columns: 4
-      component: rectangle_dc798a8d
+      component: rectangle_b3809cf3
       rows: 9
       spacing:
       - 20
@@ -25,8 +25,8 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_05d1b8c2
-  compass_9714634f:
+    name: array_2030fc32
+  compass_c5baf54c:
     changed:
       port_type: null
       size:
@@ -53,8 +53,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_9714634f
-  rectangle_9714634f:
+    name: compass_c5baf54c
+  rectangle_c5baf54c:
     changed:
       port_type: null
       size:
@@ -81,7 +81,7 @@ cells:
     function_name: rectangle
     info_version: 1
     module: gdsfactory.components.rectangle
-    name: rectangle_9714634f
+    name: rectangle_c5baf54c
   rectangle_with_slits:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_resistance_sheet_.yml
+++ b/gdsfactory/tests/test_components/test_settings_resistance_sheet_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_09edc7bd:
-    changed:
-      layer:
-      - 3
-      - 0
-      size:
-      - 80
-      - 80
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 3
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 80
-      - 80
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_09edc7bd
-  compass_5402b302:
+  compass_4e3c2ec7:
     changed:
       layer:
       - 3
@@ -58,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_5402b302
-  compass_c15b4e69:
+    name: compass_4e3c2ec7
+  compass_5fed87fe:
     changed:
       layer:
       - 41
@@ -88,38 +58,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c15b4e69
-  compass_c305bcfa:
-    changed:
-      layer:
-      - 24
-      - 0
-      size:
-      - 80
-      - 80
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 24
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 80
-      - 80
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_c305bcfa
-  compass_cc9a3711:
+    name: compass_5fed87fe
+  compass_9462dcce:
     changed:
       layer:
       - 24
@@ -148,8 +88,68 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_cc9a3711
-  contact_3a2b60f1:
+    name: compass_9462dcce
+  compass_bc2c230b:
+    changed:
+      layer:
+      - 3
+      - 0
+      size:
+      - 80
+      - 80
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 3
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 80
+      - 80
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_bc2c230b
+  compass_eae75e74:
+    changed:
+      layer:
+      - 24
+      - 0
+      size:
+      - 80
+      - 80
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 24
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 80
+      - 80
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_eae75e74
+  contact_bb6256f2:
     changed:
       layers:
       - - 3
@@ -215,7 +215,7 @@ cells:
     - 41
     - 0
     module: gdsfactory.components.contact
-    name: contact_3a2b60f1
+    name: contact_bb6256f2
     size:
     - 80
     - 80

--- a/gdsfactory/tests/test_components/test_settings_ring_double_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_.yml
@@ -1,10 +1,6 @@
 cells:
-  coupler_ring_884bafc4:
+  coupler_ring_1f8e1c06:
     changed:
-      bend: null
-      cross_section:
-        function: cross_section
-      gap: 0.2
       length_x: 0.01
       radius: 10
     default:
@@ -34,7 +30,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_884bafc4
+    name: coupler_ring_1f8e1c06
   ring_double:
     changed: {}
     default:
@@ -65,10 +61,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_double
     name: ring_double
-  straight_5743d35a:
+  straight_c138f2c4:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.01
     default:
       cross_section:
@@ -86,7 +80,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_c138f2c4
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_double_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_.yml
@@ -1,5 +1,5 @@
 cells:
-  coupler_ring_1f8e1c06:
+  coupler_ring_cd892edd:
     changed:
       length_x: 0.01
       radius: 10
@@ -30,7 +30,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_1f8e1c06
+    name: coupler_ring_cd892edd
   ring_double:
     changed: {}
     default:
@@ -61,7 +61,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_double
     name: ring_double
-  straight_c138f2c4:
+  straight_c49ce9c6:
     changed:
       length: 0.01
     default:
@@ -80,7 +80,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c49ce9c6
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_52724fdf:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 4
-      - 4
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 4
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_52724fdf
-  compass_c920c7aa:
+  compass_0f060968:
     changed:
       layer:
       - 45
@@ -58,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c920c7aa
-  compass_f639aa23:
+    name: compass_0f060968
+  compass_4b89a55a:
     changed:
       layer:
       - 49
@@ -88,8 +58,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f639aa23
-  contact_00c518be:
+    name: compass_4b89a55a
+  compass_e9fd1346:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 4
+      - 4
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 4
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_e9fd1346
+  contact_f6c435f1:
     changed:
       layers:
       - - 47
@@ -151,11 +151,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_00c518be
+    name: contact_f6c435f1
     size:
     - 4
     - 4
-  coupler_ring_5779f456:
+  coupler_ring_b1bf2a47:
     changed:
       bend_cross_section:
         function: strip_heater_metal
@@ -189,7 +189,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_5779f456
+    name: coupler_ring_b1bf2a47
   ring_double_heater:
     changed: {}
     default:
@@ -276,7 +276,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_double_heater
     name: ring_double_heater
-  straight_ffdb2b22:
+  straight_c6165933:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -297,7 +297,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_ffdb2b22
+    name: straight_c6165933
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
@@ -89,7 +89,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_f639aa23
-  contact_6eee07f8:
+  contact_00c518be:
     changed:
       layers:
       - - 47
@@ -101,16 +101,6 @@ cells:
       size:
       - 4
       - 4
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
     default:
       layer_port: null
       layers:
@@ -161,18 +151,14 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_6eee07f8
+    name: contact_00c518be
     size:
     - 4
     - 4
-  coupler_ring_538ed52b:
+  coupler_ring_5779f456:
     changed:
-      bend: null
       bend_cross_section:
         function: strip_heater_metal
-      cross_section:
-        function: cross_section
-      gap: 0.2
       length_x: 0.01
       radius: 10
     default:
@@ -203,7 +189,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_538ed52b
+    name: coupler_ring_5779f456
   ring_double_heater:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_4725f0ef:
+  bend_euler_2e0a66fe:
     changed:
-      cross_section:
-        function: cross_section
       radius: 10
     default:
       angle: 90
@@ -28,17 +26,13 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_4725f0ef
+    name: bend_euler_2e0a66fe
     radius: 10
     radius_min: 7.061
-  coupler_ring_6859e681:
+  coupler_ring_354ce3d3:
     changed:
       bend:
         function: bend_euler
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 4
       radius: 10
     default:
       bend: null
@@ -68,7 +62,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_6859e681
+    name: coupler_ring_354ce3d3
   ring_single:
     changed: {}
     default:
@@ -101,33 +95,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_single
     name: ring_single
-  straight_178d4157:
+  straight_1469c185:
     changed:
-      cross_section:
-        function: cross_section
-      length: 4
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 4
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 4
-    module: gdsfactory.components.straight
-    name: straight_178d4157
-    width: 0.5
-  straight_417ceb80:
-    changed:
-      cross_section:
-        function: cross_section
       length: 0.6
     default:
       cross_section:
@@ -145,7 +114,28 @@ cells:
     info_version: 1
     length: 0.6
     module: gdsfactory.components.straight
-    name: straight_417ceb80
+    name: straight_1469c185
+    width: 0.5
+  straight_defbc978:
+    changed:
+      length: 4
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 4
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 4
+    module: gdsfactory.components.straight
+    name: straight_defbc978
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_.yml
@@ -29,7 +29,7 @@ cells:
     name: bend_euler_2e0a66fe
     radius: 10
     radius_min: 7.061
-  coupler_ring_354ce3d3:
+  coupler_ring_3363c15c:
     changed:
       bend:
         function: bend_euler
@@ -62,7 +62,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_354ce3d3
+    name: coupler_ring_3363c15c
   ring_single:
     changed: {}
     default:
@@ -95,7 +95,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_single
     name: ring_single
-  straight_1469c185:
+  straight_c1e7b81b:
     changed:
       length: 0.6
     default:
@@ -114,7 +114,7 @@ cells:
     info_version: 1
     length: 0.6
     module: gdsfactory.components.straight
-    name: straight_1469c185
+    name: straight_c1e7b81b
     width: 0.5
   straight_defbc978:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
@@ -1,40 +1,6 @@
 cells:
-  bend_euler_4725f0ef:
+  bend_euler_212e6ad7:
     changed:
-      cross_section:
-        function: cross_section
-      radius: 10
-    default:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      with_arc_floorplan: true
-      with_cladding_box: true
-    dy: 10
-    full:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      radius: 10
-      with_arc_floorplan: true
-      with_cladding_box: true
-    function_name: bend_euler
-    info_version: 1
-    length: 16.637
-    module: gdsfactory.components.bend_euler
-    name: bend_euler_4725f0ef
-    radius: 10
-    radius_min: 7.061
-  bend_euler_a519ff2d:
-    changed:
-      cross_section:
-        function: cross_section
       radius: 5
     default:
       angle: 90
@@ -60,54 +26,43 @@ cells:
     info_version: 1
     length: 8.318
     module: gdsfactory.components.bend_euler
-    name: bend_euler_a519ff2d
+    name: bend_euler_212e6ad7
     radius: 5
     radius_min: 3.53
-  coupler_ring_ca9f110c:
+  bend_euler_2e0a66fe:
     changed:
-      bend:
-        function: bend_euler
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 10
-      radius: 5
+      radius: 10
     default:
-      bend: null
-      bend_cross_section: null
-      coupler90:
-        function: coupler90
-      coupler_straight:
-        function: coupler_straight
+      angle: 90
       cross_section:
         function: cross_section
-      gap: 0.2
-      length_x: 4
-      radius: 5
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      with_arc_floorplan: true
+      with_cladding_box: true
+    dy: 10
     full:
-      bend:
-        function: bend_euler
-      bend_cross_section: null
-      coupler90:
-        function: coupler90
-      coupler_straight:
-        function: coupler_straight
+      angle: 90
       cross_section:
         function: cross_section
-      gap: 0.2
-      length_x: 10
-      radius: 5
-    function_name: coupler_ring
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      radius: 10
+      with_arc_floorplan: true
+      with_cladding_box: true
+    function_name: bend_euler
     info_version: 1
-    module: gdsfactory.components.coupler_ring
-    name: coupler_ring_ca9f110c
-  coupler_ring_e9939844:
+    length: 16.637
+    module: gdsfactory.components.bend_euler
+    name: bend_euler_2e0a66fe
+    radius: 10
+    radius_min: 7.061
+  coupler_ring_a7946fc0:
     changed:
       bend:
         function: bend_euler
-      cross_section:
-        function: cross_section
-      gap: 0.2
       length_x: 20
       radius: 10
     default:
@@ -138,41 +93,41 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_e9939844
-  ring_single_245fa0a7:
+    name: coupler_ring_a7946fc0
+  coupler_ring_fc464cd9:
     changed:
-      length_x: 20
-      radius: 10
-    default:
       bend:
         function: bend_euler
-      coupler_ring:
-        function: coupler_ring
+      length_x: 10
+    default:
+      bend: null
+      bend_cross_section: null
+      coupler90:
+        function: coupler90
+      coupler_straight:
+        function: coupler_straight
       cross_section:
         function: cross_section
       gap: 0.2
       length_x: 4
-      length_y: 0.6
-      radius: 10
-      straight:
-        function: straight
+      radius: 5
     full:
       bend:
         function: bend_euler
-      coupler_ring:
-        function: coupler_ring
+      bend_cross_section: null
+      coupler90:
+        function: coupler90
+      coupler_straight:
+        function: coupler_straight
       cross_section:
         function: cross_section
       gap: 0.2
-      length_x: 20
-      length_y: 0.6
-      radius: 10
-      straight:
-        function: straight
-    function_name: ring_single
+      length_x: 10
+      radius: 5
+    function_name: coupler_ring
     info_version: 1
-    module: gdsfactory.components.ring_single
-    name: ring_single_245fa0a7
+    module: gdsfactory.components.coupler_ring
+    name: coupler_ring_fc464cd9
   ring_single_a371eccc:
     changed:
       length_x: 10
@@ -235,10 +190,61 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_single_array
     name: ring_single_array
-  straight_417ceb80:
+  ring_single_fdbd008a:
     changed:
+      length_x: 20
+    default:
+      bend:
+        function: bend_euler
+      coupler_ring:
+        function: coupler_ring
       cross_section:
         function: cross_section
+      gap: 0.2
+      length_x: 4
+      length_y: 0.6
+      radius: 10
+      straight:
+        function: straight
+    full:
+      bend:
+        function: bend_euler
+      coupler_ring:
+        function: coupler_ring
+      cross_section:
+        function: cross_section
+      gap: 0.2
+      length_x: 20
+      length_y: 0.6
+      radius: 10
+      straight:
+        function: straight
+    function_name: ring_single
+    info_version: 1
+    module: gdsfactory.components.ring_single
+    name: ring_single_fdbd008a
+  straight:
+    changed: {}
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10
+    module: gdsfactory.components.straight
+    name: straight
+    width: 0.5
+  straight_1469c185:
+    changed:
       length: 0.6
     default:
       cross_section:
@@ -256,35 +262,10 @@ cells:
     info_version: 1
     length: 0.6
     module: gdsfactory.components.straight
-    name: straight_417ceb80
+    name: straight_1469c185
     width: 0.5
-  straight_457f2252:
+  straight_870620aa:
     changed:
-      cross_section:
-        function: cross_section
-      length: 10
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 10
-    module: gdsfactory.components.straight
-    name: straight_457f2252
-    width: 0.5
-  straight_6c1c731d:
-    changed:
-      cross_section:
-        function: cross_section
       length: 20
     default:
       cross_section:
@@ -302,7 +283,7 @@ cells:
     info_version: 1
     length: 20
     module: gdsfactory.components.straight
-    name: straight_6c1c731d
+    name: straight_870620aa
     width: 0.5
   straight_b3dac65b:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
@@ -59,7 +59,41 @@ cells:
     name: bend_euler_2e0a66fe
     radius: 10
     radius_min: 7.061
-  coupler_ring_a7946fc0:
+  coupler_ring_44049f35:
+    changed:
+      bend:
+        function: bend_euler
+      length_x: 10
+    default:
+      bend: null
+      bend_cross_section: null
+      coupler90:
+        function: coupler90
+      coupler_straight:
+        function: coupler_straight
+      cross_section:
+        function: cross_section
+      gap: 0.2
+      length_x: 4
+      radius: 5
+    full:
+      bend:
+        function: bend_euler
+      bend_cross_section: null
+      coupler90:
+        function: coupler90
+      coupler_straight:
+        function: coupler_straight
+      cross_section:
+        function: cross_section
+      gap: 0.2
+      length_x: 10
+      radius: 5
+    function_name: coupler_ring
+    info_version: 1
+    module: gdsfactory.components.coupler_ring
+    name: coupler_ring_44049f35
+  coupler_ring_50a0fda3:
     changed:
       bend:
         function: bend_euler
@@ -93,41 +127,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_a7946fc0
-  coupler_ring_fc464cd9:
-    changed:
-      bend:
-        function: bend_euler
-      length_x: 10
-    default:
-      bend: null
-      bend_cross_section: null
-      coupler90:
-        function: coupler90
-      coupler_straight:
-        function: coupler_straight
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 4
-      radius: 5
-    full:
-      bend:
-        function: bend_euler
-      bend_cross_section: null
-      coupler90:
-        function: coupler90
-      coupler_straight:
-        function: coupler_straight
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 10
-      radius: 5
-    function_name: coupler_ring
-    info_version: 1
-    module: gdsfactory.components.coupler_ring
-    name: coupler_ring_fc464cd9
+    name: coupler_ring_50a0fda3
   ring_single_a371eccc:
     changed:
       length_x: 10
@@ -243,27 +243,6 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_1469c185:
-    changed:
-      length: 0.6
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.6
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.6
-    module: gdsfactory.components.straight
-    name: straight_1469c185
-    width: 0.5
   straight_870620aa:
     changed:
       length: 20
@@ -305,6 +284,27 @@ cells:
     length: 5
     module: gdsfactory.components.straight
     name: straight_b3dac65b
+    width: 0.5
+  straight_c1e7b81b:
+    changed:
+      length: 0.6
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.6
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.6
+    module: gdsfactory.components.straight
+    name: straight_c1e7b81b
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_98cb77bf:
+  bend_euler_ad3c06b6:
     changed:
       radius: 5
       width: 0.5
@@ -28,7 +28,7 @@ cells:
     info_version: 1
     length: 8.318
     module: gdsfactory.components.bend_euler
-    name: bend_euler_98cb77bf
+    name: bend_euler_ad3c06b6
     radius: 5
     radius_min: 3.53
   coupler_ring:
@@ -61,29 +61,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.coupler_ring
     name: coupler_ring
-  straight_a96febb9:
-    changed:
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 10
-    module: gdsfactory.components.straight
-    name: straight_a96febb9
-    width: 0.5
-  straight_d4fc336a:
+  straight_d4cb55ff:
     changed:
       length: 4
       width: 0.5
@@ -104,7 +82,29 @@ cells:
     info_version: 1
     length: 4
     module: gdsfactory.components.straight
-    name: straight_d4fc336a
+    name: straight_d4cb55ff
+    width: 0.5
+  straight_d6e1c0cf:
+    changed:
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10
+    module: gdsfactory.components.straight
+    name: straight_d6e1c0cf
     width: 0.5
   taper_2e9853cc:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
@@ -31,11 +31,8 @@ cells:
     name: bend_euler_98cb77bf
     radius: 5
     radius_min: 3.53
-  coupler_ring_6a2f750e:
-    changed:
-      gap: 0.2
-      length_x: 4
-      radius: 5
+  coupler_ring:
+    changed: {}
     default:
       bend: null
       bend_cross_section: null
@@ -63,10 +60,9 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_6a2f750e
-  straight_9fb198d1:
+    name: coupler_ring
+  straight_a96febb9:
     changed:
-      length: 10
       width: 0.5
     default:
       cross_section:
@@ -85,7 +81,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_9fb198d1
+    name: straight_a96febb9
     width: 0.5
   straight_d4fc336a:
     changed:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_euler_6dcba006:
+  bend_euler_93d83bb0:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -28,40 +28,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_6dcba006
+    name: bend_euler_93d83bb0
     radius: 10
     radius_min: 7.061
-  compass_52724fdf:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 4
-      - 4
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 4
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_52724fdf
-  compass_c920c7aa:
+  compass_0f060968:
     changed:
       layer:
       - 45
@@ -90,8 +60,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c920c7aa
-  compass_f639aa23:
+    name: compass_0f060968
+  compass_4b89a55a:
     changed:
       layer:
       - 49
@@ -120,8 +90,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f639aa23
-  contact_00c518be:
+    name: compass_4b89a55a
+  compass_e9fd1346:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 4
+      - 4
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 4
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_e9fd1346
+  contact_f6c435f1:
     changed:
       layers:
       - - 47
@@ -183,11 +183,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_00c518be
+    name: contact_f6c435f1
     size:
     - 4
     - 4
-  coupler_ring_c97f91c7:
+  coupler_ring_4ad3cb8d:
     changed:
       bend:
         function: bend_euler
@@ -223,7 +223,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_c97f91c7
+    name: coupler_ring_4ad3cb8d
   ring_single_heater:
     changed: {}
     default:
@@ -312,30 +312,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_single_heater
     name: ring_single_heater
-  straight_5844ea34:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      length: 0.6
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      length: 0.6
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.6
-    module: gdsfactory.components.straight
-    name: straight_5844ea34
-    width: 0.5
-  straight_c075a8bf:
+  straight_1a39e145:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -356,7 +333,30 @@ cells:
     info_version: 1
     length: 4
     module: gdsfactory.components.straight
-    name: straight_c075a8bf
+    name: straight_1a39e145
+    width: 0.5
+  straight_baf9a54b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      length: 0.6
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      length: 0.6
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.6
+    module: gdsfactory.components.straight
+    name: straight_baf9a54b
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
@@ -121,7 +121,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_f639aa23
-  contact_6eee07f8:
+  contact_00c518be:
     changed:
       layers:
       - - 47
@@ -133,16 +133,6 @@ cells:
       size:
       - 4
       - 4
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
     default:
       layer_port: null
       layers:
@@ -193,20 +183,16 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_6eee07f8
+    name: contact_00c518be
     size:
     - 4
     - 4
-  coupler_ring_5edf6857:
+  coupler_ring_c97f91c7:
     changed:
       bend:
         function: bend_euler
       bend_cross_section:
         function: strip_heater_metal
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 4
       radius: 10
     default:
       bend: null
@@ -237,7 +223,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_5edf6857
+    name: coupler_ring_c97f91c7
   ring_single_heater:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_seal_ring_.yml
+++ b/gdsfactory/tests/test_components/test_settings_seal_ring_.yml
@@ -1,65 +1,5 @@
 cells:
-  compass_1ee15e31:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 10
-      - 25
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 25
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_1ee15e31
-  compass_487addde:
-    changed:
-      layer:
-      - 41
-      - 0
-      size:
-      - 44
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 41
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 44
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_487addde
-  compass_63f1d448:
+  compass_04d08b60:
     changed:
       layer:
       - 41
@@ -88,8 +28,98 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_63f1d448
-  compass_8526a86d:
+    name: compass_04d08b60
+  compass_06a559dd:
+    changed:
+      layer:
+      - 41
+      - 0
+      size:
+      - 44
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 41
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 44
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_06a559dd
+  compass_753a8cb9:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 44
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 44
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_753a8cb9
+  compass_79666d6d:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 10
+      - 25
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 25
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_79666d6d
+  compass_8ad40ee7:
     changed:
       layer:
       - 45
@@ -118,38 +148,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8526a86d
-  compass_9823baac:
-    changed:
-      layer:
-      - 45
-      - 0
-      size:
-      - 44
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 44
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_9823baac
-  compass_b029e935:
+    name: compass_8ad40ee7
+  compass_8b32099f:
     changed:
       layer:
       - 49
@@ -178,67 +178,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b029e935
-  contact_0c2ee789:
-    changed:
-      size:
-      - 44
-      - 10
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 44
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_0c2ee789
-    size:
-    - 44
-    - 10
-  contact_9296beeb:
+    name: compass_8b32099f
+  contact_8fd8fe9b:
     changed:
       size:
       - 10
@@ -293,10 +234,69 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_9296beeb
+    name: contact_8fd8fe9b
     size:
     - 10
     - 25
+  contact_b3a87156:
+    changed:
+      size:
+      - 44
+      - 10
+    default:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 44
+      - 10
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_b3a87156
+    size:
+    - 44
+    - 10
   seal_ring:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_spiral_external_io_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_external_io_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   spiral_external_io:
@@ -60,56 +58,8 @@ cells:
     length: 9003.302
     module: gdsfactory.components.spiral_external_io
     name: spiral_external_io
-  straight_0182467e:
+  straight_06f075bd:
     changed:
-      cross_section:
-        function: cross_section
-      length: 351
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 351
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 351
-    module: gdsfactory.components.straight
-    name: straight_0182467e
-    width: 0.5
-  straight_23e55000:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 8
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 8
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 8
-    module: gdsfactory.components.straight
-    name: straight_23e55000
-    width: 0.5
-  straight_27af19c6:
-    changed:
-      cross_section:
-        function: cross_section
       length: 68
     default:
       cross_section:
@@ -127,380 +77,10 @@ cells:
     info_version: 1
     length: 68
     module: gdsfactory.components.straight
-    name: straight_27af19c6
+    name: straight_06f075bd
     width: 0.5
-  straight_29d3bdbc:
+  straight_10148060:
     changed:
-      cross_section:
-        function: cross_section
-      length: 369
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 369
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 369
-    module: gdsfactory.components.straight
-    name: straight_29d3bdbc
-    width: 0.5
-  straight_2a1241f2:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 33
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 33
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 33
-    module: gdsfactory.components.straight
-    name: straight_2a1241f2
-    width: 0.5
-  straight_333fe4a4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 345
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 345
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 345
-    module: gdsfactory.components.straight
-    name: straight_333fe4a4
-    width: 0.5
-  straight_3ba9d90a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 78
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 78
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 78
-    module: gdsfactory.components.straight
-    name: straight_3ba9d90a
-    width: 0.5
-  straight_48cc40f3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 26
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 26
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 26
-    module: gdsfactory.components.straight
-    name: straight_48cc40f3
-    width: 0.5
-  straight_668c79e4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 56
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 56
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 56
-    module: gdsfactory.components.straight
-    name: straight_668c79e4
-    width: 0.5
-  straight_6b7f6121:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 387
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 387
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 387
-    module: gdsfactory.components.straight
-    name: straight_6b7f6121
-    width: 0.5
-  straight_6c1c731d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 20
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 20
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 20
-    module: gdsfactory.components.straight
-    name: straight_6c1c731d
-    width: 0.5
-  straight_880835d3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 84
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 84
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 84
-    module: gdsfactory.components.straight
-    name: straight_880835d3
-    width: 0.5
-  straight_8c1eb73b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 62
-    module: gdsfactory.components.straight
-    name: straight_8c1eb73b
-    width: 0.5
-  straight_9201bcdc:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 44
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 44
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 44
-    module: gdsfactory.components.straight
-    name: straight_9201bcdc
-    width: 0.5
-  straight_96054871:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 381
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 381
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 381
-    module: gdsfactory.components.straight
-    name: straight_96054871
-    width: 0.5
-  straight_9802c890:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 50
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 50
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 50
-    module: gdsfactory.components.straight
-    name: straight_9802c890
-    width: 0.5
-  straight_9d6d1c19:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 357
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 357
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 357
-    module: gdsfactory.components.straight
-    name: straight_9d6d1c19
-    width: 0.5
-  straight_a36cf020:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 32
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 32
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 32
-    module: gdsfactory.components.straight
-    name: straight_a36cf020
-    width: 0.5
-  straight_ae4b38f0:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 393
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 393
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 393
-    module: gdsfactory.components.straight
-    name: straight_ae4b38f0
-    width: 0.5
-  straight_b37f39b0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 339
     default:
       cross_section:
@@ -518,13 +98,11 @@ cells:
     info_version: 1
     length: 339
     module: gdsfactory.components.straight
-    name: straight_b37f39b0
+    name: straight_10148060
     width: 0.5
-  straight_bbc9a5f4:
+  straight_169860b0:
     changed:
-      cross_section:
-        function: cross_section
-      length: 38
+      length: 393
     default:
       cross_section:
         function: cross_section
@@ -534,19 +112,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 38
+      length: 393
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 38
+    length: 393
     module: gdsfactory.components.straight
-    name: straight_bbc9a5f4
+    name: straight_169860b0
     width: 0.5
-  straight_cd563a7f:
+  straight_262e9af4:
     changed:
-      cross_section:
-        function: cross_section
       length: 14
     default:
       cross_section:
@@ -564,35 +140,10 @@ cells:
     info_version: 1
     length: 14
     module: gdsfactory.components.straight
-    name: straight_cd563a7f
+    name: straight_262e9af4
     width: 0.5
-  straight_dc0699f9:
+  straight_431b7111:
     changed:
-      cross_section:
-        function: cross_section
-      length: 363
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 363
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 363
-    module: gdsfactory.components.straight
-    name: straight_dc0699f9
-    width: 0.5
-  straight_e01d8133:
-    changed:
-      cross_section:
-        function: cross_section
       length: 375
     default:
       cross_section:
@@ -610,13 +161,11 @@ cells:
     info_version: 1
     length: 375
     module: gdsfactory.components.straight
-    name: straight_e01d8133
+    name: straight_431b7111
     width: 0.5
-  straight_e7395bed:
+  straight_7b17241b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 5
+      length: 351
     default:
       cross_section:
         function: cross_section
@@ -626,19 +175,143 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 5
+      length: 351
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 5
+    length: 351
     module: gdsfactory.components.straight
-    name: straight_e7395bed
+    name: straight_7b17241b
     width: 0.5
-  straight_f981fc54:
+  straight_870620aa:
     changed:
+      length: 20
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 20
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 20
+    module: gdsfactory.components.straight
+    name: straight_870620aa
+    width: 0.5
+  straight_8cf9b40f:
+    changed:
+      length: 363
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 363
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 363
+    module: gdsfactory.components.straight
+    name: straight_8cf9b40f
+    width: 0.5
+  straight_8f2699f3:
+    changed:
+      length: 38
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 38
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 38
+    module: gdsfactory.components.straight
+    name: straight_8f2699f3
+    width: 0.5
+  straight_8faea990:
+    changed:
+      length: 33
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 33
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 33
+    module: gdsfactory.components.straight
+    name: straight_8faea990
+    width: 0.5
+  straight_ab63e38b:
+    changed:
+      length: 62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 62
+    module: gdsfactory.components.straight
+    name: straight_ab63e38b
+    width: 0.5
+  straight_ace9cea9:
+    changed:
+      length: 357
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 357
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 357
+    module: gdsfactory.components.straight
+    name: straight_ace9cea9
+    width: 0.5
+  straight_b031fc97:
+    changed:
       length: 333
     default:
       cross_section:
@@ -656,7 +329,280 @@ cells:
     info_version: 1
     length: 333
     module: gdsfactory.components.straight
-    name: straight_f981fc54
+    name: straight_b031fc97
+    width: 0.5
+  straight_b2043dae:
+    changed:
+      length: 381
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 381
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 381
+    module: gdsfactory.components.straight
+    name: straight_b2043dae
+    width: 0.5
+  straight_b3dac65b:
+    changed:
+      length: 5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 5
+    module: gdsfactory.components.straight
+    name: straight_b3dac65b
+    width: 0.5
+  straight_b46aa9ac:
+    changed:
+      length: 56
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 56
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 56
+    module: gdsfactory.components.straight
+    name: straight_b46aa9ac
+    width: 0.5
+  straight_b692cc79:
+    changed:
+      length: 8
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 8
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 8
+    module: gdsfactory.components.straight
+    name: straight_b692cc79
+    width: 0.5
+  straight_b8045e4f:
+    changed:
+      length: 44
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 44
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 44
+    module: gdsfactory.components.straight
+    name: straight_b8045e4f
+    width: 0.5
+  straight_dfb3ba7e:
+    changed:
+      length: 387
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 387
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 387
+    module: gdsfactory.components.straight
+    name: straight_dfb3ba7e
+    width: 0.5
+  straight_e02fd04f:
+    changed:
+      length: 345
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 345
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 345
+    module: gdsfactory.components.straight
+    name: straight_e02fd04f
+    width: 0.5
+  straight_e409b023:
+    changed:
+      length: 26
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 26
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 26
+    module: gdsfactory.components.straight
+    name: straight_e409b023
+    width: 0.5
+  straight_ef64f397:
+    changed:
+      length: 84
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 84
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 84
+    module: gdsfactory.components.straight
+    name: straight_ef64f397
+    width: 0.5
+  straight_f38c2995:
+    changed:
+      length: 50
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 50
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 50
+    module: gdsfactory.components.straight
+    name: straight_f38c2995
+    width: 0.5
+  straight_f421295d:
+    changed:
+      length: 32
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 32
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 32
+    module: gdsfactory.components.straight
+    name: straight_f421295d
+    width: 0.5
+  straight_f85f18c2:
+    changed:
+      length: 78
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 78
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 78
+    module: gdsfactory.components.straight
+    name: straight_f85f18c2
+    width: 0.5
+  straight_fd42ee6c:
+    changed:
+      length: 369
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 369
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 369
+    module: gdsfactory.components.straight
+    name: straight_fd42ee6c
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,14 +24,12 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_d80b08de:
+  bend_euler_8d359e58:
     changed:
       angle: 180
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -57,7 +53,7 @@ cells:
     info_version: 1
     length: 42.818
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d80b08de
+    name: bend_euler_8d359e58
     radius: 10
     radius_min: 9.086
   spiral_inner_io:
@@ -105,79 +101,8 @@ cells:
     length: 11584.394
     module: gdsfactory.components.spiral_inner_io
     name: spiral_inner_io
-  straight_0182467e:
+  straight_0320d336:
     changed:
-      cross_section:
-        function: cross_section
-      length: 351
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 351
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 351
-    module: gdsfactory.components.straight
-    name: straight_0182467e
-    width: 0.5
-  straight_09a5ec89:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 66
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 66
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 66
-    module: gdsfactory.components.straight
-    name: straight_09a5ec89
-    width: 0.5
-  straight_1aad43d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 126
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 126
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 126
-    module: gdsfactory.components.straight
-    name: straight_1aad43d1
-    width: 0.5
-  straight_2184bc45:
-    changed:
-      cross_section:
-        function: cross_section
       length: 108
     default:
       cross_section:
@@ -195,334 +120,10 @@ cells:
     info_version: 1
     length: 108
     module: gdsfactory.components.straight
-    name: straight_2184bc45
+    name: straight_0320d336
     width: 0.5
-  straight_29d3bdbc:
+  straight_10148060:
     changed:
-      cross_section:
-        function: cross_section
-      length: 369
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 369
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 369
-    module: gdsfactory.components.straight
-    name: straight_29d3bdbc
-    width: 0.5
-  straight_2a431b77:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 132
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 132
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 132
-    module: gdsfactory.components.straight
-    name: straight_2a431b77
-    width: 0.5
-  straight_333fe4a4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 345
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 345
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 345
-    module: gdsfactory.components.straight
-    name: straight_333fe4a4
-    width: 0.5
-  straight_378b7dde:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 49
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 49
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 49
-    module: gdsfactory.components.straight
-    name: straight_378b7dde
-    width: 0.5
-  straight_3ba9d90a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 78
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 78
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 78
-    module: gdsfactory.components.straight
-    name: straight_3ba9d90a
-    width: 0.5
-  straight_6b7f6121:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 387
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 387
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 387
-    module: gdsfactory.components.straight
-    name: straight_6b7f6121
-    width: 0.5
-  straight_87fa83b4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 90
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 90
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 90
-    module: gdsfactory.components.straight
-    name: straight_87fa83b4
-    width: 0.5
-  straight_880835d3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 84
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 84
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 84
-    module: gdsfactory.components.straight
-    name: straight_880835d3
-    width: 0.5
-  straight_900506c4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 120
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 120
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 120
-    module: gdsfactory.components.straight
-    name: straight_900506c4
-    width: 0.5
-  straight_9441d5f4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 114
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 114
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 114
-    module: gdsfactory.components.straight
-    name: straight_9441d5f4
-    width: 0.5
-  straight_96054871:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 381
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 381
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 381
-    module: gdsfactory.components.straight
-    name: straight_96054871
-    width: 0.5
-  straight_9956341e:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 96
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 96
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 96
-    module: gdsfactory.components.straight
-    name: straight_9956341e
-    width: 0.5
-  straight_9d6d1c19:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 357
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 357
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 357
-    module: gdsfactory.components.straight
-    name: straight_9d6d1c19
-    width: 0.5
-  straight_a5b0fdd6:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 102
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 102
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 102
-    module: gdsfactory.components.straight
-    name: straight_a5b0fdd6
-    width: 0.5
-  straight_b37f39b0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 339
     default:
       cross_section:
@@ -540,13 +141,11 @@ cells:
     info_version: 1
     length: 339
     module: gdsfactory.components.straight
-    name: straight_b37f39b0
+    name: straight_10148060
     width: 0.5
-  straight_b3a7a091:
+  straight_1321de89:
     changed:
-      cross_section:
-        function: cross_section
-      length: 327
+      length: 120
     default:
       cross_section:
         function: cross_section
@@ -556,157 +155,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 327
+      length: 120
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 327
+    length: 120
     module: gdsfactory.components.straight
-    name: straight_b3a7a091
+    name: straight_1321de89
     width: 0.5
-  straight_c15b2170:
+  straight_1ab0b3c3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 410
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 410
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 410
-    module: gdsfactory.components.straight
-    name: straight_c15b2170
-    width: 0.5
-  straight_c5b03d60:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 72
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 72
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 72
-    module: gdsfactory.components.straight
-    name: straight_c5b03d60
-    width: 0.5
-  straight_d98e39ce:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 150
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 150
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 150
-    module: gdsfactory.components.straight
-    name: straight_d98e39ce
-    width: 0.5
-  straight_dc0699f9:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 363
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 363
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 363
-    module: gdsfactory.components.straight
-    name: straight_dc0699f9
-    width: 0.5
-  straight_df3c5ae4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 3
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 3
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 3
-    module: gdsfactory.components.straight
-    name: straight_df3c5ae4
-    width: 0.5
-  straight_e01d8133:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 375
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375
-    module: gdsfactory.components.straight
-    name: straight_e01d8133
-    width: 0.5
-  straight_e041d7da:
-    changed:
-      cross_section:
-        function: cross_section
       length: 46
     default:
       cross_section:
@@ -724,13 +183,11 @@ cells:
     info_version: 1
     length: 46
     module: gdsfactory.components.straight
-    name: straight_e041d7da
+    name: straight_1ab0b3c3
     width: 0.5
-  straight_f95c83c0:
+  straight_2dcab9f2:
     changed:
-      cross_section:
-        function: cross_section
-      length: 280
+      length: 3
     default:
       cross_section:
         function: cross_section
@@ -740,19 +197,269 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 280
+      length: 3
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 280
+    length: 3
     module: gdsfactory.components.straight
-    name: straight_f95c83c0
+    name: straight_2dcab9f2
     width: 0.5
-  straight_f981fc54:
+  straight_3739f84f:
     changed:
+      length: 72
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 72
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 72
+    module: gdsfactory.components.straight
+    name: straight_3739f84f
+    width: 0.5
+  straight_431b7111:
+    changed:
+      length: 375
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375
+    module: gdsfactory.components.straight
+    name: straight_431b7111
+    width: 0.5
+  straight_51aafb07:
+    changed:
+      length: 132
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 132
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 132
+    module: gdsfactory.components.straight
+    name: straight_51aafb07
+    width: 0.5
+  straight_58615677:
+    changed:
+      length: 150
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 150
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 150
+    module: gdsfactory.components.straight
+    name: straight_58615677
+    width: 0.5
+  straight_7b17241b:
+    changed:
+      length: 351
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 351
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 351
+    module: gdsfactory.components.straight
+    name: straight_7b17241b
+    width: 0.5
+  straight_81c43b9d:
+    changed:
+      length: 49
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 49
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 49
+    module: gdsfactory.components.straight
+    name: straight_81c43b9d
+    width: 0.5
+  straight_83919495:
+    changed:
+      length: 410
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 410
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 410
+    module: gdsfactory.components.straight
+    name: straight_83919495
+    width: 0.5
+  straight_8cf9b40f:
+    changed:
+      length: 363
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 363
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 363
+    module: gdsfactory.components.straight
+    name: straight_8cf9b40f
+    width: 0.5
+  straight_97eab636:
+    changed:
+      length: 102
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 102
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 102
+    module: gdsfactory.components.straight
+    name: straight_97eab636
+    width: 0.5
+  straight_98f58fc6:
+    changed:
+      length: 327
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 327
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 327
+    module: gdsfactory.components.straight
+    name: straight_98f58fc6
+    width: 0.5
+  straight_a2954ddf:
+    changed:
+      length: 126
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 126
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 126
+    module: gdsfactory.components.straight
+    name: straight_a2954ddf
+    width: 0.5
+  straight_ace9cea9:
+    changed:
+      length: 357
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 357
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 357
+    module: gdsfactory.components.straight
+    name: straight_ace9cea9
+    width: 0.5
+  straight_b031fc97:
+    changed:
       length: 333
     default:
       cross_section:
@@ -770,7 +477,238 @@ cells:
     info_version: 1
     length: 333
     module: gdsfactory.components.straight
-    name: straight_f981fc54
+    name: straight_b031fc97
+    width: 0.5
+  straight_b2043dae:
+    changed:
+      length: 381
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 381
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 381
+    module: gdsfactory.components.straight
+    name: straight_b2043dae
+    width: 0.5
+  straight_b7ee19a8:
+    changed:
+      length: 90
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 90
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 90
+    module: gdsfactory.components.straight
+    name: straight_b7ee19a8
+    width: 0.5
+  straight_d39b5064:
+    changed:
+      length: 114
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 114
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 114
+    module: gdsfactory.components.straight
+    name: straight_d39b5064
+    width: 0.5
+  straight_d4cb7bb4:
+    changed:
+      length: 96
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 96
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 96
+    module: gdsfactory.components.straight
+    name: straight_d4cb7bb4
+    width: 0.5
+  straight_d70a9bb7:
+    changed:
+      length: 66
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 66
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 66
+    module: gdsfactory.components.straight
+    name: straight_d70a9bb7
+    width: 0.5
+  straight_dfb3ba7e:
+    changed:
+      length: 387
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 387
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 387
+    module: gdsfactory.components.straight
+    name: straight_dfb3ba7e
+    width: 0.5
+  straight_e02fd04f:
+    changed:
+      length: 345
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 345
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 345
+    module: gdsfactory.components.straight
+    name: straight_e02fd04f
+    width: 0.5
+  straight_eb8678ca:
+    changed:
+      length: 280
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 280
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 280
+    module: gdsfactory.components.straight
+    name: straight_eb8678ca
+    width: 0.5
+  straight_ef64f397:
+    changed:
+      length: 84
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 84
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 84
+    module: gdsfactory.components.straight
+    name: straight_ef64f397
+    width: 0.5
+  straight_f85f18c2:
+    changed:
+      length: 78
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 78
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 78
+    module: gdsfactory.components.straight
+    name: straight_f85f18c2
+    width: 0.5
+  straight_fd42ee6c:
+    changed:
+      length: 369
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 369
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 369
+    module: gdsfactory.components.straight
+    name: straight_fd42ee6c
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,14 +24,12 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_d80b08de:
+  bend_euler_8d359e58:
     changed:
       angle: 180
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -57,14 +53,11 @@ cells:
     info_version: 1
     length: 42.818
     module: gdsfactory.components.bend_euler
-    name: bend_euler_d80b08de
+    name: bend_euler_8d359e58
     radius: 10
     radius_min: 9.086
-  spiral_inner_io_82cec748:
+  spiral_inner_io_50517bc3:
     changed:
-      cross_section:
-        function: cross_section
-      cross_section_bend: null
       grating_spacing: 200
       x_straight_inner_left: 75
       x_straight_inner_right: 40
@@ -112,14 +105,11 @@ cells:
     info_version: 1
     length: 9973.394
     module: gdsfactory.components.spiral_inner_io
-    name: spiral_inner_io_82cec748
-  spiral_inner_io_82cec74_33144991:
+    name: spiral_inner_io_50517bc3
+  spiral_inner_io_50517bc_c5d5c76b:
     changed: {}
     child:
       changed:
-        cross_section:
-          function: cross_section
-        cross_section_bend: null
         grating_spacing: 200
         x_straight_inner_left: 75
         x_straight_inner_right: 40
@@ -167,7 +157,7 @@ cells:
       info_version: 1
       length: 9973.394
       module: gdsfactory.components.spiral_inner_io
-      name: spiral_inner_io_82cec748
+      name: spiral_inner_io_50517bc3
     default:
       cross_section:
         function: cross_section
@@ -191,402 +181,9 @@ cells:
     function_name: spiral_inner_io_fiber_single
     info_version: 1
     module: gdsfactory.components.spiral_inner_io
-    name: spiral_inner_io_82cec74_33144991
-  straight_0182467e:
+    name: spiral_inner_io_50517bc_c5d5c76b
+  straight_10148060:
     changed:
-      cross_section:
-        function: cross_section
-      length: 351
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 351
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 351
-    module: gdsfactory.components.straight
-    name: straight_0182467e
-    width: 0.5
-  straight_02f354e7:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 22
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22
-    module: gdsfactory.components.straight
-    name: straight_02f354e7
-    width: 0.5
-  straight_29d3bdbc:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 369
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 369
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 369
-    module: gdsfactory.components.straight
-    name: straight_29d3bdbc
-    width: 0.5
-  straight_2e74308b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 58
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 58
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 58
-    module: gdsfactory.components.straight
-    name: straight_2e74308b
-    width: 0.5
-  straight_333fe4a4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 345
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 345
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 345
-    module: gdsfactory.components.straight
-    name: straight_333fe4a4
-    width: 0.5
-  straight_39a4c60f:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 398
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 398
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 398
-    module: gdsfactory.components.straight
-    name: straight_39a4c60f
-    width: 0.5
-  straight_39f7b9a2:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 64
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 64
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 64
-    module: gdsfactory.components.straight
-    name: straight_39f7b9a2
-    width: 0.5
-  straight_3e7fb4ec:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 321
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 321
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 321
-    module: gdsfactory.components.straight
-    name: straight_3e7fb4ec
-    width: 0.5
-  straight_445dfbe9:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 28
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 28
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 28
-    module: gdsfactory.components.straight
-    name: straight_445dfbe9
-    width: 0.5
-  straight_68c84375:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_68c84375
-    width: 0.5
-  straight_6f13c431:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 76
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 76
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 76
-    module: gdsfactory.components.straight
-    name: straight_6f13c431
-    width: 0.5
-  straight_728fe460:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 52
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 52
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 52
-    module: gdsfactory.components.straight
-    name: straight_728fe460
-    width: 0.5
-  straight_7d60adbe:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 82
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 82
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 82
-    module: gdsfactory.components.straight
-    name: straight_7d60adbe
-    width: 0.5
-  straight_97abb23c:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 39
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 39
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 39
-    module: gdsfactory.components.straight
-    name: straight_97abb23c
-    width: 0.5
-  straight_9d6d1c19:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 357
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 357
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 357
-    module: gdsfactory.components.straight
-    name: straight_9d6d1c19
-    width: 0.5
-  straight_af861f6d:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 243
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 243
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 243
-    module: gdsfactory.components.straight
-    name: straight_af861f6d
-    width: 0.5
-  straight_b0a4a9d3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 315
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 315
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 315
-    module: gdsfactory.components.straight
-    name: straight_b0a4a9d3
-    width: 0.5
-  straight_b37f39b0:
-    changed:
-      cross_section:
-        function: cross_section
       length: 339
     default:
       cross_section:
@@ -604,196 +201,10 @@ cells:
     info_version: 1
     length: 339
     module: gdsfactory.components.straight
-    name: straight_b37f39b0
+    name: straight_10148060
     width: 0.5
-  straight_b3a7a091:
+  straight_1ab0b3c3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 327
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 327
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 327
-    module: gdsfactory.components.straight
-    name: straight_b3a7a091
-    width: 0.5
-  straight_b5891e42:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 34
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 34
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 34
-    module: gdsfactory.components.straight
-    name: straight_b5891e42
-    width: 0.5
-  straight_c284a1b0:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 36
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 36
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 36
-    module: gdsfactory.components.straight
-    name: straight_c284a1b0
-    width: 0.5
-  straight_d0075ac9:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 70
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 70
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 70
-    module: gdsfactory.components.straight
-    name: straight_d0075ac9
-    width: 0.5
-  straight_d9996de2:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 40
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 40
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 40
-    module: gdsfactory.components.straight
-    name: straight_d9996de2
-    width: 0.5
-  straight_dc0699f9:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 363
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 363
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 363
-    module: gdsfactory.components.straight
-    name: straight_dc0699f9
-    width: 0.5
-  straight_df3c5ae4:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 3
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 3
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 3
-    module: gdsfactory.components.straight
-    name: straight_df3c5ae4
-    width: 0.5
-  straight_e01d8133:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 375
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375
-    module: gdsfactory.components.straight
-    name: straight_e01d8133
-    width: 0.5
-  straight_e041d7da:
-    changed:
-      cross_section:
-        function: cross_section
       length: 46
     default:
       cross_section:
@@ -811,12 +222,409 @@ cells:
     info_version: 1
     length: 46
     module: gdsfactory.components.straight
-    name: straight_e041d7da
+    name: straight_1ab0b3c3
     width: 0.5
-  straight_f981fc54:
+  straight_1bbf3947:
     changed:
+      length: 16
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_1bbf3947
+    width: 0.5
+  straight_228d134a:
+    changed:
+      length: 28
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 28
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 28
+    module: gdsfactory.components.straight
+    name: straight_228d134a
+    width: 0.5
+  straight_2dcab9f2:
+    changed:
+      length: 3
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 3
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 3
+    module: gdsfactory.components.straight
+    name: straight_2dcab9f2
+    width: 0.5
+  straight_3ed2e45e:
+    changed:
+      length: 36
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 36
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 36
+    module: gdsfactory.components.straight
+    name: straight_3ed2e45e
+    width: 0.5
+  straight_4174e3dd:
+    changed:
+      length: 34
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 34
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 34
+    module: gdsfactory.components.straight
+    name: straight_4174e3dd
+    width: 0.5
+  straight_431b7111:
+    changed:
+      length: 375
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375
+    module: gdsfactory.components.straight
+    name: straight_431b7111
+    width: 0.5
+  straight_44305c1c:
+    changed:
+      length: 243
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 243
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 243
+    module: gdsfactory.components.straight
+    name: straight_44305c1c
+    width: 0.5
+  straight_5dcf99c9:
+    changed:
+      length: 315
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 315
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 315
+    module: gdsfactory.components.straight
+    name: straight_5dcf99c9
+    width: 0.5
+  straight_61f19a9d:
+    changed:
+      length: 82
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 82
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 82
+    module: gdsfactory.components.straight
+    name: straight_61f19a9d
+    width: 0.5
+  straight_637e13ba:
+    changed:
+      length: 22
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22
+    module: gdsfactory.components.straight
+    name: straight_637e13ba
+    width: 0.5
+  straight_71630b7f:
+    changed:
+      length: 39
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 39
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 39
+    module: gdsfactory.components.straight
+    name: straight_71630b7f
+    width: 0.5
+  straight_78b1bdd0:
+    changed:
+      length: 76
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 76
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 76
+    module: gdsfactory.components.straight
+    name: straight_78b1bdd0
+    width: 0.5
+  straight_78c54834:
+    changed:
+      length: 70
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 70
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 70
+    module: gdsfactory.components.straight
+    name: straight_78c54834
+    width: 0.5
+  straight_7b17241b:
+    changed:
+      length: 351
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 351
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 351
+    module: gdsfactory.components.straight
+    name: straight_7b17241b
+    width: 0.5
+  straight_8cf9b40f:
+    changed:
+      length: 363
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 363
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 363
+    module: gdsfactory.components.straight
+    name: straight_8cf9b40f
+    width: 0.5
+  straight_98f58fc6:
+    changed:
+      length: 327
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 327
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 327
+    module: gdsfactory.components.straight
+    name: straight_98f58fc6
+    width: 0.5
+  straight_9f19f1c0:
+    changed:
+      length: 58
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 58
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 58
+    module: gdsfactory.components.straight
+    name: straight_9f19f1c0
+    width: 0.5
+  straight_a0fa6555:
+    changed:
+      length: 64
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 64
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 64
+    module: gdsfactory.components.straight
+    name: straight_a0fa6555
+    width: 0.5
+  straight_ace9cea9:
+    changed:
+      length: 357
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 357
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 357
+    module: gdsfactory.components.straight
+    name: straight_ace9cea9
+    width: 0.5
+  straight_b031fc97:
+    changed:
       length: 333
     default:
       cross_section:
@@ -834,15 +642,138 @@ cells:
     info_version: 1
     length: 333
     module: gdsfactory.components.straight
-    name: straight_f981fc54
+    name: straight_b031fc97
+    width: 0.5
+  straight_b24e342f:
+    changed:
+      length: 40
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 40
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 40
+    module: gdsfactory.components.straight
+    name: straight_b24e342f
+    width: 0.5
+  straight_c8827c11:
+    changed:
+      length: 321
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 321
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 321
+    module: gdsfactory.components.straight
+    name: straight_c8827c11
+    width: 0.5
+  straight_e02fd04f:
+    changed:
+      length: 345
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 345
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 345
+    module: gdsfactory.components.straight
+    name: straight_e02fd04f
+    width: 0.5
+  straight_e4b0b0dd:
+    changed:
+      length: 398
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 398
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 398
+    module: gdsfactory.components.straight
+    name: straight_e4b0b0dd
+    width: 0.5
+  straight_fbffef7d:
+    changed:
+      length: 52
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 52
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 52
+    module: gdsfactory.components.straight
+    name: straight_fbffef7d
+    width: 0.5
+  straight_fd42ee6c:
+    changed:
+      length: 369
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 369
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 369
+    module: gdsfactory.components.straight
+    name: straight_fd42ee6c
     width: 0.5
 info:
   changed: {}
   child:
     changed:
-      cross_section:
-        function: cross_section
-      cross_section_bend: null
       grating_spacing: 200
       x_straight_inner_left: 75
       x_straight_inner_right: 40
@@ -890,7 +821,7 @@ info:
     info_version: 1
     length: 9973.394
     module: gdsfactory.components.spiral_inner_io
-    name: spiral_inner_io_82cec748
+    name: spiral_inner_io_50517bc3
   default:
     cross_section:
       function: cross_section
@@ -914,7 +845,7 @@ info:
   function_name: spiral_inner_io_fiber_single
   info_version: 1
   module: gdsfactory.components.spiral_inner_io
-  name: spiral_inner_io_82cec74_33144991
+  name: spiral_inner_io_50517bc_c5d5c76b
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_splitter_chain_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_chain_.yml
@@ -1,20 +1,7 @@
 cells:
-  bezier_2ee69c51:
+  bezier_55a6d777:
     changed:
-      control_points:
-      - - 0
-        - 0
-      - - 5
-        - 0
-      - - 5
-        - 2
-      - - 10
-        - 2
-      layer:
-      - 1
-      - 0
       npoints: 99
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -63,26 +50,13 @@ cells:
     length: 10.278
     min_bend_radius: 9.959
     module: gdsfactory.components.bezier
-    name: bezier_2ee69c51
+    name: bezier_55a6d777
     start_angle: 0.235
-  bezier_2ee69c51_bend_s:
+  bezier_55a6d777_bend_s:
     changed: {}
     child:
       changed:
-        control_points:
-        - - 0
-          - 0
-        - - 5
-          - 0
-        - - 5
-          - 2
-        - - 10
-          - 2
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -131,7 +105,7 @@ cells:
       length: 10.278
       min_bend_radius: 9.959
       module: gdsfactory.components.bezier
-      name: bezier_2ee69c51
+      name: bezier_55a6d777
       start_angle: 0.235
     default:
       cross_section:
@@ -155,7 +129,7 @@ cells:
     length: 10.278
     min_bend_radius: 9.959
     module: gdsfactory.components.bend_s
-    name: bezier_2ee69c51_bend_s
+    name: bezier_55a6d777_bend_s
     start_angle: 0.235
   mmi1x2:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,10 +24,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_dd2e1266:
+  bezier_19eb54b0:
     changed:
       control_points:
       - - 0
@@ -40,11 +38,7 @@ cells:
         - 11.875
       - - 90
         - 11.875
-      layer:
-      - 1
-      - 0
       npoints: 99
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -93,12 +87,10 @@ cells:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bezier
-    name: bezier_dd2e1266
+    name: bezier_19eb54b0
     start_angle: 0.155
-  bezier_dd2e1266_bend_s_845a372c:
+  bezier_19eb54b0_bend_s_c9943693:
     changed:
-      cross_section:
-        function: cross_section
       size:
       - 90
       - 11.875
@@ -113,11 +105,7 @@ cells:
           - 11.875
         - - 90
           - 11.875
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -166,7 +154,7 @@ cells:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bezier
-      name: bezier_dd2e1266
+      name: bezier_19eb54b0
       start_angle: 0.155
     default:
       cross_section:
@@ -190,7 +178,7 @@ cells:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bend_s
-    name: bezier_dd2e1266_bend_s_845a372c
+    name: bezier_19eb54b0_bend_s_c9943693
     start_angle: 0.155
   mmi1x2:
     changed: {}
@@ -225,8 +213,6 @@ cells:
   splitter_tree:
     bend_s:
       changed:
-        cross_section:
-          function: cross_section
         size:
         - 90
         - 11.875
@@ -241,11 +227,7 @@ cells:
             - 11.875
           - - 90
             - 11.875
-          layer:
-          - 1
-          - 0
           npoints: 99
-          width: 0.5
         default:
           control_points:
           - - 0
@@ -294,7 +276,7 @@ cells:
         length: 91.103
         min_bend_radius: 129.147
         module: gdsfactory.components.bezier
-        name: bezier_dd2e1266
+        name: bezier_19eb54b0
         start_angle: 0.155
       default:
         cross_section:
@@ -318,7 +300,7 @@ cells:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bend_s
-      name: bezier_dd2e1266_bend_s_845a372c
+      name: bezier_19eb54b0_bend_s_c9943693
       start_angle: 0.155
     changed: {}
     default:
@@ -349,10 +331,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.splitter_tree
     name: splitter_tree
-  straight_5743d35a:
+  straight_c138f2c4:
     changed:
-      cross_section:
-        function: cross_section
       length: 0.01
     default:
       cross_section:
@@ -370,12 +350,10 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_c138f2c4
     width: 0.5
-  straight_7115e8d3:
+  straight_d03a81da:
     changed:
-      cross_section:
-        function: cross_section
       length: 44.49
     default:
       cross_section:
@@ -393,12 +371,10 @@ cells:
     info_version: 1
     length: 44.49
     module: gdsfactory.components.straight
-    name: straight_7115e8d3
+    name: straight_d03a81da
     width: 0.5
-  straight_c610a7d9:
+  straight_dc1c4f5d:
     changed:
-      cross_section:
-        function: cross_section
       length: 4.375
     default:
       cross_section:
@@ -416,13 +392,11 @@ cells:
     info_version: 1
     length: 4.375
     module: gdsfactory.components.straight
-    name: straight_c610a7d9
+    name: straight_dc1c4f5d
     width: 0.5
 info:
   bend_s:
     changed:
-      cross_section:
-        function: cross_section
       size:
       - 90
       - 11.875
@@ -437,11 +411,7 @@ info:
           - 11.875
         - - 90
           - 11.875
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -490,7 +460,7 @@ info:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bezier
-      name: bezier_dd2e1266
+      name: bezier_19eb54b0
       start_angle: 0.155
     default:
       cross_section:
@@ -514,7 +484,7 @@ info:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bend_s
-    name: bezier_dd2e1266_bend_s_845a372c
+    name: bezier_19eb54b0_bend_s_c9943693
     start_angle: 0.155
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_19eb54b0:
+  bezier_0f875e22:
     changed:
       control_points:
       - - 0
@@ -87,9 +87,9 @@ cells:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bezier
-    name: bezier_19eb54b0
+    name: bezier_0f875e22
     start_angle: 0.155
-  bezier_19eb54b0_bend_s_c9943693:
+  bezier_0f875e22_bend_s_d9870dad:
     changed:
       size:
       - 90
@@ -154,7 +154,7 @@ cells:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bezier
-      name: bezier_19eb54b0
+      name: bezier_0f875e22
       start_angle: 0.155
     default:
       cross_section:
@@ -178,7 +178,7 @@ cells:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bend_s
-    name: bezier_19eb54b0_bend_s_c9943693
+    name: bezier_0f875e22_bend_s_d9870dad
     start_angle: 0.155
   mmi1x2:
     changed: {}
@@ -276,7 +276,7 @@ cells:
         length: 91.103
         min_bend_radius: 129.147
         module: gdsfactory.components.bezier
-        name: bezier_19eb54b0
+        name: bezier_0f875e22
         start_angle: 0.155
       default:
         cross_section:
@@ -300,7 +300,7 @@ cells:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bend_s
-      name: bezier_19eb54b0_bend_s_c9943693
+      name: bezier_0f875e22_bend_s_d9870dad
       start_angle: 0.155
     changed: {}
     default:
@@ -331,28 +331,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.splitter_tree
     name: splitter_tree
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_d03a81da:
+  straight_a0061144:
     changed:
       length: 44.49
     default:
@@ -371,9 +350,9 @@ cells:
     info_version: 1
     length: 44.49
     module: gdsfactory.components.straight
-    name: straight_d03a81da
+    name: straight_a0061144
     width: 0.5
-  straight_dc1c4f5d:
+  straight_c1fd458a:
     changed:
       length: 4.375
     default:
@@ -392,7 +371,28 @@ cells:
     info_version: 1
     length: 4.375
     module: gdsfactory.components.straight
-    name: straight_dc1c4f5d
+    name: straight_c1fd458a
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
     width: 0.5
 info:
   bend_s:
@@ -460,7 +460,7 @@ info:
       length: 91.103
       min_bend_radius: 129.147
       module: gdsfactory.components.bezier
-      name: bezier_19eb54b0
+      name: bezier_0f875e22
       start_angle: 0.155
     default:
       cross_section:
@@ -484,7 +484,7 @@ info:
     length: 91.103
     min_bend_radius: 129.147
     module: gdsfactory.components.bend_s
-    name: bezier_19eb54b0_bend_s_c9943693
+    name: bezier_0f875e22_bend_s_d9870dad
     start_angle: 0.155
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_staircase_.yml
+++ b/gdsfactory/tests/test_components/test_settings_staircase_.yml
@@ -50,7 +50,7 @@ cells:
     module: gdsfactory.components.cutback_bend
     n_bends: 8
     name: staircase
-  straight_ffad5cea:
+  straight_3855ab9a:
     changed:
       length: 5
       width: 0.5
@@ -71,7 +71,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.straight
-    name: straight_ffad5cea
+    name: straight_3855ab9a
     width: 0.5
 info:
   changed: {}

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -427,7 +427,7 @@ cells:
     size:
     - 10
     - 10
-  extrude_d66e7f03:
+  extrude_1256186e:
     changed:
       cross_section:
         aliases:
@@ -467,8 +467,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -546,8 +546,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -588,7 +588,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_d66e7f03
+    name: extrude_1256186e
   straight_37297705:
     changed:
       cross_section:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -239,8 +239,13 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_e429d7e7
-  contact_016afa8d:
+  contact_6a9c3f6d:
     changed:
+      size:
+      - 10
+      - 10
+    default:
+      layer_port: null
       layers:
       - - 41
         - 0
@@ -249,7 +254,29 @@ cells:
       - - 49
         - 0
       size:
-      - 310
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 10
       - 10
       vias:
       - enclosure: 2
@@ -261,6 +288,21 @@ cells:
         layer:
         - 43
         - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_6a9c3f6d
+    size:
+    - 10
+    - 10
+  contact_99fb4fc8:
+    changed:
+      size:
+      - 310
+      - 10
     default:
       layer_port: null
       layers:
@@ -311,85 +353,9 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_016afa8d
+    name: contact_99fb4fc8
     size:
     - 310
-    - 10
-  contact_32dac979:
-    changed:
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_32dac979
-    size:
-    - 10
     - 10
   contact_ef2ac9d0:
     changed:
@@ -638,12 +604,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.straight_heater_doped_rib
     name: straight_heater_doped_rib
-  taper_cross_section_3652c7ff:
+  taper_cross_section_c0a36130:
     changed:
-      cross_section1:
-        function: cross_section
-        sections:
-        - slab
       cross_section2:
         function: rib_heater_doped
         heater_gap: 0.8
@@ -681,7 +643,7 @@ cells:
     function_name: taper_cross_section
     info_version: 1
     module: gdsfactory.components.taper_cross_section
-    name: taper_cross_section_3652c7ff
+    name: taper_cross_section_c0a36130
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -1,8 +1,38 @@
 cells:
-  compass_018d2943:
+  compass_01ef3f1c:
     changed:
       layer:
-      - 3
+      - 41
+      - 0
+      size:
+      - 310
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 41
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 310
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_01ef3f1c
+  compass_27f93906:
+    changed:
+      layer:
+      - 41
       - 0
       size:
       - 10
@@ -18,7 +48,7 @@ cells:
       - 2
     full:
       layer:
-      - 3
+      - 41
       - 0
       port_inclusion: 0
       port_type: electrical
@@ -28,8 +58,98 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_018d2943
-  compass_44af43f4:
+    name: compass_27f93906
+  compass_342f16e4:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_342f16e4
+  compass_3e08739f:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_3e08739f
+  compass_743f285f:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 310
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 310
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_743f285f
+  compass_8c68905a:
     changed:
       layer:
       - 24
@@ -58,11 +178,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_44af43f4
-  compass_5903820c:
+    name: compass_8c68905a
+  compass_9dede8ef:
     changed:
       layer:
-      - 49
+      - 3
       - 0
       size:
       - 10
@@ -78,7 +198,7 @@ cells:
       - 2
     full:
       layer:
-      - 49
+      - 3
       - 0
       port_inclusion: 0
       port_type: electrical
@@ -88,38 +208,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_5903820c
-  compass_67c6df50:
-    changed:
-      layer:
-      - 41
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 41
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_67c6df50
-  compass_70bcd629:
+    name: compass_9dede8ef
+  compass_a9fd9f7a:
     changed:
       layer:
       - 49
@@ -148,157 +238,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_70bcd629
-  compass_a7656554:
-    changed:
-      layer:
-      - 41
-      - 0
-      size:
-      - 310
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 41
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 310
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_a7656554
-  compass_cfeb36a5:
-    changed:
-      layer:
-      - 45
-      - 0
-      size:
-      - 310
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 310
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_cfeb36a5
-  compass_e429d7e7:
-    changed:
-      layer:
-      - 45
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_e429d7e7
-  contact_6a9c3f6d:
-    changed:
-      size:
-      - 10
-      - 10
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_6a9c3f6d
-    size:
-    - 10
-    - 10
-  contact_99fb4fc8:
+    name: compass_a9fd9f7a
+  contact_16df2ed1:
     changed:
       size:
       - 310
@@ -353,11 +294,70 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_99fb4fc8
+    name: contact_16df2ed1
     size:
     - 310
     - 10
-  contact_ef2ac9d0:
+  contact_b5c6cc96:
+    changed:
+      size:
+      - 10
+      - 10
+    default:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 10
+      - 10
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_b5c6cc96
+    size:
+    - 10
+    - 10
+  contact_ee5fd2ac:
     changed:
       layers:
       - - 3
@@ -423,13 +423,83 @@ cells:
     - 41
     - 0
     module: gdsfactory.components.contact
-    name: contact_ef2ac9d0
+    name: contact_ee5fd2ac
     size:
     - 10
     - 10
-  extrude_c3ae1f05:
+  extrude_d66e7f03:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       p: path_df9f9721565520dc57f5cb1446179439
     default:
       cross_section: null
@@ -438,7 +508,77 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       layer: null
       p: path_df9f9721565520dc57f5cb1446179439
       simplify: null
@@ -448,8 +588,8 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_c3ae1f05
-  straight_8d718ae9:
+    name: extrude_d66e7f03
+  straight_37297705:
     changed:
       cross_section:
         function: rib_heater_doped
@@ -476,7 +616,7 @@ cells:
     info_version: 1
     length: 300
     module: gdsfactory.components.straight
-    name: straight_8d718ae9
+    name: straight_37297705
     width: 0.5
   straight_heater_doped_rib:
     changed: {}
@@ -604,7 +744,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.straight_heater_doped_rib
     name: straight_heater_doped_rib
-  taper_cross_section_c0a36130:
+  taper_cross_section_71a7e441:
     changed:
       cross_section2:
         function: rib_heater_doped
@@ -643,7 +783,7 @@ cells:
     function_name: taper_cross_section
     info_version: 1
     module: gdsfactory.components.taper_cross_section
-    name: taper_cross_section_c0a36130
+    name: taper_cross_section_71a7e441
 info:
   changed: {}
   default:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -1,34 +1,4 @@
 cells:
-  compass_3c3280cc:
-    changed:
-      layer:
-      - 1
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_3c3280cc
   compass_44af43f4:
     changed:
       layer:
@@ -119,6 +89,33 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_67c6df50
+  compass_6a9c3f6d:
+    changed:
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_6a9c3f6d
   compass_70bcd629:
     changed:
       layer:
@@ -239,158 +236,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_e429d7e7
-  contact_016afa8d:
-    changed:
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 310
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 310
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_016afa8d
-    size:
-    - 310
-    - 10
-  contact_32dac979:
-    changed:
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_32dac979
-    size:
-    - 10
-    - 10
   contact_5fef78eb:
     changed:
       layers:
@@ -460,6 +305,124 @@ cells:
     name: contact_5fef78eb
     size:
     - 10
+    - 10
+  contact_6a9c3f6d:
+    changed:
+      size:
+      - 10
+      - 10
+    default:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 10
+      - 10
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_6a9c3f6d
+    size:
+    - 10
+    - 10
+  contact_99fb4fc8:
+    changed:
+      size:
+      - 310
+      - 10
+    default:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 310
+      - 10
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_99fb4fc8
+    size:
+    - 310
     - 10
   extrude_94545d1a:
     changed:
@@ -656,12 +619,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.straight_heater_doped_rib
     name: straight_heater_doped_r_3a183396
-  taper_cross_section_bc4ced8f:
+  taper_cross_section_415080e4:
     changed:
-      cross_section1:
-        function: cross_section
-        sections:
-        - slab
       cross_section2:
         function: strip_heater_doped
         heater_gap: 0.8
@@ -699,7 +658,7 @@ cells:
     function_name: taper_cross_section
     info_version: 1
     module: gdsfactory.components.taper_cross_section
-    name: taper_cross_section_bc4ced8f
+    name: taper_cross_section_415080e4
 info:
   changed:
     contact:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -1,5 +1,155 @@
 cells:
-  compass_44af43f4:
+  compass_01ef3f1c:
+    changed:
+      layer:
+      - 41
+      - 0
+      size:
+      - 310
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 41
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 310
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_01ef3f1c
+  compass_27f93906:
+    changed:
+      layer:
+      - 41
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 41
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_27f93906
+  compass_342f16e4:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_342f16e4
+  compass_3e08739f:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_3e08739f
+  compass_743f285f:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 310
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 310
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_743f285f
+  compass_8c68905a:
     changed:
       layer:
       - 24
@@ -28,95 +178,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_44af43f4
-  compass_5903820c:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_5903820c
-  compass_67c6df50:
-    changed:
-      layer:
-      - 41
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 41
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_67c6df50
-  compass_6a9c3f6d:
-    changed:
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_6a9c3f6d
-  compass_70bcd629:
+    name: compass_8c68905a
+  compass_a9fd9f7a:
     changed:
       layer:
       - 49
@@ -145,72 +208,9 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_70bcd629
-  compass_a7656554:
+    name: compass_a9fd9f7a
+  compass_b5c6cc96:
     changed:
-      layer:
-      - 41
-      - 0
-      size:
-      - 310
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 41
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 310
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_a7656554
-  compass_cfeb36a5:
-    changed:
-      layer:
-      - 45
-      - 0
-      size:
-      - 310
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 310
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_cfeb36a5
-  compass_e429d7e7:
-    changed:
-      layer:
-      - 45
-      - 0
       size:
       - 10
       - 10
@@ -225,7 +225,7 @@ cells:
       - 2
     full:
       layer:
-      - 45
+      - 1
       - 0
       port_inclusion: 0
       port_type: electrical
@@ -235,8 +235,67 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_e429d7e7
-  contact_5fef78eb:
+    name: compass_b5c6cc96
+  contact_16df2ed1:
+    changed:
+      size:
+      - 310
+      - 10
+    default:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 11
+      - 11
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    full:
+      layer_port: null
+      layers:
+      - - 41
+        - 0
+      - - 45
+        - 0
+      - - 49
+        - 0
+      size:
+      - 310
+      - 10
+      vias:
+      - enclosure: 2
+        function: via
+        layer:
+        - 44
+        - 0
+      - function: via
+        layer:
+        - 43
+        - 0
+    function_name: contact
+    info_version: 1
+    layer:
+    - 49
+    - 0
+    module: gdsfactory.components.contact
+    name: contact_16df2ed1
+    size:
+    - 310
+    - 10
+  contact_4776ac85:
     changed:
       layers:
       - - 1
@@ -302,11 +361,11 @@ cells:
     - 41
     - 0
     module: gdsfactory.components.contact
-    name: contact_5fef78eb
+    name: contact_4776ac85
     size:
     - 10
     - 10
-  contact_6a9c3f6d:
+  contact_b5c6cc96:
     changed:
       size:
       - 10
@@ -361,72 +420,52 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_6a9c3f6d
+    name: contact_b5c6cc96
     size:
     - 10
     - 10
-  contact_99fb4fc8:
+  extrude_a4160797:
     changed:
-      size:
-      - 310
-      - 10
-    default:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 11
-      - 11
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    full:
-      layer_port: null
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
-      size:
-      - 310
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
-    function_name: contact
-    info_version: 1
-    layer:
-    - 49
-    - 0
-    module: gdsfactory.components.contact
-    name: contact_99fb4fc8
-    size:
-    - 310
-    - 10
-  extrude_94545d1a:
-    changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
       p: path_df9f9721565520dc57f5cb1446179439
     default:
       cross_section: null
@@ -435,7 +474,46 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
       layer: null
       p: path_df9f9721565520dc57f5cb1446179439
       simplify: null
@@ -445,8 +523,8 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_94545d1a
-  straight_6fffabef:
+    name: extrude_a4160797
+  straight_025b0198:
     changed:
       cross_section:
         function: strip_heater_doped
@@ -473,9 +551,9 @@ cells:
     info_version: 1
     length: 300
     module: gdsfactory.components.straight
-    name: straight_6fffabef
+    name: straight_025b0198
     width: 0.5
-  straight_heater_doped_r_3a183396:
+  straight_heater_doped_r_4e195e5a:
     changed:
       contact:
         function: contact
@@ -618,8 +696,8 @@ cells:
     function_name: straight_heater_doped_rib
     info_version: 1
     module: gdsfactory.components.straight_heater_doped_rib
-    name: straight_heater_doped_r_3a183396
-  taper_cross_section_415080e4:
+    name: straight_heater_doped_r_4e195e5a
+  taper_cross_section_62afd0c9:
     changed:
       cross_section2:
         function: strip_heater_doped
@@ -658,7 +736,7 @@ cells:
     function_name: taper_cross_section
     info_version: 1
     module: gdsfactory.components.taper_cross_section
-    name: taper_cross_section_415080e4
+    name: taper_cross_section_62afd0c9
 info:
   changed:
     contact:
@@ -802,7 +880,7 @@ info:
   function_name: straight_heater_doped_rib
   info_version: 1
   module: gdsfactory.components.straight_heater_doped_rib
-  name: straight_heater_doped_r_3a183396
+  name: straight_heater_doped_r_4e195e5a
 ports:
   bot_e1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -424,7 +424,7 @@ cells:
     size:
     - 10
     - 10
-  extrude_a4160797:
+  extrude_c1013d2e:
     changed:
       cross_section:
         aliases:
@@ -448,8 +448,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -496,8 +496,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -523,7 +523,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_a4160797
+    name: extrude_c1013d2e
   straight_025b0198:
     changed:
       cross_section:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
@@ -1,8 +1,8 @@
 cells:
-  array_d995c19f:
+  array_c207f8ab:
     changed:
       columns: 1
-      component: straight_568cb457_exten_2872a9d7
+      component: straight_420e2e24_exten_9c2fcdd3
       rows: 3
       spacing:
       - 0
@@ -17,7 +17,7 @@ cells:
       - 150
     full:
       columns: 1
-      component: straight_568cb457_exten_2872a9d7
+      component: straight_420e2e24_exten_9c2fcdd3
       rows: 3
       spacing:
       - 0
@@ -25,7 +25,7 @@ cells:
     function_name: array
     info_version: 1
     module: gdsfactory.components.array_component
-    name: array_d995c19f
+    name: array_c207f8ab
   bend_euler_212e6ad7:
     changed:
       radius: 5
@@ -56,37 +56,7 @@ cells:
     name: bend_euler_212e6ad7
     radius: 5
     radius_min: 3.53
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -115,8 +85,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -145,8 +145,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  contact_f7ba3155:
+    name: compass_aa9c3262
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -205,11 +205,78 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_1427c4e9:
+  straight_639ee035:
+    changed:
+      length: 2.01
+      radius: 5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2.01
+      npoints: 2
+      radius: 5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2.01
+    module: gdsfactory.components.straight
+    name: straight_639ee035
+    width: 0.5
+  straight_66e52e36:
+    changed:
+      length: 15
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 15
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 15
+    module: gdsfactory.components.straight
+    name: straight_66e52e36
+    width: 0.5
+  straight_f5683146:
+    changed:
+      length: 10.02
+      radius: 5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 10.02
+      npoints: 2
+      radius: 5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 10.02
+    module: gdsfactory.components.straight
+    name: straight_f5683146
+    width: 0.5
+  straight_f7357ae7:
     changed:
       cross_section:
         function: cross_section
@@ -238,53 +305,9 @@ cells:
     info_version: 1
     length: 69.779
     module: gdsfactory.components.straight
-    name: straight_1427c4e9
+    name: straight_f7357ae7
     width: 2.5
-  straight_66e52e36:
-    changed:
-      length: 15
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15
-    module: gdsfactory.components.straight
-    name: straight_66e52e36
-    width: 0.5
-  straight_738e1843:
-    changed:
-      length: 10.02
-      radius: 5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 10.02
-      npoints: 2
-      radius: 5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 10.02
-    module: gdsfactory.components.straight
-    name: straight_738e1843
-    width: 0.5
-  straight_a2d3ad7a:
+  straight_f8b67ad1:
     changed:
       length: 0.01
       radius: 5
@@ -305,30 +328,7 @@ cells:
     info_version: 1
     length: 0.01
     module: gdsfactory.components.straight
-    name: straight_a2d3ad7a
-    width: 0.5
-  straight_a4ea9c3b:
-    changed:
-      length: 2.01
-      radius: 5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2.01
-      npoints: 2
-      radius: 5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2.01
-    module: gdsfactory.components.straight
-    name: straight_a4ea9c3b
+    name: straight_f8b67ad1
     width: 0.5
   straight_heater_meander:
     changed: {}
@@ -406,7 +406,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.straight_heater_meander
     name: straight_heater_meander
-  taper_ef058905:
+  taper_d98bd3f7:
     changed:
       cross_section:
         function: cross_section
@@ -440,7 +440,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.taper
-    name: taper_ef058905
+    name: taper_d98bd3f7
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
@@ -26,10 +26,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.array_component
     name: array_d995c19f
-  bend_euler_a519ff2d:
+  bend_euler_212e6ad7:
     changed:
-      cross_section:
-        function: cross_section
       radius: 5
     default:
       angle: 90
@@ -55,7 +53,7 @@ cells:
     info_version: 1
     length: 8.318
     module: gdsfactory.components.bend_euler
-    name: bend_euler_a519ff2d
+    name: bend_euler_212e6ad7
     radius: 5
     radius_min: 3.53
   compass_164fc476:
@@ -148,7 +146,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_8e661824
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -156,16 +154,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -217,7 +205,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -252,10 +240,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_1427c4e9
     width: 2.5
-  straight_396b7705:
+  straight_66e52e36:
     changed:
-      cross_section:
-        function: cross_section
       length: 15
     default:
       cross_section:
@@ -273,37 +259,10 @@ cells:
     info_version: 1
     length: 15
     module: gdsfactory.components.straight
-    name: straight_396b7705
+    name: straight_66e52e36
     width: 0.5
-  straight_763c11c2:
+  straight_738e1843:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      radius: 5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      radius: 5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_763c11c2
-    width: 0.5
-  straight_c5b20cce:
-    changed:
-      cross_section:
-        function: cross_section
       length: 10.02
       radius: 5
     default:
@@ -323,12 +282,33 @@ cells:
     info_version: 1
     length: 10.02
     module: gdsfactory.components.straight
-    name: straight_c5b20cce
+    name: straight_738e1843
     width: 0.5
-  straight_dbc1e874:
+  straight_a2d3ad7a:
     changed:
+      length: 0.01
+      radius: 5
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      radius: 5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_a2d3ad7a
+    width: 0.5
+  straight_a4ea9c3b:
+    changed:
       length: 2.01
       radius: 5
     default:
@@ -348,7 +328,7 @@ cells:
     info_version: 1
     length: 2.01
     module: gdsfactory.components.straight
-    name: straight_dbc1e874
+    name: straight_a4ea9c3b
     width: 0.5
   straight_heater_meander:
     changed: {}
@@ -426,7 +406,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.straight_heater_meander
     name: straight_heater_meander
-  taper_d31ba445:
+  taper_ef058905:
     changed:
       cross_section:
         function: cross_section
@@ -434,7 +414,6 @@ cells:
         - 47
         - 0
         width: 2.5
-      length: 10
       width1: 11
       width2: 2.5
     default:
@@ -461,7 +440,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.taper
-    name: taper_d31ba445
+    name: taper_ef058905
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
@@ -133,7 +133,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -141,16 +141,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -202,7 +192,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -58,8 +28,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -88,21 +88,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -118,22 +118,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -192,61 +192,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -269,7 +219,57 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:
@@ -347,7 +347,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -378,7 +378,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
@@ -133,7 +133,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -141,16 +141,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -202,7 +192,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -58,8 +28,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -88,21 +88,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -118,22 +118,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -192,61 +192,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -269,7 +219,57 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
     width: 0.5
   straight_heater_metal_u_e2b56ba0:
     changed:
@@ -349,7 +349,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_e2b56ba0
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -380,7 +380,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
@@ -133,7 +133,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_78f4176a
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -141,16 +141,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -202,7 +192,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -58,8 +28,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -88,21 +88,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_78f4176a:
+    name: compass_aa9c3262
+  component_sequence_033ec12e:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_26d32982
+        - straight_f170ab50
         - o1
         - o2
     default:
@@ -118,22 +118,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_26d32982
+        - straight_f170ab50
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_78f4176a
-  contact_f7ba3155:
+    name: component_sequence_033ec12e
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -192,61 +192,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_26d32982:
-    changed:
-      cross_section:
-        function: strip_heater_metal_undercut
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal_undercut
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_26d32982
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -269,7 +219,57 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_f170ab50:
+    changed:
+      cross_section:
+        function: strip_heater_metal_undercut
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal_undercut
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_f170ab50
     width: 0.5
   straight_heater_metal_undercut:
     changed: {}
@@ -346,7 +346,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_undercut
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -377,7 +377,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -133,7 +133,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -141,16 +141,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -202,7 +192,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -58,8 +28,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -88,21 +88,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -118,22 +118,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -192,61 +192,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -269,7 +219,57 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
     width: 0.5
   straight_heater_metal_u_e2b56ba0:
     changed:
@@ -349,7 +349,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_e2b56ba0
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -380,7 +380,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:

--- a/gdsfactory/tests/test_components/test_settings_straight_pin_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pin_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_23f1de76:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 480
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 480
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_23f1de76
-  compass_2d2aeb66:
+  compass_106d863e:
     changed:
       layer:
       - 45
@@ -58,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_2d2aeb66
-  compass_4369a919:
+    name: compass_106d863e
+  compass_3fb3549b:
     changed:
       layer:
       - 41
@@ -88,8 +58,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_4369a919
-  compass_cd64a6d4:
+    name: compass_3fb3549b
+  compass_4f070c5b:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 480
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 480
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_4f070c5b
+  compass_8cc1d700:
     changed:
       layer:
       - 3
@@ -118,8 +118,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_cd64a6d4
-  contact_e2c9b8f6:
+    name: compass_8cc1d700
+  contact_a69541f2:
     changed:
       layers:
       - - 3
@@ -203,11 +203,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_e2c9b8f6
+    name: contact_a69541f2
     size:
     - 480
     - 10
-  straight_fec761a3:
+  straight_9f3c9a08:
     changed:
       cross_section:
         function: pin
@@ -228,7 +228,7 @@ cells:
     info_version: 1
     length: 480
     module: gdsfactory.components.straight
-    name: straight_fec761a3
+    name: straight_9f3c9a08
     width: 0.5
   straight_pin:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_23f1de76:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 480
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 480
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_23f1de76
-  compass_2d2aeb66:
+  compass_106d863e:
     changed:
       layer:
       - 45
@@ -58,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_2d2aeb66
-  compass_4369a919:
+    name: compass_106d863e
+  compass_3fb3549b:
     changed:
       layer:
       - 41
@@ -88,8 +58,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_4369a919
-  contact_c18d5743:
+    name: compass_3fb3549b
+  compass_4f070c5b:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 480
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 480
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_4f070c5b
+  contact_52a05976:
     changed:
       size:
       - 480
@@ -144,11 +144,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_c18d5743
+    name: contact_52a05976
     size:
     - 480
     - 10
-  contact_slot_945954a1:
+  contact_slot_d1b27c34:
     changed:
       layers:
       - - 41
@@ -209,11 +209,11 @@ cells:
     function_name: contact_slot
     info_version: 1
     module: gdsfactory.components.contact_slot
-    name: contact_slot_945954a1
+    name: contact_slot_d1b27c34
     size:
     - 480
     - 10
-  straight_fec761a3:
+  straight_9f3c9a08:
     changed:
       cross_section:
         function: pin
@@ -234,7 +234,7 @@ cells:
     info_version: 1
     length: 480
     module: gdsfactory.components.straight
-    name: straight_fec761a3
+    name: straight_9f3c9a08
     width: 0.5
   straight_pin_slot:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
@@ -89,28 +89,11 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_4369a919
-  contact_5c360167:
+  contact_c18d5743:
     changed:
-      layers:
-      - - 41
-        - 0
-      - - 45
-        - 0
-      - - 49
-        - 0
       size:
       - 480
       - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
     default:
       layer_port: null
       layers:
@@ -161,7 +144,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_5c360167
+    name: contact_c18d5743
     size:
     - 480
     - 10

--- a/gdsfactory/tests/test_components/test_settings_straight_pn_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pn_.yml
@@ -1,35 +1,5 @@
 cells:
-  compass_23f1de76:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 480
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 480
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_23f1de76
-  compass_2d2aeb66:
+  compass_106d863e:
     changed:
       layer:
       - 45
@@ -58,8 +28,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_2d2aeb66
-  compass_4369a919:
+    name: compass_106d863e
+  compass_3fb3549b:
     changed:
       layer:
       - 41
@@ -88,8 +58,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_4369a919
-  compass_cd64a6d4:
+    name: compass_3fb3549b
+  compass_4f070c5b:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 480
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 480
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_4f070c5b
+  compass_8cc1d700:
     changed:
       layer:
       - 3
@@ -118,8 +118,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_cd64a6d4
-  contact_e2c9b8f6:
+    name: compass_8cc1d700
+  contact_a69541f2:
     changed:
       layers:
       - - 3
@@ -203,11 +203,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_e2c9b8f6
+    name: contact_a69541f2
     size:
     - 480
     - 10
-  straight_d5a2eac3:
+  straight_61941bd7:
     changed:
       cross_section:
         function: pn
@@ -228,9 +228,9 @@ cells:
     info_version: 1
     length: 480
     module: gdsfactory.components.straight
-    name: straight_d5a2eac3
+    name: straight_61941bd7
     width: 0.5
-  straight_pin_5f3c3d8d:
+  straight_pin_b5110479:
     changed:
       cross_section:
         function: pn
@@ -303,7 +303,7 @@ cells:
     function_name: straight_pin
     info_version: 1
     module: gdsfactory.components.straight_pin
-    name: straight_pin_5f3c3d8d
+    name: straight_pin_b5110479
   taper_strip_to_ridge:
     changed: {}
     default:
@@ -416,7 +416,7 @@ info:
   function_name: straight_pin
   info_version: 1
   module: gdsfactory.components.straight_pin
-  name: straight_pin_5f3c3d8d
+  name: straight_pin_b5110479
 ports:
   bot_e1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_straight_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_rib_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_59648496:
+  straight_9b75572a:
     changed:
       cross_section:
         cladding_offset: 0
@@ -31,7 +31,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_59648496
+    name: straight_9b75572a
     width: 0.5
 info:
   changed:
@@ -65,7 +65,7 @@ info:
   info_version: 1
   length: 10
   module: gdsfactory.components.straight
-  name: straight_59648496
+  name: straight_9b75572a
   width: 0.5
 ports:
   o1:

--- a/gdsfactory/tests/test_components/test_settings_straight_rib_tapered_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_rib_tapered_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_59648496:
+  straight_9b75572a:
     changed:
       cross_section:
         cladding_offset: 0
@@ -31,9 +31,9 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_59648496
+    name: straight_9b75572a
     width: 0.5
-  straight_59648496_exten_0c897020:
+  straight_9b75572a_exten_c7ec24a3:
     changed:
       component:
         cross_section:
@@ -81,7 +81,7 @@ cells:
       info_version: 1
       length: 10
       module: gdsfactory.components.straight
-      name: straight_59648496
+      name: straight_9b75572a
       width: 0.5
     default:
       centered: false
@@ -117,7 +117,7 @@ cells:
     function_name: extend_ports
     info_version: 1
     module: gdsfactory.components.extension
-    name: straight_59648496_exten_0c897020
+    name: straight_9b75572a_exten_c7ec24a3
 info:
   changed:
     component:
@@ -166,7 +166,7 @@ info:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_59648496
+    name: straight_9b75572a
     width: 0.5
   default:
     centered: false
@@ -202,7 +202,7 @@ info:
   function_name: extend_ports
   info_version: 1
   module: gdsfactory.components.extension
-  name: straight_59648496_exten_0c897020
+  name: straight_9b75572a_exten_c7ec24a3
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_6e8a823c:
+  bezier_545f6fee:
     changed:
       control_points:
       - - 0
@@ -87,9 +87,9 @@ cells:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bezier
-    name: bezier_6e8a823c
+    name: bezier_545f6fee
     start_angle: 0.057
-  bezier_6e8a823c_bend_s_c234ff0c:
+  bezier_545f6fee_bend_s_065bf85b:
     changed:
       size:
       - 500
@@ -154,7 +154,7 @@ cells:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bezier
-      name: bezier_6e8a823c
+      name: bezier_545f6fee
       start_angle: 0.057
     default:
       cross_section:
@@ -178,39 +178,9 @@ cells:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bend_s
-    name: bezier_6e8a823c_bend_s_c234ff0c
+    name: bezier_545f6fee_bend_s_065bf85b
     start_angle: 0.057
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -239,8 +209,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -269,21 +269,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -299,22 +299,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -373,7 +373,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -435,7 +435,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_a3182728:
+  mzi_2c7bfd7f:
     changed:
       combiner:
         function: mmi2x2
@@ -496,8 +496,8 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_a3182728
-  splitter_tree_3ca16676:
+    name: mzi_2c7bfd7f
+  splitter_tree_8d0e26e1:
     bend_s:
       changed:
         size:
@@ -563,7 +563,7 @@ cells:
         length: 500.845
         min_bend_radius: 1870.03
         module: gdsfactory.components.bezier
-        name: bezier_6e8a823c
+        name: bezier_545f6fee
         start_angle: 0.057
       default:
         cross_section:
@@ -587,7 +587,7 @@ cells:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bend_s
-      name: bezier_6e8a823c_bend_s_c234ff0c
+      name: bezier_545f6fee_bend_s_065bf85b
       start_angle: 0.057
     changed:
       coupler:
@@ -640,7 +640,7 @@ cells:
     function_name: splitter_tree
     info_version: 1
     module: gdsfactory.components.splitter_tree
-    name: splitter_tree_3ca16676
+    name: splitter_tree_8d0e26e1
   straight:
     changed: {}
     default:
@@ -661,74 +661,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_37d9ef2b:
-    changed:
-      length: 310.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 310.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 310.09
-    module: gdsfactory.components.straight
-    name: straight_37d9ef2b
-    width: 0.5
-  straight_76a4ed9f:
-    changed:
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_76a4ed9f
-    width: 0.5
-  straight_a49b5f82:
+  straight_12b874c7:
     changed:
       length: 68.89
     default:
@@ -747,9 +680,9 @@ cells:
     info_version: 1
     length: 68.89
     module: gdsfactory.components.straight
-    name: straight_a49b5f82
+    name: straight_12b874c7
     width: 0.5
-  straight_abd19b3c:
+  straight_32b5b455:
     changed:
       length: 29.375
     default:
@@ -768,55 +701,9 @@ cells:
     info_version: 1
     length: 29.375
     module: gdsfactory.components.straight
-    name: straight_abd19b3c
+    name: straight_32b5b455
     width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -839,7 +726,120 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5b70f7d2:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_5b70f7d2
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_98977119:
+    changed:
+      length: 310.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 310.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 310.09
+    module: gdsfactory.components.straight
+    name: straight_98977119
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -938,7 +938,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -969,7 +969,7 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
@@ -1038,7 +1038,7 @@ info:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bezier
-      name: bezier_6e8a823c
+      name: bezier_545f6fee
       start_angle: 0.057
     default:
       cross_section:
@@ -1062,7 +1062,7 @@ info:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bend_s
-    name: bezier_6e8a823c_bend_s_c234ff0c
+    name: bezier_545f6fee_bend_s_065bf85b
     start_angle: 0.057
   changed:
     coupler:
@@ -1115,7 +1115,7 @@ info:
   function_name: splitter_tree
   info_version: 1
   module: gdsfactory.components.splitter_tree
-  name: splitter_tree_3ca16676
+  name: splitter_tree_8d0e26e1
 ports:
   e1_0_1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,10 +24,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_1cd7d155:
+  bezier_6e8a823c:
     changed:
       control_points:
       - - 0
@@ -40,11 +38,7 @@ cells:
         - 24.375
       - - 500
         - 24.375
-      layer:
-      - 1
-      - 0
       npoints: 99
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -93,12 +87,10 @@ cells:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bezier
-    name: bezier_1cd7d155
+    name: bezier_6e8a823c
     start_angle: 0.057
-  bezier_1cd7d155_bend_s_74621b0d:
+  bezier_6e8a823c_bend_s_c234ff0c:
     changed:
-      cross_section:
-        function: cross_section
       size:
       - 500
       - 24.375
@@ -113,11 +105,7 @@ cells:
           - 24.375
         - - 500
           - 24.375
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -166,7 +154,7 @@ cells:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bezier
-      name: bezier_1cd7d155
+      name: bezier_6e8a823c
       start_angle: 0.057
     default:
       cross_section:
@@ -190,7 +178,7 @@ cells:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bend_s
-    name: bezier_1cd7d155_bend_s_74621b0d
+    name: bezier_6e8a823c_bend_s_c234ff0c
     start_angle: 0.057
   compass_164fc476:
     changed:
@@ -326,7 +314,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -334,16 +322,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -395,7 +373,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -522,8 +500,6 @@ cells:
   splitter_tree_3ca16676:
     bend_s:
       changed:
-        cross_section:
-          function: cross_section
         size:
         - 500
         - 24.375
@@ -538,11 +514,7 @@ cells:
             - 24.375
           - - 500
             - 24.375
-          layer:
-          - 1
-          - 0
           npoints: 99
-          width: 0.5
         default:
           control_points:
           - - 0
@@ -591,7 +563,7 @@ cells:
         length: 500.845
         min_bend_radius: 1870.03
         module: gdsfactory.components.bezier
-        name: bezier_1cd7d155
+        name: bezier_6e8a823c
         start_angle: 0.057
       default:
         cross_section:
@@ -615,7 +587,7 @@ cells:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bend_s
-      name: bezier_1cd7d155_bend_s_74621b0d
+      name: bezier_6e8a823c_bend_s_c234ff0c
       start_angle: 0.057
     changed:
       coupler:
@@ -669,33 +641,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.splitter_tree
     name: splitter_tree_3ca16676
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -712,7 +659,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_1da190e0
+    name: straight
     width: 0.5
   straight_32174f25:
     changed:
@@ -739,79 +686,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_3d0e809e:
+  straight_37d9ef2b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 68.89
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 68.89
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 68.89
-    module: gdsfactory.components.straight
-    name: straight_3d0e809e
-    width: 0.5
-  straight_4e82411b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.09
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.09
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.09
-    module: gdsfactory.components.straight
-    name: straight_4e82411b
-    width: 0.5
-  straight_5743d35a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_814d0e25:
-    changed:
-      cross_section:
-        function: cross_section
       length: 310.09
     default:
       cross_section:
@@ -829,7 +705,70 @@ cells:
     info_version: 1
     length: 310.09
     module: gdsfactory.components.straight
-    name: straight_814d0e25
+    name: straight_37d9ef2b
+    width: 0.5
+  straight_76a4ed9f:
+    changed:
+      length: 0.09
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.09
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.09
+    module: gdsfactory.components.straight
+    name: straight_76a4ed9f
+    width: 0.5
+  straight_a49b5f82:
+    changed:
+      length: 68.89
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 68.89
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 68.89
+    module: gdsfactory.components.straight
+    name: straight_a49b5f82
+    width: 0.5
+  straight_abd19b3c:
+    changed:
+      length: 29.375
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 29.375
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 29.375
+    module: gdsfactory.components.straight
+    name: straight_abd19b3c
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -856,11 +795,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_b6a0f387:
+  straight_c138f2c4:
     changed:
-      cross_section:
-        function: cross_section
-      length: 29.375
+      length: 0.01
     default:
       cross_section:
         function: cross_section
@@ -870,14 +807,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 29.375
+      length: 0.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 29.375
+    length: 0.01
     module: gdsfactory.components.straight
-    name: straight_b6a0f387
+    name: straight_c138f2c4
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -903,6 +840,27 @@ cells:
     length: 6
     module: gdsfactory.components.straight
     name: straight_e3f148d8
+    width: 0.5
+  straight_fba69bc3:
+    changed:
+      length: 2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 2
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 2
+    module: gdsfactory.components.straight
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:
@@ -1017,8 +975,6 @@ cells:
 info:
   bend_s:
     changed:
-      cross_section:
-        function: cross_section
       size:
       - 500
       - 24.375
@@ -1033,11 +989,7 @@ info:
           - 24.375
         - - 500
           - 24.375
-        layer:
-        - 1
-        - 0
         npoints: 99
-        width: 0.5
       default:
         control_points:
         - - 0
@@ -1086,7 +1038,7 @@ info:
       length: 500.845
       min_bend_radius: 1870.03
       module: gdsfactory.components.bezier
-      name: bezier_1cd7d155
+      name: bezier_6e8a823c
       start_angle: 0.057
     default:
       cross_section:
@@ -1110,7 +1062,7 @@ info:
     length: 500.845
     min_bend_radius: 1870.03
     module: gdsfactory.components.bend_s
-    name: bezier_1cd7d155_bend_s_74621b0d
+    name: bezier_6e8a823c_bend_s_c234ff0c
     start_angle: 0.057
   changed:
     coupler:

--- a/gdsfactory/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
@@ -1,20 +1,52 @@
 cells:
-  taper_0p5_to_3_l36:
+  taper_from_csv:
     changed: {}
-    default: {}
-    full: {}
-    function_name: taper_0p5_to_3_l36
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_0p5_to_3_l36
+    name: taper_from_csv
 info:
   changed: {}
-  default: {}
-  full: {}
-  function_name: taper_0p5_to_3_l36
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_0p5_to_3_l36
+  name: taper_from_csv
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -1,7 +1,77 @@
 cells:
-  extrude_465e033e:
+  extrude_ca2fda7d:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: linear
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: linear
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: linear
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: linear
       p: path_c939b54c37f7fe69df0534ac53495b62
     default:
       cross_section: null
@@ -10,7 +80,77 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: linear
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: linear
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: linear
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: linear
       layer: null
       p: path_c939b54c37f7fe69df0534ac53495b62
       simplify: null
@@ -20,7 +160,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_465e033e
+    name: extrude_ca2fda7d
   taper_cross_section_f1747efd:
     changed:
       linear: true

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -1,5 +1,5 @@
 cells:
-  extrude_ca2fda7d:
+  extrude_8de17bbb:
     changed:
       cross_section:
         aliases:
@@ -39,8 +39,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -118,8 +118,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -160,7 +160,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_ca2fda7d
+    name: extrude_8de17bbb
   taper_cross_section_f1747efd:
     changed:
       linear: true

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -1,5 +1,5 @@
 cells:
-  extrude_d8a78e1f:
+  extrude_5bd7411a:
     changed:
       cross_section:
         aliases:
@@ -39,8 +39,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -118,8 +118,8 @@ cells:
         port_types:
         - optical
         ports:
-        - o2
         - o1
+        - o2
         sections:
         - hidden: false
           layer:
@@ -160,7 +160,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_d8a78e1f
+    name: extrude_5bd7411a
   taper_cross_section_f6e3006a:
     changed:
       npoints: 101

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -1,7 +1,77 @@
 cells:
-  extrude_96406c1e:
+  extrude_d8a78e1f:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       p: path_ed76b77e33fcc87170ee125e6372cc8f
     default:
       cross_section: null
@@ -10,7 +80,77 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          _default:
+            hidden: false
+            layer:
+            - 1
+            - 0
+            name: _default
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - o1
+            - o2
+            width:
+              function: sine
+          slab:
+            hidden: false
+            layer:
+            - 3
+            - 0
+            name: slab
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - o2
+        - o1
+        sections:
+        - hidden: false
+          layer:
+          - 1
+          - 0
+          name: _default
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - o1
+          - o2
+          width:
+            function: sine
+        - hidden: false
+          layer:
+          - 3
+          - 0
+          name: slab
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       layer: null
       p: path_ed76b77e33fcc87170ee125e6372cc8f
       simplify: null
@@ -20,7 +160,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.path
-    name: extrude_96406c1e
+    name: extrude_d8a78e1f
   taper_cross_section_f6e3006a:
     changed:
       npoints: 101

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -21,9 +21,8 @@ cells:
     length: 10
     module: gdsfactory.path
     name: extrude_96406c1e
-  taper_cross_section_11c0a1bc:
+  taper_cross_section_f6e3006a:
     changed:
-      linear: false
       npoints: 101
     default:
       cross_section1:
@@ -60,10 +59,9 @@ cells:
     function_name: taper_cross_section
     info_version: 1
     module: gdsfactory.components.taper_cross_section
-    name: taper_cross_section_11c0a1bc
+    name: taper_cross_section_f6e3006a
 info:
   changed:
-    linear: false
     npoints: 101
   default:
     cross_section1:
@@ -100,7 +98,7 @@ info:
   function_name: taper_cross_section
   info_version: 1
   module: gdsfactory.components.taper_cross_section
-  name: taper_cross_section_11c0a1bc
+  name: taper_cross_section_f6e3006a
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
@@ -1,5 +1,5 @@
 cells:
-  taper_from_csv_81b1c118:
+  taper_from_csv_a843f238:
     changed:
       filepath: taper_strip_0p5_10_100.csv
     default:
@@ -23,7 +23,7 @@ cells:
     function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_from_csv_81b1c118
+    name: taper_from_csv_a843f238
 info:
   changed:
     filepath: taper_strip_0p5_10_100.csv
@@ -48,7 +48,7 @@ info:
   function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_from_csv_81b1c118
+  name: taper_from_csv_a843f238
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
@@ -1,20 +1,54 @@
 cells:
-  taper_w10_l100:
-    changed: {}
-    default: {}
-    full: {}
-    function_name: taper_w10_l100
+  taper_from_csv_81b1c118:
+    changed:
+      filepath: taper_strip_0p5_10_100.csv
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_10_100.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_w10_l100
+    name: taper_from_csv_81b1c118
 info:
-  changed: {}
-  default: {}
-  full: {}
-  function_name: taper_w10_l100
+  changed:
+    filepath: taper_strip_0p5_10_100.csv
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_10_100.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_w10_l100
+  name: taper_from_csv_81b1c118
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
@@ -1,5 +1,5 @@
 cells:
-  taper_from_csv_09c12db2:
+  taper_from_csv_ba1cb547:
     changed:
       filepath: taper_strip_0p5_10_150.csv
     default:
@@ -23,7 +23,7 @@ cells:
     function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_from_csv_09c12db2
+    name: taper_from_csv_ba1cb547
 info:
   changed:
     filepath: taper_strip_0p5_10_150.csv
@@ -48,7 +48,7 @@ info:
   function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_from_csv_09c12db2
+  name: taper_from_csv_ba1cb547
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
@@ -1,20 +1,54 @@
 cells:
-  taper_w10_l150:
-    changed: {}
-    default: {}
-    full: {}
-    function_name: taper_w10_l150
+  taper_from_csv_09c12db2:
+    changed:
+      filepath: taper_strip_0p5_10_150.csv
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_10_150.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_w10_l150
+    name: taper_from_csv_09c12db2
 info:
-  changed: {}
-  default: {}
-  full: {}
-  function_name: taper_w10_l150
+  changed:
+    filepath: taper_strip_0p5_10_150.csv
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_10_150.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_w10_l150
+  name: taper_from_csv_09c12db2
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
@@ -1,5 +1,5 @@
 cells:
-  taper_from_csv_613e656a:
+  taper_from_csv_ddf33da0:
     changed:
       filepath: taper_strip_0p5_10_200.csv
     default:
@@ -23,7 +23,7 @@ cells:
     function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_from_csv_613e656a
+    name: taper_from_csv_ddf33da0
 info:
   changed:
     filepath: taper_strip_0p5_10_200.csv
@@ -48,7 +48,7 @@ info:
   function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_from_csv_613e656a
+  name: taper_from_csv_ddf33da0
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
@@ -1,20 +1,54 @@
 cells:
-  taper_w10_l200:
-    changed: {}
-    default: {}
-    full: {}
-    function_name: taper_w10_l200
+  taper_from_csv_613e656a:
+    changed:
+      filepath: taper_strip_0p5_10_200.csv
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_10_200.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_w10_l200
+    name: taper_from_csv_613e656a
 info:
-  changed: {}
-  default: {}
-  full: {}
-  function_name: taper_w10_l200
+  changed:
+    filepath: taper_strip_0p5_10_200.csv
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_10_200.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_w10_l200
+  name: taper_from_csv_613e656a
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
@@ -1,5 +1,5 @@
 cells:
-  taper_from_csv_151cbee0:
+  taper_from_csv_7fc5bca1:
     changed:
       filepath: taper_strip_0p5_11_200.csv
     default:
@@ -23,7 +23,7 @@ cells:
     function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_from_csv_151cbee0
+    name: taper_from_csv_7fc5bca1
 info:
   changed:
     filepath: taper_strip_0p5_11_200.csv
@@ -48,7 +48,7 @@ info:
   function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_from_csv_151cbee0
+  name: taper_from_csv_7fc5bca1
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
@@ -1,20 +1,54 @@
 cells:
-  taper_w11_l200:
-    changed: {}
-    default: {}
-    full: {}
-    function_name: taper_w11_l200
+  taper_from_csv_151cbee0:
+    changed:
+      filepath: taper_strip_0p5_11_200.csv
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_11_200.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_w11_l200
+    name: taper_from_csv_151cbee0
 info:
-  changed: {}
-  default: {}
-  full: {}
-  function_name: taper_w11_l200
+  changed:
+    filepath: taper_strip_0p5_11_200.csv
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_11_200.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_w11_l200
+  name: taper_from_csv_151cbee0
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
@@ -1,20 +1,54 @@
 cells:
-  taper_w12_l200:
-    changed: {}
-    default: {}
-    full: {}
-    function_name: taper_w12_l200
+  taper_from_csv_aeb11bd1:
+    changed:
+      filepath: taper_strip_0p5_12_200.csv
+    default:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_3_36.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    full:
+      cladding_offset: 3
+      filepath: taper_strip_0p5_12_200.csv
+      layer:
+      - 1
+      - 0
+      layer_cladding:
+      - 111
+      - 0
+    function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_w12_l200
+    name: taper_from_csv_aeb11bd1
 info:
-  changed: {}
-  default: {}
-  full: {}
-  function_name: taper_w12_l200
+  changed:
+    filepath: taper_strip_0p5_12_200.csv
+  default:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_3_36.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  full:
+    cladding_offset: 3
+    filepath: taper_strip_0p5_12_200.csv
+    layer:
+    - 1
+    - 0
+    layer_cladding:
+    - 111
+    - 0
+  function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_w12_l200
+  name: taper_from_csv_aeb11bd1
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
@@ -1,5 +1,5 @@
 cells:
-  taper_from_csv_aeb11bd1:
+  taper_from_csv_540e4c87:
     changed:
       filepath: taper_strip_0p5_12_200.csv
     default:
@@ -23,7 +23,7 @@ cells:
     function_name: taper_from_csv
     info_version: 1
     module: gdsfactory.components.taper_from_csv
-    name: taper_from_csv_aeb11bd1
+    name: taper_from_csv_540e4c87
 info:
   changed:
     filepath: taper_strip_0p5_12_200.csv
@@ -48,7 +48,7 @@ info:
   function_name: taper_from_csv
   info_version: 1
   module: gdsfactory.components.taper_from_csv
-  name: taper_from_csv_aeb11bd1
+  name: taper_from_csv_540e4c87
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
@@ -1,10 +1,6 @@
 cells:
-  text_rectangular_2705ebf9:
-    changed:
-      layer:
-      - 1
-      - 0
-      text: abcd
+  text_rectangular:
+    changed: {}
     default:
       font:
         function: rectangular_font
@@ -32,13 +28,12 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_2705ebf9
-  text_rectangular_5719a560:
+    name: text_rectangular
+  text_rectangular_b665fe57:
     changed:
       layer:
-      - 41
+      - 45
       - 0
-      text: abcd
     default:
       font:
         function: rectangular_font
@@ -56,7 +51,7 @@ cells:
         function: rectangular_font
       justify: left
       layer:
-      - 41
+      - 45
       - 0
       position:
       - 0
@@ -66,8 +61,8 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_5719a560
-  text_rectangular_83bce1_c69186bd:
+    name: text_rectangular_b665fe57
+  text_rectangular_e73c7b_56e35f25:
     changed:
       factory:
         function: text_rectangular
@@ -86,7 +81,6 @@ cells:
         layer:
         - 49
         - 0
-        text: abcd
       default:
         font:
           function: rectangular_font
@@ -114,7 +108,7 @@ cells:
       function_name: text_rectangular
       info_version: 1
       module: gdsfactory.components.text_rectangular
-      name: text_rectangular_83bce1ad
+      name: text_rectangular_e73c7be4
     default:
       factory:
         function: cross
@@ -139,13 +133,12 @@ cells:
     function_name: copy_layers
     info_version: 1
     module: gdsfactory.components.copy_layers
-    name: text_rectangular_83bce1_c69186bd
-  text_rectangular_83bce1ad:
+    name: text_rectangular_e73c7b_56e35f25
+  text_rectangular_e73c7be4:
     changed:
       layer:
       - 49
       - 0
-      text: abcd
     default:
       font:
         function: rectangular_font
@@ -173,13 +166,12 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_83bce1ad
-  text_rectangular_efc9b880:
+    name: text_rectangular_e73c7be4
+  text_rectangular_e9647926:
     changed:
       layer:
-      - 45
+      - 41
       - 0
-      text: abcd
     default:
       font:
         function: rectangular_font
@@ -197,7 +189,7 @@ cells:
         function: rectangular_font
       justify: left
       layer:
-      - 45
+      - 41
       - 0
       position:
       - 0
@@ -207,7 +199,7 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_efc9b880
+    name: text_rectangular_e9647926
 info:
   changed:
     factory:
@@ -227,7 +219,6 @@ info:
       layer:
       - 49
       - 0
-      text: abcd
     default:
       font:
         function: rectangular_font
@@ -255,7 +246,7 @@ info:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_83bce1ad
+    name: text_rectangular_e73c7be4
   default:
     factory:
       function: cross
@@ -280,6 +271,6 @@ info:
   function_name: copy_layers
   info_version: 1
   module: gdsfactory.components.copy_layers
-  name: text_rectangular_83bce1_c69186bd
+  name: text_rectangular_e73c7b_56e35f25
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
@@ -29,10 +29,10 @@ cells:
     info_version: 1
     module: gdsfactory.components.text_rectangular
     name: text_rectangular
-  text_rectangular_b665fe57:
+  text_rectangular_1728a687:
     changed:
       layer:
-      - 45
+      - 49
       - 0
     default:
       font:
@@ -51,7 +51,7 @@ cells:
         function: rectangular_font
       justify: left
       layer:
-      - 45
+      - 49
       - 0
       position:
       - 0
@@ -61,8 +61,8 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_b665fe57
-  text_rectangular_e73c7b_56e35f25:
+    name: text_rectangular_1728a687
+  text_rectangular_1728a6_2f9cb8aa:
     changed:
       factory:
         function: text_rectangular
@@ -108,7 +108,7 @@ cells:
       function_name: text_rectangular
       info_version: 1
       module: gdsfactory.components.text_rectangular
-      name: text_rectangular_e73c7be4
+      name: text_rectangular_1728a687
     default:
       factory:
         function: cross
@@ -133,11 +133,11 @@ cells:
     function_name: copy_layers
     info_version: 1
     module: gdsfactory.components.copy_layers
-    name: text_rectangular_e73c7b_56e35f25
-  text_rectangular_e73c7be4:
+    name: text_rectangular_1728a6_2f9cb8aa
+  text_rectangular_820a0b5f:
     changed:
       layer:
-      - 49
+      - 45
       - 0
     default:
       font:
@@ -156,7 +156,7 @@ cells:
         function: rectangular_font
       justify: left
       layer:
-      - 49
+      - 45
       - 0
       position:
       - 0
@@ -166,8 +166,8 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_e73c7be4
-  text_rectangular_e9647926:
+    name: text_rectangular_820a0b5f
+  text_rectangular_87c94e73:
     changed:
       layer:
       - 41
@@ -199,7 +199,7 @@ cells:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_e9647926
+    name: text_rectangular_87c94e73
 info:
   changed:
     factory:
@@ -246,7 +246,7 @@ info:
     function_name: text_rectangular
     info_version: 1
     module: gdsfactory.components.text_rectangular
-    name: text_rectangular_e73c7be4
+    name: text_rectangular_1728a687
   default:
     factory:
       function: cross
@@ -271,6 +271,6 @@ info:
   function_name: copy_layers
   info_version: 1
   module: gdsfactory.components.copy_layers
-  name: text_rectangular_e73c7b_56e35f25
+  name: text_rectangular_1728a6_2f9cb8aa
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_verniers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_verniers_.yml
@@ -1,74 +1,5 @@
 cells:
-  straight_000ced35:
-    changed:
-      length: 100
-      width: 0.3
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 100
-      npoints: 2
-      width: 0.3
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 100
-    module: gdsfactory.components.straight
-    name: straight_000ced35
-    width: 0.3
-  straight_1d5ce988:
-    changed:
-      length: 100
-      width: 0.2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 100
-      npoints: 2
-      width: 0.2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 100
-    module: gdsfactory.components.straight
-    name: straight_1d5ce988
-    width: 0.2
-  straight_7bc6fbea:
-    changed:
-      length: 100
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 100
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 100
-    module: gdsfactory.components.straight
-    name: straight_7bc6fbea
-    width: 0.5
-  straight_daeefb16:
+  straight_259e29a2:
     changed:
       length: 100
       width: 0.1
@@ -89,9 +20,55 @@ cells:
     info_version: 1
     length: 100
     module: gdsfactory.components.straight
-    name: straight_daeefb16
+    name: straight_259e29a2
     width: 0.1
-  straight_dbe34808:
+  straight_50783ad4:
+    changed:
+      length: 100
+      width: 0.3
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 100
+      npoints: 2
+      width: 0.3
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 100
+    module: gdsfactory.components.straight
+    name: straight_50783ad4
+    width: 0.3
+  straight_805c819f:
+    changed:
+      length: 100
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 100
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 100
+    module: gdsfactory.components.straight
+    name: straight_805c819f
+    width: 0.5
+  straight_8a05f37d:
     changed:
       length: 100
       width: 0.4
@@ -112,8 +89,31 @@ cells:
     info_version: 1
     length: 100
     module: gdsfactory.components.straight
-    name: straight_dbe34808
+    name: straight_8a05f37d
     width: 0.4
+  straight_b44e9212:
+    changed:
+      length: 100
+      width: 0.2
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 100
+      npoints: 2
+      width: 0.2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 100
+    module: gdsfactory.components.straight
+    name: straight_b44e9212
+    width: 0.2
   verniers:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_via1_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via1_.yml
@@ -1,5 +1,5 @@
 cells:
-  via_0b2d8623:
+  via_ebd8e362:
     changed:
       enclosure: 2
       layer:
@@ -35,7 +35,7 @@ cells:
     function_name: via
     info_version: 1
     module: gdsfactory.components.via
-    name: via_0b2d8623
+    name: via_ebd8e362
     size:
     - 0.7
     - 0.7
@@ -78,7 +78,7 @@ info:
   function_name: via
   info_version: 1
   module: gdsfactory.components.via
-  name: via_0b2d8623
+  name: via_ebd8e362
   size:
   - 0.7
   - 0.7

--- a/gdsfactory/tests/test_components/test_settings_via2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via2_.yml
@@ -1,5 +1,5 @@
 cells:
-  via_dfb2d6c0:
+  via_fd13653e:
     changed:
       layer:
       - 43
@@ -34,7 +34,7 @@ cells:
     function_name: via
     info_version: 1
     module: gdsfactory.components.via
-    name: via_dfb2d6c0
+    name: via_fd13653e
     size:
     - 0.7
     - 0.7
@@ -76,7 +76,7 @@ info:
   function_name: via
   info_version: 1
   module: gdsfactory.components.via
-  name: via_dfb2d6c0
+  name: via_fd13653e
   size:
   - 0.7
   - 0.7

--- a/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
@@ -391,7 +391,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_f8ff546d
-  contact_16d0347b:
+  contact_41680d71:
     changed:
       layers:
       - - 47
@@ -401,18 +401,8 @@ cells:
       - - 49
         - 0
       size:
-      - 10
-      - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
+      - 150
+      - 150
     default:
       layer_port: null
       layers:
@@ -445,8 +435,8 @@ cells:
       - - 49
         - 0
       size:
-      - 10
-      - 10
+      - 150
+      - 150
       vias:
       - enclosure: 2
         function: via
@@ -463,11 +453,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_16d0347b
+    name: contact_41680d71
     size:
-    - 10
-    - 10
-  contact_84c67b1a:
+    - 150
+    - 150
+  contact_8f0662dd:
     changed:
       layers:
       - - 47
@@ -479,16 +469,6 @@ cells:
       size:
       - 30
       - 10
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
     default:
       layer_port: null
       layers:
@@ -539,11 +519,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_84c67b1a
+    name: contact_8f0662dd
     size:
     - 30
     - 10
-  contact_87aeec60:
+  contact_f6d43dc5:
     changed:
       layers:
       - - 47
@@ -553,18 +533,8 @@ cells:
       - - 49
         - 0
       size:
-      - 150
-      - 150
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
-        - 0
+      - 10
+      - 10
     default:
       layer_port: null
       layers:
@@ -597,8 +567,8 @@ cells:
       - - 49
         - 0
       size:
-      - 150
-      - 150
+      - 10
+      - 10
       vias:
       - enclosure: 2
         function: via
@@ -615,10 +585,10 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_87aeec60
+    name: contact_f6d43dc5
     size:
-    - 150
-    - 150
+    - 10
+    - 10
   via_cutback:
     changed: {}
     default:

--- a/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
@@ -1,5 +1,5 @@
 cells:
-  _via_iterable_488817b3:
+  _via_iterable_f08e9e28:
     changed:
       layer1:
       - 47
@@ -30,98 +30,8 @@ cells:
     function_name: _via_iterable
     info_version: 1
     module: gdsfactory.components.via_cutback
-    name: _via_iterable_488817b3
-  compass_09373c73:
-    changed:
-      layer:
-      - 45
-      - 0
-      size:
-      - 150
-      - 150
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 150
-      - 150
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_09373c73
-  compass_1976da67:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_1976da67
-  compass_1be62a3c:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 150
-      - 150
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 150
-      - 150
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_1be62a3c
-  compass_1ee85f0c:
+    name: _via_iterable_f08e9e28
+  compass_1ab156b5:
     changed:
       layer:
       - 47
@@ -150,11 +60,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_1ee85f0c
-  compass_5903820c:
+    name: compass_1ab156b5
+  compass_342f16e4:
     changed:
       layer:
-      - 49
+      - 45
       - 0
       size:
       - 10
@@ -170,7 +80,7 @@ cells:
       - 2
     full:
       layer:
-      - 49
+      - 45
       - 0
       port_inclusion: 0
       port_type: electrical
@@ -180,8 +90,8 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_5903820c
-  compass_ac0c3f29:
+    name: compass_342f16e4
+  compass_3cdcd640:
     changed:
       layer:
       - 41
@@ -210,14 +120,14 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_ac0c3f29
-  compass_b796e8b0:
+    name: compass_3cdcd640
+  compass_3e08739f:
     changed:
       layer:
-      - 45
+      - 49
       - 0
       size:
-      - 30
+      - 10
       - 10
     default:
       layer:
@@ -230,18 +140,18 @@ cells:
       - 2
     full:
       layer:
-      - 45
+      - 49
       - 0
       port_inclusion: 0
       port_type: electrical
       size:
-      - 30
+      - 10
       - 10
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_b796e8b0
-  compass_c742e2c3:
+    name: compass_3e08739f
+  compass_592e1768:
     changed:
       layer:
       - 47
@@ -270,71 +180,11 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_c742e2c3
-  compass_e429d7e7:
+    name: compass_592e1768
+  compass_5958a8af:
     changed:
       layer:
       - 45
-      - 0
-      size:
-      - 10
-      - 10
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 45
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 10
-      - 10
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_e429d7e7
-  compass_e956677d:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 150
-      - 150
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 150
-      - 150
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_e956677d
-  compass_eb6d9a94:
-    changed:
-      layer:
-      - 49
       - 0
       size:
       - 30
@@ -350,7 +200,7 @@ cells:
       - 2
     full:
       layer:
-      - 49
+      - 45
       - 0
       port_inclusion: 0
       port_type: electrical
@@ -360,8 +210,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_eb6d9a94
-  compass_f8ff546d:
+    name: compass_5958a8af
+  compass_5a3015f4:
+    changed:
+      layer:
+      - 45
+      - 0
+      size:
+      - 150
+      - 150
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 45
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 150
+      - 150
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5a3015f4
+  compass_6e9dd272:
     changed:
       layer:
       - 40
@@ -390,8 +270,128 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_f8ff546d
-  contact_41680d71:
+    name: compass_6e9dd272
+  compass_755c9444:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 10
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 10
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_755c9444
+  compass_a2539b1a:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 150
+      - 150
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 150
+      - 150
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_a2539b1a
+  compass_c115b7ac:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 150
+      - 150
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 150
+      - 150
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_c115b7ac
+  compass_db0c6079:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 30
+      - 10
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 30
+      - 10
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_db0c6079
+  contact_04d8a26f:
     changed:
       layers:
       - - 47
@@ -453,11 +453,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_41680d71
+    name: contact_04d8a26f
     size:
     - 150
     - 150
-  contact_8f0662dd:
+  contact_20d34c1b:
     changed:
       layers:
       - - 47
@@ -519,11 +519,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_8f0662dd
+    name: contact_20d34c1b
     size:
     - 30
     - 10
-  contact_f6d43dc5:
+  contact_e37aabb7:
     changed:
       layers:
       - - 47
@@ -585,7 +585,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f6d43dc5
+    name: contact_e37aabb7
     size:
     - 10
     - 10

--- a/gdsfactory/tests/test_components/test_settings_viac_.yml
+++ b/gdsfactory/tests/test_components/test_settings_viac_.yml
@@ -1,9 +1,6 @@
 cells:
-  via_3db94f98:
-    changed:
-      layer:
-      - 40
-      - 0
+  via:
+    changed: {}
     default:
       cladding_offset: 0
       enclosure: 1
@@ -34,7 +31,7 @@ cells:
     function_name: via
     info_version: 1
     module: gdsfactory.components.via
-    name: via_3db94f98
+    name: via
     size:
     - 0.7
     - 0.7
@@ -42,10 +39,7 @@ cells:
     - 2
     - 2
 info:
-  changed:
-    layer:
-    - 40
-    - 0
+  changed: {}
   default:
     cladding_offset: 0
     enclosure: 1
@@ -76,7 +70,7 @@ info:
   function_name: via
   info_version: 1
   module: gdsfactory.components.via
-  name: via_3db94f98
+  name: via
   size:
   - 0.7
   - 0.7

--- a/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_e57a8330:
+  straight_d9d77473:
     changed:
       cross_section:
         function: cross_section
@@ -13,7 +13,6 @@ cells:
         - electrical
         - electrical
         width: 10
-      length: 10
       with_cladding_box: false
     default:
       cross_section:
@@ -41,7 +40,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_e57a8330
+    name: straight_d9d77473
     width: 10
   wire_corner:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_d9d77473:
+  straight_22f074f5:
     changed:
       cross_section:
         function: cross_section
@@ -40,7 +40,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_d9d77473
+    name: straight_22f074f5
     width: 10
   wire_corner:
     changed: {}

--- a/gdsfactory/tests/test_components/test_settings_wire_straight_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_straight_.yml
@@ -1,5 +1,5 @@
 cells:
-  straight_d9d77473:
+  straight_22f074f5:
     changed:
       cross_section:
         function: cross_section
@@ -40,7 +40,7 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_d9d77473
+    name: straight_22f074f5
     width: 10
 info:
   changed:
@@ -83,7 +83,7 @@ info:
   info_version: 1
   length: 10
   module: gdsfactory.components.straight
-  name: straight_d9d77473
+  name: straight_22f074f5
   width: 10
 ports:
   e1:

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -89,37 +87,6 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_280a2d8b
-  compass_6ffda32f:
-    changed:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      size:
-      - 100
-      - 100
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 100
-      - 100
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_6ffda32f
   compass_8e661824:
     changed:
       layer:
@@ -150,6 +117,36 @@ cells:
     info_version: 1
     module: gdsfactory.components.compass
     name: compass_8e661824
+  compass_a0b38c11:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 100
+      - 100
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 100
+      - 100
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_a0b38c11
   component_sequence_e4dca69b:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
@@ -194,7 +191,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -202,16 +199,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -263,7 +250,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -473,11 +460,8 @@ cells:
     size:
     - 100
     - 100
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -487,19 +471,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -517,12 +499,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -532,37 +513,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -589,11 +547,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -603,14 +559,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -637,10 +593,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -658,13 +633,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -674,14 +647,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -708,11 +681,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -722,14 +693,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,68 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_7a93663b:
+    changed:
+      layer:
+      - 49
+      - 0
+      size:
+      - 100
+      - 100
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 49
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 100
+      - 100
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_7a93663b
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,51 +146,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  compass_a0b38c11:
-    changed:
-      layer:
-      - 49
-      - 0
-      size:
-      - 100
-      - 100
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 49
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 100
-      - 100
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_a0b38c11
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -176,22 +176,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -250,7 +250,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -282,7 +282,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -339,10 +339,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_electr_62814515:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_electr_20c1736e:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -400,7 +400,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       layer:
       - 31
@@ -413,7 +413,7 @@ cells:
         function: select_ports
         port_type: electrical
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       layer:
       - 31
       - 0
@@ -427,7 +427,7 @@ cells:
     function_name: add_electrical_pads_shortest
     info_version: 1
     module: gdsfactory.routing.add_electrical_pads_shortest
-    name: mzi_d275fe52_add_electr_62814515
+    name: mzi_15f399ec_add_electr_20c1736e
   pad:
     changed: {}
     default:
@@ -480,183 +480,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -679,7 +503,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -778,7 +778,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -809,12 +809,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -872,7 +872,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     layer:
     - 31
@@ -885,7 +885,7 @@ info:
       function: select_ports
       port_type: electrical
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     layer:
     - 31
     - 0
@@ -899,7 +899,7 @@ info:
   function_name: add_electrical_pads_shortest
   info_version: 1
   module: gdsfactory.routing.add_electrical_pads_shortest
-  name: mzi_d275fe52_add_electr_62814515
+  name: mzi_15f399ec_add_electr_20c1736e
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -252,7 +252,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -309,10 +309,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_electr_8764ac02:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_electr_1bbbc24e:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -370,7 +370,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       layer:
       - 31
@@ -384,7 +384,7 @@ cells:
       - 0
       - 100
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       layer:
       - 31
       - 0
@@ -399,7 +399,7 @@ cells:
     function_name: add_electrical_pads_top
     info_version: 1
     module: gdsfactory.routing.add_electrical_pads_top
-    name: mzi_d275fe52_add_electr_8764ac02
+    name: mzi_15f399ec_add_electr_1bbbc24e
   pad_array_d3f18571:
     changed:
       columns: 2
@@ -448,183 +448,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -647,7 +471,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -746,7 +746,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -777,12 +777,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -840,7 +840,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     layer:
     - 31
@@ -854,7 +854,7 @@ info:
     - 0
     - 100
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     layer:
     - 31
     - 0
@@ -869,7 +869,7 @@ info:
   function_name: add_electrical_pads_top
   info_version: 1
   module: gdsfactory.routing.add_electrical_pads_top
-  name: mzi_d275fe52_add_electr_8764ac02
+  name: mzi_15f399ec_add_electr_1bbbc24e
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -412,10 +400,9 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_electrical_pads_top
     name: mzi_d275fe52_add_electr_8764ac02
-  pad_array_838b16d5:
+  pad_array_d3f18571:
     changed:
       columns: 2
-      orientation: 270
     default:
       columns: 6
       orientation: 270
@@ -437,15 +424,12 @@ cells:
     function_name: pad_array
     info_version: 1
     module: gdsfactory.components.pad
-    name: pad_array_838b16d5
+    name: pad_array_d3f18571
     size:
     - 100
     - 100
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -455,19 +439,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -485,12 +467,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -500,37 +481,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -557,11 +515,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -571,14 +527,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -605,10 +561,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -626,13 +601,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -642,14 +615,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -676,11 +649,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -690,14 +661,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -1,9 +1,6 @@
 cells:
-  bend_euler_0c3469c8:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -16,7 +13,6 @@ cells:
     dy: 10
     full:
       angle: 90
-      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -28,13 +24,12 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_0c3469c8
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_1da190e0:
+  bend_euler_2630f5fb:
     changed:
-      cross_section:
-        function: cross_section
+      auto_widen: true
     default:
       angle: 90
       cross_section:
@@ -47,6 +42,7 @@ cells:
     dy: 10
     full:
       angle: 90
+      auto_widen: true
       cross_section:
         function: cross_section
       direction: ccw
@@ -58,7 +54,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -217,7 +213,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -225,16 +221,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -286,13 +272,12 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -345,7 +330,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -545,11 +530,8 @@ cells:
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
     name: mzi_d275fe52_add_fiber__542edc06
-  straight_06b7497a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 43.5
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -559,20 +541,41 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 43.5
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 43.5
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_06b7497a
+    name: straight
     width: 0.5
-  straight_15a9c8d1:
+  straight_0092608c:
     changed:
+      auto_widen: true
+      length: 367.16
+    default:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 367.16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 367.16
+    module: gdsfactory.components.straight
+    name: straight_0092608c
+    width: 0.5
+  straight_0723ff82:
+    changed:
+      length: 11
     default:
       cross_section:
         function: cross_section
@@ -582,19 +585,40 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 11
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 11
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight_0723ff82
     width: 0.5
-  straight_18ee7f79:
+  straight_0d50a8c6:
     changed:
+      auto_widen: true
+      length: 363
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 363
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 363
+    module: gdsfactory.components.straight
+    name: straight_0d50a8c6
+    width: 0.5
+  straight_213f8dff:
+    changed:
       length: 375.42
     default:
       cross_section:
@@ -612,12 +636,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -627,60 +650,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
-    width: 0.5
-  straight_30cdd8a6:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 57.975
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 57.975
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 57.975
-    module: gdsfactory.components.straight
-    name: straight_30cdd8a6
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -707,222 +684,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_336f2b64:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 140.51
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 140.51
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 140.51
-    module: gdsfactory.components.straight
-    name: straight_336f2b64
-    width: 0.5
-  straight_367e51dc:
+  straight_357443e8:
     changed:
       auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1.75
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 1.75
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 1.75
-    module: gdsfactory.components.straight
-    name: straight_367e51dc
-    width: 0.5
-  straight_5743d35a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_59affde8:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 19.51
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 19.51
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 19.51
-    module: gdsfactory.components.straight
-    name: straight_59affde8
-    width: 0.5
-  straight_6c7d4024:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 15.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15.25
-    module: gdsfactory.components.straight
-    name: straight_6c7d4024
-    width: 0.5
-  straight_763e1ea3:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 35.552
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 35.552
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 35.552
-    module: gdsfactory.components.straight
-    name: straight_763e1ea3
-    width: 0.5
-  straight_7a1490a4:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 0.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.5
-    module: gdsfactory.components.straight
-    name: straight_7a1490a4
-    width: 0.5
-  straight_8b49dbde:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 136.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 136.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 136.25
-    module: gdsfactory.components.straight
-    name: straight_8b49dbde
-    width: 0.5
-  straight_8c790a0a:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 51.975
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 51.975
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 51.975
-    module: gdsfactory.components.straight
-    name: straight_8c790a0a
-    width: 0.5
-  straight_ac80ac01:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
       length: 361.16
     default:
       cross_section:
@@ -941,7 +705,200 @@ cells:
     info_version: 1
     length: 361.16
     module: gdsfactory.components.straight
-    name: straight_ac80ac01
+    name: straight_357443e8
+    width: 0.5
+  straight_4ebf6673:
+    changed:
+      length: 140.51
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 140.51
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 140.51
+    module: gdsfactory.components.straight
+    name: straight_4ebf6673
+    width: 0.5
+  straight_53bdf814:
+    changed:
+      auto_widen: true
+      length: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 0.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.5
+    module: gdsfactory.components.straight
+    name: straight_53bdf814
+    width: 0.5
+  straight_5656be49:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_5656be49
+    width: 0.5
+  straight_740dd040:
+    changed:
+      length: 57.975
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 57.975
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 57.975
+    module: gdsfactory.components.straight
+    name: straight_740dd040
+    width: 0.5
+  straight_831943ee:
+    changed:
+      length: 35.552
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 35.552
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 35.552
+    module: gdsfactory.components.straight
+    name: straight_831943ee
+    width: 0.5
+  straight_83634e83:
+    changed:
+      auto_widen: true
+      length: 357
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 357
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 357
+    module: gdsfactory.components.straight
+    name: straight_83634e83
+    width: 0.5
+  straight_9785b75f:
+    changed:
+      length: 136.25
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 136.25
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 136.25
+    module: gdsfactory.components.straight
+    name: straight_9785b75f
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_ab8cb916:
+    changed:
+      length: 51.975
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 51.975
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 51.975
+    module: gdsfactory.components.straight
+    name: straight_ab8cb916
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -968,10 +925,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bc29f1fe:
+  straight_b1688d7b:
     changed:
-      cross_section:
-        function: cross_section
       length: 17
     default:
       cross_section:
@@ -989,12 +944,75 @@ cells:
     info_version: 1
     length: 17
     module: gdsfactory.components.straight
-    name: straight_bc29f1fe
+    name: straight_b1688d7b
     width: 0.5
-  straight_bd3b506b:
+  straight_b597c5d0:
     changed:
+      auto_widen: true
+      length: 1.75
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: true
+      cross_section:
+        function: cross_section
+      length: 1.75
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 1.75
+    module: gdsfactory.components.straight
+    name: straight_b597c5d0
+    width: 0.5
+  straight_c138f2c4:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c21f313f:
+    changed:
+      length: 19.51
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 19.51
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 19.51
+    module: gdsfactory.components.straight
+    name: straight_c21f313f
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -1012,13 +1030,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_c7b35a9f:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 11
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -1028,20 +1044,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 11
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 11
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_c7b35a9f
+    name: straight_c4f7f930
     width: 0.5
-  straight_ca7e7c8f:
+  straight_dd59df62:
     changed:
-      cross_section:
-        function: cross_section
-      length: 488
+      length: 15.25
     default:
       cross_section:
         function: cross_section
@@ -1051,87 +1065,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 488
+      length: 15.25
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 488
+    length: 15.25
     module: gdsfactory.components.straight
-    name: straight_ca7e7c8f
-    width: 0.5
-  straight_cd61840b:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_cd61840b
-    width: 0.5
-  straight_d336f4e4:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 357
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 357
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 357
-    module: gdsfactory.components.straight
-    name: straight_d336f4e4
-    width: 0.5
-  straight_e388ea45:
-    changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 363
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 363
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 363
-    module: gdsfactory.components.straight
-    name: straight_e388ea45
+    name: straight_dd59df62
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -1158,12 +1099,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_ecae7989:
+  straight_f0fa08f8:
     changed:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 367.16
+      length: 488
     default:
       cross_section:
         function: cross_section
@@ -1171,23 +1109,20 @@ cells:
       npoints: 2
       with_cladding_box: true
     full:
-      auto_widen: true
       cross_section:
         function: cross_section
-      length: 367.16
+      length: 488
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 367.16
+    length: 488
     module: gdsfactory.components.straight
-    name: straight_ecae7989
+    name: straight_f0fa08f8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -1197,14 +1132,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -57,7 +57,7 @@ cells:
     name: bend_euler_2630f5fb
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -78,38 +78,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+    name: circle_925ccccf
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -138,8 +108,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -168,21 +168,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -198,22 +198,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -272,7 +272,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -362,7 +362,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -419,10 +419,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_fiber__542edc06:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_fiber__6ace91e9:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -480,7 +480,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       bend:
         function: bend_euler
@@ -506,7 +506,7 @@ cells:
     full:
       bend:
         function: bend_euler
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       component_name: null
       cross_section:
         function: cross_section
@@ -529,7 +529,7 @@ cells:
     function_name: add_fiber_array
     info_version: 1
     module: gdsfactory.routing.add_fiber_array
-    name: mzi_d275fe52_add_fiber__542edc06
+    name: mzi_15f399ec_add_fiber__6ace91e9
   straight:
     changed: {}
     default:
@@ -549,29 +549,6 @@ cells:
     length: 10
     module: gdsfactory.components.straight
     name: straight
-    width: 0.5
-  straight_0092608c:
-    changed:
-      auto_widen: true
-      length: 367.16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: true
-      cross_section:
-        function: cross_section
-      length: 367.16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 367.16
-    module: gdsfactory.components.straight
-    name: straight_0092608c
     width: 0.5
   straight_0723ff82:
     changed:
@@ -617,9 +594,10 @@ cells:
     module: gdsfactory.components.straight
     name: straight_0d50a8c6
     width: 0.5
-  straight_213f8dff:
+  straight_34c5e31c:
     changed:
-      length: 375.42
+      auto_widen: true
+      length: 367.16
     default:
       cross_section:
         function: cross_section
@@ -627,44 +605,24 @@ cells:
       npoints: 2
       with_cladding_box: true
     full:
+      auto_widen: true
       cross_section:
         function: cross_section
-      length: 375.42
+      length: 367.16
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 375.42
+    length: 367.16
     module: gdsfactory.components.straight
-    name: straight_213f8dff
+    name: straight_34c5e31c
     width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 30
+      length: 6
     default:
       cross_section:
         function: cross_section
@@ -675,16 +633,16 @@ cells:
       cross_section:
         function: strip_heater_metal
       heater_width: 2.5
-      length: 30
+      length: 6
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 30
+    length: 6
     module: gdsfactory.components.straight
-    name: straight_32174f25
+    name: straight_3fe7bc16
     width: 0.5
-  straight_357443e8:
+  straight_43dd4652:
     changed:
       auto_widen: true
       length: 361.16
@@ -705,11 +663,11 @@ cells:
     info_version: 1
     length: 361.16
     module: gdsfactory.components.straight
-    name: straight_357443e8
+    name: straight_43dd4652
     width: 0.5
-  straight_4ebf6673:
+  straight_5c4ff448:
     changed:
-      length: 140.51
+      length: 375.42
     default:
       cross_section:
         function: cross_section
@@ -719,16 +677,16 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 140.51
+      length: 375.42
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 140.51
+    length: 375.42
     module: gdsfactory.components.straight
-    name: straight_4ebf6673
+    name: straight_5c4ff448
     width: 0.5
-  straight_53bdf814:
+  straight_66a04034:
     changed:
       auto_widen: true
       length: 0.5
@@ -749,30 +707,9 @@ cells:
     info_version: 1
     length: 0.5
     module: gdsfactory.components.straight
-    name: straight_53bdf814
+    name: straight_66a04034
     width: 0.5
-  straight_5656be49:
-    changed:
-      length: 43.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 43.5
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 43.5
-    module: gdsfactory.components.straight
-    name: straight_5656be49
-    width: 0.5
-  straight_740dd040:
+  straight_67d50770:
     changed:
       length: 57.975
     default:
@@ -791,9 +728,9 @@ cells:
     info_version: 1
     length: 57.975
     module: gdsfactory.components.straight
-    name: straight_740dd040
+    name: straight_67d50770
     width: 0.5
-  straight_831943ee:
+  straight_764e0e0e:
     changed:
       length: 35.552
     default:
@@ -812,7 +749,7 @@ cells:
     info_version: 1
     length: 35.552
     module: gdsfactory.components.straight
-    name: straight_831943ee
+    name: straight_764e0e0e
     width: 0.5
   straight_83634e83:
     changed:
@@ -837,9 +774,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_83634e83
     width: 0.5
-  straight_9785b75f:
+  straight_8adab4e9:
     changed:
-      length: 136.25
+      length: 19.51
     default:
       cross_section:
         function: cross_section
@@ -849,14 +786,39 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 136.25
+      length: 19.51
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 136.25
+    length: 19.51
     module: gdsfactory.components.straight
-    name: straight_9785b75f
+    name: straight_8adab4e9
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
     width: 0.5
   straight_a4be237b:
     changed:
@@ -879,7 +841,28 @@ cells:
     module: gdsfactory.components.straight
     name: straight_a4be237b
     width: 0.5
-  straight_ab8cb916:
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_ae278c9e:
     changed:
       length: 51.975
     default:
@@ -898,32 +881,7 @@ cells:
     info_version: 1
     length: 51.975
     module: gdsfactory.components.straight
-    name: straight_ab8cb916
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
+    name: straight_ae278c9e
     width: 0.5
   straight_b1688d7b:
     changed:
@@ -946,7 +904,95 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b1688d7b
     width: 0.5
-  straight_b597c5d0:
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_b81889b2:
+    changed:
+      length: 43.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 43.5
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 43.5
+    module: gdsfactory.components.straight
+    name: straight_b81889b2
+    width: 0.5
+  straight_c34a854f:
+    changed:
+      length: 15.25
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 15.25
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 15.25
+    module: gdsfactory.components.straight
+    name: straight_c34a854f
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_c8c6f318:
     changed:
       auto_widen: true
       length: 1.75
@@ -967,11 +1013,11 @@ cells:
     info_version: 1
     length: 1.75
     module: gdsfactory.components.straight
-    name: straight_b597c5d0
+    name: straight_c8c6f318
     width: 0.5
-  straight_c138f2c4:
+  straight_c903521c:
     changed:
-      length: 0.01
+      length: 136.25
     default:
       cross_section:
         function: cross_section
@@ -981,18 +1027,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 136.25
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 136.25
     module: gdsfactory.components.straight
-    name: straight_c138f2c4
+    name: straight_c903521c
     width: 0.5
-  straight_c21f313f:
+  straight_e7366ec0:
     changed:
-      length: 19.51
+      length: 140.51
     default:
       cross_section:
         function: cross_section
@@ -1002,16 +1048,16 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 19.51
+      length: 140.51
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 19.51
+    length: 140.51
     module: gdsfactory.components.straight
-    name: straight_c21f313f
+    name: straight_e7366ec0
     width: 0.5
-  straight_c35d6331:
+  straight_ea4b467a:
     changed:
       length: 45.62
     default:
@@ -1030,74 +1076,7 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_dd59df62:
-    changed:
-      length: 15.25
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 15.25
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 15.25
-    module: gdsfactory.components.straight
-    name: straight_dd59df62
-    width: 0.5
-  straight_e3f148d8:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 6
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 6
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 6
-    module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_ea4b467a
     width: 0.5
   straight_f0fa08f8:
     changed:
@@ -1119,6 +1098,27 @@ cells:
     length: 488
     module: gdsfactory.components.straight
     name: straight_f0fa08f8
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -1217,7 +1217,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -1248,12 +1248,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -1311,7 +1311,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     bend:
       function: bend_euler
@@ -1337,7 +1337,7 @@ info:
   full:
     bend:
       function: bend_euler
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     component_name: null
     cross_section:
       function: cross_section
@@ -1360,7 +1360,7 @@ info:
   function_name: add_fiber_array
   info_version: 1
   module: gdsfactory.routing.add_fiber_array
-  name: mzi_d275fe52_add_fiber__542edc06
+  name: mzi_15f399ec_add_fiber__6ace91e9
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -50,7 +50,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -71,38 +71,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+    name: circle_925ccccf
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -131,8 +101,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -161,21 +161,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -191,22 +191,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -265,7 +265,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -355,7 +355,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -412,13 +412,13 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_fiber__c4ec0ee2:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_fiber__bc8622b4:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
-        component: mzi_d275fe52
+        component: mzi_15f399ec
         origin:
         - 12.75
         - 0.625
@@ -479,7 +479,7 @@ cells:
         function_name: mzi
         info_version: 1
         module: gdsfactory.components.mzi
-        name: mzi_d275fe52
+        name: mzi_15f399ec
       default:
         axis: null
         destination: null
@@ -488,7 +488,7 @@ cells:
         - 0
       full:
         axis: null
-        component: mzi_d275fe52
+        component: mzi_15f399ec
         destination: null
         origin:
         - 12.75
@@ -496,7 +496,7 @@ cells:
       function_name: move
       info_version: 1
       module: gdsfactory.functions
-      name: mzi_d275fe52_move_8b7d623f
+      name: mzi_15f399ec_move_801164c2
     default:
       bend:
         function: bend_circular
@@ -531,7 +531,7 @@ cells:
     full:
       bend:
         function: bend_circular
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       component_name: null
       cross_section:
         function: cross_section
@@ -563,10 +563,10 @@ cells:
     function_name: add_fiber_single
     info_version: 1
     module: gdsfactory.routing.add_fiber_single
-    name: mzi_d275fe52_add_fiber__c4ec0ee2
-  mzi_d275fe52_move_8b7d623f:
+    name: mzi_15f399ec_add_fiber__bc8622b4
+  mzi_15f399ec_move_801164c2:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       origin:
       - 12.75
       - 0.625
@@ -627,7 +627,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       axis: null
       destination: null
@@ -636,7 +636,7 @@ cells:
       - 0
     full:
       axis: null
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       destination: null
       origin:
       - 12.75
@@ -644,7 +644,7 @@ cells:
     function_name: move
     info_version: 1
     module: gdsfactory.functions
-    name: mzi_d275fe52_move_8b7d623f
+    name: mzi_15f399ec_move_801164c2
   straight:
     changed: {}
     default:
@@ -665,100 +665,10 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_09275ddc:
+  straight_143065a8:
     changed:
       auto_widen: false
-      length: 4.4
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 4.4
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 4.4
-    module: gdsfactory.components.straight
-    name: straight_09275ddc
-    width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_4b4324d7:
-    changed:
-      auto_widen: false
-      length: 373.49
+      length: 0.01
     default:
       cross_section:
         function: cross_section
@@ -769,58 +679,16 @@ cells:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 373.49
+      length: 0.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 373.49
+    length: 0.01
     module: gdsfactory.components.straight
-    name: straight_4b4324d7
+    name: straight_143065a8
     width: 0.5
-  straight_6196d90a:
-    changed:
-      length: 496.69899999999996
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 496.69899999999996
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 496.699
-    module: gdsfactory.components.straight
-    name: straight_6196d90a
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_a89dbee6:
+  straight_37f27b10:
     changed:
       auto_widen: false
       length: 377.59
@@ -841,120 +709,9 @@ cells:
     info_version: 1
     length: 377.59
     module: gdsfactory.components.straight
-    name: straight_a89dbee6
+    name: straight_37f27b10
     width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_ca81a7bf:
-    changed:
-      auto_widen: false
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_ca81a7bf
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -977,9 +734,76 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
     width: 0.5
-  straight_ef15b717:
+  straight_56564522:
+    changed:
+      auto_widen: false
+      length: 4.4
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 4.4
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 4.4
+    module: gdsfactory.components.straight
+    name: straight_56564522
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_650baa5f:
+    changed:
+      auto_widen: false
+      length: 373.49
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 373.49
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 373.49
+    module: gdsfactory.components.straight
+    name: straight_650baa5f
+    width: 0.5
+  straight_7923093c:
     changed:
       auto_widen: false
       length: 4.35
@@ -1000,7 +824,162 @@ cells:
     info_version: 1
     length: 4.35
     module: gdsfactory.components.straight
-    name: straight_ef15b717
+    name: straight_7923093c
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -1022,6 +1001,27 @@ cells:
     length: 2
     module: gdsfactory.components.straight
     name: straight_fba69bc3
+    width: 0.5
+  straight_fdc6abc6:
+    changed:
+      length: 496.69899999999996
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 496.69899999999996
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 496.699
+    module: gdsfactory.components.straight
+    name: straight_fdc6abc6
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:
@@ -1099,7 +1099,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -1130,15 +1130,15 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       origin:
       - 12.75
       - 0.625
@@ -1199,7 +1199,7 @@ info:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       axis: null
       destination: null
@@ -1208,7 +1208,7 @@ info:
       - 0
     full:
       axis: null
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       destination: null
       origin:
       - 12.75
@@ -1216,7 +1216,7 @@ info:
     function_name: move
     info_version: 1
     module: gdsfactory.functions
-    name: mzi_d275fe52_move_8b7d623f
+    name: mzi_15f399ec_move_801164c2
   default:
     bend:
       function: bend_circular
@@ -1251,7 +1251,7 @@ info:
   full:
     bend:
       function: bend_circular
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     component_name: null
     cross_section:
       function: cross_section
@@ -1283,7 +1283,7 @@ info:
   function_name: add_fiber_single
   info_version: 1
   module: gdsfactory.routing.add_fiber_single
-  name: mzi_d275fe52_add_fiber__c4ec0ee2
+  name: mzi_15f399ec_add_fiber__bc8622b4
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -1,9 +1,7 @@
 cells:
-  bend_circular_93ab05a3:
+  bend_circular_107bf6b2:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
     default:
       angle: 90
       cross_section:
@@ -22,12 +20,10 @@ cells:
     info_version: 1
     length: 15.708
     module: gdsfactory.components.bend_circular
-    name: bend_circular_93ab05a3
+    name: bend_circular_107bf6b2
     radius: 10
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -51,7 +47,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -210,7 +206,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -218,16 +214,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -279,13 +265,12 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -338,7 +323,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -660,56 +645,8 @@ cells:
     info_version: 1
     module: gdsfactory.functions
     name: mzi_d275fe52_move_8b7d623f
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 2
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 2
-    module: gdsfactory.components.straight
-    name: straight_15a9c8d1
-    width: 0.5
-  straight_18ee7f79:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_18ee7f79
-    width: 0.5
-  straight_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -726,13 +663,11 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.straight
-    name: straight_1da190e0
+    name: straight
     width: 0.5
-  straight_21efe996:
+  straight_09275ddc:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
       length: 4.4
     default:
       cross_section:
@@ -751,13 +686,11 @@ cells:
     info_version: 1
     length: 4.4
     module: gdsfactory.components.straight
-    name: straight_21efe996
+    name: straight_09275ddc
     width: 0.5
-  straight_26b9e310:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
+      length: 375.42
     default:
       cross_section:
         function: cross_section
@@ -767,21 +700,18 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 27.01
+      length: 375.42
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 27.01
+    length: 375.42
     module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_213f8dff
     width: 0.5
-  straight_2d1c34e3:
+  straight_226a1d45:
     changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 4.35
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -789,17 +719,16 @@ cells:
       npoints: 2
       with_cladding_box: true
     full:
-      auto_widen: false
       cross_section:
         function: cross_section
-      length: 4.35
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 4.35
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_2d1c34e3
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -826,36 +755,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_422ae14a:
+  straight_4b4324d7:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_422ae14a
-    width: 0.5
-  straight_50c16c18:
-    changed:
-      auto_widen: false
-      cross_section:
-        function: cross_section
       length: 373.49
     default:
       cross_section:
@@ -874,35 +776,10 @@ cells:
     info_version: 1
     length: 373.49
     module: gdsfactory.components.straight
-    name: straight_50c16c18
+    name: straight_4b4324d7
     width: 0.5
-  straight_5743d35a:
+  straight_6196d90a:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_888542a9:
-    changed:
-      cross_section:
-        function: cross_section
       length: 496.69899999999996
     default:
       cross_section:
@@ -920,7 +797,51 @@ cells:
     info_version: 1
     length: 496.699
     module: gdsfactory.components.straight
-    name: straight_888542a9
+    name: straight_6196d90a
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a89dbee6:
+    changed:
+      auto_widen: false
+      length: 377.59
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 377.59
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 377.59
+    module: gdsfactory.components.straight
+    name: straight_a89dbee6
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -947,10 +868,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -968,13 +908,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -984,14 +922,37 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
+    width: 0.5
+  straight_ca81a7bf:
+    changed:
+      auto_widen: false
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      auto_widen: false
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_ca81a7bf
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -1018,12 +979,10 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_f9512f41:
+  straight_ef15b717:
     changed:
       auto_widen: false
-      cross_section:
-        function: cross_section
-      length: 377.59
+      length: 4.35
     default:
       cross_section:
         function: cross_section
@@ -1034,20 +993,18 @@ cells:
       auto_widen: false
       cross_section:
         function: cross_section
-      length: 377.59
+      length: 4.35
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 377.59
+    length: 4.35
     module: gdsfactory.components.straight
-    name: straight_f9512f41
+    name: straight_ef15b717
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -1057,14 +1014,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -185,7 +183,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -193,16 +191,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -254,13 +242,12 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -313,7 +300,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -499,11 +486,8 @@ cells:
     info_version: 1
     module: gdsfactory.add_grating_couplers
     name: mzi_d275fe52_add_gratin_85d33944
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -513,19 +497,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -543,12 +525,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -558,37 +539,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -615,11 +573,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -629,14 +585,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -663,10 +619,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -684,13 +659,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -700,14 +673,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -734,11 +707,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -748,14 +719,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,38 +48,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+    name: circle_925ccccf
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -108,8 +78,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -138,21 +138,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -168,22 +168,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -242,7 +242,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -332,7 +332,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -389,10 +389,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_gratin_85d33944:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_gratin_5c0763cc:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -450,7 +450,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       component_name: null
       gc_port_name: o1
@@ -467,7 +467,7 @@ cells:
         function: select_ports
         port_type: optical
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       component_name: null
       gc_port_name: o1
       get_input_labels_function:
@@ -485,7 +485,7 @@ cells:
     function_name: add_grating_couplers
     info_version: 1
     module: gdsfactory.add_grating_couplers
-    name: mzi_d275fe52_add_gratin_85d33944
+    name: mzi_15f399ec_add_gratin_5c0763cc
   straight:
     changed: {}
     default:
@@ -506,183 +506,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -705,7 +529,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -804,7 +804,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -835,12 +835,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -898,7 +898,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     component_name: null
     gc_port_name: o1
@@ -915,7 +915,7 @@ info:
       function: select_ports
       port_type: optical
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     component_name: null
     gc_port_name: o1
     get_input_labels_function:
@@ -933,6 +933,6 @@ info:
   function_name: add_grating_couplers
   info_version: 1
   module: gdsfactory.add_grating_couplers
-  name: mzi_d275fe52_add_gratin_85d33944
+  name: mzi_15f399ec_add_gratin_5c0763cc
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   circle_602e85fd:
@@ -185,7 +183,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -193,16 +191,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -254,13 +242,12 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
-  grating_coupler_ellipti_b632d295:
+  grating_coupler_ellipti_db285fcb:
     changed:
-      polarization: te
       taper_angle: 35
     default:
       end_straight_length: 0.2
@@ -313,7 +300,7 @@ cells:
     function_name: grating_coupler_elliptical_trenches
     info_version: 1
     module: gdsfactory.components.grating_coupler_elliptical_trenches
-    name: grating_coupler_ellipti_b632d295
+    name: grating_coupler_ellipti_db285fcb
     period: 0.6759999999999999
     polarization: te
     wavelength: 1.53
@@ -519,11 +506,8 @@ cells:
     info_version: 1
     module: gdsfactory.add_grating_couplers
     name: mzi_d275fe52_add_gratin_45b84cde
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -533,19 +517,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -563,12 +545,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -578,37 +559,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -635,33 +593,8 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_6eec1091:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_5743d35a
-    width: 0.5
-  straight_a19e1464:
-    changed:
-      cross_section:
-        function: cross_section
       length: 1.5543122344752192e-15
     default:
       cross_section:
@@ -679,7 +612,28 @@ cells:
     info_version: 1
     length: 0
     module: gdsfactory.components.straight
-    name: straight_a19e1464
+    name: straight_6eec1091
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -706,10 +660,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -727,13 +700,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -743,14 +714,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -777,11 +748,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -791,14 +760,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  circle_602e85fd:
+  circle_925ccccf:
     changed:
       layer:
       - 203
@@ -48,38 +48,8 @@ cells:
     function_name: circle
     info_version: 1
     module: gdsfactory.components.circle
-    name: circle_602e85fd
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+    name: circle_925ccccf
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -108,8 +78,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -138,21 +138,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -168,22 +168,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -242,7 +242,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -332,7 +332,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -389,10 +389,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_gratin_45b84cde:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_gratin_7a8e913c:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -450,7 +450,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       component_name: null
       cross_section:
@@ -477,7 +477,7 @@ cells:
         function: straight
       with_loopback: true
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       component_name: null
       cross_section:
         function: cross_section
@@ -505,7 +505,7 @@ cells:
     function_name: add_grating_couplers_with_loopback_fiber_single
     info_version: 1
     module: gdsfactory.add_grating_couplers
-    name: mzi_d275fe52_add_gratin_45b84cde
+    name: mzi_15f399ec_add_gratin_7a8e913c
   straight:
     changed: {}
     default:
@@ -526,74 +526,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_6eec1091:
+  straight_094cc3c9:
     changed:
       length: 1.5543122344752192e-15
     default:
@@ -612,118 +545,9 @@ cells:
     info_version: 1
     length: 0
     module: gdsfactory.components.straight
-    name: straight_6eec1091
+    name: straight_094cc3c9
     width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -746,7 +570,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -845,7 +845,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -876,12 +876,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -939,7 +939,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     component_name: null
     cross_section:
@@ -966,7 +966,7 @@ info:
       function: straight
     with_loopback: true
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     component_name: null
     cross_section:
       function: cross_section
@@ -994,6 +994,6 @@ info:
   function_name: add_grating_couplers_with_loopback_fiber_single
   info_version: 1
   module: gdsfactory.add_grating_couplers
-  name: mzi_d275fe52_add_gratin_45b84cde
+  name: mzi_15f399ec_add_gratin_7a8e913c
 ports: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -252,7 +252,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -309,10 +309,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_paddin_5974fadf:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_paddin_b8137b15:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -370,20 +370,20 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       layers:
       - - 67
         - 0
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       layers:
       - - 67
         - 0
     function_name: add_padding_container
     info_version: 1
     module: gdsfactory.add_padding
-    name: mzi_d275fe52_add_paddin_5974fadf
+    name: mzi_15f399ec_add_paddin_b8137b15
   straight:
     changed: {}
     default:
@@ -404,183 +404,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -603,7 +427,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -702,7 +702,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -733,12 +733,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -796,20 +796,20 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     layers:
     - - 67
       - 0
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     layers:
     - - 67
       - 0
   function_name: add_padding_container
   info_version: 1
   module: gdsfactory.add_padding
-  name: mzi_d275fe52_add_paddin_5974fadf
+  name: mzi_15f399ec_add_paddin_b8137b15
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -396,11 +384,8 @@ cells:
     info_version: 1
     module: gdsfactory.add_padding
     name: mzi_d275fe52_add_paddin_5974fadf
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -410,19 +395,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -440,12 +423,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -455,37 +437,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -512,11 +471,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -526,14 +483,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -560,10 +517,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -581,13 +557,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -597,14 +571,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -631,11 +605,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -645,14 +617,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -252,7 +252,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -309,10 +309,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_add_termin_6cebb3a1:
+    name: mzi_15f399ec
+  mzi_15f399ec_add_termin_603207a4:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -370,7 +370,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       port_name: null
       port_type: optical
@@ -379,7 +379,7 @@ cells:
         function: taper
         width2: 0.1
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       port_name: null
       port_type: optical
       ports: null
@@ -389,7 +389,7 @@ cells:
     function_name: add_termination
     info_version: 1
     module: gdsfactory.add_termination
-    name: mzi_d275fe52_add_termin_6cebb3a1
+    name: mzi_15f399ec_add_termin_603207a4
   straight:
     changed: {}
     default:
@@ -410,183 +410,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -609,7 +433,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -708,7 +708,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_39079628:
+  taper_09ea774b:
     changed:
       width2: 0.1
     default:
@@ -731,10 +731,10 @@ cells:
     info_version: 1
     length: 10
     module: gdsfactory.components.taper
-    name: taper_39079628
+    name: taper_09ea774b
     width1: 0.5
     width2: 0.1
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -765,12 +765,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -828,7 +828,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     port_name: null
     port_type: optical
@@ -837,7 +837,7 @@ info:
       function: taper
       width2: 0.1
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     port_name: null
     port_type: optical
     ports: null
@@ -847,7 +847,7 @@ info:
   function_name: add_termination
   info_version: 1
   module: gdsfactory.add_termination
-  name: mzi_d275fe52_add_termin_6cebb3a1
+  name: mzi_15f399ec_add_termin_603207a4
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -402,11 +390,8 @@ cells:
     info_version: 1
     module: gdsfactory.add_termination
     name: mzi_d275fe52_add_termin_6cebb3a1
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -416,19 +401,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -446,12 +429,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -461,37 +443,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -518,11 +477,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -532,14 +489,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -566,10 +523,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -587,13 +563,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -603,14 +577,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -637,11 +611,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -651,14 +623,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
@@ -43,10 +43,8 @@ cells:
     module: gdsfactory.components.bend_circular
     name: bend_circular_fe5fb2bc
     radius: 10
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -70,7 +68,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -207,7 +205,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -215,16 +213,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -276,7 +264,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -477,11 +465,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.bend_port
     name: mzi_d275fe52_bend_port_65f7119b
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -491,19 +476,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -521,12 +504,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -536,37 +518,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -636,11 +595,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_527cba51
     width: 10
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -650,14 +607,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -684,10 +641,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -705,13 +681,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -721,14 +695,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -755,11 +729,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -769,14 +741,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
@@ -1,5 +1,5 @@
 cells:
-  bend_circular_fe5fb2bc:
+  bend_circular_dc86f403:
     changed:
       angle: 180
       cross_section:
@@ -41,7 +41,7 @@ cells:
     info_version: 1
     length: 31.416
     module: gdsfactory.components.bend_circular
-    name: bend_circular_fe5fb2bc
+    name: bend_circular_dc86f403
     radius: 10
   bend_euler:
     changed: {}
@@ -71,37 +71,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -130,8 +100,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -160,21 +160,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -190,22 +190,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -264,7 +264,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -296,7 +296,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -353,10 +353,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_bend_port_65f7119b:
+    name: mzi_15f399ec
+  mzi_15f399ec_bend_port_3310a856:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -414,7 +414,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       angle: 180
       bend:
@@ -443,7 +443,7 @@ cells:
       angle: 180
       bend:
         function: bend_circular
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       cross_section:
         function: cross_section
         layer:
@@ -464,7 +464,7 @@ cells:
     function_name: bend_port
     info_version: 1
     module: gdsfactory.components.bend_port
-    name: mzi_d275fe52_bend_port_65f7119b
+    name: mzi_15f399ec_bend_port_3310a856
   straight:
     changed: {}
     default:
@@ -485,74 +485,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_527cba51:
+  straight_16515acc:
     changed:
       cross_section:
         function: cross_section
@@ -593,118 +526,9 @@ cells:
     info_version: 1
     length: 352
     module: gdsfactory.components.straight
-    name: straight_527cba51
+    name: straight_16515acc
     width: 10
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -727,7 +551,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -826,7 +826,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -857,12 +857,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -920,7 +920,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     angle: 180
     bend:
@@ -949,7 +949,7 @@ info:
     angle: 180
     bend:
       function: bend_circular
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     cross_section:
       function: cross_section
       layer:
@@ -970,7 +970,7 @@ info:
   function_name: bend_port
   info_version: 1
   module: gdsfactory.components.bend_port
-  name: mzi_d275fe52_bend_port_65f7119b
+  name: mzi_15f399ec_bend_port_3310a856
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_cavity_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_cavity_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,11 +220,11 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
-  coupler_3e9f9e6a:
+  coupler_4e842e54:
     changed:
       gap: 0.2
       length: 0.1
@@ -255,7 +255,7 @@ cells:
     length: 10.319
     min_bend_radius: 9.387
     module: gdsfactory.components.coupler
-    name: coupler_3e9f9e6a
+    name: coupler_4e842e54
   mmi2x2:
     changed: {}
     default:
@@ -284,7 +284,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -341,10 +341,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_cavity_65f7119b:
+    name: mzi_15f399ec
+  mzi_15f399ec_cavity_3310a856:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -402,7 +402,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       component:
         function: dbr
@@ -411,7 +411,7 @@ cells:
       gap: 0.2
       length: 0.1
     full:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       coupler:
         function: coupler
       gap: 0.2
@@ -419,7 +419,7 @@ cells:
     function_name: cavity
     info_version: 1
     module: gdsfactory.components.cavity
-    name: mzi_d275fe52_cavity_65f7119b
+    name: mzi_15f399ec_cavity_3310a856
   straight:
     changed: {}
     default:
@@ -440,183 +440,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -639,7 +463,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -738,7 +738,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -769,12 +769,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -832,7 +832,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     component:
       function: dbr
@@ -841,7 +841,7 @@ info:
     gap: 0.2
     length: 0.1
   full:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     coupler:
       function: coupler
     gap: 0.2
@@ -849,7 +849,7 @@ info:
   function_name: cavity
   info_version: 1
   module: gdsfactory.components.cavity
-  name: mzi_d275fe52_cavity_65f7119b
+  name: mzi_15f399ec_cavity_3310a856
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_cavity_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_cavity_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -432,11 +420,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.cavity
     name: mzi_d275fe52_cavity_65f7119b
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -446,19 +431,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -476,12 +459,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -491,37 +473,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -548,11 +507,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -562,14 +519,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -596,10 +553,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -617,13 +593,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -633,14 +607,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -667,11 +641,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -681,14 +653,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -408,11 +396,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.extension
     name: mzi_d275fe52_extend_por_41f60d23
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -422,19 +407,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -452,12 +435,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -467,37 +449,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -524,11 +483,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -538,14 +495,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -572,10 +529,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -593,13 +569,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -609,14 +583,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -643,11 +617,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -657,14 +629,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -252,7 +252,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -309,10 +309,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_extend_por_41f60d23:
+    name: mzi_15f399ec
+  mzi_15f399ec_extend_por_8f850168:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -370,7 +370,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       centered: false
       component:
@@ -384,7 +384,7 @@ cells:
       port_type: optical
     full:
       centered: false
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       cross_section: null
       extension_factory: null
       length: 5
@@ -395,7 +395,7 @@ cells:
     function_name: extend_ports
     info_version: 1
     module: gdsfactory.components.extension
-    name: mzi_d275fe52_extend_por_41f60d23
+    name: mzi_15f399ec_extend_por_8f850168
   straight:
     changed: {}
     default:
@@ -416,183 +416,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -615,7 +439,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -714,7 +714,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -745,12 +745,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -808,7 +808,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     centered: false
     component:
@@ -822,7 +822,7 @@ info:
     port_type: optical
   full:
     centered: false
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     cross_section: null
     extension_factory: null
     length: 5
@@ -833,7 +833,7 @@ info:
   function_name: extend_ports
   info_version: 1
   module: gdsfactory.components.extension
-  name: mzi_d275fe52_extend_por_41f60d23
+  name: mzi_15f399ec_extend_por_8f850168
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_d1b4a139:
+  bezier_b60035b7:
     changed:
       control_points:
       - - 0
@@ -89,39 +89,9 @@ cells:
     length: 25.117
     min_bend_radius: 8.705
     module: gdsfactory.components.bezier
-    name: bezier_d1b4a139
+    name: bezier_b60035b7
     start_angle: -0.766
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -150,8 +120,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -180,21 +180,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -210,22 +210,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -284,7 +284,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -316,7 +316,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -373,10 +373,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_fanout2x2_65f7119b:
+    name: mzi_15f399ec
+  mzi_15f399ec_fanout2x2_3310a856:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -434,7 +434,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       bend_length: null
       cross_section:
@@ -447,7 +447,7 @@ cells:
       with_cladding_box: true
     full:
       bend_length: null
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       cross_section:
         function: cross_section
       npoints: 101
@@ -459,7 +459,7 @@ cells:
     function_name: fanout2x2
     info_version: 1
     module: gdsfactory.routing.fanout2x2
-    name: mzi_d275fe52_fanout2x2_65f7119b
+    name: mzi_15f399ec_fanout2x2_3310a856
   straight:
     changed: {}
     default:
@@ -480,183 +480,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -679,7 +503,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -778,7 +778,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -809,12 +809,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -872,7 +872,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     bend_length: null
     cross_section:
@@ -885,7 +885,7 @@ info:
     with_cladding_box: true
   full:
     bend_length: null
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     cross_section:
       function: cross_section
     npoints: 101
@@ -897,7 +897,7 @@ info:
   function_name: fanout2x2
   info_version: 1
   module: gdsfactory.routing.fanout2x2
-  name: mzi_d275fe52_fanout2x2_65f7119b
+  name: mzi_15f399ec_fanout2x2_3310a856
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,10 +24,10 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
-  bezier_862baa15:
+  bezier_d1b4a139:
     changed:
       control_points:
       - - 0
@@ -41,12 +39,8 @@ cells:
       - - 20
         - -13.317499999999999
       end_angle: 0
-      layer:
-      - 1
-      - 0
       npoints: 101
       start_angle: 0
-      width: 0.5
     default:
       control_points:
       - - 0
@@ -95,7 +89,7 @@ cells:
     length: 25.117
     min_bend_radius: 8.705
     module: gdsfactory.components.bezier
-    name: bezier_862baa15
+    name: bezier_d1b4a139
     start_angle: -0.766
   compass_164fc476:
     changed:
@@ -231,7 +225,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -239,16 +233,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -300,7 +284,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -476,11 +460,8 @@ cells:
     info_version: 1
     module: gdsfactory.routing.fanout2x2
     name: mzi_d275fe52_fanout2x2_65f7119b
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -490,19 +471,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -520,12 +499,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -535,37 +513,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -592,11 +547,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -606,14 +559,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -640,10 +593,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -661,13 +633,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -677,14 +647,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -711,11 +681,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -725,14 +693,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
@@ -27,7 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  bend_euler_98cb77bf:
+  bend_euler_ad3c06b6:
     changed:
       radius: 5
       width: 0.5
@@ -56,40 +56,10 @@ cells:
     info_version: 1
     length: 8.318
     module: gdsfactory.components.bend_euler
-    name: bend_euler_98cb77bf
+    name: bend_euler_ad3c06b6
     radius: 5
     radius_min: 3.53
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -118,8 +88,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -148,21 +148,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -178,22 +178,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -252,7 +252,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -314,7 +314,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -371,10 +371,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_ring_singl_a263f7dd:
+    name: mzi_15f399ec
+  mzi_15f399ec_ring_singl_4eab0c3f:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -432,7 +432,7 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       bend:
         function: bend_euler
@@ -452,7 +452,7 @@ cells:
     full:
       bend:
         function: bend_euler
-      component: mzi_d275fe52
+      component: mzi_15f399ec
       coupler:
         function: coupler_ring
       gap: 0.2
@@ -466,7 +466,7 @@ cells:
     function_name: ring_single_dut
     info_version: 1
     module: gdsfactory.components.ring_single_dut
-    name: mzi_d275fe52_ring_singl_a263f7dd
+    name: mzi_15f399ec_ring_singl_4eab0c3f
   straight:
     changed: {}
     default:
@@ -487,74 +487,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_4896020e:
+  straight_08695092:
     changed:
       length: 421.76
       width: 0.5
@@ -575,141 +508,9 @@ cells:
     info_version: 1
     length: 421.76
     module: gdsfactory.components.straight
-    name: straight_4896020e
+    name: straight_08695092
     width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_d4fc336a:
-    changed:
-      length: 4
-      width: 0.5
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 4
-      npoints: 2
-      width: 0.5
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 4
-    module: gdsfactory.components.straight
-    name: straight_d4fc336a
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -732,7 +533,206 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_d4cb55ff:
+    changed:
+      length: 4
+      width: 0.5
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 4
+      npoints: 2
+      width: 0.5
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 4
+    module: gdsfactory.components.straight
+    name: straight_d4cb55ff
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -831,7 +831,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -862,12 +862,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -925,7 +925,7 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     bend:
       function: bend_euler
@@ -945,7 +945,7 @@ info:
   full:
     bend:
       function: bend_euler
-    component: mzi_d275fe52
+    component: mzi_15f399ec
     coupler:
       function: coupler_ring
     gap: 0.2
@@ -959,7 +959,7 @@ info:
   function_name: ring_single_dut
   info_version: 1
   module: gdsfactory.components.ring_single_dut
-  name: mzi_d275fe52_ring_singl_a263f7dd
+  name: mzi_15f399ec_ring_singl_4eab0c3f
 ports:
   o1:
     layer:

--- a/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   bend_euler_98cb77bf:
@@ -195,7 +193,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -203,16 +201,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -264,15 +252,12 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
-  coupler_ring_6a2f750e:
-    changed:
-      gap: 0.2
-      length_x: 4
-      radius: 5
+  coupler_ring:
+    changed: {}
     default:
       bend: null
       bend_cross_section: null
@@ -300,7 +285,7 @@ cells:
     function_name: coupler_ring
     info_version: 1
     module: gdsfactory.components.coupler_ring
-    name: coupler_ring_6a2f750e
+    name: coupler_ring
   mmi2x2:
     changed: {}
     default:
@@ -482,11 +467,8 @@ cells:
     info_version: 1
     module: gdsfactory.components.ring_single_dut
     name: mzi_d275fe52_ring_singl_a263f7dd
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -496,19 +478,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -526,12 +506,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -541,37 +520,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -621,11 +577,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_4896020e
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -635,14 +589,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -669,10 +623,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -690,13 +663,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -706,14 +677,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_d4fc336a:
     changed:
@@ -763,11 +734,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -777,14 +746,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_rotate_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_rotate_.yml
@@ -1,8 +1,6 @@
 cells:
-  bend_euler_1da190e0:
-    changed:
-      cross_section:
-        function: cross_section
+  bend_euler:
+    changed: {}
     default:
       angle: 90
       cross_section:
@@ -26,7 +24,7 @@ cells:
     info_version: 1
     length: 16.637
     module: gdsfactory.components.bend_euler
-    name: bend_euler_1da190e0
+    name: bend_euler
     radius: 10
     radius_min: 7.061
   compass_164fc476:
@@ -163,7 +161,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.component_sequence
     name: component_sequence_e4dca69b
-  contact_46068602:
+  contact_f7ba3155:
     changed:
       layers:
       - - 47
@@ -171,16 +169,6 @@ cells:
       - - 45
         - 0
       - - 49
-        - 0
-      vias:
-      - enclosure: 2
-        function: via
-        layer:
-        - 44
-        - 0
-      - function: via
-        layer:
-        - 43
         - 0
     default:
       layer_port: null
@@ -232,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_46068602
+    name: contact_f7ba3155
     size:
     - 11
     - 11
@@ -392,11 +380,8 @@ cells:
     info_version: 1
     module: gdsfactory.functions
     name: mzi_d275fe52_rotate_65f7119b
-  straight_15a9c8d1:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 2
+  straight:
+    changed: {}
     default:
       cross_section:
         function: cross_section
@@ -406,19 +391,17 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 2
+      length: 10
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 2
+    length: 10
     module: gdsfactory.components.straight
-    name: straight_15a9c8d1
+    name: straight
     width: 0.5
-  straight_18ee7f79:
+  straight_213f8dff:
     changed:
-      cross_section:
-        function: cross_section
       length: 375.42
     default:
       cross_section:
@@ -436,12 +419,11 @@ cells:
     info_version: 1
     length: 375.42
     module: gdsfactory.components.straight
-    name: straight_18ee7f79
+    name: straight_213f8dff
     width: 0.5
-  straight_1da190e0:
+  straight_226a1d45:
     changed:
-      cross_section:
-        function: cross_section
+      length: 22.01
     default:
       cross_section:
         function: cross_section
@@ -451,37 +433,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 10
+      length: 22.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 10
+    length: 22.01
     module: gdsfactory.components.straight
-    name: straight_1da190e0
-    width: 0.5
-  straight_26b9e310:
-    changed:
-      cross_section:
-        function: cross_section
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_26b9e310
+    name: straight_226a1d45
     width: 0.5
   straight_32174f25:
     changed:
@@ -508,11 +467,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_32174f25
     width: 0.5
-  straight_5743d35a:
+  straight_a4be237b:
     changed:
-      cross_section:
-        function: cross_section
-      length: 0.01
+      length: 7
     default:
       cross_section:
         function: cross_section
@@ -522,14 +479,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 0.01
+      length: 7
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 0.01
+    length: 7
     module: gdsfactory.components.straight
-    name: straight_5743d35a
+    name: straight_a4be237b
     width: 0.5
   straight_b0b74a72:
     changed:
@@ -556,10 +513,29 @@ cells:
     module: gdsfactory.components.straight
     name: straight_b0b74a72
     width: 0.5
-  straight_bd3b506b:
+  straight_c138f2c4:
     changed:
+      length: 0.01
+    default:
       cross_section:
         function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c138f2c4
+    width: 0.5
+  straight_c35d6331:
+    changed:
       length: 45.62
     default:
       cross_section:
@@ -577,13 +553,11 @@ cells:
     info_version: 1
     length: 45.62
     module: gdsfactory.components.straight
-    name: straight_bd3b506b
+    name: straight_c35d6331
     width: 0.5
-  straight_cd61840b:
+  straight_c4f7f930:
     changed:
-      cross_section:
-        function: cross_section
-      length: 7
+      length: 27.01
     default:
       cross_section:
         function: cross_section
@@ -593,14 +567,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 7
+      length: 27.01
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 7
+    length: 27.01
     module: gdsfactory.components.straight
-    name: straight_cd61840b
+    name: straight_c4f7f930
     width: 0.5
   straight_e3f148d8:
     changed:
@@ -627,11 +601,9 @@ cells:
     module: gdsfactory.components.straight
     name: straight_e3f148d8
     width: 0.5
-  straight_fe273143:
+  straight_fba69bc3:
     changed:
-      cross_section:
-        function: cross_section
-      length: 22.01
+      length: 2
     default:
       cross_section:
         function: cross_section
@@ -641,14 +613,14 @@ cells:
     full:
       cross_section:
         function: cross_section
-      length: 22.01
+      length: 2
       npoints: 2
       with_cladding_box: true
     function_name: straight
     info_version: 1
-    length: 22.01
+    length: 2
     module: gdsfactory.components.straight
-    name: straight_fe273143
+    name: straight_fba69bc3
     width: 0.5
   straight_heater_metal_u_6e8de97e:
     changed:

--- a/gdsfactory/tests/test_containers/test_settings_rotate_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_rotate_.yml
@@ -27,37 +27,7 @@ cells:
     name: bend_euler
     radius: 10
     radius_min: 7.061
-  compass_164fc476:
-    changed:
-      layer:
-      - 47
-      - 0
-      size:
-      - 11
-      - 11
-    default:
-      layer:
-      - 1
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 4
-      - 2
-    full:
-      layer:
-      - 47
-      - 0
-      port_inclusion: 0
-      port_type: electrical
-      size:
-      - 11
-      - 11
-    function_name: compass
-    info_version: 1
-    module: gdsfactory.components.compass
-    name: compass_164fc476
-  compass_280a2d8b:
+  compass_0570d255:
     changed:
       layer:
       - 45
@@ -86,8 +56,38 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_280a2d8b
-  compass_8e661824:
+    name: compass_0570d255
+  compass_5fa76f9c:
+    changed:
+      layer:
+      - 47
+      - 0
+      size:
+      - 11
+      - 11
+    default:
+      layer:
+      - 1
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 4
+      - 2
+    full:
+      layer:
+      - 47
+      - 0
+      port_inclusion: 0
+      port_type: electrical
+      size:
+      - 11
+      - 11
+    function_name: compass
+    info_version: 1
+    module: gdsfactory.components.compass
+    name: compass_5fa76f9c
+  compass_aa9c3262:
     changed:
       layer:
       - 49
@@ -116,21 +116,21 @@ cells:
     function_name: compass
     info_version: 1
     module: gdsfactory.components.compass
-    name: compass_8e661824
-  component_sequence_e4dca69b:
+    name: compass_aa9c3262
+  component_sequence_49cb6528:
     changed:
       sequence: -UHUHUHUHUHUHUHUH-
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     default:
@@ -146,22 +146,22 @@ cells:
       start_orientation: 0
       symbol_to_component:
         '-':
-        - straight_b0b74a72
+        - straight_b73ad70b
         - o1
         - o2
         H:
-        - straight_e3f148d8
+        - straight_3fe7bc16
         - o1
         - o2
         U:
-        - straight_32174f25
+        - straight_9496f45c
         - o1
         - o2
     function_name: component_sequence
     info_version: 1
     module: gdsfactory.components.component_sequence
-    name: component_sequence_e4dca69b
-  contact_f7ba3155:
+    name: component_sequence_49cb6528
+  contact_02e7e014:
     changed:
       layers:
       - - 47
@@ -220,7 +220,7 @@ cells:
     - 49
     - 0
     module: gdsfactory.components.contact
-    name: contact_f7ba3155
+    name: contact_02e7e014
     size:
     - 11
     - 11
@@ -252,7 +252,7 @@ cells:
     info_version: 1
     module: gdsfactory.components.mmi2x2
     name: mmi2x2
-  mzi_d275fe52:
+  mzi_15f399ec:
     changed:
       length_x: null
       splitter:
@@ -309,10 +309,10 @@ cells:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
-  mzi_d275fe52_rotate_65f7119b:
+    name: mzi_15f399ec
+  mzi_15f399ec_rotate_3310a856:
     changed:
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     child:
       changed:
         length_x: null
@@ -370,16 +370,16 @@ cells:
       function_name: mzi
       info_version: 1
       module: gdsfactory.components.mzi
-      name: mzi_d275fe52
+      name: mzi_15f399ec
     default:
       angle: 90
     full:
       angle: 90
-      component: mzi_d275fe52
+      component: mzi_15f399ec
     function_name: rotate
     info_version: 1
     module: gdsfactory.functions
-    name: mzi_d275fe52_rotate_65f7119b
+    name: mzi_15f399ec_rotate_3310a856
   straight:
     changed: {}
     default:
@@ -400,183 +400,7 @@ cells:
     module: gdsfactory.components.straight
     name: straight
     width: 0.5
-  straight_213f8dff:
-    changed:
-      length: 375.42
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 375.42
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 375.42
-    module: gdsfactory.components.straight
-    name: straight_213f8dff
-    width: 0.5
-  straight_226a1d45:
-    changed:
-      length: 22.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 22.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 22.01
-    module: gdsfactory.components.straight
-    name: straight_226a1d45
-    width: 0.5
-  straight_32174f25:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 30
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 30
-    module: gdsfactory.components.straight
-    name: straight_32174f25
-    width: 0.5
-  straight_a4be237b:
-    changed:
-      length: 7
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 7
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 7
-    module: gdsfactory.components.straight
-    name: straight_a4be237b
-    width: 0.5
-  straight_b0b74a72:
-    changed:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: strip_heater_metal
-      heater_width: 2.5
-      length: 16
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 16
-    module: gdsfactory.components.straight
-    name: straight_b0b74a72
-    width: 0.5
-  straight_c138f2c4:
-    changed:
-      length: 0.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 0.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 0.01
-    module: gdsfactory.components.straight
-    name: straight_c138f2c4
-    width: 0.5
-  straight_c35d6331:
-    changed:
-      length: 45.62
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 45.62
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 45.62
-    module: gdsfactory.components.straight
-    name: straight_c35d6331
-    width: 0.5
-  straight_c4f7f930:
-    changed:
-      length: 27.01
-    default:
-      cross_section:
-        function: cross_section
-      length: 10
-      npoints: 2
-      with_cladding_box: true
-    full:
-      cross_section:
-        function: cross_section
-      length: 27.01
-      npoints: 2
-      with_cladding_box: true
-    function_name: straight
-    info_version: 1
-    length: 27.01
-    module: gdsfactory.components.straight
-    name: straight_c4f7f930
-    width: 0.5
-  straight_e3f148d8:
+  straight_3fe7bc16:
     changed:
       cross_section:
         function: strip_heater_metal
@@ -599,7 +423,183 @@ cells:
     info_version: 1
     length: 6
     module: gdsfactory.components.straight
-    name: straight_e3f148d8
+    name: straight_3fe7bc16
+    width: 0.5
+  straight_5c4ff448:
+    changed:
+      length: 375.42
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 375.42
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 375.42
+    module: gdsfactory.components.straight
+    name: straight_5c4ff448
+    width: 0.5
+  straight_9496f45c:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 30
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 30
+    module: gdsfactory.components.straight
+    name: straight_9496f45c
+    width: 0.5
+  straight_a4be237b:
+    changed:
+      length: 7
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 7
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 7
+    module: gdsfactory.components.straight
+    name: straight_a4be237b
+    width: 0.5
+  straight_a72098b6:
+    changed:
+      length: 27.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 27.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 27.01
+    module: gdsfactory.components.straight
+    name: straight_a72098b6
+    width: 0.5
+  straight_b73ad70b:
+    changed:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: strip_heater_metal
+      heater_width: 2.5
+      length: 16
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 16
+    module: gdsfactory.components.straight
+    name: straight_b73ad70b
+    width: 0.5
+  straight_c49ce9c6:
+    changed:
+      length: 0.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 0.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 0.01
+    module: gdsfactory.components.straight
+    name: straight_c49ce9c6
+    width: 0.5
+  straight_ea4b467a:
+    changed:
+      length: 45.62
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 45.62
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 45.62
+    module: gdsfactory.components.straight
+    name: straight_ea4b467a
+    width: 0.5
+  straight_f4f54b88:
+    changed:
+      length: 22.01
+    default:
+      cross_section:
+        function: cross_section
+      length: 10
+      npoints: 2
+      with_cladding_box: true
+    full:
+      cross_section:
+        function: cross_section
+      length: 22.01
+      npoints: 2
+      with_cladding_box: true
+    function_name: straight
+    info_version: 1
+    length: 22.01
+    module: gdsfactory.components.straight
+    name: straight_f4f54b88
     width: 0.5
   straight_fba69bc3:
     changed:
@@ -698,7 +698,7 @@ cells:
     module: gdsfactory.components.straight_heater_metal
     name: straight_heater_metal_u_6e8de97e
     resistance: null
-  taper_ea91ec9c:
+  taper_13d39a01:
     changed:
       layer:
       - 47
@@ -729,12 +729,12 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.components.taper
-    name: taper_ea91ec9c
+    name: taper_13d39a01
     width1: 11
     width2: 2.5
 info:
   changed:
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   child:
     changed:
       length_x: null
@@ -792,16 +792,16 @@ info:
     function_name: mzi
     info_version: 1
     module: gdsfactory.components.mzi
-    name: mzi_d275fe52
+    name: mzi_15f399ec
   default:
     angle: 90
   full:
     angle: 90
-    component: mzi_d275fe52
+    component: mzi_15f399ec
   function_name: rotate
   info_version: 1
   module: gdsfactory.functions
-  name: mzi_d275fe52_rotate_65f7119b
+  name: mzi_15f399ec_rotate_3310a856
 ports:
   e1:
     layer:

--- a/gdsfactory/tests/test_import_gds_markers.py
+++ b/gdsfactory/tests/test_import_gds_markers.py
@@ -5,7 +5,6 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
 from gdsfactory.add_ports import add_ports_from_markers_center
-from gdsfactory.port import auto_rename_ports
 
 # gdspaths = [gf.CONFIG["gdsdir"] / name for name in ["mmi1x2.gds", "mzi2x2.gds"]]
 gdspaths = [gf.CONFIG["gdsdir"] / name for name in ["mzi2x2.gds"]]
@@ -15,15 +14,19 @@ gdspaths = [gf.CONFIG["gdsdir"] / name for name in ["mzi2x2.gds"]]
 def test_components_ports(
     gdspath: Path, data_regression: DataRegressionFixture
 ) -> gf.Component:
-    c = gf.import_gds(gdspath)
-    add_ports_from_markers_center(c)
-    auto_rename_ports(c)
+    """Read ports from markers."""
+    c = gf.import_gds(gdspath, decorator=add_ports_from_markers_center)
+    # c = c.copy()
+    # add_ports_from_markers_center(c)
+    # c.auto_rename_ports()
     data_regression.check(c.to_dict())
 
 
 if __name__ == "__main__":
-    c = gf.import_gds(gdspaths[0])
-    add_ports_from_markers_center(c)
-    auto_rename_ports(c)
+    c = gf.import_gds(gdspaths[0], decorator=add_ports_from_markers_center)
+    # c = c.copy()
+    # add_ports_from_markers_center(c)
+    # c.auto_rename_ports()
     print(c.ports.keys())
     print(c.name)
+    c.show()

--- a/gdsfactory/tests/test_name.py
+++ b/gdsfactory/tests/test_name.py
@@ -63,19 +63,22 @@ def test_float_point_errors():
 #         return gf.c.compass(layer=layer)
 
 #     c2 = compass()
+#     print(c1.name)
+#     print(c2.name)
+
 #     assert c1.name != c2.name, f"{c1.name} should differ from {c2.name}"
 
 
 if __name__ == "__main__":
-    # test_name_partial_functions()
+    test_name_partial_functions()
     # test_name_int_float()
     # test_name_different_signatures()
 
-    c1 = gf.c.compass()
+    # c1 = gf.c.compass()
 
-    @gf.cell
-    def compass(layer=(2, 0)):
-        return gf.c.compass(layer=layer)
+    # @gf.cell
+    # def compass(layer=(2, 0)):
+    #     return gf.c.compass(layer=layer)
 
-    c2 = compass()
-    assert c1.name != c2.name, f"{c1.name} should differ from {c2.name}"
+    # c2 = compass()
+    # assert c1.name != c2.name, f"{c1.name} should differ from {c2.name}"

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_False_.yml
@@ -1,108 +1,108 @@
 connections:
-  bend_euler_7f403255_33p138_18p538,o1: straight_325d35db_38p0_11p4,o2
-  bend_euler_7f403255_33p138_18p538,o2: straight_e8243227_26p5_23p4,o1
-  bend_euler_7f403255_33p138_4p262,o1: straight_e8243227_26p5_m0p6,o2
-  bend_euler_7f403255_33p138_4p262,o2: straight_325d35db_38p0_11p4,o1
-  bend_euler_d48fbab9_30p112_16p512,o1: bend_euler_d48fbab9_30p112_6p288,o2
-  bend_euler_d48fbab9_30p112_16p512,o2: taper_5ef18b11_22p5_21p4,o1
-  bend_euler_d48fbab9_30p112_6p288,o1: taper_c63e501a_22p5_1p4,o2
-  coupler_8eaa93fc_5p0_0p4,o3: taper_c63e501a_22p5_1p4,o1
-  coupler_8eaa93fc_5p0_0p4,o4: taper_8a817cb1_22p5_m0p6,o1
-  coupler_cb43455d_1p5_22p4,o3: taper_feb4a44d_16p5_23p4,o2
-  coupler_cb43455d_1p5_22p4,o4: taper_95acb109_16p5_21p4,o2
-  straight_0832c2df_19p5_21p4,o1: taper_5ef18b11_22p5_21p4,o2
-  straight_0832c2df_19p5_21p4,o2: taper_95acb109_16p5_21p4,o1
-  straight_dab38390_19p5_23p4,o1: taper_85794c73_22p5_23p4,o2
-  straight_dab38390_19p5_23p4,o2: taper_feb4a44d_16p5_23p4,o1
-  straight_e8243227_26p5_23p4,o2: taper_85794c73_22p5_23p4,o1
-  straight_e8243227_26p5_m0p6,o1: taper_8a817cb1_22p5_m0p6,o2
+  bend_euler_4320041f_30p112_16p512,o1: bend_euler_4320041f_30p112_6p288,o2
+  bend_euler_4320041f_30p112_16p512,o2: taper_a8f0c5a3_22p5_21p4,o1
+  bend_euler_4320041f_30p112_6p288,o1: taper_1f59777d_22p5_1p4,o2
+  bend_euler_d805decb_33p138_18p538,o1: straight_714c2263_38p0_11p4,o2
+  bend_euler_d805decb_33p138_18p538,o2: straight_e1606af8_26p5_23p4,o1
+  bend_euler_d805decb_33p138_4p262,o1: straight_e1606af8_26p5_m0p6,o2
+  bend_euler_d805decb_33p138_4p262,o2: straight_714c2263_38p0_11p4,o1
+  coupler_35cf121f_1p5_22p4,o3: taper_e53c3c15_16p5_23p4,o2
+  coupler_35cf121f_1p5_22p4,o4: taper_64468ccd_16p5_21p4,o2
+  coupler_a95c47ae_5p0_0p4,o3: taper_1f59777d_22p5_1p4,o1
+  coupler_a95c47ae_5p0_0p4,o4: taper_66f9ba3d_22p5_m0p6,o1
+  straight_214611f8_19p5_21p4,o1: taper_a8f0c5a3_22p5_21p4,o2
+  straight_214611f8_19p5_21p4,o2: taper_64468ccd_16p5_21p4,o1
+  straight_558b3f05_19p5_23p4,o1: taper_5f48a32e_22p5_23p4,o2
+  straight_558b3f05_19p5_23p4,o2: taper_e53c3c15_16p5_23p4,o1
+  straight_e1606af8_26p5_23p4,o2: taper_5f48a32e_22p5_23p4,o1
+  straight_e1606af8_26p5_m0p6,o1: taper_66f9ba3d_22p5_m0p6,o2
 instances:
-  bend_euler_7f403255_33p138_18p538:
-    component: bend_euler
-    settings:
-      radius: 10
-      width: 0.55
-  bend_euler_7f403255_33p138_4p262:
-    component: bend_euler
-    settings:
-      radius: 10
-      width: 0.55
-  bend_euler_d48fbab9_30p112_16p512:
+  bend_euler_4320041f_30p112_16p512:
     component: bend_euler
     settings:
       radius: 10
       width: 0.45
-  bend_euler_d48fbab9_30p112_6p288:
+  bend_euler_4320041f_30p112_6p288:
     component: bend_euler
     settings:
       radius: 10
       width: 0.45
-  coupler_8eaa93fc_5p0_0p4:
-    component: coupler
+  bend_euler_d805decb_33p138_18p538:
+    component: bend_euler
     settings:
-      dy: 2
-      gap: 0.3
-      length: 10
-  coupler_cb43455d_1p5_22p4:
+      radius: 10
+      width: 0.55
+  bend_euler_d805decb_33p138_4p262:
+    component: bend_euler
+    settings:
+      radius: 10
+      width: 0.55
+  coupler_35cf121f_1p5_22p4:
     component: coupler
     settings:
       dy: 2
       gap: 0.2
       length: 5
-  straight_0832c2df_19p5_21p4:
+  coupler_a95c47ae_5p0_0p4:
+    component: coupler
+    settings:
+      dy: 2
+      gap: 0.3
+      length: 10
+  straight_214611f8_19p5_21p4:
     component: straight
     settings:
       length: 1
       width: 0.55
-  straight_325d35db_38p0_11p4:
-    component: straight
-    settings:
-      length: 4
-      width: 0.55
-  straight_dab38390_19p5_23p4:
+  straight_558b3f05_19p5_23p4:
     component: straight
     settings:
       length: 1
       width: 0.45
-  straight_e8243227_26p5_23p4:
+  straight_714c2263_38p0_11p4:
+    component: straight
+    settings:
+      length: 4
+      width: 0.55
+  straight_e1606af8_26p5_23p4:
     component: straight
     settings:
       length: 3
       width: 0.55
-  straight_e8243227_26p5_m0p6:
+  straight_e1606af8_26p5_m0p6:
     component: straight
     settings:
       length: 3
       width: 0.55
-  taper_5ef18b11_22p5_21p4:
+  taper_1f59777d_22p5_1p4:
     component: taper
     settings:
       length: 5
-      width1: 0.45
-      width2: 0.55
-  taper_85794c73_22p5_23p4:
+      width2: 0.45
+  taper_5f48a32e_22p5_23p4:
     component: taper
     settings:
       length: 5
       width1: 0.55
       width2: 0.45
-  taper_8a817cb1_22p5_m0p6:
-    component: taper
-    settings:
-      length: 5
-      width2: 0.55
-  taper_95acb109_16p5_21p4:
+  taper_64468ccd_16p5_21p4:
     component: taper
     settings:
       length: 5
       width1: 0.55
       width2: 0.5
-  taper_c63e501a_22p5_1p4:
+  taper_66f9ba3d_22p5_m0p6:
     component: taper
     settings:
       length: 5
-      width2: 0.45
-  taper_feb4a44d_16p5_23p4:
+      width2: 0.55
+  taper_a8f0c5a3_22p5_21p4:
+    component: taper
+    settings:
+      length: 5
+      width1: 0.45
+      width2: 0.55
+  taper_e53c3c15_16p5_23p4:
     component: taper
     settings:
       length: 5
@@ -110,93 +110,93 @@ instances:
       width2: 0.5
 name: mzit
 placements:
-  bend_euler_7f403255_33p138_18p538:
-    mirror: false
-    rotation: 90
-    x: 38.0
-    y: 13.4
-  bend_euler_7f403255_33p138_4p262:
-    mirror: false
-    rotation: 0
-    x: 28.0
-    y: -0.6
-  bend_euler_d48fbab9_30p112_16p512:
+  bend_euler_4320041f_30p112_16p512:
     mirror: false
     rotation: 90
     x: 35.0
     y: 11.4
-  bend_euler_d48fbab9_30p112_6p288:
+  bend_euler_4320041f_30p112_6p288:
     mirror: false
     rotation: 0
     x: 25.0
     y: 1.4
-  coupler_8eaa93fc_5p0_0p4:
+  bend_euler_d805decb_33p138_18p538:
+    mirror: false
+    rotation: 90
+    x: 38.0
+    y: 13.4
+  bend_euler_d805decb_33p138_4p262:
     mirror: false
     rotation: 0
-    x: 0.0
-    y: 0.0
-  coupler_cb43455d_1p5_22p4:
+    x: 28.0
+    y: -0.6
+  coupler_35cf121f_1p5_22p4:
     mirror: false
     rotation: 0
     x: -1.0
     y: 22.05
-  straight_0832c2df_19p5_21p4:
+  coupler_a95c47ae_5p0_0p4:
+    mirror: false
+    rotation: 0
+    x: 0.0
+    y: 0.0
+  straight_214611f8_19p5_21p4:
     mirror: false
     rotation: 180
     x: 20.0
     y: 21.4
-  straight_325d35db_38p0_11p4:
+  straight_558b3f05_19p5_23p4:
+    mirror: false
+    rotation: 180
+    x: 20.0
+    y: 23.4
+  straight_714c2263_38p0_11p4:
     mirror: false
     rotation: 90
     x: 38.0
     y: 9.4
-  straight_dab38390_19p5_23p4:
-    mirror: false
-    rotation: 180
-    x: 20.0
-    y: 23.4
-  straight_e8243227_26p5_23p4:
+  straight_e1606af8_26p5_23p4:
     mirror: false
     rotation: 180
     x: 28.0
     y: 23.4
-  straight_e8243227_26p5_m0p6:
+  straight_e1606af8_26p5_m0p6:
     mirror: false
     rotation: 0
     x: 25.0
     y: -0.6
-  taper_5ef18b11_22p5_21p4:
-    mirror: false
-    rotation: 180
-    x: 25.0
-    y: 21.4
-  taper_85794c73_22p5_23p4:
-    mirror: false
-    rotation: 180
-    x: 25.0
-    y: 23.4
-  taper_8a817cb1_22p5_m0p6:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: -0.6
-  taper_95acb109_16p5_21p4:
-    mirror: false
-    rotation: 180
-    x: 19.0
-    y: 21.4
-  taper_c63e501a_22p5_1p4:
+  taper_1f59777d_22p5_1p4:
     mirror: false
     rotation: 0
     x: 20.0
     y: 1.4
-  taper_feb4a44d_16p5_23p4:
+  taper_5f48a32e_22p5_23p4:
+    mirror: false
+    rotation: 180
+    x: 25.0
+    y: 23.4
+  taper_64468ccd_16p5_21p4:
+    mirror: false
+    rotation: 180
+    x: 19.0
+    y: 21.4
+  taper_66f9ba3d_22p5_m0p6:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: -0.6
+  taper_a8f0c5a3_22p5_21p4:
+    mirror: false
+    rotation: 180
+    x: 25.0
+    y: 21.4
+  taper_e53c3c15_16p5_23p4:
     mirror: false
     rotation: 180
     x: 19.0
     y: 23.4
 ports:
-  o1: coupler_8eaa93fc_5p0_0p4,o1
-  o2: coupler_8eaa93fc_5p0_0p4,o2
-  o3: coupler_cb43455d_1p5_22p4,o1
-  o4: coupler_cb43455d_1p5_22p4,o2
+  o1: coupler_a95c47ae_5p0_0p4,o1
+  o2: coupler_a95c47ae_5p0_0p4,o2
+  o3: coupler_35cf121f_1p5_22p4,o1
+  o4: coupler_35cf121f_1p5_22p4,o2

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_False_.yml
@@ -5,9 +5,9 @@ connections:
   bend_euler_7f403255_33p138_4p262,o2: straight_325d35db_38p0_11p4,o1
   bend_euler_d48fbab9_30p112_16p512,o1: bend_euler_d48fbab9_30p112_6p288,o2
   bend_euler_d48fbab9_30p112_16p512,o2: taper_5ef18b11_22p5_21p4,o1
-  bend_euler_d48fbab9_30p112_6p288,o1: taper_35742b85_22p5_1p4,o2
-  coupler_8eaa93fc_5p0_0p4,o3: taper_35742b85_22p5_1p4,o1
-  coupler_8eaa93fc_5p0_0p4,o4: taper_497b9706_22p5_m0p6,o1
+  bend_euler_d48fbab9_30p112_6p288,o1: taper_c63e501a_22p5_1p4,o2
+  coupler_8eaa93fc_5p0_0p4,o3: taper_c63e501a_22p5_1p4,o1
+  coupler_8eaa93fc_5p0_0p4,o4: taper_8a817cb1_22p5_m0p6,o1
   coupler_cb43455d_1p5_22p4,o3: taper_feb4a44d_16p5_23p4,o2
   coupler_cb43455d_1p5_22p4,o4: taper_95acb109_16p5_21p4,o2
   straight_0832c2df_19p5_21p4,o1: taper_5ef18b11_22p5_21p4,o2
@@ -15,7 +15,7 @@ connections:
   straight_dab38390_19p5_23p4,o1: taper_85794c73_22p5_23p4,o2
   straight_dab38390_19p5_23p4,o2: taper_feb4a44d_16p5_23p4,o1
   straight_e8243227_26p5_23p4,o2: taper_85794c73_22p5_23p4,o1
-  straight_e8243227_26p5_m0p6,o1: taper_497b9706_22p5_m0p6,o2
+  straight_e8243227_26p5_m0p6,o1: taper_8a817cb1_22p5_m0p6,o2
 instances:
   bend_euler_7f403255_33p138_18p538:
     component: bend_euler
@@ -74,18 +74,6 @@ instances:
     settings:
       length: 3
       width: 0.55
-  taper_35742b85_22p5_1p4:
-    component: taper
-    settings:
-      length: 5
-      width1: 0.5
-      width2: 0.45
-  taper_497b9706_22p5_m0p6:
-    component: taper
-    settings:
-      length: 5
-      width1: 0.5
-      width2: 0.55
   taper_5ef18b11_22p5_21p4:
     component: taper
     settings:
@@ -98,12 +86,22 @@ instances:
       length: 5
       width1: 0.55
       width2: 0.45
+  taper_8a817cb1_22p5_m0p6:
+    component: taper
+    settings:
+      length: 5
+      width2: 0.55
   taper_95acb109_16p5_21p4:
     component: taper
     settings:
       length: 5
       width1: 0.55
       width2: 0.5
+  taper_c63e501a_22p5_1p4:
+    component: taper
+    settings:
+      length: 5
+      width2: 0.45
   taper_feb4a44d_16p5_23p4:
     component: taper
     settings:
@@ -167,16 +165,6 @@ placements:
     rotation: 0
     x: 25.0
     y: -0.6
-  taper_35742b85_22p5_1p4:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: 1.4
-  taper_497b9706_22p5_m0p6:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: -0.6
   taper_5ef18b11_22p5_21p4:
     mirror: false
     rotation: 180
@@ -187,11 +175,21 @@ placements:
     rotation: 180
     x: 25.0
     y: 23.4
+  taper_8a817cb1_22p5_m0p6:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: -0.6
   taper_95acb109_16p5_21p4:
     mirror: false
     rotation: 180
     x: 19.0
     y: 21.4
+  taper_c63e501a_22p5_1p4:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: 1.4
   taper_feb4a44d_16p5_23p4:
     mirror: false
     rotation: 180

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_True_.yml
@@ -5,9 +5,9 @@ connections:
   bend_euler_7f403255_33p138_4p262,o2: straight_325d35db_38p0_11p4,o1
   bend_euler_d48fbab9_30p112_16p512,o1: bend_euler_d48fbab9_30p112_6p288,o2
   bend_euler_d48fbab9_30p112_16p512,o2: taper_5ef18b11_22p5_21p4,o1
-  bend_euler_d48fbab9_30p112_6p288,o1: taper_35742b85_22p5_1p4,o2
-  coupler_8eaa93fc_5p0_0p4,o3: taper_35742b85_22p5_1p4,o1
-  coupler_8eaa93fc_5p0_0p4,o4: taper_497b9706_22p5_m0p6,o1
+  bend_euler_d48fbab9_30p112_6p288,o1: taper_c63e501a_22p5_1p4,o2
+  coupler_8eaa93fc_5p0_0p4,o3: taper_c63e501a_22p5_1p4,o1
+  coupler_8eaa93fc_5p0_0p4,o4: taper_8a817cb1_22p5_m0p6,o1
   coupler_cb43455d_1p5_22p4,o3: taper_feb4a44d_16p5_23p4,o2
   coupler_cb43455d_1p5_22p4,o4: taper_95acb109_16p5_21p4,o2
   straight_0832c2df_19p5_21p4,o1: taper_5ef18b11_22p5_21p4,o2
@@ -15,7 +15,7 @@ connections:
   straight_dab38390_19p5_23p4,o1: taper_85794c73_22p5_23p4,o2
   straight_dab38390_19p5_23p4,o2: taper_feb4a44d_16p5_23p4,o1
   straight_e8243227_26p5_23p4,o2: taper_85794c73_22p5_23p4,o1
-  straight_e8243227_26p5_m0p6,o1: taper_497b9706_22p5_m0p6,o2
+  straight_e8243227_26p5_m0p6,o1: taper_8a817cb1_22p5_m0p6,o2
 instances:
   bend_euler_7f403255_33p138_18p538:
     component: bend_euler
@@ -140,26 +140,6 @@ instances:
       npoints: 2
       width: 0.55
       with_cladding_box: true
-  taper_35742b85_22p5_1p4:
-    component: taper
-    settings:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.45
-      with_cladding_box: true
-  taper_497b9706_22p5_m0p6:
-    component: taper
-    settings:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
   taper_5ef18b11_22p5_21p4:
     component: taper
     settings:
@@ -180,6 +160,16 @@ instances:
       width1: 0.55
       width2: 0.45
       with_cladding_box: true
+  taper_8a817cb1_22p5_m0p6:
+    component: taper
+    settings:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.55
+      with_cladding_box: true
   taper_95acb109_16p5_21p4:
     component: taper
     settings:
@@ -189,6 +179,16 @@ instances:
       port: null
       width1: 0.55
       width2: 0.5
+      with_cladding_box: true
+  taper_c63e501a_22p5_1p4:
+    component: taper
+    settings:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.5
+      width2: 0.45
       with_cladding_box: true
   taper_feb4a44d_16p5_23p4:
     component: taper
@@ -257,16 +257,6 @@ placements:
     rotation: 0
     x: 25.0
     y: -0.6
-  taper_35742b85_22p5_1p4:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: 1.4
-  taper_497b9706_22p5_m0p6:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: -0.6
   taper_5ef18b11_22p5_21p4:
     mirror: false
     rotation: 180
@@ -277,11 +267,21 @@ placements:
     rotation: 180
     x: 25.0
     y: 23.4
+  taper_8a817cb1_22p5_m0p6:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: -0.6
   taper_95acb109_16p5_21p4:
     mirror: false
     rotation: 180
     x: 19.0
     y: 21.4
+  taper_c63e501a_22p5_1p4:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: 1.4
   taper_feb4a44d_16p5_23p4:
     mirror: false
     rotation: 180

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_True_.yml
@@ -1,49 +1,23 @@
 connections:
-  bend_euler_7f403255_33p138_18p538,o1: straight_325d35db_38p0_11p4,o2
-  bend_euler_7f403255_33p138_18p538,o2: straight_e8243227_26p5_23p4,o1
-  bend_euler_7f403255_33p138_4p262,o1: straight_e8243227_26p5_m0p6,o2
-  bend_euler_7f403255_33p138_4p262,o2: straight_325d35db_38p0_11p4,o1
-  bend_euler_d48fbab9_30p112_16p512,o1: bend_euler_d48fbab9_30p112_6p288,o2
-  bend_euler_d48fbab9_30p112_16p512,o2: taper_5ef18b11_22p5_21p4,o1
-  bend_euler_d48fbab9_30p112_6p288,o1: taper_c63e501a_22p5_1p4,o2
-  coupler_8eaa93fc_5p0_0p4,o3: taper_c63e501a_22p5_1p4,o1
-  coupler_8eaa93fc_5p0_0p4,o4: taper_8a817cb1_22p5_m0p6,o1
-  coupler_cb43455d_1p5_22p4,o3: taper_feb4a44d_16p5_23p4,o2
-  coupler_cb43455d_1p5_22p4,o4: taper_95acb109_16p5_21p4,o2
-  straight_0832c2df_19p5_21p4,o1: taper_5ef18b11_22p5_21p4,o2
-  straight_0832c2df_19p5_21p4,o2: taper_95acb109_16p5_21p4,o1
-  straight_dab38390_19p5_23p4,o1: taper_85794c73_22p5_23p4,o2
-  straight_dab38390_19p5_23p4,o2: taper_feb4a44d_16p5_23p4,o1
-  straight_e8243227_26p5_23p4,o2: taper_85794c73_22p5_23p4,o1
-  straight_e8243227_26p5_m0p6,o1: taper_8a817cb1_22p5_m0p6,o2
+  bend_euler_4320041f_30p112_16p512,o1: bend_euler_4320041f_30p112_6p288,o2
+  bend_euler_4320041f_30p112_16p512,o2: taper_a8f0c5a3_22p5_21p4,o1
+  bend_euler_4320041f_30p112_6p288,o1: taper_1f59777d_22p5_1p4,o2
+  bend_euler_d805decb_33p138_18p538,o1: straight_714c2263_38p0_11p4,o2
+  bend_euler_d805decb_33p138_18p538,o2: straight_e1606af8_26p5_23p4,o1
+  bend_euler_d805decb_33p138_4p262,o1: straight_e1606af8_26p5_m0p6,o2
+  bend_euler_d805decb_33p138_4p262,o2: straight_714c2263_38p0_11p4,o1
+  coupler_35cf121f_1p5_22p4,o3: taper_e53c3c15_16p5_23p4,o2
+  coupler_35cf121f_1p5_22p4,o4: taper_64468ccd_16p5_21p4,o2
+  coupler_a95c47ae_5p0_0p4,o3: taper_1f59777d_22p5_1p4,o1
+  coupler_a95c47ae_5p0_0p4,o4: taper_66f9ba3d_22p5_m0p6,o1
+  straight_214611f8_19p5_21p4,o1: taper_a8f0c5a3_22p5_21p4,o2
+  straight_214611f8_19p5_21p4,o2: taper_64468ccd_16p5_21p4,o1
+  straight_558b3f05_19p5_23p4,o1: taper_5f48a32e_22p5_23p4,o2
+  straight_558b3f05_19p5_23p4,o2: taper_e53c3c15_16p5_23p4,o1
+  straight_e1606af8_26p5_23p4,o2: taper_5f48a32e_22p5_23p4,o1
+  straight_e1606af8_26p5_m0p6,o1: taper_66f9ba3d_22p5_m0p6,o2
 instances:
-  bend_euler_7f403255_33p138_18p538:
-    component: bend_euler
-    settings:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      radius: 10
-      width: 0.55
-      with_arc_floorplan: true
-      with_cladding_box: true
-  bend_euler_7f403255_33p138_4p262:
-    component: bend_euler
-    settings:
-      angle: 90
-      cross_section:
-        function: cross_section
-      direction: ccw
-      npoints: 720
-      p: 0.5
-      radius: 10
-      width: 0.55
-      with_arc_floorplan: true
-      with_cladding_box: true
-  bend_euler_d48fbab9_30p112_16p512:
+  bend_euler_4320041f_30p112_16p512:
     component: bend_euler
     settings:
       angle: 90
@@ -56,7 +30,7 @@ instances:
       width: 0.45
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_d48fbab9_30p112_6p288:
+  bend_euler_4320041f_30p112_6p288:
     component: bend_euler
     settings:
       angle: 90
@@ -69,20 +43,33 @@ instances:
       width: 0.45
       with_arc_floorplan: true
       with_cladding_box: true
-  coupler_8eaa93fc_5p0_0p4:
-    component: coupler
+  bend_euler_d805decb_33p138_18p538:
+    component: bend_euler
     settings:
-      coupler_straight:
-        function: coupler_straight
-      coupler_symmetric:
-        function: coupler_symmetric
+      angle: 90
       cross_section:
         function: cross_section
-      dx: 10
-      dy: 2
-      gap: 0.3
-      length: 10
-  coupler_cb43455d_1p5_22p4:
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      radius: 10
+      width: 0.55
+      with_arc_floorplan: true
+      with_cladding_box: true
+  bend_euler_d805decb_33p138_4p262:
+    component: bend_euler
+    settings:
+      angle: 90
+      cross_section:
+        function: cross_section
+      direction: ccw
+      npoints: 720
+      p: 0.5
+      radius: 10
+      width: 0.55
+      with_arc_floorplan: true
+      with_cladding_box: true
+  coupler_35cf121f_1p5_22p4:
     component: coupler
     settings:
       coupler_straight:
@@ -95,7 +82,20 @@ instances:
       dy: 2
       gap: 0.2
       length: 5
-  straight_0832c2df_19p5_21p4:
+  coupler_a95c47ae_5p0_0p4:
+    component: coupler
+    settings:
+      coupler_straight:
+        function: coupler_straight
+      coupler_symmetric:
+        function: coupler_symmetric
+      cross_section:
+        function: cross_section
+      dx: 10
+      dy: 2
+      gap: 0.3
+      length: 10
+  straight_214611f8_19p5_21p4:
     component: straight
     settings:
       cross_section:
@@ -104,16 +104,7 @@ instances:
       npoints: 2
       width: 0.55
       with_cladding_box: true
-  straight_325d35db_38p0_11p4:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 4
-      npoints: 2
-      width: 0.55
-      with_cladding_box: true
-  straight_dab38390_19p5_23p4:
+  straight_558b3f05_19p5_23p4:
     component: straight
     settings:
       cross_section:
@@ -122,7 +113,16 @@ instances:
       npoints: 2
       width: 0.45
       with_cladding_box: true
-  straight_e8243227_26p5_23p4:
+  straight_714c2263_38p0_11p4:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 4
+      npoints: 2
+      width: 0.55
+      with_cladding_box: true
+  straight_e1606af8_26p5_23p4:
     component: straight
     settings:
       cross_section:
@@ -131,7 +131,7 @@ instances:
       npoints: 2
       width: 0.55
       with_cladding_box: true
-  straight_e8243227_26p5_m0p6:
+  straight_e1606af8_26p5_m0p6:
     component: straight
     settings:
       cross_section:
@@ -140,17 +140,17 @@ instances:
       npoints: 2
       width: 0.55
       with_cladding_box: true
-  taper_5ef18b11_22p5_21p4:
+  taper_1f59777d_22p5_1p4:
     component: taper
     settings:
       cross_section:
         function: cross_section
       length: 5
       port: null
-      width1: 0.45
-      width2: 0.55
+      width1: 0.5
+      width2: 0.45
       with_cladding_box: true
-  taper_85794c73_22p5_23p4:
+  taper_5f48a32e_22p5_23p4:
     component: taper
     settings:
       cross_section:
@@ -160,17 +160,7 @@ instances:
       width1: 0.55
       width2: 0.45
       with_cladding_box: true
-  taper_8a817cb1_22p5_m0p6:
-    component: taper
-    settings:
-      cross_section:
-        function: cross_section
-      length: 5
-      port: null
-      width1: 0.5
-      width2: 0.55
-      with_cladding_box: true
-  taper_95acb109_16p5_21p4:
+  taper_64468ccd_16p5_21p4:
     component: taper
     settings:
       cross_section:
@@ -180,7 +170,7 @@ instances:
       width1: 0.55
       width2: 0.5
       with_cladding_box: true
-  taper_c63e501a_22p5_1p4:
+  taper_66f9ba3d_22p5_m0p6:
     component: taper
     settings:
       cross_section:
@@ -188,9 +178,19 @@ instances:
       length: 5
       port: null
       width1: 0.5
-      width2: 0.45
+      width2: 0.55
       with_cladding_box: true
-  taper_feb4a44d_16p5_23p4:
+  taper_a8f0c5a3_22p5_21p4:
+    component: taper
+    settings:
+      cross_section:
+        function: cross_section
+      length: 5
+      port: null
+      width1: 0.45
+      width2: 0.55
+      with_cladding_box: true
+  taper_e53c3c15_16p5_23p4:
     component: taper
     settings:
       cross_section:
@@ -202,93 +202,93 @@ instances:
       with_cladding_box: true
 name: mzit
 placements:
-  bend_euler_7f403255_33p138_18p538:
-    mirror: false
-    rotation: 90
-    x: 38.0
-    y: 13.4
-  bend_euler_7f403255_33p138_4p262:
-    mirror: false
-    rotation: 0
-    x: 28.0
-    y: -0.6
-  bend_euler_d48fbab9_30p112_16p512:
+  bend_euler_4320041f_30p112_16p512:
     mirror: false
     rotation: 90
     x: 35.0
     y: 11.4
-  bend_euler_d48fbab9_30p112_6p288:
+  bend_euler_4320041f_30p112_6p288:
     mirror: false
     rotation: 0
     x: 25.0
     y: 1.4
-  coupler_8eaa93fc_5p0_0p4:
+  bend_euler_d805decb_33p138_18p538:
+    mirror: false
+    rotation: 90
+    x: 38.0
+    y: 13.4
+  bend_euler_d805decb_33p138_4p262:
     mirror: false
     rotation: 0
-    x: 0.0
-    y: 0.0
-  coupler_cb43455d_1p5_22p4:
+    x: 28.0
+    y: -0.6
+  coupler_35cf121f_1p5_22p4:
     mirror: false
     rotation: 0
     x: -1.0
     y: 22.05
-  straight_0832c2df_19p5_21p4:
+  coupler_a95c47ae_5p0_0p4:
+    mirror: false
+    rotation: 0
+    x: 0.0
+    y: 0.0
+  straight_214611f8_19p5_21p4:
     mirror: false
     rotation: 180
     x: 20.0
     y: 21.4
-  straight_325d35db_38p0_11p4:
+  straight_558b3f05_19p5_23p4:
+    mirror: false
+    rotation: 180
+    x: 20.0
+    y: 23.4
+  straight_714c2263_38p0_11p4:
     mirror: false
     rotation: 90
     x: 38.0
     y: 9.4
-  straight_dab38390_19p5_23p4:
-    mirror: false
-    rotation: 180
-    x: 20.0
-    y: 23.4
-  straight_e8243227_26p5_23p4:
+  straight_e1606af8_26p5_23p4:
     mirror: false
     rotation: 180
     x: 28.0
     y: 23.4
-  straight_e8243227_26p5_m0p6:
+  straight_e1606af8_26p5_m0p6:
     mirror: false
     rotation: 0
     x: 25.0
     y: -0.6
-  taper_5ef18b11_22p5_21p4:
-    mirror: false
-    rotation: 180
-    x: 25.0
-    y: 21.4
-  taper_85794c73_22p5_23p4:
-    mirror: false
-    rotation: 180
-    x: 25.0
-    y: 23.4
-  taper_8a817cb1_22p5_m0p6:
-    mirror: false
-    rotation: 0
-    x: 20.0
-    y: -0.6
-  taper_95acb109_16p5_21p4:
-    mirror: false
-    rotation: 180
-    x: 19.0
-    y: 21.4
-  taper_c63e501a_22p5_1p4:
+  taper_1f59777d_22p5_1p4:
     mirror: false
     rotation: 0
     x: 20.0
     y: 1.4
-  taper_feb4a44d_16p5_23p4:
+  taper_5f48a32e_22p5_23p4:
+    mirror: false
+    rotation: 180
+    x: 25.0
+    y: 23.4
+  taper_64468ccd_16p5_21p4:
+    mirror: false
+    rotation: 180
+    x: 19.0
+    y: 21.4
+  taper_66f9ba3d_22p5_m0p6:
+    mirror: false
+    rotation: 0
+    x: 20.0
+    y: -0.6
+  taper_a8f0c5a3_22p5_21p4:
+    mirror: false
+    rotation: 180
+    x: 25.0
+    y: 21.4
+  taper_e53c3c15_16p5_23p4:
     mirror: false
     rotation: 180
     x: 19.0
     y: 23.4
 ports:
-  o1: coupler_8eaa93fc_5p0_0p4,o1
-  o2: coupler_8eaa93fc_5p0_0p4,o2
-  o3: coupler_cb43455d_1p5_22p4,o1
-  o4: coupler_cb43455d_1p5_22p4,o2
+  o1: coupler_a95c47ae_5p0_0p4,o1
+  o2: coupler_a95c47ae_5p0_0p4,o2
+  o3: coupler_35cf121f_1p5_22p4,o1
+  o4: coupler_35cf121f_1p5_22p4,o2

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_lattice_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_lattice_False_.yml
@@ -1,22 +1,19 @@
 connections: {}
 instances:
-  mzit_f7e2e81d_19p138_11p4:
+  mzit_5c28f5cb_19p138_11p4:
     component: mzit
     settings:
-      coupler_gap1: 0.2
-      coupler_gap2: 0.3
       coupler_length1: 10
       coupler_length2: 20
-      delta_length: 10
 name: mzit_lattice
 placements:
-  mzit_f7e2e81d_19p138_11p4:
+  mzit_5c28f5cb_19p138_11p4:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
 ports:
-  o1: mzit_f7e2e81d_19p138_11p4,o1
-  o2: mzit_f7e2e81d_19p138_11p4,o2
-  o3: mzit_f7e2e81d_19p138_11p4,o3
-  o4: mzit_f7e2e81d_19p138_11p4,o4
+  o1: mzit_5c28f5cb_19p138_11p4,o1
+  o2: mzit_5c28f5cb_19p138_11p4,o2
+  o3: mzit_5c28f5cb_19p138_11p4,o3
+  o4: mzit_5c28f5cb_19p138_11p4,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_mzit_lattice_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_mzit_lattice_True_.yml
@@ -1,6 +1,6 @@
 connections: {}
 instances:
-  mzit_f7e2e81d_19p138_11p4:
+  mzit_5c28f5cb_19p138_11p4:
     component: mzit
     settings:
       Ls: 1
@@ -27,13 +27,13 @@ instances:
       w2: 0.55
 name: mzit_lattice
 placements:
-  mzit_f7e2e81d_19p138_11p4:
+  mzit_5c28f5cb_19p138_11p4:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
 ports:
-  o1: mzit_f7e2e81d_19p138_11p4,o1
-  o2: mzit_f7e2e81d_19p138_11p4,o2
-  o3: mzit_f7e2e81d_19p138_11p4,o3
-  o4: mzit_f7e2e81d_19p138_11p4,o4
+  o1: mzit_5c28f5cb_19p138_11p4,o1
+  o2: mzit_5c28f5cb_19p138_11p4,o2
+  o3: mzit_5c28f5cb_19p138_11p4,o3
+  o4: mzit_5c28f5cb_19p138_11p4,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_double_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_double_False_.yml
@@ -1,51 +1,51 @@
 connections:
-  coupler_ring_1f8e1c06_m0p005_16p185,o2: straight_c138f2c4_10p0_10p705,o2
-  coupler_ring_1f8e1c06_m0p005_16p185,o3: straight_c138f2c4_m10p01_10p705,o2
-  coupler_ring_1f8e1c06_m0p005_5p225,o2: straight_c138f2c4_m10p01_10p705,o1
-  coupler_ring_1f8e1c06_m0p005_5p225,o3: straight_c138f2c4_10p0_10p705,o1
+  coupler_ring_cd892edd_m0p005_16p185,o2: straight_c49ce9c6_10p0_10p705,o2
+  coupler_ring_cd892edd_m0p005_16p185,o3: straight_c49ce9c6_m10p01_10p705,o2
+  coupler_ring_cd892edd_m0p005_5p225,o2: straight_c49ce9c6_m10p01_10p705,o1
+  coupler_ring_cd892edd_m0p005_5p225,o3: straight_c49ce9c6_10p0_10p705,o1
 instances:
-  coupler_ring_1f8e1c06_m0p005_16p185:
+  coupler_ring_cd892edd_m0p005_16p185:
     component: coupler_ring
     settings:
       length_x: 0.01
       radius: 10
-  coupler_ring_1f8e1c06_m0p005_5p225:
+  coupler_ring_cd892edd_m0p005_5p225:
     component: coupler_ring
     settings:
       length_x: 0.01
       radius: 10
-  straight_c138f2c4_10p0_10p705:
+  straight_c49ce9c6_10p0_10p705:
     component: straight
     settings:
       length: 0.01
-  straight_c138f2c4_m10p01_10p705:
+  straight_c49ce9c6_m10p01_10p705:
     component: straight
     settings:
       length: 0.01
 name: ring_double
 placements:
-  coupler_ring_1f8e1c06_m0p005_16p185:
+  coupler_ring_cd892edd_m0p005_16p185:
     mirror: false
     rotation: 180
     x: -0.01
     y: 21.41
-  coupler_ring_1f8e1c06_m0p005_5p225:
+  coupler_ring_cd892edd_m0p005_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_c138f2c4_10p0_10p705:
+  straight_c49ce9c6_10p0_10p705:
     mirror: false
     rotation: 90
     x: 10.0
     y: 10.7
-  straight_c138f2c4_m10p01_10p705:
+  straight_c49ce9c6_m10p01_10p705:
     mirror: false
     rotation: 90
     x: -10.01
     y: 10.7
 ports:
-  o1: coupler_ring_1f8e1c06_m0p005_5p225,o1
-  o2: coupler_ring_1f8e1c06_m0p005_5p225,o4
-  o3: coupler_ring_1f8e1c06_m0p005_16p185,o4
-  o4: coupler_ring_1f8e1c06_m0p005_16p185,o1
+  o1: coupler_ring_cd892edd_m0p005_5p225,o1
+  o2: coupler_ring_cd892edd_m0p005_5p225,o4
+  o3: coupler_ring_cd892edd_m0p005_16p185,o4
+  o4: coupler_ring_cd892edd_m0p005_16p185,o1

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_double_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_double_False_.yml
@@ -1,63 +1,51 @@
 connections:
-  coupler_ring_884bafc4_m0p005_16p185,o2: straight_5743d35a_10p0_10p705,o2
-  coupler_ring_884bafc4_m0p005_16p185,o3: straight_5743d35a_m10p01_10p705,o2
-  coupler_ring_884bafc4_m0p005_5p225,o2: straight_5743d35a_m10p01_10p705,o1
-  coupler_ring_884bafc4_m0p005_5p225,o3: straight_5743d35a_10p0_10p705,o1
+  coupler_ring_1f8e1c06_m0p005_16p185,o2: straight_c138f2c4_10p0_10p705,o2
+  coupler_ring_1f8e1c06_m0p005_16p185,o3: straight_c138f2c4_m10p01_10p705,o2
+  coupler_ring_1f8e1c06_m0p005_5p225,o2: straight_c138f2c4_m10p01_10p705,o1
+  coupler_ring_1f8e1c06_m0p005_5p225,o3: straight_c138f2c4_10p0_10p705,o1
 instances:
-  coupler_ring_884bafc4_m0p005_16p185:
+  coupler_ring_1f8e1c06_m0p005_16p185:
     component: coupler_ring
     settings:
-      bend: null
-      cross_section:
-        function: cross_section
-      gap: 0.2
       length_x: 0.01
       radius: 10
-  coupler_ring_884bafc4_m0p005_5p225:
+  coupler_ring_1f8e1c06_m0p005_5p225:
     component: coupler_ring
     settings:
-      bend: null
-      cross_section:
-        function: cross_section
-      gap: 0.2
       length_x: 0.01
       radius: 10
-  straight_5743d35a_10p0_10p705:
+  straight_c138f2c4_10p0_10p705:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
       length: 0.01
-  straight_5743d35a_m10p01_10p705:
+  straight_c138f2c4_m10p01_10p705:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
       length: 0.01
 name: ring_double
 placements:
-  coupler_ring_884bafc4_m0p005_16p185:
+  coupler_ring_1f8e1c06_m0p005_16p185:
     mirror: false
     rotation: 180
     x: -0.01
     y: 21.41
-  coupler_ring_884bafc4_m0p005_5p225:
+  coupler_ring_1f8e1c06_m0p005_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_5743d35a_10p0_10p705:
+  straight_c138f2c4_10p0_10p705:
     mirror: false
     rotation: 90
     x: 10.0
     y: 10.7
-  straight_5743d35a_m10p01_10p705:
+  straight_c138f2c4_m10p01_10p705:
     mirror: false
     rotation: 90
     x: -10.01
     y: 10.7
 ports:
-  o1: coupler_ring_884bafc4_m0p005_5p225,o1
-  o2: coupler_ring_884bafc4_m0p005_5p225,o4
-  o3: coupler_ring_884bafc4_m0p005_16p185,o4
-  o4: coupler_ring_884bafc4_m0p005_16p185,o1
+  o1: coupler_ring_1f8e1c06_m0p005_5p225,o1
+  o2: coupler_ring_1f8e1c06_m0p005_5p225,o4
+  o3: coupler_ring_1f8e1c06_m0p005_16p185,o4
+  o4: coupler_ring_1f8e1c06_m0p005_16p185,o1

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_double_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_double_True_.yml
@@ -1,10 +1,10 @@
 connections:
-  coupler_ring_1f8e1c06_m0p005_16p185,o2: straight_c138f2c4_10p0_10p705,o2
-  coupler_ring_1f8e1c06_m0p005_16p185,o3: straight_c138f2c4_m10p01_10p705,o2
-  coupler_ring_1f8e1c06_m0p005_5p225,o2: straight_c138f2c4_m10p01_10p705,o1
-  coupler_ring_1f8e1c06_m0p005_5p225,o3: straight_c138f2c4_10p0_10p705,o1
+  coupler_ring_cd892edd_m0p005_16p185,o2: straight_c49ce9c6_10p0_10p705,o2
+  coupler_ring_cd892edd_m0p005_16p185,o3: straight_c49ce9c6_m10p01_10p705,o2
+  coupler_ring_cd892edd_m0p005_5p225,o2: straight_c49ce9c6_m10p01_10p705,o1
+  coupler_ring_cd892edd_m0p005_5p225,o3: straight_c49ce9c6_10p0_10p705,o1
 instances:
-  coupler_ring_1f8e1c06_m0p005_16p185:
+  coupler_ring_cd892edd_m0p005_16p185:
     component: coupler_ring
     settings:
       bend: null
@@ -18,7 +18,7 @@ instances:
       gap: 0.2
       length_x: 0.01
       radius: 10
-  coupler_ring_1f8e1c06_m0p005_5p225:
+  coupler_ring_cd892edd_m0p005_5p225:
     component: coupler_ring
     settings:
       bend: null
@@ -32,7 +32,7 @@ instances:
       gap: 0.2
       length_x: 0.01
       radius: 10
-  straight_c138f2c4_10p0_10p705:
+  straight_c49ce9c6_10p0_10p705:
     component: straight
     settings:
       cross_section:
@@ -40,7 +40,7 @@ instances:
       length: 0.01
       npoints: 2
       with_cladding_box: true
-  straight_c138f2c4_m10p01_10p705:
+  straight_c49ce9c6_m10p01_10p705:
     component: straight
     settings:
       cross_section:
@@ -50,28 +50,28 @@ instances:
       with_cladding_box: true
 name: ring_double
 placements:
-  coupler_ring_1f8e1c06_m0p005_16p185:
+  coupler_ring_cd892edd_m0p005_16p185:
     mirror: false
     rotation: 180
     x: -0.01
     y: 21.41
-  coupler_ring_1f8e1c06_m0p005_5p225:
+  coupler_ring_cd892edd_m0p005_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_c138f2c4_10p0_10p705:
+  straight_c49ce9c6_10p0_10p705:
     mirror: false
     rotation: 90
     x: 10.0
     y: 10.7
-  straight_c138f2c4_m10p01_10p705:
+  straight_c49ce9c6_m10p01_10p705:
     mirror: false
     rotation: 90
     x: -10.01
     y: 10.7
 ports:
-  o1: coupler_ring_1f8e1c06_m0p005_5p225,o1
-  o2: coupler_ring_1f8e1c06_m0p005_5p225,o4
-  o3: coupler_ring_1f8e1c06_m0p005_16p185,o4
-  o4: coupler_ring_1f8e1c06_m0p005_16p185,o1
+  o1: coupler_ring_cd892edd_m0p005_5p225,o1
+  o2: coupler_ring_cd892edd_m0p005_5p225,o4
+  o3: coupler_ring_cd892edd_m0p005_16p185,o4
+  o4: coupler_ring_cd892edd_m0p005_16p185,o1

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_double_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_double_True_.yml
@@ -1,10 +1,10 @@
 connections:
-  coupler_ring_884bafc4_m0p005_16p185,o2: straight_5743d35a_10p0_10p705,o2
-  coupler_ring_884bafc4_m0p005_16p185,o3: straight_5743d35a_m10p01_10p705,o2
-  coupler_ring_884bafc4_m0p005_5p225,o2: straight_5743d35a_m10p01_10p705,o1
-  coupler_ring_884bafc4_m0p005_5p225,o3: straight_5743d35a_10p0_10p705,o1
+  coupler_ring_1f8e1c06_m0p005_16p185,o2: straight_c138f2c4_10p0_10p705,o2
+  coupler_ring_1f8e1c06_m0p005_16p185,o3: straight_c138f2c4_m10p01_10p705,o2
+  coupler_ring_1f8e1c06_m0p005_5p225,o2: straight_c138f2c4_m10p01_10p705,o1
+  coupler_ring_1f8e1c06_m0p005_5p225,o3: straight_c138f2c4_10p0_10p705,o1
 instances:
-  coupler_ring_884bafc4_m0p005_16p185:
+  coupler_ring_1f8e1c06_m0p005_16p185:
     component: coupler_ring
     settings:
       bend: null
@@ -18,7 +18,7 @@ instances:
       gap: 0.2
       length_x: 0.01
       radius: 10
-  coupler_ring_884bafc4_m0p005_5p225:
+  coupler_ring_1f8e1c06_m0p005_5p225:
     component: coupler_ring
     settings:
       bend: null
@@ -32,7 +32,7 @@ instances:
       gap: 0.2
       length_x: 0.01
       radius: 10
-  straight_5743d35a_10p0_10p705:
+  straight_c138f2c4_10p0_10p705:
     component: straight
     settings:
       cross_section:
@@ -40,7 +40,7 @@ instances:
       length: 0.01
       npoints: 2
       with_cladding_box: true
-  straight_5743d35a_m10p01_10p705:
+  straight_c138f2c4_m10p01_10p705:
     component: straight
     settings:
       cross_section:
@@ -50,28 +50,28 @@ instances:
       with_cladding_box: true
 name: ring_double
 placements:
-  coupler_ring_884bafc4_m0p005_16p185:
+  coupler_ring_1f8e1c06_m0p005_16p185:
     mirror: false
     rotation: 180
     x: -0.01
     y: 21.41
-  coupler_ring_884bafc4_m0p005_5p225:
+  coupler_ring_1f8e1c06_m0p005_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_5743d35a_10p0_10p705:
+  straight_c138f2c4_10p0_10p705:
     mirror: false
     rotation: 90
     x: 10.0
     y: 10.7
-  straight_5743d35a_m10p01_10p705:
+  straight_c138f2c4_m10p01_10p705:
     mirror: false
     rotation: 90
     x: -10.01
     y: 10.7
 ports:
-  o1: coupler_ring_884bafc4_m0p005_5p225,o1
-  o2: coupler_ring_884bafc4_m0p005_5p225,o4
-  o3: coupler_ring_884bafc4_m0p005_16p185,o4
-  o4: coupler_ring_884bafc4_m0p005_16p185,o1
+  o1: coupler_ring_1f8e1c06_m0p005_5p225,o1
+  o2: coupler_ring_1f8e1c06_m0p005_5p225,o4
+  o3: coupler_ring_1f8e1c06_m0p005_16p185,o4
+  o4: coupler_ring_1f8e1c06_m0p005_16p185,o1

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_False_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_2e0a66fe_5p125_16p425,o1: straight_1469c185_10p0_11p0,o1
+  bend_euler_2e0a66fe_5p125_16p425,o1: straight_c1e7b81b_10p0_11p0,o1
   bend_euler_2e0a66fe_5p125_16p425,o2: straight_defbc978_m2p0_21p3,o1
   bend_euler_2e0a66fe_m9p125_16p425,o1: straight_defbc978_m2p0_21p3,o2
-  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_1469c185_m14p0_11p0,o2
-  coupler_ring_354ce3d3_m2p0_5p225,o2: straight_1469c185_m14p0_11p0,o1
-  coupler_ring_354ce3d3_m2p0_5p225,o3: straight_1469c185_10p0_11p0,o2
+  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_c1e7b81b_m14p0_11p0,o2
+  coupler_ring_3363c15c_m2p0_5p225,o2: straight_c1e7b81b_m14p0_11p0,o1
+  coupler_ring_3363c15c_m2p0_5p225,o3: straight_c1e7b81b_10p0_11p0,o2
 instances:
   bend_euler_2e0a66fe_5p125_16p425:
     component: bend_euler
@@ -14,17 +14,17 @@ instances:
     component: bend_euler
     settings:
       radius: 10
-  coupler_ring_354ce3d3_m2p0_5p225:
+  coupler_ring_3363c15c_m2p0_5p225:
     component: coupler_ring
     settings:
       bend:
         function: bend_euler
       radius: 10
-  straight_1469c185_10p0_11p0:
+  straight_c1e7b81b_10p0_11p0:
     component: straight
     settings:
       length: 0.6
-  straight_1469c185_m14p0_11p0:
+  straight_c1e7b81b_m14p0_11p0:
     component: straight
     settings:
       length: 0.6
@@ -44,17 +44,17 @@ placements:
     rotation: 180
     x: -4.0
     y: 21.3
-  coupler_ring_354ce3d3_m2p0_5p225:
+  coupler_ring_3363c15c_m2p0_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_1469c185_10p0_11p0:
+  straight_c1e7b81b_10p0_11p0:
     mirror: false
     rotation: 270
     x: 10.0
     y: 11.3
-  straight_1469c185_m14p0_11p0:
+  straight_c1e7b81b_m14p0_11p0:
     mirror: false
     rotation: 90
     x: -14.0
@@ -65,5 +65,5 @@ placements:
     x: 0.0
     y: 21.3
 ports:
-  o1: coupler_ring_354ce3d3_m2p0_5p225,o1
-  o2: coupler_ring_354ce3d3_m2p0_5p225,o4
+  o1: coupler_ring_3363c15c_m2p0_5p225,o1
+  o2: coupler_ring_3363c15c_m2p0_5p225,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_False_.yml
@@ -1,83 +1,69 @@
 connections:
-  bend_euler_4725f0ef_5p125_16p425,o1: straight_417ceb80_10p0_11p0,o1
-  bend_euler_4725f0ef_5p125_16p425,o2: straight_178d4157_m2p0_21p3,o1
-  bend_euler_4725f0ef_m9p125_16p425,o1: straight_178d4157_m2p0_21p3,o2
-  bend_euler_4725f0ef_m9p125_16p425,o2: straight_417ceb80_m14p0_11p0,o2
-  coupler_ring_6859e681_m2p0_5p225,o2: straight_417ceb80_m14p0_11p0,o1
-  coupler_ring_6859e681_m2p0_5p225,o3: straight_417ceb80_10p0_11p0,o2
+  bend_euler_2e0a66fe_5p125_16p425,o1: straight_1469c185_10p0_11p0,o1
+  bend_euler_2e0a66fe_5p125_16p425,o2: straight_defbc978_m2p0_21p3,o1
+  bend_euler_2e0a66fe_m9p125_16p425,o1: straight_defbc978_m2p0_21p3,o2
+  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_1469c185_m14p0_11p0,o2
+  coupler_ring_354ce3d3_m2p0_5p225,o2: straight_1469c185_m14p0_11p0,o1
+  coupler_ring_354ce3d3_m2p0_5p225,o3: straight_1469c185_10p0_11p0,o2
 instances:
-  bend_euler_4725f0ef_5p125_16p425:
+  bend_euler_2e0a66fe_5p125_16p425:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  bend_euler_4725f0ef_m9p125_16p425:
+  bend_euler_2e0a66fe_m9p125_16p425:
     component: bend_euler
     settings:
-      cross_section:
-        function: cross_section
       radius: 10
-  coupler_ring_6859e681_m2p0_5p225:
+  coupler_ring_354ce3d3_m2p0_5p225:
     component: coupler_ring
     settings:
       bend:
         function: bend_euler
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 4
       radius: 10
-  straight_178d4157_m2p0_21p3:
+  straight_1469c185_10p0_11p0:
     component: straight
     settings:
-      cross_section:
-        function: cross_section
+      length: 0.6
+  straight_1469c185_m14p0_11p0:
+    component: straight
+    settings:
+      length: 0.6
+  straight_defbc978_m2p0_21p3:
+    component: straight
+    settings:
       length: 4
-  straight_417ceb80_10p0_11p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 0.6
-  straight_417ceb80_m14p0_11p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 0.6
 name: ring_single
 placements:
-  bend_euler_4725f0ef_5p125_16p425:
+  bend_euler_2e0a66fe_5p125_16p425:
     mirror: false
     rotation: 90
     x: 10.0
     y: 11.3
-  bend_euler_4725f0ef_m9p125_16p425:
+  bend_euler_2e0a66fe_m9p125_16p425:
     mirror: false
     rotation: 180
     x: -4.0
     y: 21.3
-  coupler_ring_6859e681_m2p0_5p225:
+  coupler_ring_354ce3d3_m2p0_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_178d4157_m2p0_21p3:
-    mirror: false
-    rotation: 180
-    x: 0.0
-    y: 21.3
-  straight_417ceb80_10p0_11p0:
+  straight_1469c185_10p0_11p0:
     mirror: false
     rotation: 270
     x: 10.0
     y: 11.3
-  straight_417ceb80_m14p0_11p0:
+  straight_1469c185_m14p0_11p0:
     mirror: false
     rotation: 90
     x: -14.0
     y: 10.7
+  straight_defbc978_m2p0_21p3:
+    mirror: false
+    rotation: 180
+    x: 0.0
+    y: 21.3
 ports:
-  o1: coupler_ring_6859e681_m2p0_5p225,o1
-  o2: coupler_ring_6859e681_m2p0_5p225,o4
+  o1: coupler_ring_354ce3d3_m2p0_5p225,o1
+  o2: coupler_ring_354ce3d3_m2p0_5p225,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_True_.yml
@@ -1,10 +1,10 @@
 connections:
-  bend_euler_2e0a66fe_5p125_16p425,o1: straight_1469c185_10p0_11p0,o1
+  bend_euler_2e0a66fe_5p125_16p425,o1: straight_c1e7b81b_10p0_11p0,o1
   bend_euler_2e0a66fe_5p125_16p425,o2: straight_defbc978_m2p0_21p3,o1
   bend_euler_2e0a66fe_m9p125_16p425,o1: straight_defbc978_m2p0_21p3,o2
-  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_1469c185_m14p0_11p0,o2
-  coupler_ring_354ce3d3_m2p0_5p225,o2: straight_1469c185_m14p0_11p0,o1
-  coupler_ring_354ce3d3_m2p0_5p225,o3: straight_1469c185_10p0_11p0,o2
+  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_c1e7b81b_m14p0_11p0,o2
+  coupler_ring_3363c15c_m2p0_5p225,o2: straight_c1e7b81b_m14p0_11p0,o1
+  coupler_ring_3363c15c_m2p0_5p225,o3: straight_c1e7b81b_10p0_11p0,o2
 instances:
   bend_euler_2e0a66fe_5p125_16p425:
     component: bend_euler
@@ -30,7 +30,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  coupler_ring_354ce3d3_m2p0_5p225:
+  coupler_ring_3363c15c_m2p0_5p225:
     component: coupler_ring
     settings:
       bend:
@@ -45,7 +45,7 @@ instances:
       gap: 0.2
       length_x: 4
       radius: 10
-  straight_1469c185_10p0_11p0:
+  straight_c1e7b81b_10p0_11p0:
     component: straight
     settings:
       cross_section:
@@ -53,7 +53,7 @@ instances:
       length: 0.6
       npoints: 2
       with_cladding_box: true
-  straight_1469c185_m14p0_11p0:
+  straight_c1e7b81b_m14p0_11p0:
     component: straight
     settings:
       cross_section:
@@ -81,17 +81,17 @@ placements:
     rotation: 180
     x: -4.0
     y: 21.3
-  coupler_ring_354ce3d3_m2p0_5p225:
+  coupler_ring_3363c15c_m2p0_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_1469c185_10p0_11p0:
+  straight_c1e7b81b_10p0_11p0:
     mirror: false
     rotation: 270
     x: 10.0
     y: 11.3
-  straight_1469c185_m14p0_11p0:
+  straight_c1e7b81b_m14p0_11p0:
     mirror: false
     rotation: 90
     x: -14.0
@@ -102,5 +102,5 @@ placements:
     x: 0.0
     y: 21.3
 ports:
-  o1: coupler_ring_354ce3d3_m2p0_5p225,o1
-  o2: coupler_ring_354ce3d3_m2p0_5p225,o4
+  o1: coupler_ring_3363c15c_m2p0_5p225,o1
+  o2: coupler_ring_3363c15c_m2p0_5p225,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_True_.yml
@@ -1,12 +1,12 @@
 connections:
-  bend_euler_4725f0ef_5p125_16p425,o1: straight_417ceb80_10p0_11p0,o1
-  bend_euler_4725f0ef_5p125_16p425,o2: straight_178d4157_m2p0_21p3,o1
-  bend_euler_4725f0ef_m9p125_16p425,o1: straight_178d4157_m2p0_21p3,o2
-  bend_euler_4725f0ef_m9p125_16p425,o2: straight_417ceb80_m14p0_11p0,o2
-  coupler_ring_6859e681_m2p0_5p225,o2: straight_417ceb80_m14p0_11p0,o1
-  coupler_ring_6859e681_m2p0_5p225,o3: straight_417ceb80_10p0_11p0,o2
+  bend_euler_2e0a66fe_5p125_16p425,o1: straight_1469c185_10p0_11p0,o1
+  bend_euler_2e0a66fe_5p125_16p425,o2: straight_defbc978_m2p0_21p3,o1
+  bend_euler_2e0a66fe_m9p125_16p425,o1: straight_defbc978_m2p0_21p3,o2
+  bend_euler_2e0a66fe_m9p125_16p425,o2: straight_1469c185_m14p0_11p0,o2
+  coupler_ring_354ce3d3_m2p0_5p225,o2: straight_1469c185_m14p0_11p0,o1
+  coupler_ring_354ce3d3_m2p0_5p225,o3: straight_1469c185_10p0_11p0,o2
 instances:
-  bend_euler_4725f0ef_5p125_16p425:
+  bend_euler_2e0a66fe_5p125_16p425:
     component: bend_euler
     settings:
       angle: 90
@@ -18,7 +18,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  bend_euler_4725f0ef_m9p125_16p425:
+  bend_euler_2e0a66fe_m9p125_16p425:
     component: bend_euler
     settings:
       angle: 90
@@ -30,7 +30,7 @@ instances:
       radius: 10
       with_arc_floorplan: true
       with_cladding_box: true
-  coupler_ring_6859e681_m2p0_5p225:
+  coupler_ring_354ce3d3_m2p0_5p225:
     component: coupler_ring
     settings:
       bend:
@@ -45,7 +45,23 @@ instances:
       gap: 0.2
       length_x: 4
       radius: 10
-  straight_178d4157_m2p0_21p3:
+  straight_1469c185_10p0_11p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 0.6
+      npoints: 2
+      with_cladding_box: true
+  straight_1469c185_m14p0_11p0:
+    component: straight
+    settings:
+      cross_section:
+        function: cross_section
+      length: 0.6
+      npoints: 2
+      with_cladding_box: true
+  straight_defbc978_m2p0_21p3:
     component: straight
     settings:
       cross_section:
@@ -53,54 +69,38 @@ instances:
       length: 4
       npoints: 2
       with_cladding_box: true
-  straight_417ceb80_10p0_11p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 0.6
-      npoints: 2
-      with_cladding_box: true
-  straight_417ceb80_m14p0_11p0:
-    component: straight
-    settings:
-      cross_section:
-        function: cross_section
-      length: 0.6
-      npoints: 2
-      with_cladding_box: true
 name: ring_single
 placements:
-  bend_euler_4725f0ef_5p125_16p425:
+  bend_euler_2e0a66fe_5p125_16p425:
     mirror: false
     rotation: 90
     x: 10.0
     y: 11.3
-  bend_euler_4725f0ef_m9p125_16p425:
+  bend_euler_2e0a66fe_m9p125_16p425:
     mirror: false
     rotation: 180
     x: -4.0
     y: 21.3
-  coupler_ring_6859e681_m2p0_5p225:
+  coupler_ring_354ce3d3_m2p0_5p225:
     mirror: false
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_178d4157_m2p0_21p3:
-    mirror: false
-    rotation: 180
-    x: 0.0
-    y: 21.3
-  straight_417ceb80_10p0_11p0:
+  straight_1469c185_10p0_11p0:
     mirror: false
     rotation: 270
     x: 10.0
     y: 11.3
-  straight_417ceb80_m14p0_11p0:
+  straight_1469c185_m14p0_11p0:
     mirror: false
     rotation: 90
     x: -14.0
     y: 10.7
+  straight_defbc978_m2p0_21p3:
+    mirror: false
+    rotation: 180
+    x: 0.0
+    y: 21.3
 ports:
-  o1: coupler_ring_6859e681_m2p0_5p225,o1
-  o2: coupler_ring_6859e681_m2p0_5p225,o4
+  o1: coupler_ring_354ce3d3_m2p0_5p225,o1
+  o2: coupler_ring_354ce3d3_m2p0_5p225,o4

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_array_False_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_array_False_.yml
@@ -1,32 +1,31 @@
 connections:
-  ring_single_245fa0a7_30p0_10p65,o1: straight_b3dac65b_7p5_0p0,o2
   ring_single_a371eccc_m5p0_5p65,o2: straight_b3dac65b_7p5_0p0,o1
+  ring_single_fdbd008a_30p0_10p65,o1: straight_b3dac65b_7p5_0p0,o2
 instances:
-  ring_single_245fa0a7_30p0_10p65:
-    component: ring_single
-    settings:
-      length_x: 20
-      radius: 10
   ring_single_a371eccc_m5p0_5p65:
     component: ring_single
     settings:
       length_x: 10
       radius: 5
+  ring_single_fdbd008a_30p0_10p65:
+    component: ring_single
+    settings:
+      length_x: 20
   straight_b3dac65b_7p5_0p0:
     component: straight
     settings:
       length: 5
 name: ring_single_array
 placements:
-  ring_single_245fa0a7_30p0_10p65:
-    mirror: false
-    rotation: 0
-    x: 40.0
-    y: 0.0
   ring_single_a371eccc_m5p0_5p65:
     mirror: false
     rotation: 0
     x: 0.0
+    y: 0.0
+  ring_single_fdbd008a_30p0_10p65:
+    mirror: false
+    rotation: 0
+    x: 40.0
     y: 0.0
   straight_b3dac65b_7p5_0p0:
     mirror: false
@@ -35,4 +34,4 @@ placements:
     y: 0.0
 ports:
   o1: ring_single_a371eccc_m5p0_5p65,o1
-  o2: ring_single_245fa0a7_30p0_10p65,o2
+  o2: ring_single_fdbd008a_30p0_10p65,o2

--- a/gdsfactory/tests/test_netlists/test_netlists_ring_single_array_True_.yml
+++ b/gdsfactory/tests/test_netlists/test_netlists_ring_single_array_True_.yml
@@ -1,22 +1,7 @@
 connections:
-  ring_single_245fa0a7_30p0_10p65,o1: straight_b3dac65b_7p5_0p0,o2
   ring_single_a371eccc_m5p0_5p65,o2: straight_b3dac65b_7p5_0p0,o1
+  ring_single_fdbd008a_30p0_10p65,o1: straight_b3dac65b_7p5_0p0,o2
 instances:
-  ring_single_245fa0a7_30p0_10p65:
-    component: ring_single
-    settings:
-      bend:
-        function: bend_euler
-      coupler_ring:
-        function: coupler_ring
-      cross_section:
-        function: cross_section
-      gap: 0.2
-      length_x: 20
-      length_y: 0.6
-      radius: 10
-      straight:
-        function: straight
   ring_single_a371eccc_m5p0_5p65:
     component: ring_single
     settings:
@@ -32,6 +17,21 @@ instances:
       radius: 5
       straight:
         function: straight
+  ring_single_fdbd008a_30p0_10p65:
+    component: ring_single
+    settings:
+      bend:
+        function: bend_euler
+      coupler_ring:
+        function: coupler_ring
+      cross_section:
+        function: cross_section
+      gap: 0.2
+      length_x: 20
+      length_y: 0.6
+      radius: 10
+      straight:
+        function: straight
   straight_b3dac65b_7p5_0p0:
     component: straight
     settings:
@@ -42,15 +42,15 @@ instances:
       with_cladding_box: true
 name: ring_single_array
 placements:
-  ring_single_245fa0a7_30p0_10p65:
-    mirror: false
-    rotation: 0
-    x: 40.0
-    y: 0.0
   ring_single_a371eccc_m5p0_5p65:
     mirror: false
     rotation: 0
     x: 0.0
+    y: 0.0
+  ring_single_fdbd008a_30p0_10p65:
+    mirror: false
+    rotation: 0
+    x: 40.0
     y: 0.0
   straight_b3dac65b_7p5_0p0:
     mirror: false
@@ -59,4 +59,4 @@ placements:
     y: 0.0
 ports:
   o1: ring_single_a371eccc_m5p0_5p65,o1
-  o2: ring_single_245fa0a7_30p0_10p65,o2
+  o2: ring_single_fdbd008a_30p0_10p65,o2

--- a/gdsfactory/tests/test_paths.py
+++ b/gdsfactory/tests/test_paths.py
@@ -90,7 +90,7 @@ def transition():
 
     # Create the second CrossSection that we want to transition to
     X2 = gf.CrossSection()
-    X2.add(width=1, offset=0, layer=2, name="wg", ports=("in2", "out2"))
+    X2.add(width=1, offset=0, layer=2, name="wg", ports=("in1", "out1"))
     X2.add(width=3.5, offset=0, layer=3, name="etch")
     X2.add(width=3, offset=5, layer=1, name="wg2")
 
@@ -111,11 +111,11 @@ def transition():
     # wg_trans.pprint()
 
     wg1_ref = c << wg1
-    wg2_ref = c << wg2
     wgt_ref = c << wg_trans
+    wgt_ref.connect("in1", wg1_ref.ports["out1"])
 
-    wgt_ref.connect("in2", wg1_ref.ports["out1"])
-    wg2_ref.connect("in2", wgt_ref.ports["out1"])
+    wg2_ref = c << wg2
+    wg2_ref.connect("in1", wgt_ref.ports["out1"])
     return c
 
 

--- a/gdsfactory/tests/test_paths/test_settings_transition_.yml
+++ b/gdsfactory/tests/test_paths/test_settings_transition_.yml
@@ -1,7 +1,84 @@
 cells:
-  extrude_1ac1c90c:
+  extrude_2ef12866:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 2.2
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1.2
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 3
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 1.1
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1.2
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 2.2
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 3
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 1.1
       p: path_d275aaf04a29c0536924c88e46512f29
     default:
       cross_section: null
@@ -10,7 +87,84 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 2.2
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1.2
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 3
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 1.1
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1.2
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 2.2
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 3
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 1.1
       layer: null
       p: path_d275aaf04a29c0536924c88e46512f29
       simplify: null
@@ -20,10 +174,87 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.path
-    name: extrude_1ac1c90c
-  extrude_bdcc3302:
+    name: extrude_2ef12866
+  extrude_7b8a4349:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 3.5
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 5
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 3
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 3.5
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 5
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 3
       p: path_d275aaf04a29c0536924c88e46512f29
     default:
       cross_section: null
@@ -32,7 +263,84 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 3.5
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 5
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 3
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 3.5
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 5
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 3
       layer: null
       p: path_d275aaf04a29c0536924c88e46512f29
       simplify: null
@@ -42,10 +350,99 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.path
-    name: extrude_bdcc3302
-  extrude_c61f54b8:
+    name: extrude_7b8a4349
+  extrude_cf5289a9:
     changed:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width:
+              function: sine
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width:
+            function: sine
+        - hidden: false
+          layer: 3
+          name: etch
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       p: path_9d4e7574f0f651972e1f0c1247df2061
     default:
       cross_section: null
@@ -54,7 +451,96 @@ cells:
       width: null
       widths: null
     full:
-      cross_section: {}
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width:
+              function: sine
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset:
+              function: sine
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width:
+              function: sine
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - out1
+        - in1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width:
+            function: sine
+        - hidden: false
+          layer: 3
+          name: etch
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset:
+            function: sine
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width:
+            function: sine
       layer: null
       p: path_9d4e7574f0f651972e1f0c1247df2061
       simplify: null
@@ -64,7 +550,7 @@ cells:
     info_version: 1
     length: 29.452
     module: gdsfactory.path
-    name: extrude_c61f54b8
+    name: extrude_cf5289a9
   transition:
     changed: {}
     default: {}

--- a/gdsfactory/tests/test_paths/test_settings_transition_.yml
+++ b/gdsfactory/tests/test_paths/test_settings_transition_.yml
@@ -1,181 +1,5 @@
 cells:
-  extrude_2ef12866:
-    changed:
-      cross_section:
-        aliases:
-          etch:
-            hidden: false
-            layer: 3
-            name: etch
-            offset: 0
-            port_types:
-            - optical
-            - optical
-            ports:
-            - null
-            - null
-            width: 2.2
-          wg:
-            hidden: false
-            layer: 2
-            name: wg
-            offset: 0
-            port_types:
-            - optical
-            - optical
-            ports:
-            - in1
-            - out1
-            width: 1.2
-          wg2:
-            hidden: false
-            layer: 1
-            name: wg2
-            offset: 3
-            port_types:
-            - optical
-            - optical
-            ports:
-            - null
-            - null
-            width: 1.1
-        info: {}
-        port_types:
-        - optical
-        ports:
-        - out1
-        - in1
-        sections:
-        - hidden: false
-          layer: 2
-          name: wg
-          offset: 0
-          port_types:
-          - optical
-          - optical
-          ports:
-          - in1
-          - out1
-          width: 1.2
-        - hidden: false
-          layer: 3
-          name: etch
-          offset: 0
-          port_types:
-          - optical
-          - optical
-          ports:
-          - null
-          - null
-          width: 2.2
-        - hidden: false
-          layer: 1
-          name: wg2
-          offset: 3
-          port_types:
-          - optical
-          - optical
-          ports:
-          - null
-          - null
-          width: 1.1
-      p: path_d275aaf04a29c0536924c88e46512f29
-    default:
-      cross_section: null
-      layer: null
-      simplify: null
-      width: null
-      widths: null
-    full:
-      cross_section:
-        aliases:
-          etch:
-            hidden: false
-            layer: 3
-            name: etch
-            offset: 0
-            port_types:
-            - optical
-            - optical
-            ports:
-            - null
-            - null
-            width: 2.2
-          wg:
-            hidden: false
-            layer: 2
-            name: wg
-            offset: 0
-            port_types:
-            - optical
-            - optical
-            ports:
-            - in1
-            - out1
-            width: 1.2
-          wg2:
-            hidden: false
-            layer: 1
-            name: wg2
-            offset: 3
-            port_types:
-            - optical
-            - optical
-            ports:
-            - null
-            - null
-            width: 1.1
-        info: {}
-        port_types:
-        - optical
-        ports:
-        - out1
-        - in1
-        sections:
-        - hidden: false
-          layer: 2
-          name: wg
-          offset: 0
-          port_types:
-          - optical
-          - optical
-          ports:
-          - in1
-          - out1
-          width: 1.2
-        - hidden: false
-          layer: 3
-          name: etch
-          offset: 0
-          port_types:
-          - optical
-          - optical
-          ports:
-          - null
-          - null
-          width: 2.2
-        - hidden: false
-          layer: 1
-          name: wg2
-          offset: 3
-          port_types:
-          - optical
-          - optical
-          ports:
-          - null
-          - null
-          width: 1.1
-      layer: null
-      p: path_d275aaf04a29c0536924c88e46512f29
-      simplify: null
-      width: null
-      widths: null
-    function_name: extrude
-    info_version: 1
-    length: 5
-    module: gdsfactory.path
-    name: extrude_2ef12866
-  extrude_7b8a4349:
+  extrude_49367db1:
     changed:
       cross_section:
         aliases:
@@ -219,8 +43,8 @@ cells:
         port_types:
         - optical
         ports:
-        - out1
         - in1
+        - out1
         sections:
         - hidden: false
           layer: 2
@@ -305,8 +129,8 @@ cells:
         port_types:
         - optical
         ports:
-        - out1
         - in1
+        - out1
         sections:
         - hidden: false
           layer: 2
@@ -350,8 +174,8 @@ cells:
     info_version: 1
     length: 5
     module: gdsfactory.path
-    name: extrude_7b8a4349
-  extrude_cf5289a9:
+    name: extrude_49367db1
+  extrude_4b36d6e9:
     changed:
       cross_section:
         aliases:
@@ -401,8 +225,8 @@ cells:
         port_types:
         - optical
         ports:
-        - out1
         - in1
+        - out1
         sections:
         - hidden: false
           layer: 2
@@ -499,8 +323,8 @@ cells:
         port_types:
         - optical
         ports:
-        - out1
         - in1
+        - out1
         sections:
         - hidden: false
           layer: 2
@@ -550,7 +374,183 @@ cells:
     info_version: 1
     length: 29.452
     module: gdsfactory.path
-    name: extrude_cf5289a9
+    name: extrude_4b36d6e9
+  extrude_a53c4651:
+    changed:
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 2.2
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1.2
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 3
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 1.1
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - in1
+        - out1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1.2
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 2.2
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 3
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 1.1
+      p: path_d275aaf04a29c0536924c88e46512f29
+    default:
+      cross_section: null
+      layer: null
+      simplify: null
+      width: null
+      widths: null
+    full:
+      cross_section:
+        aliases:
+          etch:
+            hidden: false
+            layer: 3
+            name: etch
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 2.2
+          wg:
+            hidden: false
+            layer: 2
+            name: wg
+            offset: 0
+            port_types:
+            - optical
+            - optical
+            ports:
+            - in1
+            - out1
+            width: 1.2
+          wg2:
+            hidden: false
+            layer: 1
+            name: wg2
+            offset: 3
+            port_types:
+            - optical
+            - optical
+            ports:
+            - null
+            - null
+            width: 1.1
+        info: {}
+        port_types:
+        - optical
+        ports:
+        - in1
+        - out1
+        sections:
+        - hidden: false
+          layer: 2
+          name: wg
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - in1
+          - out1
+          width: 1.2
+        - hidden: false
+          layer: 3
+          name: etch
+          offset: 0
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 2.2
+        - hidden: false
+          layer: 1
+          name: wg2
+          offset: 3
+          port_types:
+          - optical
+          - optical
+          ports:
+          - null
+          - null
+          width: 1.1
+      layer: null
+      p: path_d275aaf04a29c0536924c88e46512f29
+      simplify: null
+      width: null
+      widths: null
+    function_name: extrude
+    info_version: 1
+    length: 5
+    module: gdsfactory.path
+    name: extrude_a53c4651
   transition:
     changed: {}
     default: {}

--- a/gdsfactory/types.py
+++ b/gdsfactory/types.py
@@ -43,6 +43,7 @@ Anchor = Literal[
     "center",
     "cc",
 ]
+Axis = Literal["x", "y"]
 
 NSEW = Literal["N", "S", "E", "W"]
 


### PR DESCRIPTION
- Consider only changed component args and kwargs when calculating hash for component name
- meep plugin write_sparameters_meep_mpi deletes old file when overwrite=True
- ensure write_sparameters_meep `**kwargs` have valid simulation settings
- fix component lattice mutability
- Component.auto_rename_ports() raises MutabilityError if component is locked
- add `Component.is_unlocked()` that raises MutabilityError
- rename component_lattice `components` to `symbol_to_component`
- raise error when trying to add two ports with the same name in `gf.add_ports.add_ports_from_markers_center`. Before it was just ignoring ports if it already had a port with the same name, so it was hard to debug.
- difftest adds failed test to logger.error, to clearly see test_errors and to log test error traces
- clean_value calls clean_value_json, so we only need to maintain one function to serialize both settings and name
