### PR TITLE
Path length match routing

### DIFF
--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -26,6 +26,8 @@ from gdsfactory.cross_section import strip
 from gdsfactory.port import Port
 from gdsfactory.routing.get_bundle_corner import get_bundle_corner
 from gdsfactory.routing.get_bundle_u import get_bundle_udirect, get_bundle_uindirect
+from gdsfactory.routing.get_bundle_from_steps import get_bundle_from_steps
+from gdsfactory.routing.get_bundle_from_waypoints import get_bundle_from_waypoints
 from gdsfactory.routing.get_route import get_route, get_route_from_waypoints
 from gdsfactory.routing.manhattan import generate_manhattan_waypoints
 from gdsfactory.routing.sort_ports import get_port_x, get_port_y
@@ -83,6 +85,8 @@ def get_bundle(
         start_straight_length: straight length at the beginning of the route.
         end_straight_length: end length at the beginning of the route.
         snap_to_grid: can snap points to grid when extruding the path.
+        steps: specify waypoint steps to route using get_bundle_from_steps
+        waypoints: specify waypoints to route using get_bundle_from_steps
 
 
     """
@@ -144,6 +148,12 @@ def get_bundle(
 
     y_start = np.mean([p.y for p in ports1])
     y_end = np.mean([p.y for p in ports2])
+
+    if "steps" in kwargs.keys():
+        return get_bundle_from_steps(**params)
+
+    elif "waypoints" in kwargs.keys():
+        return get_bundle_from_waypoints(**params)
 
     if start_axis != end_axis:
         return get_bundle_corner(**params)

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -88,8 +88,12 @@ def get_bundle(
         snap_to_grid: can snap points to grid when extruding the path.
         steps: specify waypoint steps to route using get_bundle_from_steps
         waypoints: specify waypoints to route using get_bundle_from_steps
-
-
+        path_length_match_loops: Integer number of loops to add to bundle for path length matching
+            (won't try to match if None)
+        path_length_match_extra_length: Extra length to add to path length matching loops
+            (requires path_length_match_loops != None)
+        path_length_match_modify_segment_i: Index of straight segment to add path length matching loops to
+            (requires path_length_match_loops != None)
     """
     # convert single port to list
     if isinstance(ports1, Port):

--- a/gdsfactory/routing/get_bundle_corner.py
+++ b/gdsfactory/routing/get_bundle_corner.py
@@ -6,6 +6,7 @@ from phidl.device_layout import _rotate_points
 from gdsfactory.port import Port
 from gdsfactory.routing.get_route import get_route_from_waypoints
 from gdsfactory.routing.manhattan import generate_manhattan_waypoints
+from gdsfactory.routing.path_length_matching import path_length_matched_points
 from gdsfactory.types import Route
 
 
@@ -58,6 +59,9 @@ def get_bundle_corner(
     ports2: List[Port],
     route_filter: Callable[..., Route] = get_route_from_waypoints,
     separation: float = 5.0,
+    path_length_match_loops: int = None,
+    path_length_match_extra_length: float = 0.0,
+    path_length_match_modify_segment_i: int = -2,
     **kwargs,
 ) -> List[Route]:
     r"""
@@ -105,6 +109,8 @@ def get_bundle_corner(
 
     Connect banks of ports with either 90Deg or 270Deg angle between them
     """
+    if "straight" in kwargs.keys():
+        _ = kwargs.pop("straight")
 
     routes = _get_bundle_corner_waypoints(
         ports1,
@@ -113,6 +119,15 @@ def get_bundle_corner(
         separation=separation,
         **kwargs,
     )
+    if path_length_match_loops:
+        routes = [np.array(route) for route in routes]
+        routes = path_length_matched_points(
+            routes,
+            extra_length=path_length_match_extra_length,
+            nb_loops=path_length_match_loops,
+            modify_segment_i=path_length_match_modify_segment_i,
+            **kwargs,
+        )
 
     return [route_filter(r, **kwargs) for r in routes]
 
@@ -209,8 +224,8 @@ def _get_bundle_corner_waypoints(
         end_angle_sort_index = end_angle_sort_index + 2
         end_angle_sort_index = end_angle_sort_index % 4
 
-    start_angle_sort_type = start_sort_type[start_angle_sort_index]
-    end_angle_sort_type = end_sort_type[end_angle_sort_index]
+    start_angle_sort_type = start_sort_type[int(start_angle_sort_index)]
+    end_angle_sort_type = end_sort_type[int(end_angle_sort_index)]
 
     type2key = {
         "X": lambda p: p.x,

--- a/gdsfactory/routing/get_bundle_from_steps.py
+++ b/gdsfactory/routing/get_bundle_from_steps.py
@@ -29,6 +29,9 @@ def get_bundle_from_steps(
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
     sort_ports: bool = True,
     separation: Optional[float] = None,
+    path_length_match_loops: int = None,
+    path_length_match_extra_length: float = 0.0,
+    path_length_match_modify_segment_i: int = -2,
     **kwargs
 ) -> List[Route]:
     """Returns a list of routes formed by the given waypoints steps
@@ -147,6 +150,9 @@ def get_bundle_from_steps(
         taper=taper,
         cross_section=cross_section,
         separation=separation,
+        path_length_match_extra_length=path_length_match_extra_length,
+        path_length_match_modify_segment_i=path_length_match_modify_segment_i,
+        path_length_match_loops=path_length_match_loops,
         **kwargs,
     )
 
@@ -206,7 +212,7 @@ if __name__ == "__main__":
     pb = c << gf.components.pad_array(orientation=90, columns=3)
     pt.move((300, 500))
 
-    routes = get_bundle_from_steps_electrical_multilayer(
+    routes = get_bundle_from_steps_electrical(
         pb.ports, pt.ports, end_straight_length=60, separation=30, steps=[{"dy": 100}]
     )
 

--- a/gdsfactory/routing/path_length_matching.py
+++ b/gdsfactory/routing/path_length_matching.py
@@ -215,7 +215,7 @@ def path_length_matched_points_add_waypoints(
         )
 
     # Get the points for the segment we need to modify
-    bend90 = bend(cross_section=cross_section, **kwargs)
+    bend90 = gf.get_component(bend, cross_section=cross_section, **kwargs)
 
     a = margin + bend90.info["dy"]
     if modify_segment_i < 0:


### PR DESCRIPTION
The purpose of this PR is to 
1) Allow user to specify `steps` or `waypoints` in the call to `get_bundle`
2) Add path length matching keyword arguments functions called by `get_bundle`