### PR TITLE
Shear-face waveguides: improve, document, test

### DIFF
--- a/docs/notebooks/03_waveguides_paths_crossections.ipynb
+++ b/docs/notebooks/03_waveguides_paths_crossections.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Paths and cross-sections\n",
     "\n",
@@ -27,7 +31,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -52,7 +60,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "p2 = P.copy().rotate()\n",
@@ -62,7 +74,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P.points - p2.points"
@@ -70,7 +86,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "You can also modify our Path in the same ways as any other gdsfactory object:\n",
     "\n",
@@ -81,7 +101,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P.movey(10)\n",
@@ -91,7 +115,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "You can also check the length of the curve with the `length()` method:"
    ]
@@ -99,7 +127,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P.length()"
@@ -107,7 +139,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## CrossSection\n",
     "\n",
@@ -123,7 +159,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extrude the Path and the CrossSection\n",
@@ -133,7 +173,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Option 2: Linearly-varying width\n",
     "\n",
@@ -143,7 +187,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Extrude the Path and the CrossSection\n",
@@ -153,7 +201,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Option 3: Arbitrary Cross-section\n",
     "\n",
@@ -162,7 +214,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Now, what if we want a more complicated straight?  For instance, in some\n",
     "photonic applications it's helpful to have a shallow etch that appears on either\n",
@@ -174,7 +230,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -193,7 +253,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "p = gf.path.arc()\n",
@@ -206,7 +270,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Building Paths quickly\n",
     "\n",
@@ -220,7 +288,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path()\n",
@@ -250,7 +322,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Example 2:** Create an \"S-turn\" just by making a list of `[left_turn,\n",
     "right_turn]`"
@@ -259,7 +335,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path()\n",
@@ -273,7 +353,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Example 3:** Repeat the S-turn 3 times by nesting our S-turn list in another\n",
     "list"
@@ -282,7 +366,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path()\n",
@@ -298,7 +386,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Note you can also use the Path() constructor to immediately contruct your Path:"
    ]
@@ -306,7 +398,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path([straight, left_turn, straight, right_turn, straight])\n",
@@ -315,7 +411,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Waypoint smooth paths\n",
     "\n",
@@ -325,7 +425,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "points = np.array([(20, 10), (40, 10), (20, 40), (50, 40), (50, 20), (70, 20)])\n",
@@ -336,7 +440,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -356,7 +464,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Waypoint sharp paths\n",
     "\n",
@@ -368,7 +480,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path([(20, 10), (30, 10), (40, 30), (50, 30), (50, 20), (70, 20)])\n",
@@ -377,7 +493,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Example 2:** Using the \"turn and move\" method, where you manipulate the end angle of the Path so that when you append points to it, they're in the correct direction.  *Note: It is crucial that the number of points per straight section is set to 2 (`pp.straight(length, num_pts = 2)`) otherwise the extrusion algorithm will show defects.*"
    ]
@@ -385,7 +505,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.Path()\n",
@@ -402,7 +526,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -417,7 +545,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Custom curves\n",
     "\n",
@@ -435,7 +567,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -472,7 +608,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "You can create Paths from any array of points -- just be sure that they form\n",
     "smooth curves!  If we examine our path `P` we can see that all we've simply\n",
@@ -482,7 +622,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -494,7 +638,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Simplifying / reducing point usage\n",
     "\n",
@@ -516,7 +664,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# The remaining points form a identical line to within `1e-3` from the original\n",
@@ -526,7 +678,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Let's say we need fewer points.  We can increase the simplify tolerance by\n",
     "specifying `simplify = 1e-1`.  This drops the number of points to ~400 points\n",
@@ -536,7 +692,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c = gf.path.extrude(P, cross_section=X, simplify=1e-1)\n",
@@ -545,7 +705,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Taken to absurdity, what happens if we set `simplify = 0.3`?  Once again, the\n",
     "~200 remaining points form a line that is within `0.3` units from the original\n",
@@ -555,7 +719,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c = gf.path.extrude(P, cross_section=X, simplify=0.3)\n",
@@ -564,7 +732,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Curvature calculation\n",
     "\n",
@@ -583,7 +755,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -616,7 +792,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Arc paths are equivalent to `bend_circular` and euler paths are equivalent to `bend_euler`"
    ]
@@ -624,7 +804,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "s, K = P.curvature()\n",
@@ -636,7 +820,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.path.euler(radius=3, angle=90, p=1.0, use_eff=False)\n",
@@ -648,7 +836,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "s, K = P.curvature()\n",
@@ -659,7 +851,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "You can compare two 90 degrees euler bend with 180 euler bend.\n",
     "\n",
