### PR TITLE
Fix shear face waveguides

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -472,11 +472,11 @@ def _cut_path_with_ray(
         distance = ls.project(intersection)
         distances.append(distance)
     # when trimming the start, start counting at the intersection point, then add all subsequent points
-    points = [np.array(intersections[0].coords[0]).round(3)]
+    points = [np.array(intersections[0].coords[0])]
     for point in path[1:-1]:
         if distances[0] < ls.project(sg.Point(point)) < distances[1]:
             points.append(point)
-    points.append(np.array(intersections[1].coords[0]).round(3))
+    points.append(np.array(intersections[1].coords[0]))
     return np.array(points)
 
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -321,7 +321,7 @@ def extrude(
         )
         if shear_angle_start or shear_angle_end:
             _face_angle_start = (
-                start_angle + shear_angle_start + 90 if shear_angle_start else None
+                start_angle + shear_angle_start - 90 if shear_angle_start else None
             )
             _face_angle_end = (
                 end_angle + shear_angle_end + 90 if shear_angle_end else None
@@ -455,7 +455,7 @@ def _cut_path_with_ray(
             angle_rad = np.deg2rad(angle)
             dx_far = np.cos(angle_rad) * far_distance
             dy_far = np.sin(angle_rad) * far_distance
-            d_far = point + np.array([dx_far, dy_far])
+            d_far = np.array([dx_far, dy_far])
             ls_ray = sg.LineString([point - d_far, point + d_far])
             intersection = ls.intersection(ls_ray)
 


### PR DESCRIPTION
Hi @joamatab ,

There was a small error in my most recent patch for the shear-face paths. You can see on line 458 of path.py below, I added the initial point into a vector which was supposed to be a delta-vector for the "ray" used to find intersection. This produced a small error in finding the correct endpoints of the offset paths, especially ones which are long or wide.

I fixed this error, got rid of some superfluous rounding, and added a bunch of tests.