### PR TITLE
550

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [5.5.0]
 
 - `gf.read.import_gds()` is now a cell (no more lru cache)
-- add `flatten=False` to cell and remove flatten case for `import_gds`
+- add `flatten=False` to cell and decorator
+- remove flatten argument `import_gds`
 - Component.to_dict() also exports component name
-
 
 ## [5.4.3](https://github.com/gdsfactory/gdsfactory/pull/344)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `gf.read.import_gds()` is now a cell (no more lru cache)
 - add `flatten=False` to cell and remove flatten case for `import_gds`
+- Component.to_dict() also exports component name
+
 
 ## [5.4.3](https://github.com/gdsfactory/gdsfactory/pull/344)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.5.0]
+
+- `gf.read.import_gds()` is now a cell (no more lru cache)
+- add `flatten=False` to cell and remove flatten case for `import_gds`
+
 ## [5.4.3](https://github.com/gdsfactory/gdsfactory/pull/344)
 
 - bring back python3.7 compatibility

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -994,6 +994,7 @@ class Component(Device):
             )
             d["cells"] = cells
 
+        d["name"] = self.name
         d["version"] = self.version
         d["settings"] = dict(self.settings)
         return d

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -54,7 +54,7 @@ class CrossSection(BaseModel):
     layer: Layer
     width: Union[float, Callable]
     offset: Union[float, Callable] = 0
-    radius: Optional[float]
+    radius: Optional[float] = None
     layer_bbox: Optional[Tuple[int, int]] = None
     width_wide: Optional[float] = None
     auto_widen: bool = False

--- a/gdsfactory/gds/mzi2x2.yml
+++ b/gdsfactory/gds/mzi2x2.yml
@@ -274,7 +274,7 @@ cells:
     child: null
 version: 0.0.1
 settings:
-  name: mzi
+  name: mzi_gds
   module: gdsfactory.components.mzi
   function_name: mzi
   info: {}

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
@@ -1,9 +1,12 @@
+name: straight_373b1ebb_add_t_1130d2b7
 settings:
   changed:
     component:
+      name: straight_373b1ebb_add_t_96dd4fc5
       settings:
         changed:
           component:
+            name: straight_373b1ebb
             settings:
               changed:
                 length: 20
@@ -70,6 +73,7 @@ settings:
           taper_port_name2: o2
         full:
           component:
+            name: straight_373b1ebb
             settings:
               changed:
                 length: 20
@@ -110,12 +114,13 @@ settings:
         info: {}
         info_version: 2
         module: gdsfactory.add_tapers
-        name: straight_373b1ebb_add_t_1d39f95e
+        name: straight_373b1ebb_add_t_96dd4fc5
       version: 0.0.1
     optical_routing_type: 0
   child:
     changed:
       component:
+        name: straight_373b1ebb
         settings:
           changed:
             length: 20
@@ -182,6 +187,7 @@ settings:
       taper_port_name2: o2
     full:
       component:
+        name: straight_373b1ebb
         settings:
           changed:
             length: 20
@@ -222,7 +228,7 @@ settings:
     info: {}
     info_version: 2
     module: gdsfactory.add_tapers
-    name: straight_373b1ebb_add_t_1d39f95e
+    name: straight_373b1ebb_add_t_96dd4fc5
   default:
     bend:
       function: bend_euler
@@ -253,9 +259,11 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: straight_373b1ebb_add_t_96dd4fc5
       settings:
         changed:
           component:
+            name: straight_373b1ebb
             settings:
               changed:
                 length: 20
@@ -322,6 +330,7 @@ settings:
           taper_port_name2: o2
         full:
           component:
+            name: straight_373b1ebb
             settings:
               changed:
                 length: 20
@@ -362,7 +371,7 @@ settings:
         info: {}
         info_version: 2
         module: gdsfactory.add_tapers
-        name: straight_373b1ebb_add_t_1d39f95e
+        name: straight_373b1ebb_add_t_96dd4fc5
       version: 0.0.1
     component_name: null
     cross_section:
@@ -391,5 +400,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_array
-  name: straight_373b1ebb_add_t_f3fbe555
+  name: straight_373b1ebb_add_t_1130d2b7
 version: 0.0.1

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
@@ -1,6 +1,8 @@
+name: coupler_a078f3c8_add_fi_2bb00823
 settings:
   changed:
     component:
+      name: coupler_a078f3c8
       settings:
         changed:
           gap: 0.244
@@ -97,6 +99,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: coupler_a078f3c8
       settings:
         changed:
           gap: 0.244
@@ -157,5 +160,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_a078f3c8_add_fi_a4534ac8
+  name: coupler_a078f3c8_add_fi_2bb00823
 version: 0.0.1

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
@@ -1,6 +1,8 @@
+name: coupler_bcc4a0b5_add_fi_19b29abd
 settings:
   changed:
     component:
+      name: coupler_bcc4a0b5
       settings:
         changed:
           gap: 0.2
@@ -97,6 +99,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: coupler_bcc4a0b5
       settings:
         changed:
           gap: 0.2
@@ -157,5 +160,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_bcc4a0b5_add_fi_4a1ed132
+  name: coupler_bcc4a0b5_add_fi_19b29abd
 version: 0.0.1

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
@@ -1,6 +1,8 @@
+name: coupler_a078f3c8_add_fi_13112b56
 settings:
   changed:
     component:
+      name: coupler_a078f3c8
       settings:
         changed:
           gap: 0.244
@@ -97,6 +99,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: coupler_a078f3c8
       settings:
         changed:
           gap: 0.244
@@ -157,5 +160,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_array
-  name: coupler_a078f3c8_add_fi_444a2aab
+  name: coupler_a078f3c8_add_fi_13112b56
 version: 0.0.1

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
@@ -1,3 +1,4 @@
+name: bend_euler_6d2857bb
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nc_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_596d0092
 settings:
   changed:
     decorator:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
@@ -1,3 +1,4 @@
+name: mmi1x2_62e69d12
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
@@ -1,3 +1,4 @@
+name: mmi1x2_9be21ac9
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nc_.yml
@@ -1,3 +1,4 @@
+name: mzi_89c0cb48
 settings:
   changed:
     bend:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_no_.yml
@@ -1,3 +1,4 @@
+name: mzi_c7cf2b4d
 settings:
   changed:
     bend:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
@@ -1,3 +1,4 @@
+name: straight_6d2857bb
 settings:
   changed:
     cross_section:

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -95,12 +95,19 @@ def clean_value_json(value: Any) -> Any:
 
 def clean_value_name(value: Any) -> str:
     """Returns a string representation of an object."""