@@ -669,7 +865,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -693,7 +893,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "s, K = P.curvature()\n",
@@ -704,7 +908,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Transitioning between cross-sections\n",
     "\n",
@@ -723,7 +931,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -757,7 +969,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Now let's create the transitional CrossSection by calling `transition()` with\n",
     "these two CrossSections as input. If we want the width to vary as a smooth\n",
@@ -768,7 +984,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create the transitional CrossSection\n",
@@ -784,7 +1004,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "wg1.plot()"
@@ -793,7 +1017,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "wg2.plot()"
@@ -801,7 +1029,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Now that we have all of our components, let's `connect()` everything and see\n",
     "what it looks like"
@@ -810,7 +1042,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c = gf.Component(\"transition_demo\")\n",
@@ -828,7 +1064,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Note that since `transition()` outputs a `CrossSection`, we can make the\n",
     "transition follow an arbitrary path:"
@@ -837,7 +1077,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Transition along a curving Path\n",
@@ -857,7 +1101,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Variable width / offset\n",
     "\n",
@@ -873,7 +1121,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def my_custom_width_fun(t):\n",
@@ -899,7 +1151,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can do the same thing with the offset argument:"
    ]
@@ -907,7 +1163,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def my_custom_offset_fun(t):\n",
@@ -932,7 +1192,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Offsetting a Path\n",
     "\n",
@@ -945,7 +1209,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def my_custom_offset_fun(t):\n",
@@ -968,7 +1236,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Modifying a CrossSection\n",
     "\n",
@@ -981,7 +1253,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create the Path\n",
@@ -998,7 +1274,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In case we want to change any of the CrossSection elements, we simply access the\n",
     "Python dictionary that specifies that element and modify the values"
@@ -1007,7 +1287,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -1063,7 +1347,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "len(c.references)"
@@ -1071,7 +1359,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Note**\n",
     "\n",
@@ -1083,7 +1375,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -1105,7 +1401,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "X1 = gf.CrossSection(width=1, offset=0, layer=(2, 0))\n",
@@ -1116,7 +1416,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "X2 = gf.CrossSection(width=2, offset=0, layer=(2, 0))\n",
@@ -1126,7 +1430,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "For example this will give you an error\n",
     "```\n",
@@ -1139,7 +1447,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "P = gf.path.straight(length=10, npoints=101)\n",
@@ -1153,7 +1465,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "X2 = gf.CrossSection(width=3, offset=0, layer=gf.LAYER.WG, name=\"core\", port_names=(\"o1\", \"o2\"))\n",
@@ -1164,7 +1480,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "T = gf.path.transition(X1, X2)\n",
@@ -1175,7 +1495,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c4 = gf.Component()"
@@ -1184,7 +1508,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "start_ref = c4 << c\n",
@@ -1198,7 +1526,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c4"
@@ -1206,7 +1538,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## cross-section\n",
     "\n",
@@ -1221,7 +1557,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
@@ -1231,7 +1571,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "help(gf.cross_section.cross_section)"
@@ -1240,7 +1584,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pin = gf.partial(\n",
@@ -1256,7 +1604,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "c = gf.components.straight(cross_section=pin)\n",
@@ -1266,7 +1618,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pin10 = gf.components.straight(cross_section=pin, length=5)\n",
@@ -1275,7 +1631,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "finally, you can also pass most components Dict that define the cross-section"
    ]
