### PR TITLE
431

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          make install
+          pip install flake8
+          pip install -e .
       - name: Lint with flake8
         run: |
           flake8 .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
     - add bias_gap
 - gf.components.grating_coupler_elliptical improvements:
     - add bias_gap
+- fix [serialization of ports](https://github.com/gdsfactory/gdsfactory/pull/212)
+- extend_ports works with cross_sections that do not have layer
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 4.3.1
+
+- gf.components.grating_coupler_circular improvements:
+    - rename teeth_list by a simpler widths and gaps separate arguments
+    - delete grating_coupler_circular_arbitrary as it's now unnecessary
+    - add bias_gap
+- gf.components.grating_coupler_elliptical improvements:
+    - add bias_gap
+
 ## 4.3.0
 
 - tidy3d improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     - add bias_gap
 - fix [serialization of ports](https://github.com/gdsfactory/gdsfactory/pull/212)
 - extend_ports works with cross_sections that do not have layer
+- `pip install gdsfactory` also installs most of the plugins
+    - `pip install gdsfactory[full]` only adds SIPANN (which depends on ternsorflow, which is a heavy dependency)
 
 ## 4.3.0
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ sax:
 update:
 	pur
 	pur -r requirements_dev.txt
-	pur -r requirements_full.txt
 
 publish:
 	anaconda upload environment.yml

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ sax:
 update:
 	pur
 	pur -r requirements_dev.txt
+	pur -r requirements_full.txt
 
 publish:
 	anaconda upload environment.yml

--- a/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
+++ b/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
@@ -668,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfb85af5-e827-47e8-beba-e51f5bae5bee",
+   "id": "cbe50672-4aaa-434e-a033-f2b4d5a3539d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -77,10 +77,7 @@ from gdsfactory.components.extension import extend_port, extend_ports
 from gdsfactory.components.fiber import fiber
 from gdsfactory.components.fiber_array import fiber_array
 from gdsfactory.components.grating_coupler_array import grating_coupler_array
-from gdsfactory.components.grating_coupler_circular import (
-    grating_coupler_circular,
-    grating_coupler_circular_arbitrary,
-)
+from gdsfactory.components.grating_coupler_circular import grating_coupler_circular
 from gdsfactory.components.grating_coupler_elliptical import (
     ellipse_arc,
     grating_coupler_elliptical,
@@ -302,7 +299,6 @@ factory = dict(
     grating_coupler_array=grating_coupler_array,
     grating_coupler_elliptical=grating_coupler_elliptical,
     grating_coupler_circular=grating_coupler_circular,
-    grating_coupler_circular_arbitrary=grating_coupler_circular_arbitrary,
     grating_coupler_elliptical_te=grating_coupler_elliptical_te,
     grating_coupler_elliptical_tm=grating_coupler_elliptical_tm,
     grating_coupler_elliptical_arbitrary=grating_coupler_elliptical_arbitrary,

--- a/gdsfactory/components/extension.py
+++ b/gdsfactory/components/extension.py
@@ -142,16 +142,16 @@ def extend_ports(
     for port in ports_all:
         port_name = port.name
         port = cref.ports[port_name]
-        cross_section_extension = (
-            cross_section
-            or port.cross_section
-            or cross_section_function(layer=port.layer, width=port.width)
-        )
 
         if port_name in ports_to_extend_names:
             if extension_factory:
                 extension_component = extension_factory()
             else:
+                cross_section_extension = (
+                    cross_section
+                    or port.cross_section
+                    or cross_section_function(layer=port.layer, width=port.width)
+                )
                 extension_component = gf.components.straight(
                     length=length,
                     width=port.width,

--- a/gdsfactory/components/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_coupler_elliptical.py
@@ -262,11 +262,10 @@ grating_coupler_elliptical_te = grating_coupler_elliptical
 if __name__ == "__main__":
     # c = grating_coupler_elliptical_tm(taper_length=30)
     # c = grating_coupler_elliptical_te(layer_slab=None, with_fiber_marker=False)
-    c = grating_coupler_elliptical(
-        layer_slab=gf.LAYER.SLAB150, taper_length=50, slab_xmin=-5
-    )
+    c = grating_coupler_elliptical(layer=(2, 0), taper_length=50, slab_xmin=-5)
     # print(c.polarization)
     # print(c.wavelength)
     # print(c.ports)
     # c.pprint()
+    c = gf.c.extend_ports(c)
     c.show()

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -35,6 +35,7 @@ def grating_coupler_elliptical_arbitrary(
     fiber_marker_width: float = 11.0,
     fiber_marker_layer: Optional[Layer] = gf.LAYER.TE,
     spiked: bool = True,
+    bias_gap: float = 0,
     cross_section: CrossSectionOrFactory = xs_strip,
 ) -> Component:
     r"""Grating coupler with parametrization based on Lumerical FDTD simulation.
@@ -56,9 +57,12 @@ def grating_coupler_elliptical_arbitrary(
         layer_slab: Optional slab
         slab_xmin: where 0 is at the start of the taper
         polarization: te or tm
-        fiber_marker_width
-        fiber_marker_layer
-        spiked: grating teeth have sharp spikes to avoid non-manhattan drc errors
+        fiber_marker_width:
+        fiber_marker_layer: Optional marker
+        spiked: grating teeth have spikes to avoid drc errors.
+        bias_gap: etch gap (um).
+            Positive bias increases gap and reduces width to keep period constant.
+        cross_section: cross_section factory for waveguide port.
 
     https://en.wikipedia.org/wiki/Ellipse
     c = (a1 ** 2 - b1 ** 2) ** 0.5
@@ -94,8 +98,8 @@ def grating_coupler_elliptical_arbitrary(
     c.info["polarization"] = polarization
     c.info["wavelength"] = wavelength
 
-    gaps = gf.snap.snap_to_grid(gaps)
-    widths = gf.snap.snap_to_grid(widths)
+    gaps = gf.snap.snap_to_grid(np.array(gaps) + bias_gap)
+    widths = gf.snap.snap_to_grid(np.array(widths) - bias_gap)
 
     xi = taper_length
     for gap, width in zip(gaps, widths):
@@ -169,5 +173,5 @@ def grating_coupler_elliptical_arbitrary(
 
 
 if __name__ == "__main__":
-    c = grating_coupler_elliptical_arbitrary(fiber_angle=8)
+    c = grating_coupler_elliptical_arbitrary(fiber_angle=8, bias_gap=-0.05)
     c.show()

--- a/gdsfactory/components/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_coupler_elliptical_trenches.py
@@ -46,8 +46,8 @@ def grating_coupler_elliptical_trenches(
         ncladding: cladding index
         layer: for the grating teeth
         layer_trench: for the trench
-        p_start:  first tooth
-        n_periods: number of periods
+        p_start: first tooth
+        n_periods: number of grating teeth.
         end_straight_length: at the end of
 
 

--- a/gdsfactory/simulation/simphony/__init__.py
+++ b/gdsfactory/simulation/simphony/__init__.py
@@ -1,6 +1,9 @@
 """gdsfactory simphony circuit simulation plugin"""
 
-from simphony.tools import freq2wl, wl2freq
+try:
+    from simphony.tools import freq2wl, wl2freq
+except ImportError:
+    print("To install simphony plugin make sure you `pip install gdsfactory[full]`")
 
 import gdsfactory.simulation.simphony.components as components
 from gdsfactory.simulation.simphony.add_gc import add_gc

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
@@ -2,6 +2,7 @@ settings:
   changed: {}
   child: null
   default:
+    bias_gap: 0
     cladding_offset: 2
     cross_section:
       function: cross_section
@@ -11,6 +12,7 @@ settings:
     - 0
     fiber_marker_width: 11
     fill_factor: 0.7
+    gaps: null
     layer:
     - 1
     - 0
@@ -19,6 +21,7 @@ settings:
     - 0
     layer_slab: null
     length: 30
+    n_periods: 30
     period: 1
     polarization: te
     port:
@@ -26,10 +29,11 @@ settings:
     - 0.0
     taper_angle: 30
     taper_length: 10
-    teeth_list: null
     wavelength: 1.55
     wg_width: 0.5
+    widths: null
   full:
+    bias_gap: 0
     cladding_offset: 2
     cross_section:
       function: cross_section
@@ -39,6 +43,7 @@ settings:
     - 0
     fiber_marker_width: 11
     fill_factor: 0.7
+    gaps: null
     layer:
     - 1
     - 0
@@ -47,6 +52,7 @@ settings:
     - 0
     layer_slab: null
     length: 30
+    n_periods: 30
     period: 1
     polarization: te
     port:
@@ -54,9 +60,9 @@ settings:
     - 0.0
     taper_angle: 30
     taper_length: 10
-    teeth_list: null
     wavelength: 1.55
     wg_width: 0.5
+    widths: null
   function_name: grating_coupler_circular
   info:
     polarization: te

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
@@ -2,6 +2,7 @@ settings:
   changed: {}
   child: null
   default:
+    bias_gap: 0
     cross_section:
       function: cross_section
     fiber_angle: 15
@@ -47,6 +48,7 @@ settings:
     - 0.5
     - 0.5
   full:
+    bias_gap: 0
     cross_section:
       function: cross_section
     fiber_angle: 15

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ klayout~=0.27.5
 loguru
 lytest==0.0.20
 matplotlib~=3.5.1
-networkx==2.7
+networkx~=2.6.3
 numpy>=1.20.0
 omegaconf==2.1.1
 orjson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 -e .
+bokeh~=2.2.3
 click
 gdspy==1.6.11
+holoviews~=1.14.6
+ipympl
 jsondiff
+klayout~=0.27.5
 loguru
 lytest==0.0.20
 matplotlib~=3.5.1
-networkx==2.6.3
+networkx==2.7
 numpy>=1.20.0
 omegaconf==2.1.1
 orjson
@@ -13,8 +17,9 @@ pandas
 phidl==1.6.0
 picwriter==0.5
 pydantic==1.9.0
+pyglet
 Pyqtree==1.0.0
-pytest==7.0.0
+pytest==7.0.1
 pytest-regressions==2.3.1
 qrcode==7.3.1
 rectpack==0.2.2
@@ -22,7 +27,12 @@ scikit-image
 scipy
 semantic_version
 Shapely
+simphony==0.3.0
+sklearn
+tidy3d-beta==1.1.1
 toolz==0.11.2
 tqdm
+triangle
+trimesh==3.10.2
 typing_extensions
 xmltodict==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ scikit-image
 scipy
 semantic_version
 Shapely
-simphony==0.3.0
 sklearn
 tidy3d-beta==1.1.1
 toolz==0.11.2

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,1 +1,2 @@
+simphony==0.3.0
 SiPANN==1.3.1

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,11 +1,1 @@
-bokeh~=2.2.3
-holoviews~=1.14.6
-ipympl
-klayout~=0.27.5
-pyglet
-simphony==0.3.0
 SiPANN==1.3.1
-sklearn
-tidy3d-beta==1.1.1
-triangle
-trimesh==3.9.42


### PR DESCRIPTION
- gf.components.grating_coupler_circular improvements:
    - rename teeth_list by a simpler widths and gaps separate arguments
    - delete grating_coupler_circular_arbitrary as it's now unnecessary
    - add bias_gap
- gf.components.grating_coupler_elliptical improvements:
    - add bias_gap
- fix [serialization of ports](https://github.com/gdsfactory/gdsfactory/pull/212)
- extend_ports works with cross_sections that do not have layer
- `pip install gdsfactory` also installs most of the plugins
    - `pip install gdsfactory[full]` only adds SIPANN and simphony (which depend on ternsorflow, which is a heavy dependency)
