### PR TITLE
Use shapely's implementation of simplify when extruding paths

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -14,7 +14,6 @@ import numpy as np
 import shapely.ops
 from phidl import path
 from phidl.device_layout import Path as PathPhidl
-from phidl.device_layout import _simplify
 from phidl.path import smooth as smooth_phidl
 
 from gdsfactory.cell import cell
@@ -28,6 +27,14 @@ from gdsfactory.types import (
     LayerSpec,
     PathFactory,
 )
+
+
+def _simplify(points, tolerance):
+    import shapely.geometry as sg
+
+    ls = sg.LineString(points)
+    ls_simple = ls.simplify(tolerance=tolerance)
+    return np.asarray(ls_simple.coords)
 
 
 class Path(PathPhidl):


### PR DESCRIPTION
The simplification of paths when extruding can be critical to balance precision and filesize, but it can sometimes take an overwhelming amount of time. I found shapely's implementation of simplify to be consistent with phidl's (under the hood, they both use the RDP algorithm), but it can be more than an order of magnitude faster.

From my tests, speed for phidl's implementation is highly dependent on the step size in the original points and the desired tolerance (I think this is due to their recursive algorithm). Shapely's speed is relatively flat, in comparison.

You can adjust the `radius` and `npoints` arguments of the path in the below example to see how the speed varies, but this is a fairly extreme case showing a 15x speedup on my machine, in favor of Shapely

Test case:
```python
from timeit import timeit

import gdsfactory as gf
from phidl.device_layout import _simplify
import shapely.geometry as sg
import numpy as np

TOL = 0.001


def simplify_phidl(pts):
    return _simplify(pts, tolerance=TOL)


def simplify_shapely(pts):
    shapely_ls = sg.LineString(pts)
    ls_simple = shapely_ls.simplify(tolerance=TOL)
    return np.asarray(ls_simple.coords)


if __name__ == '__main__':
    p = gf.path.euler(radius=5000, npoints=10000)
    pts = p.points

    time_phidl = timeit(lambda: simplify_phidl(pts), number=100)
    time_shapely = timeit(lambda: simplify_shapely(pts), number=100)
    print('time phidl', time_phidl)
    print('time shapely', time_shapely)
    print(f'shapely speedup: {time_phidl / time_shapely:.2f}')
```

Output:
```
time phidl 33.722930499818176
time shapely 2.247889299876988
shapely speedup: 15.00
```