### PR TITLE
Fix cross section parsing behavior in read.from_yaml

### DIFF
--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -579,9 +579,16 @@ def from_yaml(
 
         # replace partial
         for k, v in settings.items():
-            if isinstance(v, dict):
-                function_name = v.pop("function")
-                settings[k] = functools.partial(component_factory[function_name], **v)
+            if isinstance(v, dict) and "function" in v:
+                function_name = v["function"]
+                try:
+                    settings[k] = functools.partial(
+                        component_factory[function_name], **v
+                    )
+                except Exception as e:
+                    raise ValueError(
+                        f"Error trying to create cross section from dictionary setting: {e}"
+                    )
 
         ci = component_factory[component_type](**settings)
         ref = c << ci


### PR DESCRIPTION
Hi @joamatab 

This recent change to the `from_yaml()` function is problematic. It is not safe to always assume a dictionary parameter has a key called `function` in it, and I would argue that you should not even assume it is a cross section spec if it _does_ have the key `function`. This is unclear, unpredictable, and risky behavior.

I would suggest changing the spec of a cross-section dictionary to look instead like this
`cross_section`: the name of the cross section (replaces the `function` key)
`settings`: settings for the cross section

This would bring it closer to a component spec, and would also have a very clear signature. Otherwise I think it will be risky and buggy to have behavior like this embedded in this function...

Anyways, this MR doesn't go that far, but it proceeds a bit more cautiously when trying to convert potential cross-section-type parameters into cross sections.