### PR TITLE
bring back backwards compatible add_fiber_single and add_fiber_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.6.10]
+
+- add_fiber_single and add_fiber_array tries to add port with `vertical` prefix to the new component. It not adds the regular first port. This Keeps backwards compatibility with grating couplers that have no defined verical ports.
+
 ## [5.6.9](https://github.com/gdsfactory/gdsfactory/pull/389)
 
 -  add_port_from_marker function only allows for ports to be created parallel to the long side of the pin marker. [PR](https://github.com/gdsfactory/gdsfactory/pull/386)

--- a/gdsfactory/components/spiral_inner_io.py
+++ b/gdsfactory/components/spiral_inner_io.py
@@ -27,8 +27,8 @@ def spiral_inner_io(
     y_straight_inner_bottom: float = 10.0,
     grating_spacing: float = 127.0,
     waveguide_spacing: float = 3.0,
-    bend90_function: ComponentSpec = bend_euler,
-    bend180_function: ComponentSpec = bend_euler180,
+    bend90: ComponentSpec = bend_euler,
+    bend180: ComponentSpec = bend_euler180,
     straight: ComponentSpec = straight_function,
     length: Optional[float] = None,
     cross_section: CrossSectionSpec = strip,
@@ -39,25 +39,25 @@ def spiral_inner_io(
     You can add grating couplers inside .
 
     Args:
-        N: number of loops
-        x_straight_inner_right:
-        x_straight_inner_left:
-        y_straight_inner_top:
-        y_straight_inner_bottom:
-        grating_spacing: defaults to 127 for fiber array
-        waveguide_spacing: center to center spacing
-        bend90_function
-        bend180_function
-        straight: straight function
-        length: spiral target length (um), overrides x_straight_inner_left
-            to match the length by a simple 1D interpolation
-        cross_section:
-        cross_section_bend: for the bends
-        kwargs: cross_section settings
+        N: number of loops.
+        x_straight_inner_right: xlength.
+        x_straight_inner_left: x length left.
+        y_straight_inner_top: x inner top.
+        y_straight_inner_bottom: y length.
+        grating_spacing: defaults to 127 for fiber array.
+        waveguide_spacing: center to center spacing.
+        bend90: bend90 spec.
+        bend180: bend180 spec.
+        straight: straight spec.
+        length: spiral target length (um), overrides x_straight_inner_left.
+            to match the length by a simple 1D interpolation.
+        cross_section: spec.
+        cross_section_bend: for the bends.
+        kwargs: cross_section settings.
 
     """
     dx = dy = waveguide_spacing
-    x = cross_section(**kwargs)
+    x = gf.get_cross_section(cross_section, **kwargs)
     width = x.width
     layer = x.layer
     cross_section_bend = cross_section_bend or cross_section
@@ -75,12 +75,8 @@ def spiral_inner_io(
             waveguide_spacing=waveguide_spacing,
         )
 
-    _bend180 = gf.get_component(
-        bend180_function, cross_section=cross_section_bend, **kwargs
-    )
-    _bend90 = gf.get_component(
-        bend90_function, cross_section=cross_section_bend, **kwargs
-    )
+    _bend180 = gf.get_component(bend180, cross_section=cross_section_bend, **kwargs)
+    _bend90 = gf.get_component(bend90, cross_section=cross_section_bend, **kwargs)
 
     rx, ry = get_bend_port_distances(_bend90)
     _, rx180 = get_bend_port_distances(_bend180)  # rx180, second arg since we rotate
@@ -179,25 +175,28 @@ def spiral_inner_io_fiber_single(
     **kwargs
 ) -> Component:
     """Returns Spiral with 90 and 270 degree ports.
+
     You can add single fiber north and south grating couplers
     inside the spiral to save space
 
     Args:
-        cross_section: for the straight sections in the spiral
-        cross_section_bend: for the bends in the spiral
-        cross_section_ports: for input/output ports
-        x_straight_inner_right:
-        x_straight_inner_left:
-        y_straight_inner_top:
-        y_straight_inner_bottom:
-        grating_spacing:
-        N: number of loops
-        waveguide_spacing: center to center spacing
-        bend90_function
-        bend180_function
-        straight: straight function
-        length: computes spiral length from simple interpolation
-        kwargs: cross_section settings
+        cross_section: for the straight sections in the spiral.
+        cross_section_bend: for the bends in the spiral.
+        cross_section_ports: for input/output ports.
+        x_straight_inner_right: in um.
+        x_straight_inner_left: in um.
+        y_straight_inner_top: in um.
+        y_straight_inner_bottom: in um.
+        grating_spacing: in um.
+
+    Keyword Args:
+        N: number of loops.
+        waveguide_spacing: center to center spacing.
+        bend90: bend90 spec.
+        bend180: bend180 spec.
+        straight: straight spec.
+        length: computes spiral length from simple interpolation.
+        kwargs: cross_section settings.
     """
     c = Component()
     spiral = spiral_inner_io(

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -41,8 +41,8 @@ def add_fiber_array(
         component_name: for the label.
         select_ports: function to select ports.
         cross_section: cross_section function.
-        layer_label: LAYER.LABEL
         get_input_labels_function: function to get input labels for grating couplers.
+        layer_label: optional layer for grating coupler label.
 
     Keyword Args:
         taper: taper spec.
@@ -58,7 +58,7 @@ def add_fiber_array(
         force_manhattan: False
         excluded_ports: list of port names to exclude when adding gratings.
         grating_indices: list of grating coupler indices.
-        routing_straight: function .
+        routing_straight: function to route.
         routing_method: get_route.
         optical_routing_type: None: auto, 0: no extension, 1: standard, 2: check.
         gc_rotation: fiber coupler rotation in degrees. Defaults to -90.
@@ -149,13 +149,14 @@ def add_fiber_array(
 
     if gc_port_labels:
         for gc_port_label, port in zip(gc_port_labels, ports):
-            component_new.add_label(
-                text=gc_port_label, layer=layer_label, position=port.midpoint
-            )
+            if layer_label:
+                component_new.add_label(
+                    text=gc_port_label, layer=layer_label, position=port.midpoint
+                )
 
     for i, io_row in enumerate(io_gratings_lines):
         for j, io in enumerate(io_row):
-            ports = io.get_ports_list(prefix="vertical")
+            ports = io.get_ports_list(prefix="vertical") or io.get_ports_list()
             if ports:
                 port = ports[0]
                 component_new.add_port(f"{port.name}_{i}{j}", port=port)

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.grating_coupler_elliptical_trenches import grating_coupler_te
 from gdsfactory.components.straight import straight as straight_function
-from gdsfactory.config import TECH, call_if_func
+from gdsfactory.config import TECH
 from gdsfactory.functions import move_port_to_zero
 from gdsfactory.port import select_ports_optical
 from gdsfactory.routing.get_input_labels import get_input_labels
@@ -160,11 +160,10 @@ def add_fiber_single(
         and abs(optical_ports[0].x - optical_ports[1].x) > min_input_to_output_spacing
     ):
 
-        grating_coupler = call_if_func(grating_coupler)
         grating_couplers = []
         for port in cr.ports.values():
             if port.name in optical_port_names:
-                gc_ref = grating_coupler.ref()
+                gc_ref = gc.ref()
                 gc_ref.connect(gc_port_name, port)
                 grating_couplers.append(gc_ref)
 
@@ -185,7 +184,7 @@ def add_fiber_single(
             bend=bend,
             straight=straight,
             route_filter=route_filter,
-            grating_coupler=grating_coupler,
+            grating_coupler=gc,
             layer_label=layer_label,
             optical_routing_type=optical_routing_type,
             min_input_to_output_spacing=min_input_to_output_spacing,
@@ -200,13 +199,14 @@ def add_fiber_single(
 
     for e in elements:
         c.add(e)
-    for gc in grating_couplers:
-        c.add(gc)
+    for gc_ref in grating_couplers:
+        c.add(gc_ref)
 
     for i, io_row in enumerate(grating_couplers):
         if isinstance(io_row, list):
             for j, io in enumerate(io_row):
-                ports = io.get_ports_list(prefix="vertical")
+                ports = io.get_ports_list(prefix="vertical") or io.get_ports_list()
+
                 if ports:
                     port = ports[0]
                     c.add_port(f"{port.name}_{i}{j}", port=port)
@@ -216,10 +216,6 @@ def add_fiber_single(
                 port = ports[0]
                 c.add_port(f"{port.name}_{i}", port=port)
 
-    if isinstance(grating_coupler, (list, tuple)):
-        grating_coupler = grating_coupler[0]
-
-    grating_coupler = call_if_func(grating_coupler)
     if with_loopback:
         length = c.ysize - 2 * gc_port_to_edge
         wg = c << gf.get_component(
@@ -229,15 +225,15 @@ def add_fiber_single(
         wg.xmax = c.xmin - loopback_xspacing
         wg.ymin = c.ymin + gc_port_to_edge
 
-        gci = c << grating_coupler
-        gco = c << grating_coupler
+        gci = c << gc
+        gco = c << gc
         gci.connect(gc_port_name, wg.ports["o1"])
         gco.connect(gc_port_name, wg.ports["o2"])
 
         port = wg.ports["o2"]
 
-        p = grating_coupler.get_ports_list(prefix="vertical")[0]
-        pname = p.name
+        ports = gc.get_ports_list(prefix="vertical") or gc.get_ports_list()
+        pname = ports[0].name
         p1 = c.add_port(name="loopback1", port=gci.ports[pname])
         p2 = c.add_port(name="loopback2", port=gco.ports[pname])
         p1.port_type = "loopback"
@@ -245,7 +241,7 @@ def add_fiber_single(
 
         if get_input_label_text_function and get_input_label_text_loopback_function:
             text = get_input_label_text_loopback_function(
-                port=port, gc=grating_coupler, gc_index=0, component_name=component_name
+                port=port, gc=gc, gc_index=0, component_name=component_name
             )
 
             c.add_label(
@@ -257,7 +253,7 @@ def add_fiber_single(
 
             port = wg.ports["o1"]
             text = get_input_label_text_loopback_function(
-                port=port, gc=grating_coupler, gc_index=1, component_name=component_name
+                port=port, gc=gc, gc_index=1, component_name=component_name
             )
             c.add_label(
                 text=text,

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_.yml
@@ -4,11 +4,11 @@ settings:
   child: null
   default:
     N: 6
-    bend180_function:
+    bend180:
       function: bend_euler
       settings:
         angle: 180
-    bend90_function:
+    bend90:
       function: bend_euler
     cross_section:
       function: cross_section
@@ -25,11 +25,11 @@ settings:
     y_straight_inner_top: 50
   full:
     N: 6
-    bend180_function:
+    bend180:
       function: bend_euler
       settings:
         angle: 180
-    bend90_function:
+    bend90:
       function: bend_euler
     cross_section:
       function: cross_section

--- a/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
+++ b/gdsfactory/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
@@ -11,11 +11,11 @@ settings:
     child: null
     default:
       N: 6
-      bend180_function:
+      bend180:
         function: bend_euler
         settings:
           angle: 180
-      bend90_function:
+      bend90:
         function: bend_euler
       cross_section:
         function: cross_section
@@ -32,11 +32,11 @@ settings:
       y_straight_inner_top: 50
     full:
       N: 6
-      bend180_function:
+      bend180:
         function: bend_euler
         settings:
           angle: 180
-      bend90_function:
+      bend90:
         function: bend_euler
       cross_section:
         function: cross_section


### PR DESCRIPTION
- add_fiber_single and add_fiber_array tries to add port with `vertical` prefix to the new component. It not adds the regular first port. This Keeps backwards compatibility with grating couplers that have no defined verical ports.
- rename spiral_inner_io functions
