### PR TITLE
difftest should fail when there is no regression reference

### DIFF
--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -66,9 +66,10 @@ def difftest(
     component.write_gds(gdspath=run_file)
 
     if not ref_file.exists():
-        print(f"Creating GDS reference for {component.name} in {ref_file}")
         component.write_gds(gdspath=ref_file)
-        return
+        raise AssertionError(
+            f"Reference GDS file for {test_name} did not exist. Writing to {ref_file}"
+        )
 
     if filecmp.cmp(ref_file, run_file, shallow=False):
         return

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -68,7 +68,7 @@ def difftest(
     if not ref_file.exists():
         component.write_gds(gdspath=ref_file)
         raise AssertionError(
-            f"Reference GDS file for {test_name} did not exist. Writing to {ref_file}"
+            f"Reference GDS file for {test_name!r} did not exist. Writing to {ref_file!r}"
         )
 
     if filecmp.cmp(ref_file, run_file, shallow=False):


### PR DESCRIPTION
Currently difftest silently passes for tests which have no existing reference gds file. This is very dangerous, as someone could accidentally be running against an empty directory and think that all their tests are passing, when they are actually testing nothing at all.

This MR changes the behavior to fail the test but still write out the new result as the new reference. In this way, the user will know they are not correctly running the test, but they will still nicely be set up with references to use for their next run.