### PR TITLE
Fix caching and export errors

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1349,7 +1349,7 @@ class Component(Device):
         gdsdir = gdspath.parent
         gdsdir.mkdir(exist_ok=True, parents=True)
 
-        cells = self.get_dependencies()
+        cells = self.get_dependencies(recursive=True)
         cell_names = [cell.name for cell in list(cells)]
         cell_names_unique = set(cell_names)
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1296,6 +1296,7 @@ class Component(Device):
         self,
         show_ports: bool = True,
         show_subports: bool = False,
+        clear_cache: bool = True,
     ) -> None:
         """Show component in klayout.
 
@@ -1305,6 +1306,7 @@ class Component(Device):
         Args:
             show_ports: shows component with port markers and labels
             show_subports: add ports markers and labels to component references
+            clear_cache: if True, clears the cache after showing the component
         """
         from gdsfactory.add_pins import add_pins_triangle
         from gdsfactory.show import show
@@ -1320,7 +1322,7 @@ class Component(Device):
         else:
             component = self
 
-        show(component)
+        show(component, clear_cache=clear_cache)
 
     def write_gds(
         self,

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -85,7 +85,7 @@ def difftest(
         logger.error(error)
         diff = gdsdiff(ref_file, run_file, name=test_name, xor=xor)
         diff.write_gds(diff_file)
-        diff.show(show_ports=False)
+        diff.show(show_ports=False, clear_cache=False)
         print(
             "\n"
             + f"`{filename}` changed from reference {ref_file}\n"


### PR DESCRIPTION
Intermediate clearing of cache can cause errors in final gds export, by leaving two versions of the same cell lingering within subcells created before/after cache clearing. This MR does not fix that problem entirely but offers a few partial solutions.

First, it fixes an issue in the tests, by not clearing cache after failed tests. 

Second, it modifies the write_gds() function to fix the checking of duplicate cell names (recursively), and it also gives an option to choose how to handle duplicate cell names on write. It changes the default behavior to warn and overwrite duplicates, rather than throw an error.

Furthermore, I recommend we *not* clear cache by default when showing a component, but that change is not included in this MR.