### PR TITLE
Multi cross section routing

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -224,6 +224,7 @@ from gdsfactory.components.triangle import triangle, triangle2, triangle4
 from gdsfactory.components.verniers import verniers
 from gdsfactory.components.version_stamp import pixel, qrcode, version_stamp
 from gdsfactory.components.via import via, via1, via2, viac
+from gdsfactory.components.via_corner import via_corner
 from gdsfactory.components.via_cutback import via_cutback
 from gdsfactory.components.via_stack import (
     via_stack,
@@ -468,6 +469,7 @@ __all__ = [
     "via2",
     "via_cutback",
     "viac",
+    "via_corner",
     "wire_corner",
     "wire_sbend",
     "wire_straight",

--- a/gdsfactory/components/via_corner.py
+++ b/gdsfactory/components/via_corner.py
@@ -1,0 +1,86 @@
+from typing import Tuple
+
+from numpy import floor
+
+import gdsfactory as gf
+from gdsfactory.components.compass import compass
+from gdsfactory.components.via import via1
+from gdsfactory.cross_section import metal2, metal3
+from gdsfactory.port import select_ports
+from gdsfactory.types import ComponentSpec, MultiCrossSectionAngleSpec
+
+
+@gf.cell
+def via_corner(
+    cross_section: MultiCrossSectionAngleSpec = (metal2, metal3),
+    vias: Tuple[ComponentSpec] = (via1,),
+    layers_labels: Tuple[str] = ("m2", "m3"),
+    **kwargs,
+) -> gf.Component:
+    """
+    Corner via. Use in place of wire_corner to route between two layers
+    Args:
+        cross_section: list of cross_section, orientation pairs.
+        vias: vias to use to fill the rectangles.
+        layers_labels: Labels to use for each layer.
+    """
+    cross_sections = [gf.get_cross_section(x[0], **kwargs) for x in cross_section]
+    port_orientations = [x[1] for x in cross_section]
+    widths = heights = [x.width for x in cross_sections]
+    layers = [x.layer for x in cross_sections]
+    layers_ports = layers
+
+    max_width = max(widths)
+    max_height = max(heights)
+    min_height = min(heights)
+    min_width = min(widths)
+
+    a = min_width / 2
+    b = min_height / 2
+
+    c = gf.Component()
+    c.height = max_height
+    c.info["size"] = (float(max_width), float(max_height))
+    c.info["length"] = max(max_width, max_height)
+    for i, layer in enumerate(layers):
+        ref = c << compass(size=(widths[i], heights[i]), layer=layer)
+
+        if layer in layers_ports:
+            orientations = port_orientations[i]
+            if (90 in orientations) or (270 in orientations):
+                orientation = 90
+            elif (0 in orientations) or (180 in orientations):
+                orientation = 180
+            else:
+                raise ValueError(f"Port orientation {orientations} not valid.")
+            ports = ref.ports
+            ports = select_ports(ports, orientation=orientation)
+            c.add_ports(ports, prefix=f"{layers_labels[i]}_")
+
+    for via in vias:
+        via = gf.get_component(via)
+
+        w, h = via.info["size"]
+        g = via.info["enclosure"]
+        pitch_x, pitch_y = via.info["spacing"]
+
+        nb_vias_x = (min_width - w - 2 * g) / pitch_x + 1
+        nb_vias_y = (min_height - h - 2 * g) / pitch_y + 1
+
+        nb_vias_x = int(floor(nb_vias_x)) or 1
+        nb_vias_y = int(floor(nb_vias_y)) or 1
+        ref = c.add_array(
+            via, columns=nb_vias_x, rows=nb_vias_y, spacing=(pitch_x, pitch_y)
+        )
+
+        cw = (min_width - (nb_vias_x - 1) * pitch_x - w) / 2
+        ch = (min_height - (nb_vias_y - 1) * pitch_y - h) / 2
+        x0 = -a + cw + w / 2
+        y0 = -b + ch + h / 2
+        ref.move((x0, y0))
+    return c
+
+
+if __name__ == "__main__":
+    v = via_corner(cross_section=[(metal2, (0, 180)), (metal3, (90, 270))])
+    v.show()

--- a/gdsfactory/routing/__init__.py
+++ b/gdsfactory/routing/__init__.py
@@ -7,22 +7,35 @@ from gdsfactory.routing.add_electrical_pads_top_dc import add_electrical_pads_to
 from gdsfactory.routing.add_fiber_array import add_fiber_array
 from gdsfactory.routing.add_fiber_single import add_fiber_single
 from gdsfactory.routing.fanout2x2 import fanout2x2
-from gdsfactory.routing.get_bundle import get_bundle, get_bundle_electrical
+from gdsfactory.routing.get_bundle import (
+    get_bundle,
+    get_bundle_electrical,
+    get_bundle_electrical_multilayer,
+)
 from gdsfactory.routing.get_bundle_from_steps import (
     get_bundle_from_steps,
     get_bundle_from_steps_electrical,
+    get_bundle_from_steps_electrical_multilayer,
 )
-from gdsfactory.routing.get_bundle_from_waypoints import get_bundle_from_waypoints
+from gdsfactory.routing.get_bundle_from_waypoints import (
+    get_bundle_from_waypoints,
+    get_bundle_from_waypoints_electrical,
+    get_bundle_from_waypoints_electrical_multilayer,
+)
 from gdsfactory.routing.get_bundle_path_length_match import get_bundle_path_length_match
 from gdsfactory.routing.get_bundle_sbend import get_bundle_sbend
 from gdsfactory.routing.get_route import (
     get_route,
     get_route_electrical,
+    get_route_electrical_multilayer,
     get_route_from_waypoints,
+    get_route_from_waypoints_electrical,
+    get_route_from_waypoints_electrical_multilayer,
 )
 from gdsfactory.routing.get_route_from_steps import (
     get_route_from_steps,
     get_route_from_steps_electrical,
+    get_route_from_steps_electrical_multilayer,
 )
 from gdsfactory.routing.get_route_sbend import get_route_sbend
 from gdsfactory.routing.get_routes_bend180 import get_routes_bend180
@@ -41,18 +54,26 @@ __all__ = [
     "get_bundle",
     "get_bundle_from_steps",
     "get_bundle_from_steps_electrical",
+    "get_bundle_from_steps_electrical_multilayer",
     "get_bundle_electrical",
+    "get_bundle_electrical_multilayer",
     "get_bundle_path_length_match",
     "get_bundle_from_waypoints",
+    "get_bundle_from_waypoints_electrical",
+    "get_bundle_from_waypoints_electrical_multilayer",
     "get_route",
     "get_route_electrical",
+    "get_route_electrical_multilayer",
     "get_routes_bend180",
     "get_routes_straight",
     "get_route_sbend",
     "get_bundle_sbend",
     "get_route_from_waypoints",
+    "get_route_from_waypoints_electrical",
+    "get_route_from_waypoints_electrical_multilayer",
     "get_route_from_steps",
     "get_route_from_steps_electrical",
+    "get_route_from_steps_electrical_multilayer",
     "fanout2x2",
     "fanout",
     "route_ports_to_side",

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -19,6 +19,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.straight import straight as straight_function
+from gdsfactory.components.via_corner import via_corner
 from gdsfactory.components.wire import wire_corner
 from gdsfactory.config import TECH
 from gdsfactory.cross_section import strip
@@ -29,7 +30,13 @@ from gdsfactory.routing.get_route import get_route, get_route_from_waypoints
 from gdsfactory.routing.manhattan import generate_manhattan_waypoints
 from gdsfactory.routing.sort_ports import get_port_x, get_port_y
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
-from gdsfactory.types import ComponentSpec, CrossSectionSpec, Number, Route
+from gdsfactory.types import (
+    ComponentSpec,
+    CrossSectionSpec,
+    MultiCrossSectionAngleSpec,
+    Number,
+    Route,
+)
 
 METAL_MIN_SEPARATION = TECH.metal_spacing
 
@@ -42,7 +49,7 @@ def get_bundle(
     straight: ComponentSpec = straight_function,
     bend: ComponentSpec = bend_euler,
     sort_ports: bool = True,
-    cross_section: CrossSectionSpec = "strip",
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
     **kwargs,
 ) -> List[Route]:
     """Connects a bundle of ports with a river router.
@@ -195,7 +202,7 @@ def get_bundle_same_axis(
     start_straight_length: float = 0.0,
     bend: ComponentSpec = bend_euler,
     sort_ports: bool = True,
-    cross_section: CrossSectionSpec = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
     **kwargs,
 ) -> List[Route]:
     r"""Semi auto-routing for two lists of ports.
@@ -596,6 +603,15 @@ def get_bundle_same_axis_no_grouping(
 
 get_bundle_electrical = partial(
     get_bundle, bend=wire_corner, cross_section=gf.cross_section.metal3
+)
+
+get_bundle_electrical_multilayer = gf.partial(
+    get_bundle,
+    bend=via_corner,
+    cross_section=[
+        (gf.cross_section.metal2, (90, 270)),
+        (gf.cross_section.metal3, (0, 180)),
+    ],
 )
 
 

--- a/gdsfactory/routing/get_bundle_from_steps.py
+++ b/gdsfactory/routing/get_bundle_from_steps.py
@@ -6,6 +6,7 @@ import gdsfactory as gf
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.straight import straight as straight_function
 from gdsfactory.components.taper import taper as taper_function
+from gdsfactory.components.via_corner import via_corner
 from gdsfactory.components.wire import wire_corner
 from gdsfactory.port import Port
 from gdsfactory.routing.get_bundle_from_waypoints import get_bundle_from_waypoints
@@ -151,6 +152,15 @@ get_bundle_from_steps_electrical = gf.partial(
     get_bundle_from_steps, bend=wire_corner, cross_section=gf.cross_section.metal3
 )
 
+get_bundle_from_steps_electrical_multilayer = gf.partial(
+    get_bundle_from_steps,
+    bend=via_corner,
+    cross_section=[
+        (gf.cross_section.metal2, (90, 270)),
+        (gf.cross_section.metal3, (0, 180)),
+    ],
+)
+
 
 def _demo() -> None:
     c = gf.Component("get_route_from_steps_sample")
@@ -193,7 +203,7 @@ if __name__ == "__main__":
     pb = c << gf.components.pad_array(orientation=90, columns=3)
     pt.move((300, 500))
 
-    routes = gf.routing.get_bundle_from_steps_electrical(
+    routes = get_bundle_from_steps_electrical_multilayer(
         pb.ports, pt.ports, end_straight_length=60, separation=30, steps=[{"dy": 100}]
     )
 

--- a/gdsfactory/routing/get_bundle_from_waypoints.py
+++ b/gdsfactory/routing/get_bundle_from_waypoints.py
@@ -7,6 +7,8 @@ import gdsfactory as gf
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.straight import straight as straight_function
 from gdsfactory.components.taper import taper as taper_function
+from gdsfactory.components.via_corner import via_corner
+from gdsfactory.components.wire import wire_corner
 from gdsfactory.cross_section import strip
 from gdsfactory.port import Port
 from gdsfactory.routing.manhattan import (
@@ -190,6 +192,20 @@ def get_bundle_from_waypoints(
         )
         for pts, bend90 in zip(routes, bends90)
     ]
+
+
+get_bundle_from_waypoints_electrical = gf.partial(
+    get_bundle_from_waypoints, bend=wire_corner, cross_section=gf.cross_section.metal3
+)
+
+get_bundle_from_waypoints_electrical_multilayer = gf.partial(
+    get_bundle_from_waypoints_electrical,
+    bend=via_corner,
+    cross_section=[
+        (gf.cross_section.metal2, (90, 270)),
+        (gf.cross_section.metal3, (0, 180)),
+    ],
+)
 
 
 def snap_route_to_end_point_x(route, x):

--- a/gdsfactory/routing/get_bundle_path_length_match.py
+++ b/gdsfactory/routing/get_bundle_path_length_match.py
@@ -1,6 +1,6 @@
 """Routes bundles of ports (river routing).
 """
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.straight import straight as _straight
@@ -14,7 +14,12 @@ from gdsfactory.routing.get_bundle import (
 from gdsfactory.routing.get_route import get_route_from_waypoints
 from gdsfactory.routing.path_length_matching import path_length_matched_points
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
-from gdsfactory.types import ComponentSpec, CrossSectionSpec, Route
+from gdsfactory.types import (
+    ComponentSpec,
+    CrossSectionSpec,
+    MultiCrossSectionAngleSpec,
+    Route,
+)
 
 
 def get_bundle_path_length_match(
@@ -31,7 +36,7 @@ def get_bundle_path_length_match(
     start_straight_length: float = 0.0,
     route_filter: Callable = get_route_from_waypoints,
     sort_ports: bool = True,
-    cross_section: CrossSectionSpec = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
     **kwargs
 ) -> List[Route]:
     """Returns list of routes that are path length matched.

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -905,7 +905,6 @@ def round_corners(
 def generate_manhattan_waypoints(
     input_port: Port,
     output_port: Port,
-    straight: ComponentSpec = straight_function,
     start_straight_length: Optional[float] = None,
     end_straight_length: Optional[float] = None,
     min_straight_length: Optional[float] = None,
@@ -921,6 +920,8 @@ def generate_manhattan_waypoints(
         straight:
 
     """
+    if "straight" in kwargs.keys():
+        _ = kwargs.pop("straight")
 
     bend90 = (
         bend

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -94,12 +94,9 @@ def _get_bend_ports(
     """
 
     ports = bend.ports
-    if isinstance(layer, list):
-        p_w = _get_unique_port_facing(ports=ports, orientation=180, layer=layer)
-        p_n = _get_unique_port_facing(ports=ports, orientation=90, layer=layer)
-    else:
-        p_w = _get_unique_port_facing(ports=ports, orientation=180, layer=layer)
-        p_n = _get_unique_port_facing(ports=ports, orientation=90, layer=layer)
+
+    p_w = _get_unique_port_facing(ports=ports, orientation=180, layer=layer)
+    p_n = _get_unique_port_facing(ports=ports, orientation=90, layer=layer)
 
     return p_w + p_n
 

--- a/gdsfactory/routing/path_length_matching.py
+++ b/gdsfactory/routing/path_length_matching.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 import numpy as np
 from numpy import ndarray
@@ -11,7 +11,7 @@ from gdsfactory.routing.manhattan import (
     _is_vertical,
     remove_flat_angles,
 )
-from gdsfactory.types import ComponentSpec, CrossSectionSpec
+from gdsfactory.types import ComponentSpec, CrossSectionSpec, MultiCrossSectionAngleSpec
 
 
 def path_length_matched_points(
@@ -21,7 +21,7 @@ def path_length_matched_points(
     extra_length: float = 0.0,
     nb_loops: int = 1,
     bend: ComponentSpec = bend_euler,
-    cross_section: CrossSectionSpec = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
     **kwargs,
 ) -> List[ndarray]:
     """
@@ -150,7 +150,7 @@ def path_length_matched_points_add_waypoints(
     margin: float = 0.0,
     extra_length: float = 0.0,
     nb_loops: int = 1,
-    cross_section: CrossSectionSpec = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
     **kwargs,
 ) -> List[ndarray]:
     """

--- a/gdsfactory/types.py
+++ b/gdsfactory/types.py
@@ -93,6 +93,7 @@ ComponentSpecOrList = Union[ComponentSpec, List[ComponentSpec]]
 CellSpec = Union[str, ComponentFactory, Dict[str, Any]]
 ComponentSpecDict = Dict[str, ComponentSpec]
 CrossSectionSpec = Union[str, CrossSectionFactory, CrossSection, Dict[str, Any]]
+MultiCrossSectionAngleSpec = List[Tuple[CrossSectionSpec, Tuple[int, ...]]]
 
 
 class Route(BaseModel):
@@ -221,6 +222,7 @@ __all__ = (
     "Coordinates",
     "CrossSectionFactory",
     "CrossSectionOrFactory",
+    "MultiCrossSectionAngleSpec",
     "Float2",
     "Float3",
     "Floats",


### PR DESCRIPTION
Adds basic multilayer electrical routing to most routing functions

- Use via_corner instead of wire_corner for bend function
- Use MultiCrossSectionAngleSpec instead of CrossSectionSpec to define multiple cross sections
- Avoids refactoring as much as possible so it doesn't interfere with current single-layer routing