### PR TITLE
Properly serialize transitions

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -138,6 +138,8 @@ class CrossSection(CrossSectionPhidl):
         d["port_types"] = x.port_types
         d["aliases"] = x.aliases
         d["info"] = x.info
+        if hasattr(self, "cross_sections"):
+            d["cross_sections"] = [x.to_dict() for x in self.cross_sections]
         return d
 
     def get_name(self):


### PR DESCRIPTION
if a CrossSection has a cross_sections attribute (it is a transition), we should serialize it as a list of cross sections. skipping this attribute causes an improper extruded component to be reused from cache