### PR TITLE
Fix show()

### DIFF
--- a/gdsfactory/show.py
+++ b/gdsfactory/show.py
@@ -1,5 +1,4 @@
 import pathlib
-import shutil
 import tempfile
 import time
 from typing import Union
@@ -34,13 +33,14 @@ def show(component: Union[Component, str, pathlib.Path], **kwargs) -> None:
         )
 
     elif isinstance(component, Component):
-        tmp = tempfile.TemporaryDirectory().name
-        gdspath = component.write_gds(gdsdir=tmp, logging=False, **kwargs)
-        klive.show(gdspath)
-
-        time.sleep(0.1)
-        gdspath.unlink()
-        shutil.rmtree(tmp)
+        if "gdsdir" in kwargs:
+            gdspath = component.write_gds(logging=False, **kwargs)
+            klive.show(gdspath)
+        else:
+            with tempfile.TemporaryDirectory() as tmp:
+                gdspath = component.write_gds(gdsdir=tmp, logging=False, **kwargs)
+                klive.show(gdspath)
+                time.sleep(0.1)
 
     else:
         raise ValueError(

--- a/gdsfactory/tests/test_show.py
+++ b/gdsfactory/tests/test_show.py
@@ -1,0 +1,15 @@
+import pathlib
+
+import gdsfactory as gf
+
+
+def test_show():
+    c = gf.components.straight()
+    c.show()
+
+
+def test_show_with_explicit_dir(tmpdir):
+    c = gf.components.straight()
+    gf.show(c, gdsdir=tmpdir)
+    expected_output_filename: pathlib.Path = tmpdir / f"{c.name}.gds"
+    assert expected_output_filename.isfile()


### PR DESCRIPTION
This PR

1. Fixes `gf.show()` when `gdsdir` is passed as a kwarg (for cases when the user wants to retain the output gds file at a specific directory)
2. Changes the default behavior to use a context manager to clean up the temp directory after it is created
3. Adds tests for the two different invocation types