@@ -1283,7 +1643,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "gf.components.straight(\n",
@@ -1299,7 +1663,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -1339,7 +1707,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "s = gf.export.to_3d(straight_transition, layer_set=gf.layers.LAYER_SET)\n",
@@ -1347,9 +1719,189 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Waveguides with Shear Faces\n",
+    "By default, an extruded path will end in a face orthogonal to the direction of the path. In some cases, it is desired to have a sheared face that tilts at a given angle from this orthogonal baseline. This can be done by supplying the parameters `shear_angle_start` and `shear_angle_end` to the `extrude()` function."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import gdsfactory as gf\n",
+    "\n",
+    "P = gf.path.straight(length=10)\n",
+    "\n",
+    "s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90)\n",
+    "X1 = gf.CrossSection(width=1, offset=0, layer=gf.LAYER.WG, name=\"core\", port_names=(\"o1\", \"o2\"), sections=[s])\n",
+    "c = gf.path.extrude(P, X1, shear_angle_start=10, shear_angle_end=45)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "By default, the shear angle parameters are `None`, in which case shearing will not be applied to the face."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "c = gf.path.extrude(P, X1, shear_angle_start=None, shear_angle_end=10)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Shearing should work on paths of arbitrary orientation, as long as their end segments are sufficiently long."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "angle = 45\n",
+    "P = gf.path.straight(length=10).rotate(angle)\n",
+    "c = gf.path.extrude(P, X1, shear_angle_start=angle, shear_angle_end=angle)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For a segmented or curving path, the algorithm will fail if multiple points are sheared off by the operation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "angle = 15\n",
+    "P = gf.path.euler()\n",
+    "c = gf.path.extrude(P, X1, shear_angle_start=angle)  # raises ValueError because attempting to shear curved portion\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "This can be fixed by padding the end of the path with a long enough straight section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "angle = 15\n",
+    "P = gf.path.straight(length=1.0).append([gf.path.euler(), gf.path.straight(length=1.0)])\n",
+    "c = gf.path.extrude(P, X1, shear_angle_start=angle, shear_angle_end=angle)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "The port location remains the same for a sheared component. The face is rotated around the port point symmetrically and thus can be connected to other sheared components safely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "P = gf.path.straight(length=10).rotate(180)\n",
+    "\n",
+    "s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90)\n",
+    "X1 = gf.CrossSection(width=1, offset=0, layer=gf.LAYER.WG, name=\"core\", port_names=(\"o1\", \"o2\"), sections=[s])\n",
+    "c = gf.path.extrude(P, X1, shear_angle_start=10, shear_angle_end=10)\n",
+    "\n",
+    "circuit = gf.Component()\n",
+    "c1 = circuit << c\n",
+    "c2 = circuit << c\n",
+    "c3 = circuit << c\n",
+    "\n",
+    "c2.connect(port='o1', destination=c1.ports['o2'])\n",
+    "c3.connect(port='o2', destination=c2.ports['o2'])\n",
+    "circuit.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -19,6 +19,7 @@ from phidl.path import smooth as smooth_phidl
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.cross_section import CrossSection, Section, Transition
+from gdsfactory.port import Port
 from gdsfactory.types import Coordinates, CrossSectionSpec, Float2, Layer, PathFactory
 
 
