### PR TITLE
Updated Interconnect plugin

### DIFF
--- a/gdsfactory/simulation/lumerical/interconnect.py
+++ b/gdsfactory/simulation/lumerical/interconnect.py
@@ -136,10 +136,24 @@ def run_wavelength_sweep(
     extra_ona_props: dict = None,
     **kwargs,
 ):
+    """
+    Args:
+        component:
+        session:
+        port_in: specify the port in the Interconnect model to attach the ONA output to
+        ports_out: specify the ports in the Interconnect models to attach the ONA input to
+        wavelength_range:
+        n_points:
+        results:
+        extra_ona_props:
+        kwargs:
+
+    """
     import lumapi
 
     inc = session if session else lumapi.INTERCONNECT()
 
+    # Add Monte-Carlo params
     inc.addproperty("::Root Element", "MC_uniformity_thickness", "wafer", "Matrix")
     inc.addproperty("::Root Element", "MC_uniformity_width", "wafer", "Matrix")
     inc.addproperty("::Root Element", "MC_non_uniform", "wafer", "Number")
@@ -227,6 +241,7 @@ if __name__ == "__main__":
 
     gc1_netlist_instance_name = get_instance_name(component, gc1)
     gc2_netlist_instance_name = get_instance_name(component, gc2)
+
     ports_out = (
         (gc2_netlist_instance_name, "opt_fiber"),
         (gc1_netlist_instance_name, "opt_wg"),

--- a/gdsfactory/simulation/lumerical/interconnect.py
+++ b/gdsfactory/simulation/lumerical/interconnect.py
@@ -4,24 +4,34 @@ from typing import Optional, Tuple
 import numpy as np
 from omegaconf import DictConfig
 
+from gdsfactory import Component
+
 c = 2.9979e8
 pi = np.pi
+um = 1e-6
+
+
+def set_global_settings(session: object, simulation_settings: dict):
+    for param, val in zip(simulation_settings.keys(), simulation_settings.values()):
+        session.setnamed("::Root Element", param, val)
 
 
 def add_interconnect_element(
-    inc: object,
+    session: object,
     label: str,
     model: str,
     loc: Tuple[int, int] = (200.0, 200.0),
     flip_vert: bool = False,
     flip_horiz: bool = False,
-    rotation: float = 0.0
-    # **kwargs
+    rotation: float = 0.0,
+    extra_props: OrderedDict = None,
 ):
     """
+    Add an element to the Interconnect session.
+    TODO: Need to connect this to generated s-parameters and add them to the model as well
 
     Args:
-        inc: Interconnect instance
+        session: Interconnect session
         label: label for Interconnect component
         model:
         loc:
@@ -37,23 +47,23 @@ def add_interconnect_element(
             ("y position", loc[1]),
             ("horizontal flipped", float(flip_horiz)),
             ("vertical flipped", float(flip_vert)),
-            ("rotated", rotation)
-            # kwargs
+            ("rotated", rotation),
         ]
     )
-    return inc.addelement(model, properties=props)
+    if extra_props:
+        props.update(extra_props)
+    return session.addelement(model, properties=props)
 
 
 def send_to_interconnect(
-    component,
+    component: Component,
     session: Optional[object] = None,
     placements: dict = None,
     simulation_settings: OrderedDict = None,
-    run: bool = True,
     drop_port_prefix: str = None,
-    **settings
-) -> None:
-    """Send component netlist to lumerical interconnect.
+    **settings,
+) -> object:
+    """Send all components in netlist to Interconnect and make connections according to netlist.
 
     Args:
         component: component from which to extract netlist
@@ -64,7 +74,10 @@ def send_to_interconnect(
         drop_port_prefix: if components are written with some prefix, drop up to and including
             the prefix character.  (i.e. "c1_input" -> "input")
     """
-    import lumapi
+    import sys
+
+    if "lumapi" not in sys.modules.keys():
+        import lumapi
 
     inc = session or lumapi.INTERCONNECT(hide=False)
 
