### PR TITLE
4213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     - add write_sparameters_meep_1x1 for reciprocal devices (port_symmetries1x1)
     - add write_sparameters_meep_1x1_bend90 for 90degree bend simulations
 
+- fix `is_3d=False` case to run simulations in 2D with [tidy3d](https://github.com/flexcompute/tidy3d/issues/229)
+
 ## 4.2.12
 
 - update tidy3d client to latest version 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 4.2.13
+
+- gmeep simulation improvements:
+    - ymargin=3 by default
+    - add write_sparameters_meep_1x1 for reciprocal devices (port_symmetries1x1)
+    - add write_sparameters_meep_1x1_bend90 for 90degree bend simulations
+
 ## 4.2.12
 
 - update tidy3d client to latest version 1.0.2

--- a/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
+++ b/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
@@ -636,13 +636,6 @@
    "source": [
     "gm.plot.plot_sparameters(df, keys=['s41m'])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
+++ b/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
@@ -152,16 +152,14 @@
    "outputs": [],
    "source": [
     "c = gf.components.straight(length=2)\n",
-    "df = gm.write_sparameters_meep(c, run=False, ymargin_top=3, ymargin_bot=3)"
+    "df = gm.write_sparameters_meep(c, run=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because components with `left-right` ports are very common you can also use a partial function `write_sparameters_meep_east_lr` with 3um `ymargin_bot` and `ymargin_top`\n",
-    "\n",
-    "where `lr` stands for `left-right` ports"
+    "Because components with `left-right` ports are very common `write_sparameters_meep` `y_margin = 3um `"
    ]
   },
   {
@@ -170,8 +168,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = gf.components.straight(length=2)\n",
-    "df = gm.write_sparameters_meep_lr(c, run=False)"
+    "c = gf.components.taper(length=2.0, width1=0.5, width2=1, with_cladding_box=True)\n",
+    "c"
    ]
   },
   {
@@ -180,7 +178,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = gm.write_sparameters_meep_lr(c, resolution=20)"
+    "df = gm.write_sparameters_meep(c, run=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = gm.write_sparameters_meep(c, resolution=20)"
    ]
   },
   {
@@ -214,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For a straight waveguide S21 (Transmission) is around 0dB (100% transmission)"
+    "For a small taper S21 (Transmission) is around 0dB (100% transmission)"
    ]
   },
   {
@@ -243,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = gm.write_sparameters_meep(c, run=False, ymargin_bot=3, xmargin_right=3)"
+    "df = gm.write_sparameters_meep_1x1_bend90(c, run=False)"
    ]
   },
   {
@@ -252,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = gm.write_sparameters_meep_lt(c, run=False) # left top ports"
+    "df = gm.write_sparameters_meep_1x1_bend90(c, run=True)"
    ]
   },
   {
@@ -261,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = gm.write_sparameters_meep_lt(c, run=True, port_symmetries=gm.port_symmetries.port_symmetries_1x1, resolution=20)"
+    "gf.simulation.plot.plot_sparameters(df)"
    ]
   },
   {
@@ -271,15 +278,6 @@
    "outputs": [],
    "source": [
     "gf.simulation.plot.plot_sparameters(df, keys=('s21m',), logscale=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gf.simulation.plot.plot_sparameters(df, keys=('s21m',))"
    ]
   },
   {
@@ -302,11 +300,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "Here are the port symmetries for a crossing\n",
+    "\n",
+    "```python\n",
     "port_symmetries = {\n",
     "    \"o1\": {\n",
     "        \"s11\": [\"s22\", \"s33\", \"s44\"],\n",
@@ -315,7 +314,25 @@
     "        \"s41\": [\"s14\", \"s23\", \"s32\"],\n",
     "    }\n",
     "}\n",
-    "df = gm.write_sparameters_meep(c, resolution=20, port_symmetries=gm.port_symmetries.port_symmetries_crossing)"
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = gm.write_sparameters_meep(c, resolution=20, ymargin=0, port_symmetries=gm.port_symmetries.port_symmetries_crossing, run=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = gm.write_sparameters_meep(c, resolution=20, ymargin=0, port_symmetries=gm.port_symmetries.port_symmetries_crossing, run=True)"
    ]
   },
   {
@@ -340,7 +357,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see this crossing looks beautiful but is quite **lossy**"
+    "As you can see this crossing looks beautiful but is quite **lossy** (9dB @ 15550nm)"
    ]
   },
   {
@@ -396,6 +413,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "c = gf.components.coupler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "c = gf.components.coupler(length=8, gap=0.13)\n",
     "c"
    ]
@@ -406,10 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gm.write_sparameters_meep_lr(\n",
-    "    component=c,\n",
-    "    run=False\n",
-    ")"
+    "gm.write_sparameters_meep(component=c, run=False)"
    ]
   },
   {
@@ -418,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filepath = gm.write_sparameters_meep_mpi_lr(\n",
+    "filepath = gm.write_sparameters_meep_mpi(\n",
     "    component=c,\n",
     "    cores=4,\n",
     "    resolution=30,\n",
@@ -508,12 +531,11 @@
     "    c1_dict,\n",
     "]\n",
     "\n",
-    "filepaths = gm.write_sparameters_meep_batch_lr(\n",
+    "filepaths = gm.write_sparameters_meep_batch_1x1(\n",
     "    jobs=jobs,\n",
     "    cores_per_run=4,\n",
     "    total_cores=8,\n",
     "    lazy_parallelism=True,\n",
-    "    port_symmetries=gm.port_symmetries.port_symmetries_1x1\n",
     ")"
    ]
   },