+    # value1 = clean_value_json(value)
+    # print(type(value), value, value1, str(value1))
     return str(clean_value_json(value))
 
 
 if __name__ == "__main__":
     import gdsfactory as gf
 
+    # f = gf.partial(gf.c.straight, length=3)
+    # d = clean_value_json(f)
+    # print(f"{d!r}")
+
     f = gf.partial(gf.c.straight, length=3)
-    d = clean_value_json(f)
-    print(f"{d!r}")
+    c = f()
+    d = clean_value_json(c)
+    print(d, str(d))

--- a/gdsfactory/show.py
+++ b/gdsfactory/show.py
@@ -1,6 +1,4 @@
 import pathlib
-import tempfile
-import time
 from typing import Union
 
 from gdsfactory import klive
@@ -33,15 +31,8 @@ def show(component: Union[Component, str, pathlib.Path], **kwargs) -> None:
         )
 
     elif isinstance(component, Component):
-        if "gdsdir" in kwargs:
-            gdspath = component.write_gds(logging=False, **kwargs)
-            klive.show(gdspath)
-        else:
-            with tempfile.TemporaryDirectory() as tmp:
-                gdspath = component.write_gds(gdsdir=tmp, logging=False, **kwargs)
-                klive.show(gdspath)
-                time.sleep(0.1)
-
+        gdspath = component.write_gds(logging=False, **kwargs)
+        klive.show(gdspath)
     else:
         raise ValueError(
             f"Component is {type(component)}, make sure pass a Component or a path"

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_connections_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_connections_.yml
@@ -1,2 +1,3 @@
+name: sample_connections
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
@@ -1,2 +1,3 @@
+name: sample_path_length_matching
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
@@ -1,2 +1,3 @@
+name: sample_docstring
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_doe_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_doe_.yml
@@ -1,2 +1,3 @@
+name: mask
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_doe_grid_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_doe_grid_.yml
@@ -1,2 +1,3 @@
+name: mask_grid
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mirror_simple_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mirror_simple_.yml
@@ -1,2 +1,3 @@
+name: sample_mirror_simple
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
@@ -1,2 +1,3 @@
+name: sample_mmis
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
@@ -1,2 +1,3 @@
+name: sample_waypoints
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
@@ -1,2 +1,3 @@
+name: yaml_anchor
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_0_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_0_.yml
@@ -1,2 +1,3 @@
+name: mirror_port
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_1_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_1_.yml
@@ -1,2 +1,3 @@
+name: mirror_x
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_2_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_2_.yml
@@ -1,2 +1,3 @@
+name: rotation
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml2/test_components_3_.yml
+++ b/gdsfactory/tests/test_component_from_yaml2/test_components_3_.yml
@@ -1,2 +1,3 @@
+name: dxdy
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_component_from_yaml_ports.py
+++ b/gdsfactory/tests/test_component_from_yaml_ports.py
@@ -3,6 +3,7 @@ from pytest_regressions.data_regression import DataRegressionFixture
 import gdsfactory as gf
 
 yaml_str = """
+name: component_yaml_ports
 
 ports:
   o1:

--- a/gdsfactory/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
+++ b/gdsfactory/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
@@ -1,2 +1,3 @@
+name: component_yaml_ports
 settings: {}
 version: 0.0.1

--- a/gdsfactory/tests/test_components/test_settings_C_.yml
+++ b/gdsfactory/tests/test_components/test_settings_C_.yml
@@ -1,3 +1,4 @@
+name: C
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_L_.yml
+++ b/gdsfactory/tests/test_components/test_settings_L_.yml
@@ -1,3 +1,4 @@
+name: L
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_fidutials_.yml
@@ -1,3 +1,4 @@
+name: pad_array_add_fidutials
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_add_fidutials_offsets_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_fidutials_offsets_.yml
@@ -1,3 +1,4 @@
+name: pad_array_add_fidutials_offsets
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_add_frame_.yml
+++ b/gdsfactory/tests/test_components/test_settings_add_frame_.yml
@@ -1,3 +1,4 @@
+name: add_frame
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_align_wafer_.yml
@@ -1,3 +1,4 @@
+name: align_wafer
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_.yml
@@ -1,3 +1,4 @@
+name: array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_fanout_.yml
@@ -1,3 +1,4 @@
+name: array_with_fanout
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_array_with_fanout_2d_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_fanout_2d_.yml
@@ -1,3 +1,4 @@
+name: array_with_fanout_2d
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_via_.yml
@@ -1,3 +1,4 @@
+name: array_with_via
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_array_with_via_2d_.yml
+++ b/gdsfactory/tests/test_components/test_settings_array_with_via_2d_.yml
@@ -1,3 +1,4 @@
+name: array_with_via_2d
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_awg_.yml
+++ b/gdsfactory/tests/test_components/test_settings_awg_.yml
@@ -1,3 +1,4 @@
+name: awg
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bbox_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bbox_.yml
@@ -1,3 +1,4 @@
+name: bbox
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bend_circular180_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_circular180_.yml
@@ -1,3 +1,4 @@
+name: bend_circular_8d359e58
 settings:
   changed:
     angle: 180

--- a/gdsfactory/tests/test_components/test_settings_bend_circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_circular_.yml
@@ -1,3 +1,4 @@
+name: bend_circular
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bend_circular_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_circular_heater_.yml
@@ -1,3 +1,4 @@
+name: bend_circular_heater
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bend_euler180_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_euler180_.yml
@@ -1,3 +1,4 @@
+name: bend_euler_8d359e58
 settings:
   changed:
     angle: 180

--- a/gdsfactory/tests/test_components/test_settings_bend_euler_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_euler_.yml
@@ -1,3 +1,4 @@
+name: bend_euler
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bend_euler_s_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_euler_s_.yml
@@ -1,3 +1,4 @@
+name: bend_euler_s
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_port_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_metal_u_d78c69b7
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_bend_s_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_s_.yml
@@ -1,3 +1,4 @@
+name: bezier_7020f7b9_bend_s
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_bend_straight_bend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_bend_straight_bend_.yml
@@ -1,3 +1,4 @@
+name: bend_straight_bend
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cavity_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cavity_.yml
@@ -1,3 +1,4 @@
+name: dbr_cavity
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_cdc_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cdc_.yml
@@ -1,3 +1,4 @@
+name: cdc
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cdsem_all_.yml
@@ -1,3 +1,4 @@
+name: cdsem_all
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_circle_.yml
+++ b/gdsfactory/tests/test_components/test_settings_circle_.yml
@@ -1,3 +1,4 @@
+name: circle
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_compass_.yml
+++ b/gdsfactory/tests/test_components/test_settings_compass_.yml
@@ -1,3 +1,4 @@
+name: compass
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
+++ b/gdsfactory/tests/test_components/test_settings_compensation_path_.yml
@@ -1,3 +1,4 @@
+name: compensation_path
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_component_lattice_.yml
@@ -1,3 +1,4 @@
+name: component_lattice
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_copy_layers_.yml
@@ -1,3 +1,4 @@
+name: cross_2976c617_copy_layers
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_coupler90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler90_.yml
@@ -1,3 +1,4 @@
+name: coupler90
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler90bend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler90bend_.yml
@@ -1,3 +1,4 @@
+name: coupler90bend
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler90circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler90circular_.yml
@@ -1,3 +1,4 @@
+name: coupler90_528aa9f7
 settings:
   changed:
     bend:

--- a/gdsfactory/tests/test_components/test_settings_coupler_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_.yml
@@ -1,3 +1,4 @@
+name: coupler
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_adiabatic_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_adiabatic_.yml
@@ -1,3 +1,4 @@
+name: coupler_adiabatic
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_asymmetric_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_asymmetric_.yml
@@ -1,3 +1,4 @@
+name: coupler_asymmetric
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_full_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_full_.yml
@@ -1,3 +1,4 @@
+name: coupler_full
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_ring_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_ring_.yml
@@ -1,3 +1,4 @@
+name: coupler_ring
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_straight_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_straight_.yml
@@ -1,3 +1,4 @@
+name: coupler_straight
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_coupler_symmetric_.yml
+++ b/gdsfactory/tests/test_components/test_settings_coupler_symmetric_.yml
@@ -1,3 +1,4 @@
+name: coupler_symmetric
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cross_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cross_.yml
@@ -1,3 +1,4 @@
+name: cross
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_crossing45_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing45_.yml
@@ -1,3 +1,4 @@
+name: crossing45
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_crossing_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing_.yml
@@ -1,3 +1,4 @@
+name: crossing
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_crossing_arm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing_arm_.yml
@@ -1,3 +1,4 @@
+name: crossing_arm
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_crossing_etched_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing_etched_.yml
@@ -1,3 +1,4 @@
+name: crossing_etched
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_crossing_from_taper_.yml
+++ b/gdsfactory/tests/test_components/test_settings_crossing_from_taper_.yml
@@ -1,3 +1,4 @@
+name: crossing_from_taper
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend180_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend180_.yml
@@ -1,3 +1,4 @@
+name: cutback_bend180
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend180circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend180circular_.yml
@@ -1,3 +1,4 @@
+name: cutback_bend180_13911d77
 settings:
   changed:
     bend180:

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend90_.yml
@@ -1,3 +1,4 @@
+name: cutback_bend90
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend90circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend90circular_.yml
@@ -1,3 +1,4 @@
+name: cutback_bend90_d1ad1beb
 settings:
   changed:
     bend90:

--- a/gdsfactory/tests/test_components/test_settings_cutback_bend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_bend_.yml
@@ -1,3 +1,4 @@
+name: cutback_bend
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_cutback_component
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_cutback_component_mirror_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_cutback__5abf47c8
 settings:
   changed:
     mirror: true

--- a/gdsfactory/tests/test_components/test_settings_dbr_.yml
+++ b/gdsfactory/tests/test_components/test_settings_dbr_.yml
@@ -1,3 +1,4 @@
+name: dbr
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_dbr_tapered_.yml
+++ b/gdsfactory/tests/test_components/test_settings_dbr_tapered_.yml
@@ -1,3 +1,4 @@
+name: dbr_tapered
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake2_.yml
@@ -1,3 +1,4 @@
+name: delay_snake2
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake3_.yml
@@ -1,3 +1,4 @@
+name: delay_snake3
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake_.yml
@@ -1,3 +1,4 @@
+name: delay_snake
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_delay_snake_sbend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_delay_snake_sbend_.yml
@@ -1,3 +1,4 @@
+name: delay_snake_sbend
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
+++ b/gdsfactory/tests/test_components/test_settings_dicing_lane_.yml
@@ -1,3 +1,4 @@
+name: dicing_lane
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_die_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_.yml
@@ -1,3 +1,4 @@
+name: die
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_bbox_.yml
@@ -1,3 +1,4 @@
+name: rectangle_5992b8ec_die_bbox
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_die_bbox_frame_.yml
+++ b/gdsfactory/tests/test_components/test_settings_die_bbox_frame_.yml
@@ -1,3 +1,4 @@
+name: die_bbox_frame
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_disk_.yml
+++ b/gdsfactory/tests/test_components/test_settings_disk_.yml
@@ -1,3 +1,4 @@
+name: disk
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ellipse_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ellipse_.yml
@@ -1,3 +1,4 @@
+name: ellipse
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_extend_ports_.yml
+++ b/gdsfactory/tests/test_components/test_settings_extend_ports_.yml
@@ -1,3 +1,4 @@
+name: mmi1x2_extend_ports
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_fiber_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_.yml
@@ -1,3 +1,4 @@
+name: fiber
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_fiber_array_.yml
@@ -1,3 +1,4 @@
+name: fiber_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_array_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_circular_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_circular
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_elliptical
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_4a0b5da2
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_9d85a0c6
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_elliptical
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_2e0a058f
 settings:
   changed:
     fiber_marker_layer:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_7935cab4
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_loss_fi_da445079
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_loss_fiber_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_1460ca4e
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_rectangular
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_rectang_0b571e8d
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_rectang_c148e9a3
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_te_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_db285fcb
 settings:
   changed:
     taper_angle: 35

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tm_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tm_.yml
@@ -1,3 +1,4 @@
+name: grating_coupler_ellipti_2b07d8fa
 settings:
   changed:
     fiber_marker_layer:

--- a/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_grating_coupler_tree_.yml
@@ -1,3 +1,4 @@
+name: straight_array_grating__b29c362b
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_hline_.yml
+++ b/gdsfactory/tests/test_components/test_settings_hline_.yml
@@ -1,3 +1,4 @@
+name: hline
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_calipers_.yml
@@ -1,3 +1,4 @@
+name: litho_calipers
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
+++ b/gdsfactory/tests/test_components/test_settings_litho_steps_.yml
@@ -1,3 +1,4 @@
+name: litho_steps
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_logo_.yml
+++ b/gdsfactory/tests/test_components/test_settings_logo_.yml
@@ -1,3 +1,4 @@
+name: logo
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loop_mirror_.yml
@@ -1,3 +1,4 @@
+name: loop_mirror
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
@@ -1,3 +1,4 @@
+name: loss_deembedding_ch12_34
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
@@ -1,3 +1,4 @@
+name: loss_deembedding_ch13_24
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
+++ b/gdsfactory/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
@@ -1,3 +1,4 @@
+name: loss_deembedding_ch14_23
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mmi1x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mmi1x2_.yml
@@ -1,3 +1,4 @@
+name: mmi1x2
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mmi2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mmi2x2_.yml
@@ -1,3 +1,4 @@
+name: mmi2x2
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi1x2_2x2_.yml
@@ -1,3 +1,4 @@
+name: mzi_a62d3423
 settings:
   changed:
     combiner:

--- a/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi2x2_2x2_.yml
@@ -1,3 +1,4 @@
+name: mzi_d46c281f
 settings:
   changed:
     combiner:

--- a/gdsfactory/tests/test_components/test_settings_mzi_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_.yml
@@ -1,3 +1,4 @@
+name: mzi
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_arms_.yml
@@ -1,3 +1,4 @@
+name: mzi_arms
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_coupler_.yml
@@ -1,3 +1,4 @@
+name: mzi_1fc24805
 settings:
   changed:
     combiner:

--- a/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_lattice_.yml
@@ -1,3 +1,4 @@
+name: mzi_lattice
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_pads_center_.yml
@@ -1,3 +1,4 @@
+name: mzi_pads_center
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_.yml
@@ -1,3 +1,4 @@
+name: mzi_7a18d033
 settings:
   changed:
     length_x: 200

--- a/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
@@ -1,3 +1,4 @@
+name: mzi_99ca1007
 settings:
   changed:
     length_x: 200

--- a/gdsfactory/tests/test_components/test_settings_mzit_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_.yml
@@ -1,3 +1,4 @@
+name: mzit
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
+++ b/gdsfactory/tests/test_components/test_settings_mzit_lattice_.yml
@@ -1,3 +1,4 @@
+name: mzit_lattice
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_nxn_.yml
+++ b/gdsfactory/tests/test_components/test_settings_nxn_.yml
@@ -1,3 +1,4 @@
+name: nxn
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pad_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_.yml
@@ -1,3 +1,4 @@
+name: pad
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pad_array0_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_array0_.yml
@@ -1,3 +1,4 @@
+name: pad_array_3ceac6aa
 settings:
   changed:
     columns: 1

--- a/gdsfactory/tests/test_components/test_settings_pad_array180_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_array180_.yml
@@ -1,3 +1,4 @@
+name: pad_array_bc0d660e
 settings:
   changed:
     columns: 1

--- a/gdsfactory/tests/test_components/test_settings_pad_array270_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_array270_.yml
@@ -1,3 +1,4 @@
+name: pad_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pad_array90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_array90_.yml
@@ -1,3 +1,4 @@
+name: pad_array_b84950ef
 settings:
   changed:
     orientation: 90

--- a/gdsfactory/tests/test_components/test_settings_pad_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_array_.yml
@@ -1,3 +1,4 @@
+name: pad_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_open_.yml
@@ -1,3 +1,4 @@
+name: pad_gsg_short_a5a92d3b
 settings:
   changed:
     short: false

--- a/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pad_gsg_short_.yml
@@ -1,3 +1,4 @@
+name: pad_gsg_short
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pads_shorted_.yml
@@ -1,3 +1,4 @@
+name: pads_shorted
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_pixel_.yml
+++ b/gdsfactory/tests/test_components/test_settings_pixel_.yml
@@ -1,3 +1,4 @@
+name: pixel
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_qrcode_.yml
+++ b/gdsfactory/tests/test_components/test_settings_qrcode_.yml
@@ -1,3 +1,4 @@
+name: qrcode
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ramp_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ramp_.yml
@@ -1,3 +1,4 @@
+name: ramp
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_rectangle_.yml
+++ b/gdsfactory/tests/test_components/test_settings_rectangle_.yml
@@ -1,3 +1,4 @@
+name: rectangle
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
+++ b/gdsfactory/tests/test_components/test_settings_rectangle_with_slits_.yml
@@ -1,3 +1,4 @@
+name: rectangle_with_slits
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_resistance_meander_.yml
+++ b/gdsfactory/tests/test_components/test_settings_resistance_meander_.yml
@@ -1,3 +1,4 @@
+name: resistance_meander
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_resistance_sheet_.yml
+++ b/gdsfactory/tests/test_components/test_settings_resistance_sheet_.yml
@@ -1,3 +1,4 @@
+name: resistance_sheet
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_.yml
@@ -1,3 +1,4 @@
+name: ring
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_double_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_.yml
@@ -1,3 +1,4 @@
+name: ring_double
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_double_heater_.yml
@@ -1,3 +1,4 @@
+name: ring_double_heater
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_.yml
@@ -1,3 +1,4 @@
+name: ring_single
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_array_.yml
@@ -1,3 +1,4 @@
+name: ring_single_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_dut_.yml
@@ -1,3 +1,4 @@
+name: taper_2e9853cc_ring_single_dut
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
+++ b/gdsfactory/tests/test_components/test_settings_ring_single_heater_.yml
@@ -1,3 +1,4 @@
+name: ring_single_heater
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_seal_ring_.yml
+++ b/gdsfactory/tests/test_components/test_settings_seal_ring_.yml
@@ -1,3 +1,4 @@
+name: seal_ring
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_spiral_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_.yml
@@ -1,3 +1,4 @@
+name: spiral
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_spiral_circular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_circular_.yml
@@ -1,3 +1,4 @@
+name: spiral_circular
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_spiral_external_io_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_external_io_.yml
@@ -1,3 +1,4 @@
+name: spiral_external_io
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
@@ -1,3 +1,4 @@
+name: spiral_inner_io
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
@@ -1,3 +1,4 @@
+name: spiral_inner_io_50517bc_c5d5c76b
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_splitter_chain_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_chain_.yml
@@ -1,3 +1,4 @@
+name: mmi1x2_splitter_chain
 settings:
   changed: {}
   child:

--- a/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_splitter_tree_.yml
@@ -1,3 +1,4 @@
+name: splitter_tree
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_staircase_.yml
+++ b/gdsfactory/tests/test_components/test_settings_staircase_.yml
@@ -1,3 +1,4 @@
+name: staircase
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_.yml
@@ -1,3 +1,4 @@
+name: straight
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_array_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_array_.yml
@@ -1,3 +1,4 @@
+name: straight_array
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_doped_rib
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_doped_r_145caf60
 settings:
   changed:
     cross_section_heater:

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_meander_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_meander
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_metal_u_6e8de97e
 settings:
   changed:
     with_undercut: false

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_metal_u_e2b56ba0
 settings:
   changed:
     port_orientation1: 90

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_metal_undercut
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -1,3 +1,4 @@
+name: straight_heater_metal_u_e2b56ba0
 settings:
   changed:
     port_orientation1: 90

--- a/gdsfactory/tests/test_components/test_settings_straight_pin_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pin_.yml
@@ -1,3 +1,4 @@
+name: straight_pin
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pin_slot_.yml
@@ -1,3 +1,4 @@
+name: straight_pin_slot
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_straight_pn_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_pn_.yml
@@ -1,3 +1,4 @@
+name: straight_pin_b5110479
 settings:
   changed:
     cross_section:

--- a/gdsfactory/tests/test_components/test_settings_straight_rib_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_rib_.yml
@@ -1,3 +1,4 @@
+name: straight_f27b57cb
 settings:
   changed:
     cross_section:

--- a/gdsfactory/tests/test_components/test_settings_straight_rib_tapered_.yml
+++ b/gdsfactory/tests/test_components/test_settings_straight_rib_tapered_.yml
@@ -1,3 +1,4 @@
+name: straight_f27b57cb_exten_d6487edb
 settings:
   changed:
     component:

--- a/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
+++ b/gdsfactory/tests/test_components/test_settings_switch_tree_.yml
@@ -1,3 +1,4 @@
+name: splitter_tree_7c3f8531
 settings:
   changed:
     coupler:

--- a/gdsfactory/tests/test_components/test_settings_taper2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper2_.yml
@@ -1,3 +1,4 @@
+name: taper_2e9853cc
 settings:
   changed:
     width2: 3

--- a/gdsfactory/tests/test_components/test_settings_taper_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_.yml
@@ -1,3 +1,4 @@
+name: taper
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -1,3 +1,4 @@
+name: taper_cross_section_f1747efd
 settings:
   changed:
     linear: true

--- a/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -1,3 +1,4 @@
+name: taper_cross_section_f6e3006a
 settings:
   changed:
     npoints: 101

--- a/gdsfactory/tests/test_components/test_settings_taper_from_csv_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_from_csv_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_parabolic_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_parabolic_.yml
@@ -1,3 +1,4 @@
+name: taper_parabolic
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_strip_to_ridge_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_strip_to_ridge_.yml
@@ -1,3 +1,4 @@
+name: taper_strip_to_ridge
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_strip_to_ridge_trenches_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_strip_to_ridge_trenches_.yml
@@ -1,3 +1,4 @@
+name: taper_strip_to_ridge_trenches
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l100_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_d4e8fdfb
 settings:
   changed:
     filepath: taper_strip_0p5_10_100

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l150_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_04444c34
 settings:
   changed:
     filepath: taper_strip_0p5_10_150

--- a/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w10_l200_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_66e0dfe8
 settings:
   changed:
     filepath: taper_strip_0p5_10_200

--- a/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w11_l200_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_0e222243
 settings:
   changed:
     filepath: taper_strip_0p5_11_200

--- a/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
+++ b/gdsfactory/tests/test_components/test_settings_taper_w12_l200_.yml
@@ -1,3 +1,4 @@
+name: taper_from_csv_edb8f8fa
 settings:
   changed:
     filepath: taper_strip_0p5_12_200

--- a/gdsfactory/tests/test_components/test_settings_text_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_.yml
@@ -1,3 +1,4 @@
+name: text
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_text_lines_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_lines_.yml
@@ -1,3 +1,4 @@
+name: text_lines
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_text_rectangular_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_rectangular_.yml
@@ -1,3 +1,4 @@
+name: text_rectangular
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
+++ b/gdsfactory/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
@@ -1,3 +1,4 @@
+name: text_rectangular_1728a6_ebdd1ca3
 settings:
   changed:
     factory:

--- a/gdsfactory/tests/test_components/test_settings_triangle_.yml
+++ b/gdsfactory/tests/test_components/test_settings_triangle_.yml
@@ -1,3 +1,4 @@
+name: triangle
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_verniers_.yml
+++ b/gdsfactory/tests/test_components/test_settings_verniers_.yml
@@ -1,3 +1,4 @@
+name: verniers
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via1_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via1_.yml
@@ -1,3 +1,4 @@
+name: via_ebd8e362
 settings:
   changed:
     enclosure: 2

--- a/gdsfactory/tests/test_components/test_settings_via2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via2_.yml
@@ -1,3 +1,4 @@
+name: via_fd13653e
 settings:
   changed:
     layer:

--- a/gdsfactory/tests/test_components/test_settings_via_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_.yml
@@ -1,3 +1,4 @@
+name: via
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_cutback_.yml
@@ -1,3 +1,4 @@
+name: via_cutback
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via_stack_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_.yml
@@ -1,3 +1,4 @@
+name: via_stack
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via_stack_heater_m3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_heater_m3_.yml
@@ -1,3 +1,4 @@
+name: via_stack_02e7e014
 settings:
   changed:
     layers:

--- a/gdsfactory/tests/test_components/test_settings_via_stack_slab_m3_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_slab_m3_.yml
@@ -1,3 +1,4 @@
+name: via_stack_c52235cb
 settings:
   changed:
     layers:

--- a/gdsfactory/tests/test_components/test_settings_via_stack_slot_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_slot_.yml
@@ -1,3 +1,4 @@
+name: via_stack_slot
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via_stack_slot_m1_m2_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_slot_m1_m2_.yml
@@ -1,3 +1,4 @@
+name: via_stack_slot
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_via_stack_with_offset_.yml
+++ b/gdsfactory/tests/test_components/test_settings_via_stack_with_offset_.yml
@@ -1,3 +1,4 @@
+name: via_stack_with_offset
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_viac_.yml
+++ b/gdsfactory/tests/test_components/test_settings_viac_.yml
@@ -1,3 +1,4 @@
+name: via
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_wire_corner_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_corner_.yml
@@ -1,3 +1,4 @@
+name: wire_corner
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_sbend_.yml
@@ -1,3 +1,4 @@
+name: wire_sbend
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_components/test_settings_wire_straight_.yml
+++ b/gdsfactory/tests/test_components/test_settings_wire_straight_.yml
@@ -1,3 +1,4 @@
+name: straight_6805f5ea
 settings:
   changed:
     cross_section:

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_electr_f23d79f9
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -145,6 +147,7 @@ settings:
         port_type: electrical
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -225,5 +228,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_electrical_pads_shortest
-  name: mzi_2e88f57c_add_electr_3ae80ece
+  name: mzi_2e88f57c_add_electr_f23d79f9
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_electr_202f85bf
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -146,6 +148,7 @@ settings:
     - 100.0
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -227,5 +230,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_electrical_pads_top
-  name: mzi_2e88f57c_add_electr_3a36df00
+  name: mzi_2e88f57c_add_electr_202f85bf
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_fiber__0c6fc058
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -160,6 +162,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -251,5 +254,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_array
-  name: mzi_2e88f57c_add_fiber__54e0e6f9
+  name: mzi_2e88f57c_add_fiber__0c6fc058
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_move_e2f05_1bf5f9f0
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -69,6 +71,7 @@ settings:
   child:
     changed:
       component:
+        name: mzi_2e88f57c
         settings:
           changed:
             combiner:
@@ -208,6 +211,7 @@ settings:
     full:
       axis: null
       component:
+        name: mzi_2e88f57c
         settings:
           changed:
             combiner:
@@ -279,7 +283,7 @@ settings:
     info: {}
     info_version: 2
     module: gdsfactory.functions
-    name: mzi_2e88f57c_move_7a005f3a
+    name: mzi_2e88f57c_move_e2f053e4
   default:
     bend:
       function: bend_euler
@@ -317,6 +321,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -415,5 +420,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.add_fiber_single
-  name: mzi_2e88f57c_move_7a005_9987aa92
+  name: mzi_2e88f57c_move_e2f05_1bf5f9f0
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_gratin_3ead5a8f
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -149,6 +151,7 @@ settings:
         port_type: optical
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -234,5 +237,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.add_grating_couplers
-  name: mzi_2e88f57c_add_gratin_ebcaad33
+  name: mzi_2e88f57c_add_gratin_3ead5a8f
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_gratin_21665327
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -160,6 +162,7 @@ settings:
     with_loopback: true
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -256,5 +259,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.add_grating_couplers
-  name: mzi_2e88f57c_add_gratin_6a78c701
+  name: mzi_2e88f57c_add_gratin_21665327
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_padding_container_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_paddin_cc48fdaf
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -136,6 +138,7 @@ settings:
       - 0
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -208,5 +211,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.add_padding
-  name: mzi_2e88f57c_add_paddin_9b2b90c9
+  name: mzi_2e88f57c_add_paddin_cc48fdaf
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_termination_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_add_termin_c98da713
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -140,6 +142,7 @@ settings:
         width2: 0.1
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -216,5 +219,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.add_termination
-  name: mzi_2e88f57c_add_termin_61906621
+  name: mzi_2e88f57c_add_termin_c98da713
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_array_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_array_.yml
@@ -1,6 +1,8 @@
+name: array_7b26649e
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -78,6 +80,7 @@ settings:
   full:
     columns: 6
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -151,5 +154,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.array_component
-  name: array_a1719f97
+  name: array_7b26649e
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_bend_port_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_bend_port_7b26649e
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -161,6 +163,7 @@ settings:
     bend:
       function: bend_circular
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -248,5 +251,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.bend_port
-  name: mzi_2e88f57c_bend_port_a1719f97
+  name: mzi_2e88f57c_bend_port_7b26649e
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_cavity_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_cavity_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_cavity_7b26649e
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -139,6 +141,7 @@ settings:
     length: 0.1
   full:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -212,5 +215,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.cavity
-  name: mzi_2e88f57c_cavity_a1719f97
+  name: mzi_2e88f57c_cavity_7b26649e
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_extend_ports_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_extend_por_5d5c9b55
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -144,6 +146,7 @@ settings:
   full:
     centered: false
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -220,5 +223,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.extension
-  name: mzi_2e88f57c_extend_por_9d6ff089
+  name: mzi_2e88f57c_extend_por_5d5c9b55
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_fanout2x2_7b26649e
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -146,6 +148,7 @@ settings:
   full:
     bend_length: null
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -225,5 +228,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.routing.fanout2x2
-  name: mzi_2e88f57c_fanout2x2_a1719f97
+  name: mzi_2e88f57c_fanout2x2_7b26649e
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_ring_single_dut_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_ring_singl_dcdee995
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -151,6 +153,7 @@ settings:
     bend:
       function: bend_euler
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -230,5 +233,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.ring_single_dut
-  name: mzi_2e88f57c_ring_singl_31ded41e
+  name: mzi_2e88f57c_ring_singl_dcdee995
 version: 0.0.1

--- a/gdsfactory/tests/test_containers/test_settings_rotate_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_rotate_.yml
@@ -1,6 +1,8 @@
+name: mzi_2e88f57c_rotate_7b26649e
 settings:
   changed:
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -135,6 +137,7 @@ settings:
   full:
     angle: 90
     component:
+      name: mzi_2e88f57c
       settings:
         changed:
           combiner:
@@ -204,5 +207,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.functions
-  name: mzi_2e88f57c_rotate_a1719f97
+  name: mzi_2e88f57c_rotate_7b26649e
 version: 0.0.1

--- a/gdsfactory/tests/test_import_gds.py
+++ b/gdsfactory/tests/test_import_gds.py
@@ -51,8 +51,8 @@ def test_import_ports() -> gf.Component:
 
 
 if __name__ == "__main__":
-    # c = test_import_gds_hierarchy()
-    c = test_import_ports()
+    c = test_import_gds_hierarchy()
+    # c = test_import_ports()
     # c = test_import_gds_add_padding()
     c.show()
     # test_import_gds_snap_to_grid()

--- a/gdsfactory/tests/test_import_gds_markers/test_components_ports_gdspath0_.yml
+++ b/gdsfactory/tests/test_import_gds_markers/test_components_ports_gdspath0_.yml
@@ -1,3 +1,4 @@
+name: mzi_gds
 settings:
   changed: {}
   child: null
@@ -51,5 +52,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.mzi
-  name: mzi
+  name: mzi_gds
 version: 0.0.1

--- a/gdsfactory/tests/test_name_with_decorator.py
+++ b/gdsfactory/tests/test_name_with_decorator.py
@@ -11,7 +11,7 @@ def straight_with_pins(**kwargs):
 
 def test_name_with_decorator():
     c = gf.Component("test_name_with_decorator")
-    c1 = c << straight_with_pins(decorator=gf.add_padding_container)
+    c1 = c << straight_with_pins(decorator=gf.add_padding_container, flatten=True)
     c2 = c << straight_with_pins()
 
     c1.movey(-10)
@@ -41,9 +41,9 @@ def test_name_with_decorator():
 
 if __name__ == "__main__":
     c = gf.Component("test_name_with_decorator")
-    c1 = c << straight_with_pins(decorator=gf.add_padding_container)
-    c2 = c << straight_with_pins()
+    c1 = c << straight_with_pins(decorator=gf.add_padding_container, flatten=True)
     c1.movey(-10)
+    c2 = c << straight_with_pins()
     c2.movey(100)
 
     cells = c.get_dependencies()
@@ -66,3 +66,4 @@ if __name__ == "__main__":
     assert (
         not no_name_cells
     ), f"Component {c.name!r} contains {len(no_name_cells)} Unnamed cells"
+    c.show()

--- a/gdsfactory/tests/test_paths/test_settings_rename_.yml
+++ b/gdsfactory/tests/test_paths/test_settings_rename_.yml
@@ -1,3 +1,4 @@
+name: rename
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_paths/test_settings_test_path_.yml
+++ b/gdsfactory/tests/test_paths/test_settings_test_path_.yml
@@ -1,3 +1,4 @@
+name: test_path
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_paths/test_settings_transition_.yml
+++ b/gdsfactory/tests/test_paths/test_settings_transition_.yml
@@ -1,3 +1,4 @@
+name: transition
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_read_gds_with_hierarchy.py
+++ b/gdsfactory/tests/test_read_gds_with_hierarchy.py
@@ -23,7 +23,7 @@ def test_read_gds_with_settings2(data_regression: DataRegressionFixture) -> None
 
 def test_read_gds_equivalent2() -> None:
     """Ensures we can load it from GDS + YAML and get the same component settings"""
-    c1 = gf.components.mzi()
+    c1 = gf.components.mzi(name="mzi_gds")
     c2 = gf.import_gds(gdspath)
 
     d1 = c1.to_dict()
@@ -69,22 +69,15 @@ if __name__ == "__main__":
     # _write()
     # test_read_gds_equivalent2()
 
-    c = test_read_gds_hash2()
-    c.show()
+    # c = test_read_gds_hash2()
+    # c.show()
     # test_mix_cells_from_gds_and_from_function2()
 
     # test_read_gds_with_settings2()
-    # c1 = gf.components.mzi()
-    # c2 = gf.import_gds(gdspath)
-    # d1 = c1.to_dict()
-    # d2 = c2.to_dict()
-    # dd1 = c1.to_dict()
-    # dd2 = c2.to_dict()
-    # dd1["info"].pop("name")
-    # dd2["info"].pop("name")
-    # dd1.pop("cells")
-    # dd2.pop("cells")
-    # dd1.pop("ports")
-    # dd2.pop("ports")
-    # d = jsondiff.diff(dd1, dd2)
-    # print(d)
+    c1 = gf.components.mzi(name="mzi_gds")
+    c2 = gf.import_gds(gdspath)
+    d1 = c1.to_dict()
+    d2 = c2.to_dict()
+
+    d = jsondiff.diff(d1, d2)
+    print(d)

--- a/gdsfactory/tests/test_read_gds_with_hierarchy/test_read_gds_with_settings2.yml
+++ b/gdsfactory/tests/test_read_gds_with_hierarchy/test_read_gds_with_settings2.yml
@@ -1,3 +1,4 @@
+name: mzi_gds
 settings:
   changed: {}
   child: null
@@ -51,5 +52,5 @@ settings:
   info: {}
   info_version: 2
   module: gdsfactory.components.mzi
-  name: mzi
+  name: mzi_gds
 version: 0.0.1

--- a/gdsfactory/tests/test_serialize/test_settings.yml
+++ b/gdsfactory/tests/test_serialize/test_settings.yml
@@ -1,3 +1,4 @@
+name: demo_cross_section_setting
 settings:
   changed: {}
   child: null

--- a/gdsfactory/tests/test_shear_face_path.py
+++ b/gdsfactory/tests/test_shear_face_path.py
@@ -49,70 +49,6 @@ def skinny():
 
 
 @pytest.fixture
-def linear_taper():
-    P = gf.path.straight(length=10)
-
-    s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
-    X1 = gf.CrossSection(
-        width=1,
-        offset=0,
-        layer=gf.LAYER.WG,
-        name="core",
-        port_names=("o1", "o2"),
-        sections=[s],
-    )
-    s2 = gf.Section(width=2, offset=0, layer=gf.LAYER.SLAB90, name="slab")
-    X2 = gf.CrossSection(
-        width=0.5,
-        offset=0,
-        layer=gf.LAYER.WG,
-        name="core",
-        port_names=("o1", "o2"),
-        sections=[s2],
-    )
-    t = gf.path.transition(X1, X2, width_type="linear")
-    return gf.path.extrude(P, t)
-
-
-@pytest.fixture
-def linear_taper_sheared():
-    P = gf.path.straight(length=10)
-
-    s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
-    X1 = gf.CrossSection(
-        width=1,
-        offset=0,
-        layer=gf.LAYER.WG,
-        name="core",
-        port_names=("o1", "o2"),
-        sections=[s],
-    )
-    s2 = gf.Section(width=2, offset=0, layer=gf.LAYER.SLAB90, name="slab")
-    X2 = gf.CrossSection(
-        width=0.5,
-        offset=0,
-        layer=gf.LAYER.WG,
-        name="core",
-        port_names=("o1", "o2"),
-        sections=[s2],
-    )
-    t = gf.path.transition(X1, X2, width_type="linear")
-    return gf.path.extrude(P, t, shear_angle_start=10, shear_angle_end=None)
-
-
-@pytest.fixture
-def curve():
-    P = gf.path.euler()
-    return gf.path.extrude(P, "strip")
-
-
-@pytest.fixture
-def curve_sheared():
-    angle = 15
-    P = gf.path.euler()
-    return gf.path.extrude(P, "strip", shear_angle_start=angle, shear_angle_end=angle)
-
-
 def test_mate_on_shear_xor_empty(
     regular_waveguide, shear_waveguide_start, shear_waveguide_end
 ) -> None:
@@ -170,24 +106,62 @@ def test_area_stays_same_skinny(
     np.testing.assert_allclose(areas, desired=areas[0])
 
 
-# def test_area_stays_same_curve(
-#     curve,
-#     curve_sheared,
-# ):
-#     components = [
-#         curve,
-#         curve_sheared,
-#     ]
-#     areas = [c.area() for c in components]
-#     np.testing.assert_allclose(areas, desired=areas[0], atol=1e-5)
+def test_mate_on_shear_xor_empty_transition() -> None:
+    """two sheared components joined at the sheared port should appear
+    the same as two straight component joined
+    """
+    P = gf.path.straight(length=10)
 
+    s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
+    X1 = gf.CrossSection(
+        width=1,
+        offset=0,
+        layer=gf.LAYER.WG,
+        name="core",
+        port_names=("o1", "o2"),
+        sections=[s],
+    )
+    s2 = gf.Section(width=2, offset=0, layer=gf.LAYER.SLAB90, name="slab")
+    X2 = gf.CrossSection(
+        width=0.5,
+        offset=0,
+        layer=gf.LAYER.WG,
+        name="core",
+        port_names=("o1", "o2"),
+        sections=[s2],
+    )
+    t = gf.path.transition(X1, X2, width_type="linear")
+    linear_taper = gf.path.extrude(P, t)
 
-def test_mate_on_shear_xor_empty_transition(linear_taper, linear_taper_sheared) -> None:
-    # two sheared components joined at the sheared port should appear the same as two straight component joined
+    P = gf.path.straight(length=10)
+
+    s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
+    x1 = gf.CrossSection(
+        width=1,
+        offset=0,
+        layer=gf.LAYER.WG,
+        name="core",
+        port_names=("o1", "o2"),
+        sections=[s],
+    )
+    s2 = gf.Section(width=2, offset=0, layer=gf.LAYER.SLAB90, name="slab")
+    x2 = gf.CrossSection(
+        width=0.5,
+        offset=0,
+        layer=gf.LAYER.WG,
+        name="core",
+        port_names=("o1", "o2"),
+        sections=[s2],
+    )
+    t = gf.path.transition(x1, x2, width_type="linear")
+    linear_taper_sheared = gf.path.extrude(
+        P, t, shear_angle_start=10, shear_angle_end=None
+    )
+
     two_straights = gf.Component()
     c1 = two_straights << linear_taper
     c2 = two_straights << linear_taper
-    c2.connect("o1", c1.ports["o2"])
+    c2.connect("o1", c1.ports["o1"])
 
     two_shears = gf.Component()
     c1 = two_shears << linear_taper_sheared
@@ -195,23 +169,38 @@ def test_mate_on_shear_xor_empty_transition(linear_taper, linear_taper_sheared) 
     c2.connect("o1", c1.ports["o1"])
 
     xor = gf.geometry.xor_diff(two_straights, two_shears)
-    assert not xor.layers
+    xor.show()
+    # two_straights.show()
+    # two_shears.show()
+
+    area = xor.area()
+    assert area < 0.1, area
 
 
-def test_mate_on_shear_xor_empty_curve(curve, curve_sheared) -> None:
-    # two sheared components joined at the sheared port should appear the same as two straight component joined
+def test_mate_on_shear_xor_empty_curve() -> None:
+    """two sheared components joined at the sheared port should appear
+    the same as two straight component joined
+    """
+    P = gf.path.euler()
+    curve = gf.path.extrude(P, "strip")
+
+    angle = 15
+    P = gf.path.euler()
+    curve_sheared1 = gf.path.extrude(P, "strip", shear_angle_end=angle)
+    curve_sheared2 = gf.path.extrude(P, "strip", shear_angle_start=angle)
+
     two_straights = gf.Component()
     c1 = two_straights << curve
     c2 = two_straights << curve
     c2.connect("o1", c1.ports["o2"])
 
     two_shears = gf.Component()
-    c1 = two_shears << curve_sheared
-    c2 = two_shears << curve_sheared
-    c2.connect("o1", c1.ports["o1"])
+    c1 = two_shears << curve_sheared1
+    c2 = two_shears << curve_sheared2
+    c2.connect("o1", c1.ports["o2"])
 
-    xor = gf.geometry.xor_diff(two_straights, two_shears)
-    assert not xor.layers
+    xor = gf.geometry.xor_diff(two_straights, two_shears, precision=1e-2)
+    assert not xor.layers, f"{xor.layers}"
 
 
 def test_shear_angle_annotated_on_ports(
@@ -238,13 +227,26 @@ def test_port_attributes(regular_waveguide, shear_waveguide_symmetric) -> None:
 
 
 if __name__ == "__main__":
-    P = gf.path.straight(length=10)
-    regular_waveguide1 = gf.path.extrude(P, "strip")
-    P = gf.path.straight(length=10)
-    shear_waveguide_symmetric1 = gf.path.extrude(
-        P, "strip", shear_angle_start=DEMO_PORT_ANGLE, shear_angle_end=DEMO_PORT_ANGLE
-    )
-    c = test_port_attributes(
-        regular_waveguide=regular_waveguide1,
-        shear_waveguide_symmetric=shear_waveguide_symmetric1,
-    )
+    P = gf.path.euler()
+    curve = gf.path.extrude(P, "strip")
+
+    angle = 15
+    P = gf.path.euler()
+    curve_sheared1 = gf.path.extrude(P, "strip", shear_angle_end=angle)
+    curve_sheared2 = gf.path.extrude(P, "strip", shear_angle_start=angle)
+
+    two_straights = gf.Component()
+    c1 = two_straights << curve
+    c2 = two_straights << curve
+    c2.connect("o1", c1.ports["o2"])
+
+    two_shears = gf.Component()
+    c1 = two_shears << curve_sheared1
+    c2 = two_shears << curve_sheared2
+    c2.connect("o1", c1.ports["o2"])
+
+    xor = gf.geometry.xor_diff(two_straights, two_shears, precision=1e-2)
+    assert not xor.layers, f"{xor.layers}"
+
+    # two_straights.show()
+    two_shears.show()


### PR DESCRIPTION
- `gf.read.import_gds()` is now a cell (no more lru cache). LRU cache was not working properly with partial functions.
- add `flatten=False` to cell and decorator
- remove flatten argument `import_gds`
- Component.to_dict() also exports component name
- revert [show changes](https://github.com/gdsfactory/gdsfactory/pull/326/files) as it was causing some files not to reload in klayout.
