### PR TITLE
PDK Events and default decorator

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -70,6 +70,8 @@ def cell_without_validator(func):
 
     @functools.wraps(func)
     def _cell(*args, **kwargs):
+        from gdsfactory.pdk import get_active_pdk
+
         autoname = kwargs.pop("autoname", True)
         name = kwargs.pop("name", None)
         cache = kwargs.pop("cache", True)
@@ -122,7 +124,7 @@ def cell_without_validator(func):
         changed = {k: changed[k] for k in changed_arg_names}
 
         name = name or name_signature
-        decorator = kwargs.pop("decorator", None)
+        decorator = kwargs.pop("decorator", get_active_pdk().default_decorator)
         name = get_name_short(name, max_name_length=max_name_length)
 
         if (

--- a/gdsfactory/events.py
+++ b/gdsfactory/events.py
@@ -1,9 +1,3 @@
-###################################################################################################################
-# PROPRIETARY AND CONFIDENTIAL
-# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
-# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
-# RPLTD NOTICE VERSION: 1.1.1
-###################################################################################################################
 from typing import Callable
 
 

--- a/gdsfactory/events.py
+++ b/gdsfactory/events.py
@@ -1,0 +1,39 @@
+###################################################################################################################
+# PROPRIETARY AND CONFIDENTIAL
+# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
+# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
+# RPLTD NOTICE VERSION: 1.1.1
+###################################################################################################################
+from typing import Callable
+
+
+class Event(object):
+    def __init__(self):
+        self._handlers = []
+
+    def __iadd__(self, handler: Callable):
+        self.add_handler(handler)
+        return self
+
+    def __isub__(self, handler: Callable):
+        self._handlers.remove(handler)
+        return self
+
+    def add_handler(self, handler: Callable):
+        """
+        Adds a handler that will be executed when this event is fired.
+
+        Args:
+            handler: a function which matches the signature fired by this event
+        """
+        self._handlers.append(handler)
+
+    def clear_handlers(self):
+        self._handlers.clear()
+
+    def fire(self, *args, **kwargs):
+        """
+        Fires an event, calling all handlers with the passed arguments.
+        """
+        for eventhandler in self._handlers:
+            eventhandler(*args, **kwargs)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from gdsfactory.components import cells
 from gdsfactory.containers import containers as containers_default
 from gdsfactory.cross_section import cross_sections
+from gdsfactory.events import Event
 from gdsfactory.read.from_yaml import from_yaml
 from gdsfactory.types import (
     CellSpec,
@@ -71,6 +72,7 @@ class Pdk(BaseModel):
                 warnings.warn(f"Overwriting cell {name!r}")
 
             self.cells[name] = cell
+            on_cell_registered.fire(name=name, cell=cell)
 
     def register_containers(self, **kwargs) -> None:
         """Register container factories."""
@@ -84,6 +86,7 @@ class Pdk(BaseModel):
                 warnings.warn(f"Overwriting container {name!r}")
 
             self.containers[name] = cell
+            on_container_registered.fire(name=name, cell=cell)
 
     def register_cross_sections(self, **kwargs) -> None:
         """Register cross_sections factories."""
@@ -96,6 +99,7 @@ class Pdk(BaseModel):
             if name in self.cross_sections:
                 warnings.warn(f"Overwriting cross_section {name!r}")
             self.cross_sections[name] = cross_section
+            on_cross_section_registered.fire(name=name, cross_section=cross_section)
 
     def register_cells_yaml(
         self,
@@ -128,6 +132,7 @@ class Pdk(BaseModel):
                         f"ERROR: Cell name {name!r} from {filepath} already registered."
                     )
                 self.cells[name] = partial(from_yaml, filepath)
+
                 logger.info(f"{message} cell {name!r}")
 
         for k, v in kwargs.items():
@@ -310,9 +315,22 @@ def get_active_pdk() -> Pdk:
 
 def set_active_pdk(pdk: Pdk) -> None:
     global _ACTIVE_PDK
+    old_pdk = _ACTIVE_PDK
     _ACTIVE_PDK = pdk
+    on_pdk_activated.fire(old_pdk=old_pdk, new_pdk=pdk)
 
+
+on_pdk_activated: Event = Event()
+on_cell_registered: Event = Event()
+on_container_registered: Event = Event()
+on_yaml_cell_registered: Event = Event()
+on_cross_section_registered: Event = Event()
+
+on_container_registered.add_handler(on_cell_registered.fire)
+on_yaml_cell_registered.add_handler(on_cell_registered.fire)
 
 if __name__ == "__main__":
     c = _ACTIVE_PDK.get_component("straight")
     print(c.settings)
+    # on_pdk_activated += print
+    # set_active_pdk(GENERIC)


### PR DESCRIPTION
Hi @joamatab ,

This PR aims to make easier customization of PDKs by end users and applications.

I add an `Event` class which I then trigger in response to various changes to the active PDK.

I also add an attribute `default_decorator` to the PDK, which allows the user to attach a default decorator to apply to all cells in a PDK which don't explicitly specify a custom decorator.

Let me know what you think!

Troy