### PR TITLE
507

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [5.0.7]
 
-- fix tests
+- define layermap as pydantic BaseModel
+- Sometimes it is desirable to have a waveguide with a shear face (i.e. the port face is not orthogonal to the propagation direction, but slightly slanted). [PR](https://github.com/gdsfactory/gdsfactory/pull/280) adds the capability to extrude basic waveguides with shear faces.
+
 
 ## [5.0.6](https://github.com/gdsfactory/gdsfactory/pull/279)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.0.7]
+
+- fix tests
+
 ## [5.0.6](https://github.com/gdsfactory/gdsfactory/pull/279)
 
 - fix set active PDK on component_from_yaml

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,13 @@ mypy:
 build:
 	python setup.py sdist bdist_wheel
 
-devpi-release:
+upload-devpi:
 	pip install devpi-client wheel
 	devpi upload --format=bdist_wheel,sdist.tgz
+
+upload-twine: build
+	pip install twine
+	twine upload dist/*
 
 release:
 	git push origin --tags

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -11,7 +11,7 @@ from gdsfactory.components.grating_coupler_elliptical import (
 from gdsfactory.cross_section import strip as xs_strip
 from gdsfactory.geometry.functions import DEG2RAD
 from gdsfactory.tech import LAYER
-from gdsfactory.types import CrossSectionOrFactory, Floats, Layer
+from gdsfactory.types import CrossSectionSpec, Floats, Layer
 
 _gaps = (0.1,) * 10
 _widths = (0.5,) * 10
@@ -36,7 +36,7 @@ def grating_coupler_elliptical_arbitrary(
     fiber_marker_layer: Optional[Layer] = gf.LAYER.TE,
     spiked: bool = True,
     bias_gap: float = 0,
-    cross_section: CrossSectionOrFactory = xs_strip,
+    cross_section: CrossSectionSpec = xs_strip,
 ) -> Component:
     r"""Grating coupler with parametrization based on Lumerical FDTD simulation.
 
@@ -134,11 +134,7 @@ def grating_coupler_elliptical_arbitrary(
     )
 
     # Add port
-    xs = (
-        cross_section(width=wg_width, layer=layer)
-        if callable(cross_section)
-        else cross_section
-    )
+    xs = gf.get_cross_section(cross_section, width=wg_width, layer=layer)
     c.add_port(
         name="o1",
         midpoint=[x_output, 0],

--- a/gdsfactory/components/mzi.py
+++ b/gdsfactory/components/mzi.py
@@ -11,7 +11,7 @@ from gdsfactory.components.mmi2x2 import mmi2x2
 from gdsfactory.components.straight import straight as straight_function
 from gdsfactory.cross_section import strip
 from gdsfactory.routing import get_route
-from gdsfactory.types import ComponentFactory, ComponentSpec, CrossSectionSpec
+from gdsfactory.types import ComponentSpec, CrossSectionSpec
 
 
 @cell
@@ -25,7 +25,7 @@ def mzi(
     straight_x_top: Optional[ComponentSpec] = None,
     straight_x_bot: Optional[ComponentSpec] = None,
     splitter: ComponentSpec = mmi1x2,
-    combiner: Optional[ComponentFactory] = None,
+    combiner: Optional[ComponentSpec] = None,
     with_splitter: bool = True,
     port_e1_splitter: str = "o2",
     port_e0_splitter: str = "o3",
@@ -184,7 +184,6 @@ mzi_coupler = partial(
 
 
 if __name__ == "__main__":
-
     # delta_length = 116.8 / 2
     # print(delta_length)
     # c = mzi(delta_length=delta_length, with_splitter=False)

--- a/gdsfactory/components/taper_cross_section.py
+++ b/gdsfactory/components/taper_cross_section.py
@@ -2,13 +2,13 @@ import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.cross_section import rib, strip, strip_rib_tip
-from gdsfactory.types import CrossSectionOrFactory
+from gdsfactory.types import CrossSectionSpec
 
 
 @cell
 def taper_cross_section(
-    cross_section1: CrossSectionOrFactory = strip_rib_tip,
-    cross_section2: CrossSectionOrFactory = rib,
+    cross_section1: CrossSectionSpec = strip_rib_tip,
+    cross_section2: CrossSectionSpec = rib,
     length: float = 10,
     npoints: int = 100,
     linear: bool = False,
@@ -40,10 +40,8 @@ def taper_cross_section(
 
     """
     transition = gf.path.transition(
-        cross_section1=cross_section1() if callable(cross_section1) else cross_section1,
-        cross_section2=cross_section2(**kwargs)
-        if callable(cross_section2)
-        else cross_section2,
+        cross_section1=gf.get_cross_section(cross_section1),
+        cross_section2=gf.get_cross_section(cross_section2, **kwargs),
         width_type="linear" if linear else "sine",
     )
     taper_path = gf.path.straight(length=length, npoints=npoints)

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -5,13 +5,13 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight
 from gdsfactory.cross_section import metal3
-from gdsfactory.types import CrossSectionOrFactory
+from gdsfactory.types import CrossSectionSpec
 
 wire_straight = gf.partial(straight, cross_section=metal3)
 
 
 @gf.cell
-def wire_corner(cross_section: CrossSectionOrFactory = metal3, **kwargs) -> Component:
+def wire_corner(cross_section: CrossSectionSpec = metal3, **kwargs) -> Component:
     """90 degrees electrical corner
 
     Args:
@@ -19,7 +19,7 @@ def wire_corner(cross_section: CrossSectionOrFactory = metal3, **kwargs) -> Comp
         kwargs: cross_section settings
 
     """
-    x = cross_section(**kwargs) if callable(cross_section) else cross_section
+    x = gf.get_cross_section(cross_section, **kwargs)
     layer = x.layer
     width = x.width
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -218,10 +218,10 @@ def extrude(
         width:
         widths: tuple of starting and end width
         simplify: Tolerance value for the simplification algorithm.
-          All points that can be removed without changing the resulting
+          All points that can be removed without changing the resulting.
           polygon by more than the value listed here will be removed.
-        shear_angle_start: an optional angle to shear the starting face by (in degrees)
-        shear_angle_end: an optional angle to shear the ending face by (in degrees)
+        shear_angle_start: an optional angle to shear the starting face by (in degrees).
+        shear_angle_end: an optional angle to shear the ending face by (in degrees).
     """
     from gdsfactory.pdk import get_cross_section
 
@@ -399,9 +399,16 @@ def _shear_face(
     dy: float,
     shear_angle_start: Optional[float],
     shear_angle_end: Optional[float],
-):
+) -> np.ndarray:
     """
-    Displaces a point sequence offset a distance dy away by a shear angle, given in degrees, on either side.
+    Displaces a point sequence offset a distance dy away by a shear angle,
+    given in degrees, on either side.
+
+    Args:
+        points: points sequence.
+        dy: y offset.
+        shear_angle_start: an optional angle to shear the starting face by (in degrees).
+        shear_angle_end: an optional angle to shear the ending face by (in degrees).
     """
     if shear_angle_start or shear_angle_end:
         shear_angle_start = shear_angle_start or 0

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-import pydantic
 from pydantic import BaseModel
 
 module_path = pathlib.Path(__file__).parent.absolute()
@@ -12,8 +11,7 @@ def make_empty_dict() -> Dict[str, Callable]:
     return {}
 
 
-@pydantic.dataclasses.dataclass(frozen=True)
-class LayerMap:
+class LayerMap(BaseModel):
     """Generic layermap based on Textbook:
     Lukas Chrostowski, Michael Hochberg, "Silicon Photonics Design",
     Cambridge University Press 2015, page 353
@@ -64,6 +62,10 @@ class LayerMap:
     LABEL_INSTANCE: Layer = (206, 0)
     ERROR_MARKER: Layer = (207, 0)
     ERROR_PATH: Layer = (208, 0)
+
+    class Config:
+        frozen = True
+        extra = "forbid"
 
 
 LAYER = LayerMap()

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_.yml
@@ -1,17 +1,19 @@
 connections:
-  bend_euler_67p115_m5p5,o1: straight_775184d2_51p995_m0p625,o2
-  bend_euler_67p115_m5p5,o2: straight_720ba455_71p99_m20p0,o1
-  bend_euler_76p865_m34p5,o1: straight_720ba455_71p99_m20p0,o2
-  bend_euler_76p865_m34p5,o2: straight_c49ce9c6_81p995_m39p375,o1
-  mmi_bot,o1: straight_c49ce9c6_81p995_m39p375,o2
-  mmi_top,o3: straight_775184d2_51p995_m0p625,o1
+  bend_euler_fdb9781f_67p115_m5p5,o1: straight_5f7d3a14_51p995_m0p625,o2
+  bend_euler_fdb9781f_67p115_m5p5,o2: straight_8124c601_71p99_m20p0,o1
+  bend_euler_fdb9781f_76p865_m34p5,o1: straight_8124c601_71p99_m20p0,o2
+  bend_euler_fdb9781f_76p865_m34p5,o2: straight_1c2065ee_81p995_m39p375,o1
+  mmi_bot,o1: straight_1c2065ee_81p995_m39p375,o2
+  mmi_top,o3: straight_5f7d3a14_51p995_m0p625,o1
 instances:
-  bend_euler_67p115_m5p5:
+  bend_euler_fdb9781f_67p115_m5p5:
     component: bend_euler
-    settings: {}
-  bend_euler_76p865_m34p5:
+    settings:
+      cross_section: strip
+  bend_euler_fdb9781f_76p865_m34p5:
     component: bend_euler
-    settings: {}
+    settings:
+      cross_section: strip
   mmi_bot:
     component: mmi1x2
     settings:
@@ -22,26 +24,29 @@ instances:
     settings:
       length_mmi: 22
       width_mmi: 6
-  straight_720ba455_71p99_m20p0:
+  straight_1c2065ee_81p995_m39p375:
     component: straight
     settings:
-      length: 18.75
-  straight_775184d2_51p995_m0p625:
-    component: straight
-    settings:
-      length: 19.99
-  straight_c49ce9c6_81p995_m39p375:
-    component: straight
-    settings:
+      cross_section: strip
       length: 0.01
+  straight_5f7d3a14_51p995_m0p625:
+    component: straight
+    settings:
+      cross_section: strip
+      length: 19.99
+  straight_8124c601_71p99_m20p0:
+    component: straight
+    settings:
+      cross_section: strip
+      length: 18.75
 name: sample_docstring
 placements:
-  bend_euler_67p115_m5p5:
+  bend_euler_fdb9781f_67p115_m5p5:
     mirror: true
     rotation: 0
     x: 61.99
     y: -0.625
-  bend_euler_76p865_m34p5:
+  bend_euler_fdb9781f_76p865_m34p5:
     mirror: false
     rotation: 270
     x: 71.99
@@ -56,19 +61,19 @@ placements:
     rotation: 0
     x: 10.0
     y: 0.0
-  straight_720ba455_71p99_m20p0:
-    mirror: false
-    rotation: 270
-    x: 71.99
-    y: -10.625
-  straight_775184d2_51p995_m0p625:
-    mirror: false
-    rotation: 0
-    x: 42.0
-    y: -0.625
-  straight_c49ce9c6_81p995_m39p375:
+  straight_1c2065ee_81p995_m39p375:
     mirror: false
     rotation: 0
     x: 81.99
     y: -39.375
+  straight_5f7d3a14_51p995_m0p625:
+    mirror: false
+    rotation: 0
+    x: 42.0
+    y: -0.625
+  straight_8124c601_71p99_m20p0:
+    mirror: false
+    rotation: 270
+    x: 71.99
+    y: -10.625
 ports: {}

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_.yml
@@ -1,17 +1,19 @@
 connections:
-  bend_euler_115p145_5p5,o1: straight_dee7a506_62p51_0p625,o2
-  bend_euler_115p145_5p5,o2: straight_e4b574c8_120p02_50p312,o1
-  bend_euler_115p145_95p125,o1: straight_e4b574c8_120p02_50p312,o2
-  bend_euler_115p145_95p125,o2: straight_2d58b973_110p01_100p0,o1
-  mmi_long,o1: straight_2d58b973_110p01_100p0,o2
-  mmi_short,o2: straight_dee7a506_62p51_0p625,o1
+  bend_euler_fdb9781f_115p145_5p5,o1: straight_4831b31b_62p51_0p625,o2
+  bend_euler_fdb9781f_115p145_5p5,o2: straight_8a18563c_120p02_50p312,o1
+  bend_euler_fdb9781f_115p145_95p125,o1: straight_8a18563c_120p02_50p312,o2
+  bend_euler_fdb9781f_115p145_95p125,o2: straight_9b6195fc_110p01_100p0,o1
+  mmi_long,o1: straight_9b6195fc_110p01_100p0,o2
+  mmi_short,o2: straight_4831b31b_62p51_0p625,o1
 instances:
-  bend_euler_115p145_5p5:
+  bend_euler_fdb9781f_115p145_5p5:
     component: bend_euler
-    settings: {}
-  bend_euler_115p145_95p125:
+    settings:
+      cross_section: strip
+  bend_euler_fdb9781f_115p145_95p125:
     component: bend_euler
-    settings: {}
+    settings:
+      cross_section: strip
   mmi_long:
     component: mmi1x2
     settings:
@@ -22,26 +24,29 @@ instances:
     settings:
       length_mmi: 5
       width_mmi: 4.5
-  straight_2d58b973_110p01_100p0:
+  straight_4831b31b_62p51_0p625:
     component: straight
     settings:
-      length: 0.02
-  straight_dee7a506_62p51_0p625:
-    component: straight
-    settings:
+      cross_section: strip
       length: 95.02
-  straight_e4b574c8_120p02_50p312:
+  straight_8a18563c_120p02_50p312:
     component: straight
     settings:
+      cross_section: strip
       length: 79.375
+  straight_9b6195fc_110p01_100p0:
+    component: straight
+    settings:
+      cross_section: strip
+      length: 0.02
 name: Unnamed_a491ff8b
 placements:
-  bend_euler_115p145_5p5:
+  bend_euler_fdb9781f_115p145_5p5:
     mirror: false
     rotation: 0
     x: 110.02
     y: 0.625
-  bend_euler_115p145_95p125:
+  bend_euler_fdb9781f_115p145_95p125:
     mirror: false
     rotation: 90
     x: 120.02
@@ -56,21 +61,21 @@ placements:
     rotation: 0
     x: 0.0
     y: 0.0
-  straight_2d58b973_110p01_100p0:
-    mirror: false
-    rotation: 180
-    x: 110.02
-    y: 100.0
-  straight_dee7a506_62p51_0p625:
+  straight_4831b31b_62p51_0p625:
     mirror: false
     rotation: 0
     x: 15.0
     y: 0.625
-  straight_e4b574c8_120p02_50p312:
+  straight_8a18563c_120p02_50p312:
     mirror: false
     rotation: 90
     x: 120.02
     y: 10.625
+  straight_9b6195fc_110p01_100p0:
+    mirror: false
+    rotation: 180
+    x: 110.02
+    y: 100.0
 ports:
   o1: mmi_short,o1
   o2: mmi_long,o2


### PR DESCRIPTION
- define layermap as pydantic BaseModel
- Sometimes it is desirable to have a waveguide with a shear face (i.e. the port face is not orthogonal to the propagation direction, but slightly slanted). [PR](https://github.com/gdsfactory/gdsfactory/pull/280) adds the capability to extrude basic waveguides with shear faces.