@@ -81,14 +94,14 @@ def send_to_interconnect(
 
     for i, instance in enumerate(instances):
         info = instances[instance].info
-
+        extra_props = info["interconnect"] if "interconnect" in info.keys() else None
         add_interconnect_element(
-            inc=inc,
+            session=inc,
             label=instance,
             model=info.model,
-            loc=(placements[instance].x, placements[instance].y),
+            loc=(50 * placements[instance].x, 50 * placements[instance].y),
             rotation=placements[instance].rotation,
-            # **component_settings
+            extra_props=extra_props,
         )
 
     for connection in connections:
@@ -100,22 +113,81 @@ def send_to_interconnect(
             port2 = port2[port2.index(drop_port_prefix) + 1 :]
 
         # EBeam ports are not named consistently between Klayout and Interconnect..
-        # Best to use another
         if hasattr(instances[element1].info, port1):
             port1 = instances[element1].info[port1]
         if hasattr(instances[element2].info, port2):
             port2 = instances[element2].info[port2]
+
         inc.connect(element1, port1, element2, port2)
 
     if simulation_settings:
-        for param, val in zip(simulation_settings.keys(), simulation_settings.values()):
-            inc.setnamed("::Root Element", param, val)
+        set_global_settings(inc, simulation_settings)
+    return inc
 
-    if run:
-        # There's nothing to run yet so this will give an error
-        inc.run()
-    else:
-        return inc
+
+def run_wavelength_sweep(
+    component: Component,
+    session: Optional[object] = None,
+    port_in: Tuple = None,
+    ports_out: Tuple = None,
+    wavelength_range: Tuple = (1.500, 1.600),
+    n_points: int = 1000,
+    results: Tuple = ("transmission",),
+    extra_ona_props: dict = None,
+    **kwargs,
+):
+    import lumapi
+
+    inc = session if session else lumapi.INTERCONNECT()
+
+    inc.addproperty("::Root Element", "MC_uniformity_thickness", "wafer", "Matrix")
+    inc.addproperty("::Root Element", "MC_uniformity_width", "wafer", "Matrix")
+    inc.addproperty("::Root Element", "MC_non_uniform", "wafer", "Number")
+    inc.addproperty("::Root Element", "MC_grid", "wafer", "Number")
+    inc.addproperty("::Root Element", "MC_resolution_x", "wafer", "Number")
+    inc.addproperty("::Root Element", "MC_resolution_y", "wafer", "Number")
+
+    # send circuit to interconnect
+    inc = send_to_interconnect(component=component, session=inc, **kwargs)
+
+    ona_props = OrderedDict(
+        [
+            ("number of input ports", len(ports_out)),
+            ("number of points", n_points),
+            ("input parameter", "start and stop"),
+            ("start frequency", (c / (wavelength_range[1] * um))),
+            ("stop frequency", (c / (wavelength_range[0] * um))),
+            ("plot kind", "wavelength"),
+            ("relative to center", float(False)),
+        ]
+    )
+    if extra_ona_props:
+        ona_props.update(extra_ona_props)
+
+    ona = add_interconnect_element(
+        session=inc,
+        model="Optical Network Analyzer",
+        label="ONA_1",
+        loc=(0, -50),
+        extra_props=ona_props,
+    )
+
+    inc.connect(ona.name, "output", *port_in)
+    for i, port in enumerate(ports_out):
+        inc.connect(ona.name, f"input {i+1}", *ports_out[i])
+
+    inc.run()
+
+    data = dict()
+    for result in results:
+        data[result] = {
+            port: inc.getresult(ona.name, f"input {i+1}/mode 1/{result}")
+            for i, port in enumerate(ports_out)
+        }
+    # df = pd.DataFrame.from_dict(data)
+
+    # inc.close()
+    return data, session
 
 
 if __name__ == "__main__":
@@ -123,25 +195,59 @@ if __name__ == "__main__":
 
     import gdsfactory as gf
 
-    c = gf.Component()
-    gc1 = c << pdk.gc_te1550()
-    gc2 = c << pdk.gc_te1550()
-    gc3 = c << pdk.gc_te1550()
+    component = gf.Component()
+    gc1 = component << pdk.gc_te1550()
+    gc2 = component << pdk.gc_te1550()
 
-    s = c << pdk.y_splitter()
+    s = component << pdk.y_splitter()
 
     gc1.connect(port="opt1", destination=s.ports["opt1"])
     gc2.connect(port="opt1", destination=s.ports["opt2"])
-    gc3.connect(port="opt1", destination=s.ports["opt3"])
 
-    c.show()
+    component.show()
 
-    netlist = c.get_netlist()
+    netlist = component.get_netlist()
 
     simulation_settings = OrderedDict(
         [
-            ("bitrate", 2.5e10),
+            ("MC_uniformity_thickness", np.array([200, 200])),
+            ("MC_uniformity_width", np.array([200, 200])),
+            ("MC_non_uniform", 0),
+            ("MC_grid", 1e-5),
+            ("MC_resolution_x", 200),
+            ("MC_resolution_y", 0),
         ]
     )
 
-    send_to_interconnect(c, simulation_settings=simulation_settings, run=False)
+    # inc = send_to_interconnect(
+    #     component=c,
+    #     simulation_settings=simulation_settings
+    # )
+    from gdsfactory.get_netlist import get_instance_name
+
+    gc1_netlist_instance_name = get_instance_name(component, gc1)
+    gc2_netlist_instance_name = get_instance_name(component, gc2)
+    ports_out = (
+        (gc2_netlist_instance_name, "opt_fiber"),
+        (gc1_netlist_instance_name, "opt_wg"),
+    )
+    results, session = run_wavelength_sweep(
+        component=component,
+        port_in=(gc1_netlist_instance_name, "opt_fiber"),
+        ports_out=ports_out,
+        simulation_settings=simulation_settings,
+        results=("transmission",),
+    )
+
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    for port in ports_out:
+        wl = results["transmission"][port]["wavelength"] / um
+        T = 10 * np.log10(np.abs(results["transmission"][port]["TE transmission"]))
+        plt.plot(wl, T, label=f"{port}")
+    plt.legend()
+    plt.xlabel(r"Wavelength ($\mu$m)")
+    plt.ylabel("TE transmission (dB)")
+    plt.show()
+    pass


### PR DESCRIPTION
- added wavelength sweep
- cleaned up other things

This is the first working example of the plugin:
In KLayout: 2 TE grating couplers connected by a y-splitter (all EBeam components)
![image](https://user-images.githubusercontent.com/53101766/158093394-8b4af307-52b9-4524-ba81-bf0ffbfb20f0.png)

In Interconnect:
![image](https://user-images.githubusercontent.com/53101766/158093543-48cf1a62-7478-4c93-9c0a-d8cda35c166c.png)

Results visualized in Python:
![image](https://user-images.githubusercontent.com/53101766/158093595-48697464-902b-47a1-b2f0-a73f0cb08671.png)