### PR TITLE
add explicit serialization of ports

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1656,7 +1656,10 @@ def clean_value_json(value: Any) -> Any:
         value = value.to_dict()
         value = copy.deepcopy(value)
         value = clean_dict(value)
-    if isinstance(value, float) and int(value) == value:
+    elif isinstance(value, Port):
+        value = copy.deepcopy(value.settings)
+        value = clean_dict(value)
+    elif isinstance(value, float) and int(value) == value:
         value = int(value)
     elif isinstance(value, (np.int64, np.int32)):
         value = int(value)


### PR DESCRIPTION
Hi Joaquin, this fixes an issue when a port is passed as a parameter to a component. Previously it would hit the block 
```python
    elif hasattr(value, "name"):
        value = value.name
```

which would be prone to pick another component out of the cache which had a port with simply the same name passed. This is very dangerous!

This PR fixes this specific case in the short term, but long term, what do you think about
- using a package like orjson to do json serialization of the arguments
- any custom class needing to be serialized as an arg should have a custom serializer explicitly defined
- if an arg does not have an associated serializer, raise a warning and name the component with a UID instead. this will still let the user give arbitrary arguments to their component functions, and it will still ensure there are no dangerous cache issues. but, if the user wants deterministic names, they will need to go through the extra effort of adding a serializer to their custom class (or use a dataclass instead, which is automatically serializable by orjson) 