### PR TITLE
Prevent mutation of double-cached cells

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -150,6 +150,12 @@ def cell_without_validator(func):
             )
 
         component = func(*args, **kwargs)
+
+        # if the component is already in the cache, but under a different alias,
+        # make sure we use a copy, so we don't run into mutability errors
+        if id(component) in [id(v) for v in CACHE.values()]:
+            component = component.copy()
+
         metadata_child = (
             dict(component.child.settings) if hasattr(component, "child") else None
         )

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -194,7 +194,6 @@ def cell_without_validator(func):
         if decorator:
             if not callable(decorator):
                 raise ValueError(f"decorator = {type(decorator)} needs to be callable")
-            component.unlock()
             component_new = decorator(component)
             component = component_new or component
 

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -88,7 +88,6 @@ def import_gds(
 
         if hashed_name:
             D.name = get_name_short(D.name)
-        D.unlock()
 
         cell_to_device[c] = D
         D_list += [D]
@@ -157,7 +156,6 @@ def import_gds(
 
     component.info.update(**kwargs)
     component.imported_gds = True
-    component.lock()
     return component
 
 


### PR DESCRIPTION
Hi @joamatab,

This patch fixes some difficult-to-find errors having to do with mutability (you'll see it even fixes one of the existing tests, for the `grating_coupler_tree`!). Essentially, before adding a component to the CACHE, we first check if the component has already been added or not, under a different name. If it has, it copies the component before adding it again to the CACHE. This prevents errors that could arise in a variety of cases, for example

- cells which have already been instantiated, but are re-called with an explicit `name` supplied
- cells which are returned as-is inside a new `@cell`-decorated function, without being first copied
- different `from_yaml` cells, which have identical content

Furthermore I remove calls to `unlock()` within `cell()` and `import_gds()`, which I think makes everything a bit safer! Overall, I hope this MR takes a bit of a mental load off the developer, not to have to remember these patterns which are potentially dangerous. Instead, a MutabilityError should be thrown reliably in those cases.