### PR TITLE
add cross_section info to bend_euler, bend_s, and straight

### DIFF
--- a/gdsfactory/components/bend_euler.py
+++ b/gdsfactory/components/bend_euler.py
@@ -66,7 +66,9 @@ def bend_euler(
     c.info["dy"] = abs(float(p.points[0][0] - p.points[-1][0]))
     c.info["radius_min"] = snap_to_grid(p.info["Rmin"])
     c.info["radius"] = radius
-    c.info["wg_width"] = x.width
+
+    if x.info:
+        c.info.update(x.info)
 
     if with_bbox:
         padding = []

--- a/gdsfactory/components/bend_s.py
+++ b/gdsfactory/components/bend_s.py
@@ -52,6 +52,9 @@ def bend_s(
     c.info["length"] = bend.info["length"]
     c.info["min_bend_radius"] = bend.info["min_bend_radius"]
 
+    if x.info:
+        c.info.update(x.info)
+
     if with_bbox:
         padding = []
         for layer, offset in zip(x.bbox_layers, x.bbox_offsets):

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -41,6 +41,9 @@ def straight(
     c.info["length"] = length
     c.info["width"] = x.width
 
+    if x.info:
+        c.info.update(x.info)
+
     padding = []
     if with_bbox and length:
         for layer, offset in zip(x.bbox_layers, x.bbox_offsets):


### PR DESCRIPTION
Useful for the Interconnect plugin so that simulation info (properties, models, etc.) can be associated with a waveguide cross_section and the info can be added into the resulting component after extruding it.