@@ -353,28 +354,34 @@ def extrude(
             orientation = (p.start_angle + 180) % 360
             _width = width if np.isscalar(width) else width[0]
             new_port = c.add_port(
-                name=port_names[0],
-                layer=layers[0],
-                port_type=port_types[0],
-                width=_width,
-                orientation=orientation,
-                cross_section=x.cross_sections[0]
-                if hasattr(x, "cross_sections")
-                else x,
+                port=Port(
+                    name=port_names[0],
+                    layer=layers[0],
+                    port_type=port_types[0],
+                    width=_width,
+                    orientation=orientation,
+                    cross_section=x.cross_sections[0]
+                    if hasattr(x, "cross_sections")
+                    else x,
+                    shear_angle=shear_angle_start,
+                )
             )
             new_port.endpoints = (points1[0], points2[0])
         if port_names[1] is not None:
             orientation = (p.end_angle + 180) % 360
             _width = width if np.isscalar(width) else width[-1]
             new_port = c.add_port(
-                name=port_names[1],
-                layer=layers[1],
-                port_type=port_types[1],
-                width=_width,
-                orientation=orientation,
-                cross_section=x.cross_sections[1]
-                if hasattr(x, "cross_sections")
-                else x,
+                port=Port(
+                    name=port_names[1],
+                    layer=layers[1],
+                    port_type=port_types[1],
+                    width=_width,
+                    orientation=orientation,
+                    cross_section=x.cross_sections[1]
+                    if hasattr(x, "cross_sections")
+                    else x,
+                    shear_angle=shear_angle_end,
+                )
             )
             new_port.endpoints = (points2[-1], points1[-1])
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -414,21 +414,31 @@ def _shear_face(
         shear_angle_start = shear_angle_start or 0
         shear_angle_end = shear_angle_end or 0
 
-        starts_monotonically_increasing = np.all(points[1:, 0] > points[:-1, 0])
-        if not starts_monotonically_increasing:
-            raise ValueError(
-                "Cannot shear face! Current algorithm assumes that all points are monotonically increasing in x."
-            )
-        dx_start = np.tan(np.deg2rad(shear_angle_start)) * dy
-        dx_end = np.tan(np.deg2rad(shear_angle_end)) * dy
-        points = points.copy()
-        points[0][0] += dx_start
-        points[-1][0] += dx_end
-        ends_monotonically_increasing = np.all(points[1:, 0] > points[:-1, 0])
+        dl_start = np.tan(np.deg2rad(shear_angle_start)) * dy
+        dp_start = points[1] - points[0]
+        a_start = np.arctan2(dp_start[1], dp_start[0])
+        dl_end = np.tan(np.deg2rad(shear_angle_end)) * dy
+        dp_end = points[-1] - points[-2]
+        a_end = np.arctan2(dp_end[1], dp_end[0])
+        _points = points.copy()
+        _points[0] = points[0] + np.array(
+            [dl_start * np.cos(a_start), dl_start * np.sin(a_start)]
+        )
+        _points[-1] = points[-1] + np.array(
+            [dl_end * np.cos(a_end), dl_end * np.sin(a_end)]
+        )
+        points = _points
 
-        if not ends_monotonically_increasing:
+        # verify nothing went screwy
+        dp_start_final = points[1] - points[0]
+        dp_end_final = points[-1] - points[-2]
+        if not np.array_equal(np.sign(dp_start), np.sign(dp_start_final)):
             raise ValueError(
-                "Cannot shear face! Sheared segment is not monotonically increasing! Maybe the segment is too short or has curvature?"
+                "Could not apply shear face to path! Likely this means the path has curvature or segmentation near the start point"
+            )
+        if not np.array_equal(np.sign(dp_end), np.sign(dp_end_final)):
+            raise ValueError(
+                "Could not apply shear face to path! Likely this means the path has curvature or segmentation near the end point"
             )
     return points
 

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -86,6 +86,7 @@ class Port(PortPhidl):
         port_type: str = "optical",
         parent: Optional[object] = None,
         cross_section: Optional[object] = None,
+        shear_angle: Optional[object] = None,
     ) -> None:
         self.name = name
         self.midpoint = np.array(midpoint, dtype="float64")
@@ -97,22 +98,24 @@ class Port(PortPhidl):
         self.layer = layer
         self.port_type = port_type
         self.cross_section = cross_section
+        self.shear_angle = shear_angle
 
         if self.width < 0:
             raise ValueError("[PHIDL] Port width must be >=0")
         Port._next_uid += 1
 
     def to_dict(self) -> Dict[str, Any]:
-        return clean_value_json(
-            dict(
-                name=self.name,
-                width=self.width,
-                midpoint=tuple(np.round(self.midpoint, 3)),
-                orientation=int(self.orientation),
-                layer=self.layer,
-                port_type=self.port_type,
-            )
+        d = dict(
+            name=self.name,
+            width=self.width,
+            midpoint=tuple(np.round(self.midpoint, 3)),
+            orientation=int(self.orientation),
+            layer=self.layer,
+            port_type=self.port_type,
         )
+        if self.shear_angle:
+            d["shear_angle"] = self.shear_angle
+        return clean_value_json(d)
 
     def __repr__(self) -> str:
         return f"Port (name {self.name}, midpoint {self.midpoint}, width {self.width}, orientation {self.orientation}, layer {self.layer}, port_type {self.port_type})"
@@ -191,6 +194,7 @@ class Port(PortPhidl):
             layer=self.layer,
             port_type=self.port_type,
             cross_section=self.cross_section,
+            shear_angle=self.shear_angle,
         )
         new_port.info = deepcopy(self.info)
         if not new_uid:

--- a/gdsfactory/tests/test_shear_face_path.py
+++ b/gdsfactory/tests/test_shear_face_path.py
@@ -1,9 +1,3 @@
-###################################################################################################################
-# PROPRIETARY AND CONFIDENTIAL
-# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
-# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
-# RPLTD NOTICE VERSION: 1.1.1
-###################################################################################################################
 import numpy as np
 import pytest
 

--- a/gdsfactory/tests/test_shear_face_path.py
+++ b/gdsfactory/tests/test_shear_face_path.py
@@ -1,0 +1,17 @@
+###################################################################################################################
+# PROPRIETARY AND CONFIDENTIAL
+# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
+# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
+# RPLTD NOTICE VERSION: 1.1.1
+###################################################################################################################
+import pytest
+
+
+@pytest.fixture
+def shear_waveguide():
+    pass
+
+
+@pytest.fixture
+def regular_waveguide():
+    pass

--- a/gdsfactory/tests/test_shear_face_path.py
+++ b/gdsfactory/tests/test_shear_face_path.py
@@ -4,14 +4,99 @@
 # USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
 # RPLTD NOTICE VERSION: 1.1.1
 ###################################################################################################################
+import numpy as np
 import pytest
+
+import gdsfactory as gf
+
+DEMO_PORT_ANGLE = 10
 
 
 @pytest.fixture
-def shear_waveguide():
-    pass
+def shear_waveguide_symmetric():
+    P = gf.path.straight(length=10)
+    c = gf.path.extrude(
+        P, "strip", shear_angle_start=DEMO_PORT_ANGLE, shear_angle_end=DEMO_PORT_ANGLE
+    )
+    return c
+
+
+@pytest.fixture
+def shear_waveguide_start():
+    P = gf.path.straight(length=10)
+    c = gf.path.extrude(
+        P, "strip", shear_angle_start=DEMO_PORT_ANGLE, shear_angle_end=None
+    )
+    return c
+
+
+@pytest.fixture
+def shear_waveguide_end():
+    P = gf.path.straight(length=10)
+    c = gf.path.extrude(
+        P, "strip", shear_angle_start=None, shear_angle_end=DEMO_PORT_ANGLE
+    )
+    return c
 
 
 @pytest.fixture
 def regular_waveguide():
-    pass
+    P = gf.path.straight(length=10)
+    c = gf.path.extrude(P, "strip")
+    return c
+
+
+def test_mate_on_shear_xor_empty(
+    regular_waveguide, shear_waveguide_start, shear_waveguide_end
+):
+    # two sheared components joined at the sheared port should appear the same as two straight component joined
+    two_straights = gf.Component()
+    c1 = two_straights << regular_waveguide
+    c2 = two_straights << regular_waveguide
+    c2.connect("o1", c1.ports["o2"])
+
+    two_shears = gf.Component()
+    c1 = two_shears << shear_waveguide_end
+    c2 = two_shears << shear_waveguide_start
+    c2.connect("o1", c1.ports["o2"])
+
+    xor = gf.geometry.xor_diff(two_straights, two_shears)
+    assert not xor.layers
+
+
+def test_area_stays_same(
+    regular_waveguide,
+    shear_waveguide_start,
+    shear_waveguide_end,
+    shear_waveguide_symmetric,
+):
+    components = [
+        regular_waveguide,
+        shear_waveguide_start,
+        shear_waveguide_end,
+        shear_waveguide_symmetric,
+    ]
+    areas = [c.area() for c in components]
+    np.testing.assert_allclose(areas, desired=areas[0])
+
+
+def test_shear_angle_annotated_on_ports(shear_waveguide_start, shear_waveguide_end):
+    assert shear_waveguide_start.ports["o1"].shear_angle == DEMO_PORT_ANGLE
+    assert shear_waveguide_start.ports["o2"].shear_angle is None
+
+    assert shear_waveguide_end.ports["o2"].shear_angle == DEMO_PORT_ANGLE
+    assert shear_waveguide_end.ports["o1"].shear_angle is None
+
+
+@pytest.mark.skip
+def test_port_attributes(regular_waveguide, shear_waveguide_symmetric):
+    # TODO: this test should pass... why does it not? it seems to be ignoring the information supplied to the port originally and overwriting with info extracted from the face segment, which is not what it should do in this case. It should have the same attributes of an orthogonal port, but only the shear_angle attribute is different
+    regular_ports = [p.to_dict() for p in regular_waveguide.ports.values()]
+    shear_ports = [p.to_dict() for p in shear_waveguide_symmetric.ports.values()]
+
+    for p in shear_ports:
+        shear_angle = p.pop("shear_angle")
+        assert shear_angle == DEMO_PORT_ANGLE
+
+    assert regular_ports[0] == shear_ports[0]
+    assert regular_ports[1] == shear_ports[1]


### PR DESCRIPTION
This PR

- makes it possible to define shear-face waveguides at any angle
- adds a shear_angle attribute to ports
- adds demos in notebooks
- adds tests

There is still a known problem in the tests... The final test `test_port_attributes` should pass (right now I am skipping it)... A port on a sheared waveguide should have exactly the same attributes as it's more normal cousin, except for an additional shear_angle attribute. However, it does not. Somehow it appears to be getting the angle from the face of the waveguide, rather than the width of the cross section and orientation of the path, which I would expect. But the code, from what I can tell, does the latter, and I cannot seem to find where it does the former (wrong) instead. I'm perplexed. @joamatab do you know what is going on here?