### PR TITLE
Generalized shear-face paths

### DIFF
--- a/docs/notebooks/03_waveguides_paths_crossections.ipynb
+++ b/docs/notebooks/03_waveguides_paths_crossections.ipynb
@@ -1859,36 +1859,7 @@
     }
    },
    "source": [
-    "For a segmented or curving path, the algorithm will fail if multiple points are sheared off by the operation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "source": [
-    "This code will raise a `ValueError`\n",
-    "\n",
-    "```python\n",
-    "angle = 15\n",
-    "P = gf.path.euler()\n",
-    "c = gf.path.extrude(P, X1, shear_angle_start=angle)  # raises ValueError because attempting to shear curved portion\n",
-    "c.plot()\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "This can be fixed by padding the end of the path with a long enough straight section"
+    "For a non-linear path or width profile, the algorithm will intersect the path when sheared inwards and extrapolate linearly going outwards."
    ]
   },
   {
@@ -1902,7 +1873,7 @@
    "outputs": [],
    "source": [
     "angle = 15\n",
-    "P = gf.path.straight(length=1.0).append([gf.path.euler(), gf.path.straight(length=1.0)])\n",
+    "P = gf.path.euler()\n",
     "c = gf.path.extrude(P, X1, shear_angle_start=angle, shear_angle_end=angle)\n",
     "c.plot()"
    ]
@@ -1952,6 +1923,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### Transitions with Shear faces\n",
+    "You can also create a transition with a shear face"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1961,31 +1944,55 @@
    },
    "outputs": [],
    "source": [
-    "c1.ports"
+    "import numpy as np\n",
+    "import gdsfactory as gf\n",
+    "\n",
+    "P = gf.path.straight(length=10)\n",
+    "\n",
+    "X1 = gf.cross_section.strip(width=1.0)\n",
+    "X2 = gf.cross_section.strip(width=3.0)\n",
+    "t = gf.path.transition(X1, X2, width_type=\"linear\")\n",
+    "c = gf.path.extrude(P, t, shear_angle_start=10, shear_angle_end=45)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "This will also work with curves and non-linear width profiles."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "c2.ports"
+    "X1 = gf.cross_section.strip(width=1.0)\n",
+    "X2 = gf.cross_section.strip(width=3.0)\n",
+    "t = gf.path.transition(X1, X2, width_type=\"sine\")\n",
+    "\n",
+    "angle = 15\n",
+    "P = gf.path.euler()\n",
+    "c = gf.path.extrude(P, t, shear_angle_start=angle, shear_angle_end=angle)\n",
+    "c.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "PyCharm (gdsfactory)",
    "language": "python",
-   "name": "python3"
+   "name": "pycharm-38c27276"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1997,7 +2004,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -411,10 +411,11 @@ def _shear_face(
         shear_angle_start = shear_angle_start or 0
         shear_angle_end = shear_angle_end or 0
 
-        dl_start = np.tan(np.deg2rad(shear_angle_start)) * dy
+        dy = np.atleast_1d(dy)
+        dl_start = np.tan(np.deg2rad(shear_angle_start)) * dy[0]
         dp_start = points[1] - points[0]
         a_start = np.arctan2(dp_start[1], dp_start[0])
-        dl_end = np.tan(np.deg2rad(shear_angle_end)) * dy
+        dl_end = np.tan(np.deg2rad(shear_angle_end)) * dy[-1]
         dp_end = points[-1] - points[-2]
         a_end = np.arctan2(dp_end[1], dp_end[0])
         _points = points.copy()

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -405,65 +405,14 @@ def extrude(
     return c
 
 
-def _shear_face(
-    points: np.ndarray,
-    dy: float,
-    shear_angle_start: Optional[float],
-    shear_angle_end: Optional[float],
-) -> np.ndarray:
-    """
-    Displaces a point sequence offset a distance dy away by a shear angle,
-    given in degrees, on either side.
-
-    Args:
-        points: points sequence.
-        dy: y offset.
-        shear_angle_start: an optional angle to shear the starting face by (in degrees).
-        shear_angle_end: an optional angle to shear the ending face by (in degrees).
-    """
-    if shear_angle_start or shear_angle_end:
-        shear_angle_start = shear_angle_start or 0
-        shear_angle_end = shear_angle_end or 0
-
-        dy = np.atleast_1d(dy)
-        dl_start = np.tan(np.deg2rad(shear_angle_start)) * dy[0]
-        dp_start = points[1] - points[0]
-        a_start = np.arctan2(dp_start[1], dp_start[0])
-        dl_end = np.tan(np.deg2rad(shear_angle_end)) * dy[-1]
-        dp_end = points[-1] - points[-2]
-        a_end = np.arctan2(dp_end[1], dp_end[0])
-        _points = points.copy()
-        _points[0] = points[0] + np.array(
-            [dl_start * np.cos(a_start), dl_start * np.sin(a_start)]
-        )
-        _points[-1] = points[-1] + np.array(
-            [dl_end * np.cos(a_end), dl_end * np.sin(a_end)]
-        )
-        points = _points
-
-        # verify nothing went screwy
-        dp_start_final = points[1] - points[0]
-        dp_end_final = points[-1] - points[-2]
-        if not np.array_equal(np.sign(dp_start), np.sign(dp_start_final)):
-            raise ValueError(
-                "Could not apply shear face to path! Likely this means the path has curvature or segmentation near the start point"
-            )
-        if not np.array_equal(np.sign(dp_end), np.sign(dp_end_final)):
-            raise ValueError(
-                "Could not apply shear face to path! Likely this means the path has curvature or segmentation near the end point"
-            )
-    return points
-
-
 def _cut_path_with_ray(point: np.ndarray, angle: float, path: np.ndarray, start: bool):
     """
     Cuts or extends a path given a point and angle to project with
     """
     import shapely.geometry as sg
 
-    far_distance = (
-        10000  # a distance to approximate infinity to find ray-segment intersections
-    )
+    # a distance to approximate infinity to find ray-segment intersections
+    far_distance = 10000
 
     path_cmp = np.copy(path)
     # pad start

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable
 from typing import Optional
 
 import numpy as np
+import shapely.ops
 from phidl import path
 from phidl.device_layout import Path as PathPhidl
 from phidl.device_layout import _simplify
@@ -490,8 +491,13 @@ def _cut_path_with_ray(point: np.ndarray, angle: float, path: np.ndarray, start:
     intersection = ls.intersection(ls_ray)
 
     if not isinstance(intersection, sg.Point):
-        # return path
-        raise ValueError(f"Expected intersection to be a point, but got {intersection}")
+        if isinstance(intersection, sg.MultiPoint):
+            _, nearest = shapely.ops.nearest_points(sg.Point(point), intersection)
+            intersection = nearest
+        else:
+            raise ValueError(
+                f"Expected intersection to be a point, but got {intersection}"
+            )
     distance = ls.project(intersection)
     if start:
         # when trimming the start, start counting at the intersection point, then add all subsequent points


### PR DESCRIPTION
This MR generalizes the algorithm for extrusions with shear faces. It makes it possible to use them on non-linear paths and transitions. When the shear angle cuts back on the shape, it finds the intercept with each of the offset paths. When the angle extends beyond the path, it extrapolates the path linearly from the final path segment.

I also updated the notebook examples to demonstrate the new set of limitations/behavior.