### PR TITLE
524

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## 5.2.4
+
+- add route_sharp from phidl to gf.routing
+- allow ports to have None orientation. The idea is that DC ports don't care about orientation. This still requires some work.
+
 ## 5.2.3
 
 - add electrical routes to routing_strategy

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ I also recommend you install the gdsfactory link to klayout `gf tool install`
 
 ```
 mamba install gdspy -y
-pip install gdsfactory[full]
+pip install "gdsfactory[full]"
 gf tool install
 ```
 
@@ -124,7 +124,7 @@ Mamba is a faster alternative to conda, if you don't want to install mamba, you 
 For Linux and MacOs you can also install gdsfactory without Anaconda3:
 
 ```
-pip install gdsfactory[full]
+pip install "gdsfactory[full]"
 gf tool install
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,38 +1,23 @@
 # TODO
 
+- add electrical router for DC where orientation is None
 - enable rich output?
-- better electrical routers
-- more explicit Sparameter data format. Considers TE/TM modes.
-- add DVC for version control data on GCS, instead of relying gdslib second repo.
+- more explicit Sparameter data format. Consider TE/TM modes.
 - replace circular fiber marker by square
-- fix FIXMEs
-- klayout klive refresh does not maintain the position of the view any more
 - better netlist extraction
-- interface with Siepic tools? add ports as FlexPath
-- corners don't auto-taper for RF circuits
+- add DVC for version control data on GCS, instead of relying gdslib second repo.
 
 ## Plugins
 
+- snakemake: for cloud workflows
 - tidy3d: compute bend mode missmatch
-- sax. Backend that does not require JAX (for windows users)
 - simphony, update to latest version?
-- sipann
-
-Modes
-
-- include mode overlap examples
-- include modesolverpy solver
-
-Meep
-
-- Add some heuristics for optimizing number of codes in MPI. How many cores to use?
-
-Lumerical:
-
-- batch mode or run with more cores
-- eme
-- mode-solver
-- interconnect
+- sipann, equivalent for SAX?
+- Modes: include mode overlap examples, tidy3d and modesolverpy solver
+- Lumerical:
+    - batch mode or run with more cores
+    - eme
+    - mode-solver
 
 ## Someday
 

--- a/fixme/routing/routing_metal2.py
+++ b/fixme/routing/routing_metal2.py
@@ -1,0 +1,25 @@
+"""
+FIXME: electrical connections should ignore port orientation
+"""
+
+import gdsfactory as gf
+
+
+if __name__ == "__main__":
+
+    c = gf.Component("mzi_with_pads")
+    # c1 = c << gf.components.pad(port_orientation=0)
+    # c2 = c << gf.components.pad(port_orientation=180)
+
+    c1 = c << gf.components.pad(port_orientation=None)
+    c2 = c << gf.components.pad(port_orientation=None)
+
+    c2.movex(200)
+
+    route = gf.routing.get_route_electrical(
+        c1.ports["e1"],
+        c2.ports["e1"],
+    )
+    c.add(route.references)
+
+    c.show()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -444,8 +444,6 @@ class Component(Device):
         else:
             if width is None:
                 raise ValueError("Port needs width parameter (um).")
-            if orientation is None:
-                raise ValueError("Port needs orientation parameter (degrees).")
             if midpoint is None:
                 raise ValueError("Port needs midpoint parameter (x, y) um.")
             half_width = width / 2

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -226,7 +226,9 @@ class ComponentReference(DeviceReference):
             if name not in self._local_ports:
                 self._local_ports[name] = port.copy(new_uid=True)
             self._local_ports[name].midpoint = new_midpoint
-            self._local_ports[name].orientation = mod(new_orientation, 360)
+            self._local_ports[name].orientation = (
+                mod(new_orientation, 360) if new_orientation else new_orientation
+            )
             self._local_ports[name].parent = self
         # Remove any ports that no longer exist in the reference's parent
         parent_names = self.parent.ports.keys()
@@ -265,6 +267,9 @@ class ComponentReference(DeviceReference):
         """Apply GDS-type transformation to a port (x_ref)"""
         new_point = np.array(point)
         new_orientation = orientation
+
+        if orientation is None:
+            return new_point, new_orientation
 
         if x_reflection:
             new_point[1] = -new_point[1]

--- a/gdsfactory/components/pad.py
+++ b/gdsfactory/components/pad.py
@@ -15,7 +15,7 @@ def pad(
     bbox_layers: Optional[Tuple[Layer, ...]] = None,
     bbox_offsets: Optional[Tuple[float, ...]] = None,
     port_inclusion: float = 0,
-    port_orientation: int = 0,
+    port_orientation: Optional[float] = 0,
 ) -> Component:
     """Rectangular pad with 4 ports (1, 2, 3, 4)
 
@@ -25,6 +25,7 @@ def pad(
         bbox_layers:
         bbox_offsets:
         port_inclusion: from edge
+        port_orientation: in degrees.
     """
     c = Component()
     rect = compass(size=size, layer=layer, port_inclusion=port_inclusion)
@@ -46,11 +47,6 @@ def pad(
                     layer=layer,
                 )
             )
-
-    if port_orientation not in [0, 90, 180, 270]:
-        raise ValueError(
-            f"port_orientation = {port_orientation} not in [0, 90, 180, 270]"
-        )
 
     width = size[1] if port_orientation in [0, 180] else size[0]
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -27,10 +27,10 @@ class CrossSection(BaseModel):
         width: (um) or function that is parameterized from 0 to 1.
             the width at t==0 is the width at the beginning of the Path.
             the width at t==1 is the width at the end.
-        radius: main Section bend radius (um).
         offset: center offset (um) or function parameterized function from 0 to 1.
              the offset at t==0 is the offset at the beginning of the Path.
              the offset at t==1 is the offset at the end.
+        radius: main Section bend radius (um).
         layer_bbox: optional bounding box layer for device recognition. (68, 0)
         width_wide: wide waveguides width (um) for low loss routing.
         auto_widen: taper to wide waveguides for low loss routing.
@@ -47,7 +47,7 @@ class CrossSection(BaseModel):
         snap_to_grid: can snap points to grid when extruding the path.
         aliases: dict of cross_section aliases.
         decorator: function when extruding component.
-        info: settings
+        info: dict with extra settings or useful information.
         name: cross_section name.
     """
 
@@ -115,13 +115,14 @@ class Transition(CrossSection):
 
 @pydantic.validate_arguments
 def cross_section(
-    width: float = 0.5,
+    width: Union[Callable, float] = 0.5,
+    offset: Union[float, Callable] = 0,
     layer: Tuple[int, int] = (1, 0),
     width_wide: Optional[float] = None,
     auto_widen: bool = False,
     auto_widen_minimum_length: float = 200.0,
     taper_length: float = 10.0,
-    radius: float = 10.0,
+    radius: Optional[float] = 10.0,
     sections: Optional[Tuple[Section, ...]] = None,
     port_names: Tuple[str, str] = ("o1", "o2"),
     port_types: Tuple[str, str] = ("optical", "optical"),
@@ -137,13 +138,18 @@ def cross_section(
     """Return CrossSection.
 
     Args:
-        width: main section width (um).
+        width: (um) or function that is parameterized from 0 to 1.
+            the width at t==0 is the width at the beginning of the Path.
+            the width at t==1 is the width at the end.
+        offset: center offset (um) or function parameterized function from 0 to 1.
+             the offset at t==0 is the offset at the beginning of the Path.
+             the offset at t==1 is the offset at the end.
         layer: main section layer.
         width_wide: wide waveguides width (um) for low loss routing.
         auto_widen: taper to wide waveguides for low loss routing.
         auto_widen_minimum_length: minimum straight length for auto_widen.
         taper_length: taper_length for auto_widen.
-        radius: bend radius (um).
+        radius: bend radius (um)..
         sections: list of Sections(width, offset, layer, ports).
         port_names: for input and output ('o1', 'o2').
         port_types: for input and output: electrical, optical, vertical_te ...
@@ -159,6 +165,7 @@ def cross_section(
 
     x = CrossSection(
         width=width,
+        offset=offset,
         layer=layer,
         width_wide=width_wide,
         auto_widen=auto_widen,

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -91,7 +91,7 @@ class Port(PortPhidl):
         self.name = name
         self.midpoint = np.array(midpoint, dtype="float64")
         self.width = width
-        self.orientation = np.mod(orientation, 360)
+        self.orientation = np.mod(orientation, 360) if orientation else orientation
         self.parent = parent
         self.info: Dict[str, Any] = {}
         self.uid = Port._next_uid
@@ -114,7 +114,7 @@ class Port(PortPhidl):
             name=self.name,
             width=self.width,
             midpoint=tuple(np.round(self.midpoint, 3)),
-            orientation=int(self.orientation),
+            orientation=int(self.orientation) if self.orientation else self.orientation,
             layer=self.layer,
             port_type=self.port_type,
         )

--- a/gdsfactory/routing/__init__.py
+++ b/gdsfactory/routing/__init__.py
@@ -26,6 +26,7 @@ from gdsfactory.routing.get_routes_bend180 import get_routes_bend180
 from gdsfactory.routing.get_routes_straight import get_routes_straight
 from gdsfactory.routing.route_ports_to_side import route_ports_to_side
 from gdsfactory.routing.route_quad import route_quad
+from gdsfactory.routing.route_sharp import route_sharp
 from gdsfactory.routing.route_south import route_south
 
 __all__ = [
@@ -53,6 +54,7 @@ __all__ = [
     "route_ports_to_side",
     "route_south",
     "route_quad",
+    "route_sharp",
     "fanout",
     "sort_ports",
     "utils",

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -1,0 +1,389 @@
+"""Adapted from phidl.routing."""
+from typing import Optional
+
+import numpy as np
+from phidl.routing import _get_rotated_basis
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.cross_section import CrossSection
+from gdsfactory.path import Path, transition
+from gdsfactory.port import Port
+from gdsfactory.types import CrossSectionSpec, Layer
+
+
+def path_straight(port1: Port, port2: Port) -> Path:
+    """Return waypoint path between port1 and port2 in a straight line.
+    Useful when ports point directly at each other.
+
+    Args:
+        port1: start port.
+        port2: end port.
+    """
+    delta_orientation = np.round(
+        np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
+    )
+    e1, e2 = _get_rotated_basis(port1.orientation)
+    displacement = port2.midpoint - port1.midpoint
+    xrel = np.round(
+        np.dot(displacement, e1), 3
+    )  # relative position of port 2, forward/backward
+    yrel = np.round(
+        np.dot(displacement, e2), 3
+    )  # relative position of port 2, left/right
+    if (delta_orientation not in (0, 180, 360)) or (yrel != 0) or (xrel <= 0):
+        raise ValueError(
+            "[PHIDL] path_straight(): ports must point directly at each other."
+        )
+    return Path(np.array([port1.midpoint, port2.midpoint]))
+
+
+def path_L(port1: Port, port2: Port) -> Path:
+    """Return waypoint path between port1 and port2 in an L shape. Useful
+    when orthogonal ports can be directly connected with one turn.
+
+    Args:
+        port1: start port.
+        port2: end port.
+    """
+    delta_orientation = np.round(
+        np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
+    )
+    if delta_orientation not in (90, 270):
+        raise ValueError("[PHIDL] path_L(): ports must be orthogonal.")
+    e1, e2 = _get_rotated_basis(port1.orientation)
+    # assemble waypoints
+    pt1 = port1.midpoint
+    pt3 = port2.midpoint
+    delta_vec = pt3 - pt1
+    pt2 = pt1 + np.dot(delta_vec, e1) * e1
+    return Path(np.array([pt1, pt2, pt3]))
+
+
+def path_U(port1: Port, port2: Port, length1=200) -> Path:
+    """Return waypoint path between port1 and port2 in a U shape. Useful
+    when ports face the same direction or toward each other.
+
+    Args:
+        port1: start port.
+        port2: end port.
+        length1: Length of segment exiting port1.
+            Should be larger than bend radius.
+
+    """
+    delta_orientation = np.round(
+        np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
+    )
+    if delta_orientation not in (0, 180, 360):
+        raise ValueError("[PHIDL] path_U(): ports must be parallel.")
+    theta = np.radians(port1.orientation)
+    e1 = np.array([np.cos(theta), np.sin(theta)])
+    e2 = np.array([-1 * np.sin(theta), np.cos(theta)])
+    # assemble waypoints
+    pt1 = port1.midpoint
+    pt4 = port2.midpoint
+    pt2 = pt1 + length1 * e1  # outward by length1 distance
+    delta_vec = pt4 - pt2
+    pt3 = pt2 + np.dot(delta_vec, e2) * e2
+    return Path(np.array([pt1, pt2, pt3, pt4]))
+
+
+def path_J(port1: Port, port2: Port, length1=200, length2=200) -> Path:
+    """Return waypoint path between port1 and port2 in a J shape. Useful
+    when orthogonal ports cannot be connected directly with an L shape.
+
+    Args:
+        port1: start port.
+        port2: end port.
+        length1: Length of segment exiting port1.
+            Should be larger than bend radius.
+        length2: Length of segment exiting port2.
+            Should be larger than bend radius.
+
+    """
+    delta_orientation = np.round(
+        np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
+    )
+    if delta_orientation not in (90, 270):
+        raise ValueError("[PHIDL] path_J(): ports must be orthogonal.")
+    e1, _ = _get_rotated_basis(port1.orientation)
+    e2, _ = _get_rotated_basis(port2.orientation)
+    # assemble waypoints
+    pt1 = port1.midpoint
+    pt2 = pt1 + length1 * e1  # outward from port1 by length1
+    pt5 = port2.midpoint
+    pt4 = pt5 + length2 * e2  # outward from port2 by length2
+    delta_vec = pt4 - pt2
+    pt3 = pt2 + np.dot(delta_vec, e2) * e2  # move orthogonally in e2 direction
+    return Path(np.array([pt1, pt2, pt3, pt4, pt5]))
+
+
+def path_C(port1: Port, port2: Port, length1=100, left1=100, length2=100) -> Path:
+    """Return waypoint path between port1 and port2 in a C shape. Useful
+    when ports are parallel and face away from each other.
+
+    Args:
+        port1: start port.
+        port2: end port.
+        length1: Length of route segment coming out of port1. Should be at larger
+            than bend radius.
+        left1: Length of route segment that turns left (or right if negative)
+            from port1. Should be larger than twice the bend radius.
+        length2: Length of route segment coming out of port2. Should be larger
+            than bend radius.
+
+    """
+    delta_orientation = np.round(
+        np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
+    )
+    if delta_orientation not in (0, 180, 360):
+        raise ValueError("[PHIDL] path_C(): ports must be parallel.")
+    e1, e_left = _get_rotated_basis(port1.orientation)
+    e2, _ = _get_rotated_basis(port2.orientation)
+    # assemble route points
+    pt1 = port1.midpoint
+    pt2 = pt1 + length1 * e1  # outward from port1 by length1
+    pt3 = pt2 + left1 * e_left  # leftward by left1
+    pt6 = port2.midpoint
+    pt5 = pt6 + length2 * e2  # outward from port2 by length2
+    delta_vec = pt5 - pt3
+    pt4 = pt3 + np.dot(delta_vec, e1) * e1  # move orthogonally in e1 direction
+    return Path(np.array([pt1, pt2, pt3, pt4, pt5, pt6]))
+
+
+def path_manhattan(port1: Port, port2: Port, radius) -> Path:
+    """Return waypoint path between port1 and port2 using manhattan routing.
+    Routing is performed using straight, L, U, J, or C  waypoint path
+    as needed. Ports must face orthogonal or parallel directions.
+
+    Args:
+        port1: start port.
+        port2: end port.
+        radius: Bend radius for 90 degree bend.
+
+    """
+    radius = radius + 0.1  # ensure space for bend radius
+    e1, e2 = _get_rotated_basis(port1.orientation)
+    displacement = port2.midpoint - port1.midpoint
+    xrel = np.round(
+        np.dot(displacement, e1), 3
+    )  # port2 position, forward(+)/backward(-) from port 1
+    yrel = np.round(
+        np.dot(displacement, e2), 3
+    )  # port2 position, left(+)/right(-) from port1
+    orel = np.round(
+        np.abs(np.mod(port2.orientation - port1.orientation, 360)), 3
+    )  # relative orientation
+    if orel not in (0, 90, 180, 270, 360):
+        raise ValueError(
+            "[PHIDL] path_manhattan(): ports must face parallel or orthogonal directions."
+        )
+    if orel in (90, 270):
+        # Orthogonal case
+        if (
+            (orel == 90 and yrel < -1 * radius) or (orel == 270 and yrel > radius)
+        ) and xrel > radius:
+            pts = path_L(port1, port2)
+        else:
+            # Adjust length1 and length2 to ensure intermediate segments fit bend radius
+            direction = -1 if (orel == 270) else 1
+            length2 = (
+                2 * radius - direction * yrel
+                if (np.abs(radius + direction * yrel) < 2 * radius)
+                else radius
+            )
+            length1 = (
+                2 * radius + xrel if (np.abs(radius - xrel) < 2 * radius) else radius
+            )
+            pts = path_J(port1, port2, length1=length1, length2=length2)
+    else:
+        # Parallel case
+        if orel == 180 and yrel == 0 and xrel > 0:
+            pts = path_straight(port1, port2)
+        elif (orel == 180 and xrel <= 2 * radius) or (np.abs(yrel) < 2 * radius):
+            # Adjust length1 and left1 to ensure intermediate segments fit bend radius
+            left1 = (
+                np.abs(yrel) + 2 * radius if (np.abs(yrel) < 4 * radius) else 2 * radius
+            )
+            y_direction = -1 if (yrel < 0) else 1
+            left1 = y_direction * left1
+            length2 = radius
+            x_direction = -1 if (orel == 180) else 1
+            segmentx_length = np.abs(xrel + x_direction * length2 - radius)
+            if segmentx_length < 2 * radius:
+                length1 = xrel + x_direction * length2 + 2 * radius
+            else:
+                length1 = radius
+            pts = path_C(port1, port2, length1=length1, length2=length2, left1=left1)
+        else:
+            # Adjust length1 to ensure segment comes out of port2
+            length1 = radius + xrel if (orel == 0 and xrel > 0) else radius
+            pts = path_U(port1, port2, length1=length1)
+    return pts
+
+
+def path_Z(port1: Port, port2: Port, length1=100, length2=100) -> Path:
+    """Return waypoint path between port1 and port2 in a Z shape. Ports can have any relative
+    orientation.
+
+    Args:
+        port1: start port.
+        port2: end port.
+        length1: Length of route segment coming out of port1.
+        length2: Length of route segment coming out of port2.
+
+    """
+    # get basis vectors in port directions
+    e1, _ = _get_rotated_basis(port1.orientation)
+    e2, _ = _get_rotated_basis(port2.orientation)
+    # assemble route  points
+    pt1 = port1.midpoint
+    pt2 = pt1 + length1 * e1  # outward from port1 by length1
+    pt4 = port2.midpoint
+    pt3 = pt4 + length2 * e2  # outward from port2 by length2
+    return Path(np.array([pt1, pt2, pt3, pt4]))
+
+
+def path_V(port1: Port, port2: Port) -> Path:
+    """Return waypoint path between port1 and port2 in a V shape. Useful when
+    ports point to a single connecting point
+
+    Args:
+        port1: start port.
+        port2: end port.
+    """
+    # get basis vectors in port directions
+    e1, _ = _get_rotated_basis(port1.orientation)
+    e2, _ = _get_rotated_basis(port2.orientation)
+
+    # assemble route  points
+    pt1 = port1.midpoint
+    pt3 = port2.midpoint
+
+    # solve for intersection
+    E = np.column_stack((e1, -1 * e2))
+    pt2 = np.matmul(np.linalg.inv(E), pt3 - pt1)[0] * e1 + pt1
+    return Path(np.array([pt1, pt2, pt3]))
+
+
+@gf.cell
+def route_sharp(
+    port1: Port,
+    port2: Port,
+    width: Optional[float] = None,
+    path_type: str = "manhattan",
+    manual_path=None,
+    layer: Optional[Layer] = None,
+    cross_section: Optional[CrossSectionSpec] = None,
+    **kwargs
+) -> Component:
+
+    """Convenience function that routes a path between ports and immediately
+    extrudes the path to create polygons. Has several waypoint path type
+    options.  Equivalent to e.g.
+        >>> P = pr.path_manhattan(port1, port2, radius)
+        >>> D = P.extrude(width)
+
+    adapted from phidl.routing
+
+    Args:
+        port1: start port.
+        port2: end port.
+        width : None, int, float, array-like[2], or CrossSection
+            If None, the route linearly tapers between the widths the ports
+            If set to a single number (e.g. `width=1.7`): makes a fixed-width route
+            If set to a 2-element array (e.g. `width=[1.8,2.5]`): makes a route
+                whose width varies linearly from width[0] to width[1]
+            If set to a CrossSection: uses the CrossSection parameters for the route
+        path_type : {'manhattan', 'L', 'U', 'J', 'C', 'V', 'Z', 'straight', 'manual'}
+            Method of waypoint path creation. Should be one of
+                - 'manhattan' - automatic manhattan routing
+                        (see path_manhattan() ).
+                - 'L' - L-shaped path for orthogonal ports that can be directly
+                        connected (see path_L() ).
+                - 'U' - U-shaped path for parrallel or facing ports
+                        (see path_U() ).
+                - 'J' - J-shaped path for orthogonal ports that cannot be
+                        directly connected (see path_J() ).
+                - 'C' - C-shaped path for ports that face away from each
+                        other (see path_C() ).
+                - 'Z' - Z-shaped path with three segments for ports at any
+                        angles (see path_Z() ).
+                - 'V' - V-shaped path with two segments for ports at any
+                        angles (see path_V() ).
+                - 'straight' - straight path for ports that face each other
+                        see path_straight() ).
+                - 'manual' - use an explicit waypoint path provided
+                        in manual_path.
+        manual_path : array-like[N][2] or Path
+            Waypoint path for creating a manual route
+        layer: Layer to put route on.
+        **kwargs :
+            Keyword arguments passed to the waypoint path function.
+
+    Returns
+        D: Component containing the route and two ports (`1` and `2`) on either end.
+    """
+    if path_type == "straight":
+        P = path_straight(port1, port2)
+    elif path_type == "manual":
+        if not isinstance(manual_path, Path):
+            P = Path(manual_path)
+        else:
+            P = manual_path
+    elif path_type == "L":
+        P = path_L(port1, port2)
+    elif path_type == "U":
+        P = path_U(port1, port2, **kwargs)
+    elif path_type == "J":
+        P = path_J(port1, port2, **kwargs)
+    elif path_type == "C":
+        P = path_C(port1, port2, **kwargs)
+    elif path_type == "manhattan":
+        radius = max(port1.width, port2.width)
+        P = path_manhattan(port1, port2, radius=radius)
+    elif path_type == "Z":
+        P = path_Z(port1, port2, **kwargs)
+    elif path_type == "V":
+        P = path_V(port1, port2)
+    else:
+        raise ValueError(
+            """[PHIDL] route_sharp() received an invalid path_type.  Must be one of
+        {'manhattan', 'L', 'U', 'J', 'C', 'V', 'Z', 'straight', 'manual'}"""
+        )
+
+    if cross_section:
+        cross_section = gf.get_cross_section(cross_section)
+        D = P.extrude(cross_section=cross_section)
+    elif width is None:
+        layer = layer or port1.layer
+        X1 = CrossSection(width=port1.width, port_names=(1, 2), layer=layer, name="a")
+        X2 = CrossSection(width=port2.width, port_names=(1, 2), layer=layer, name="a")
+        cross_section = transition(
+            cross_section1=X1, cross_section2=X2, width_type="linear"
+        )
+        D = P.extrude(cross_section=cross_section)
+    else:
+        D = P.extrude(width=width, layer=layer)
+        if not isinstance(width, CrossSection):
+            newport1 = D.add_port(port=port1, name=1).rotate(180)
+            newport2 = D.add_port(port=port2, name=2).rotate(180)
+            if np.size(width) == 1:
+                newport1.width = width
+                newport2.width = width
+            if np.size(width) == 2:
+                newport1.width = width[0]
+                newport2.width = width[1]
+    return D
+
+
+if __name__ == "__main__":
+    c = gf.Component("pads")
+    c1 = c << gf.components.pad(port_orientation=None)
+    c2 = c << gf.components.pad(port_orientation=None)
+
+    c2.movex(400)
+    c2.movey(-200)
+
+    route = c << route_sharp(c1.ports["e4"], c2.ports["e1"], path_type="L")
+    c.show()

--- a/gdsfactory/tests/test_serialize/test_settings.yml
+++ b/gdsfactory/tests/test_serialize/test_settings.yml
@@ -16,7 +16,7 @@ settings:
       layer_bbox: null
       min_length: 0.01
       name: null
-      offset: 0
+      offset: 0.0
       port_names:
       - o1
       - o2
@@ -45,7 +45,7 @@ settings:
       layer_bbox: null
       min_length: 0.01
       name: null
-      offset: 0
+      offset: 0.0
       port_names:
       - o1
       - o2


### PR DESCRIPTION
- allow ports to have None orientation. The idea is that DC ports don't care about orientation. This still requires some work.
- adapt route_sharp from phidl to gf.routing.route_sharp for electrical routes
- cross_section function width and offset parameters are consistent with CrossSection class