@@ -544,7 +566,7 @@
    "outputs": [],
    "source": [
     "p = 2.5\n",
-    "gm.write_sparameters_meep(c, ymargin_bot=p, xmargin=p, run=False)"
+    "gm.write_sparameters_meep(c, ymargin=0, ymargin_bot=p, xmargin=p, run=False)"
    ]
   },
   {
@@ -555,6 +577,7 @@
    "source": [
     "c1_dict = dict(\n",
     "    component=c,\n",
+    "    ymargin=0,\n",
     "    ymargin_bot=p,\n",
     "    xmargin=p,\n",
     ")\n",

--- a/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
+++ b/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
@@ -425,7 +425,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ad0ae82-489e-4d23-9bf1-ecf7e8decc59",
+   "id": "10c8aecf-f405-4462-a833-aa79675ec725",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.ports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd9619c9-e5c6-4cdc-bb5a-2d73b4f7f44b",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/gdsfactory/simulation/gmeep/__init__.py
+++ b/gdsfactory/simulation/gmeep/__init__.py
@@ -11,18 +11,18 @@ from gdsfactory.simulation.gmeep.write_sparameters_grating import (
 )
 from gdsfactory.simulation.gmeep.write_sparameters_meep import (
     write_sparameters_meep,
-    write_sparameters_meep_lr,
-    write_sparameters_meep_lt,
+    write_sparameters_meep_1x1,
+    write_sparameters_meep_1x1_bend90,
 )
 from gdsfactory.simulation.gmeep.write_sparameters_meep_batch import (
     write_sparameters_meep_batch,
-    write_sparameters_meep_batch_lr,
-    write_sparameters_meep_batch_lt,
+    write_sparameters_meep_batch_1x1,
+    write_sparameters_meep_batch_1x1_bend90,
 )
 from gdsfactory.simulation.gmeep.write_sparameters_meep_mpi import (
     write_sparameters_meep_mpi,
-    write_sparameters_meep_mpi_lr,
-    write_sparameters_meep_mpi_lt,
+    write_sparameters_meep_mpi_1x1,
+    write_sparameters_meep_mpi_1x1_bend90,
 )
 
 logger.info(f"Meep {mp.__version__!r} installed at {mp.__path__!r}")
@@ -31,14 +31,14 @@ __all__ = [
     "get_simulation",
     "get_sparameters_data_meep",
     "write_sparameters_meep",
-    "write_sparameters_meep_lr",
-    "write_sparameters_meep_lt",
+    "write_sparameters_meep_1x1",
+    "write_sparameters_meep_1x1_bend90",
     "write_sparameters_meep_mpi",
-    "write_sparameters_meep_mpi_lr",
-    "write_sparameters_meep_mpi_lt",
+    "write_sparameters_meep_mpi_1x1",
+    "write_sparameters_meep_mpi_1x1_bend90",
     "write_sparameters_meep_batch",
-    "write_sparameters_meep_batch_lr",
-    "write_sparameters_meep_batch_lt",
+    "write_sparameters_meep_batch_1x1",
+    "write_sparameters_meep_batch_1x1_bend90",
     "write_sparameters_grating",
     "write_sparameters_grating_mpi",
     "write_sparameters_grating_batch",

--- a/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
@@ -16,7 +16,7 @@ def test_sparameters_straight(dataframe_regression):
     c = gf.components.straight(length=2)
     p = 3
     c = gf.add_padding_container(c, default=0, top=p, bottom=p)
-    df = gm.write_sparameters_meep(c, overwrite=True, resolution=RESOLUTION)
+    df = gm.write_sparameters_meep(c, ymargin=0, overwrite=True, resolution=RESOLUTION)
 
     # Check reasonable reflection/transmission
     assert np.allclose(df["s12m"], 1, atol=1e-02), df["s12m"]
@@ -41,7 +41,11 @@ def test_sparameters_straight_symmetric(dataframe_regression):
         }
     }
     df = gm.write_sparameters_meep(
-        c, overwrite=True, resolution=RESOLUTION, port_symmetries=port_symmetries
+        c,
+        overwrite=True,
+        resolution=RESOLUTION,
+        port_symmetries=port_symmetries,
+        ymargin=0,
     )
 
     # Check reasonable reflection/transmission
@@ -66,7 +70,11 @@ def test_sparameters_crossing_symmetric(dataframe_regression):
         }
     }
     df = gm.write_sparameters_meep(
-        c, overwrite=True, resolution=RESOLUTION, port_symmetries=port_symmetries
+        c,
+        overwrite=True,
+        resolution=RESOLUTION,
+        port_symmetries=port_symmetries,
+        ymargin=0,
     )
 
     if dataframe_regression:
@@ -78,7 +86,7 @@ def test_sparameters_straight_mpi(dataframe_regression):
     c = gf.components.straight(length=2)
     p = 3
     c = gf.add_padding_container(c, default=0, top=p, bottom=p)
-    filepath = gm.write_sparameters_meep_mpi(c, overwrite=True)
+    filepath = gm.write_sparameters_meep_mpi(c, ymargin=0, overwrite=True)
     df = pd.read_csv(filepath)
 
     # Check reasonable reflection/transmission

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import logger, sparameters_path
+from gdsfactory.simulation import port_symmetries
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_meep as get_sparameters_path,
 )
@@ -146,7 +147,7 @@ def write_sparameters_meep(
     run: bool = True,
     dispersive: bool = False,
     xmargin: float = 0,
-    ymargin: float = 0,
+    ymargin: float = 3,
     xmargin_left: float = 0,
     xmargin_right: float = 0,
     ymargin_top: float = 0,
@@ -535,12 +536,16 @@ def write_sparameters_meep(
         return df
 
 
-write_sparameters_meep_lr = gf.partial(
-    write_sparameters_meep, ymargin_top=3, ymargin_bot=3
+write_sparameters_meep_1x1 = gf.partial(
+    write_sparameters_meep, port_symmetries=port_symmetries.port_symmetries_1x1
 )
 
-write_sparameters_meep_lt = gf.partial(
-    write_sparameters_meep, ymargin_bot=3, xmargin_right=3
+write_sparameters_meep_1x1_bend90 = gf.partial(
+    write_sparameters_meep,
+    ymargin=0,
+    ymargin_bot=3,
+    xmargin_right=3,
+    port_symmetries=port_symmetries.port_symmetries_1x1,
 )
 
 sig = inspect.signature(write_sparameters_meep)
@@ -550,7 +555,7 @@ settings_write_sparameters_meep = set(sig.parameters.keys()).union(
 
 if __name__ == "__main__":
     c = gf.components.straight(length=2)
-    write_sparameters_meep_lr(c, run=False)
+    write_sparameters_meep_1x1(c, run=False)
 
     # import matplotlib.pyplot as plt
     # plt.show()

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 import gdsfactory as gf
 from gdsfactory.config import logger, sparameters_path
+from gdsfactory.simulation import port_symmetries
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_meep as get_sparameters_path,
 )
@@ -187,12 +188,16 @@ def write_sparameters_meep_batch(
     return filepaths
 
 
-write_sparameters_meep_batch_lr = gf.partial(
-    write_sparameters_meep_batch, ymargin_top=3, ymargin_bot=3
+write_sparameters_meep_batch_1x1 = gf.partial(
+    write_sparameters_meep_batch, port_symmetries=port_symmetries.port_symmetries_1x1
 )
 
-write_sparameters_meep_batch_lt = gf.partial(
-    write_sparameters_meep_batch, ymargin_bot=3, xmargin_right=3
+write_sparameters_meep_batch_1x1_bend90 = gf.partial(
+    write_sparameters_meep_batch,
+    port_symmetries=port_symmetries.port_symmetries_1x1,
+    ymargin=0,
+    ymargin_bot=3,
+    xmargin_right=3,
 )
 
 

--- a/gdsfactory/simulation/gtidy3d/get_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation.py
@@ -206,8 +206,9 @@ def get_simulation(
     for layer in component.layers:
         if layer in layer_to_thickness and layer in layer_to_material:
             thickness = layer_to_thickness[layer]
-            zmin = layer_to_zmin[layer]
-            zmax = zmin + thickness
+            zmin = layer_to_zmin[layer] if is_3d else -td.inf
+            zmax = zmin + thickness if is_3d else td.inf
+
             if (
                 layer in layer_to_material
                 and layer_to_material[layer] in material_name_to_tidy3d
@@ -426,7 +427,7 @@ if __name__ == "__main__":
     # c = gf.c.straight_rib()
 
     c = gf.c.straight()
-    sim = get_simulation(c, plot_modes=False, is_3d=False)
+    sim = get_simulation(c, plot_modes=True, is_3d=False)
 
     filepath = pathlib.Path(__file__).parent / "extra" / "wg2d.json"
     filepath.write_text(sim.json())

--- a/gdsfactory/simulation/gtidy3d/write_sparameters.py
+++ b/gdsfactory/simulation/gtidy3d/write_sparameters.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
     import gdsfactory.simulation as sim
 
     c = gf.components.straight(length=2.1)
-    df = write_sparameters_1x1(c, is_3d=False)
+    df = write_sparameters_1x1(c, is_3d=False, overwrite=False)
     sim.plot.plot_sparameters(df)
 
     # t = df.s12m


### PR DESCRIPTION
- gmeep simulation improvements:
    - ymargin=3 by default
    - add write_sparameters_meep_1x1 for reciprocal devices (port_symmetries1x1)
    - add write_sparameters_meep_1x1_bend90 for 90degree bend simulations

- fix `is_3d=False` case to run simulations in 2D with [tidy3d](https://github.com/flexcompute/tidy3d/issues/229)
