### PR TITLE
586

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.8.6]
+
+- remove gf.set_active_pdk(), as we should only be using pdk.activate(), so there is only one way to activate a PDK.
+- change default ComponentFactory from 'mmi2x2' string to straight componentFactory.
+
 ## [5.8.5](https://github.com/gdsfactory/gdsfactory/pull/433)
 
 - bring back layer validator to ensure DEVREC, PORTE and PORT are defined in the pdk

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -75,7 +75,6 @@ from gdsfactory.pdk import (
     get_cross_section,
     get_layer,
     get_active_pdk,
-    set_active_pdk,
     get_cell,
 )
 from gdsfactory.get_factories import get_cells
@@ -140,7 +139,6 @@ __all__ = [
     "Label",
     "Pdk",
     "get_active_pdk",
-    "set_active_pdk",
     "get_component",
     "get_cross_section",
     "get_cell",

--- a/gdsfactory/dft/siepic.py
+++ b/gdsfactory/dft/siepic.py
@@ -10,6 +10,7 @@ import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components import grating_coupler_te
+from gdsfactory.components.straight import straight
 from gdsfactory.port import Port
 from gdsfactory.types import ComponentReference, ComponentSpec, CrossSectionSpec, Layer
 
@@ -95,7 +96,7 @@ def get_input_labels(
 
 @cell
 def add_fiber_array_siepic(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     component_name: Optional[str] = None,
     gc_port_name: str = "o1",
     get_input_labels_function: Callable = get_input_labels,

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -38,12 +38,12 @@ layers_required = ["DEVREC", "PORT", "PORTE"]
 class Pdk(BaseModel):
     """Pdk Library to store cell and cross_section functions.
 
-    Args:
+    Attributes:
         name: PDK name.
-        cross_sections: cross_sections.
-        cells: pcells.
+        cross_sections: dict of cross_sections factories.
+        cells: dict of parametric cells that return Components.
         layers: layers dict.
-        containers: pcells that contain other cells.
+        containers: dict of parametric that contain other cells.
         base_pdk: a pdk to copy from and extend.
         default_decorator: default decorator for all cells, if not otherwise defined on the cell.
     """
@@ -64,6 +64,7 @@ class Pdk(BaseModel):
         return v
 
     def activate(self) -> None:
+        """Set current pdk to as the active pdk."""
         if self.base_pdk:
             _cross_sections = self.base_pdk.cross_sections
             _cross_sections |= self.cross_sections
@@ -83,7 +84,7 @@ class Pdk(BaseModel):
 
             if not self.default_decorator:
                 self.default_decorator = self.base_pdk.default_decorator
-        set_active_pdk(self)
+        _set_active_pdk(self)
 
     def register_cells(self, **kwargs) -> None:
         """Register cell factories."""
@@ -388,7 +389,7 @@ def get_active_pdk() -> Pdk:
     return _ACTIVE_PDK
 
 
-def set_active_pdk(pdk: Pdk) -> None:
+def _set_active_pdk(pdk: Pdk) -> None:
     global _ACTIVE_PDK
     old_pdk = _ACTIVE_PDK
     _ACTIVE_PDK = pdk

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -589,7 +589,7 @@ def _from_yaml(
         routing_strategy: for each route.
         label_instance_function: to label each instance.
     """
-    from gdsfactory.pdk import GENERIC, get_active_pdk, set_active_pdk
+    from gdsfactory.pdk import GENERIC, get_active_pdk
 
     c = Component()
     instances = {}
@@ -604,14 +604,14 @@ def _from_yaml(
     c.info = conf.get("info", {})
 
     if pdk and pdk == "generic":
-        set_active_pdk(GENERIC)
+        GENERIC.activate()
 
     elif pdk:
         module = importlib.import_module(pdk)
         pdk = getattr(module, "PDK")
         if pdk is None:
             raise ValueError(f"'from {pdk} import PDK' failed")
-        set_active_pdk(pdk)
+        pdk.activate()
 
     pdk = get_active_pdk()
 

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -1,5 +1,6 @@
 import gdsfactory as gf
 from gdsfactory.component import Component
+from gdsfactory.components.straight import straight
 from gdsfactory.port import select_ports_electrical
 from gdsfactory.routing.route_quad import route_quad
 from gdsfactory.types import ComponentSpec
@@ -7,7 +8,7 @@ from gdsfactory.types import ComponentSpec
 
 @gf.cell
 def add_electrical_pads_shortest(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     pad: ComponentSpec = "pad",
     pad_port_spacing: float = 50.0,
     select_ports=select_ports_electrical,

--- a/gdsfactory/routing/add_electrical_pads_top.py
+++ b/gdsfactory/routing/add_electrical_pads_top.py
@@ -1,6 +1,7 @@
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.pad import pad_array as pad_array_function
+from gdsfactory.components.straight import straight
 from gdsfactory.port import select_ports_electrical
 from gdsfactory.routing.route_quad import route_quad
 from gdsfactory.types import ComponentSpec, Float2
@@ -8,7 +9,7 @@ from gdsfactory.types import ComponentSpec, Float2
 
 @gf.cell
 def add_electrical_pads_top(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     spacing: Float2 = (0.0, 100.0),
     pad_array: ComponentSpec = pad_array_function,
     select_ports=select_ports_electrical,

--- a/gdsfactory/routing/add_electrical_pads_top_dc.py
+++ b/gdsfactory/routing/add_electrical_pads_top_dc.py
@@ -4,6 +4,7 @@ import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.pad import pad_array as pad_array_function
+from gdsfactory.components.straight import straight
 from gdsfactory.port import select_ports_electrical
 from gdsfactory.routing.get_bundle import get_bundle_electrical
 from gdsfactory.routing.sort_ports import sort_ports_x
@@ -12,7 +13,7 @@ from gdsfactory.types import ComponentSpec, Float2
 
 @cell
 def add_electrical_pads_top_dc(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     spacing: Float2 = (0.0, 100.0),
     pad_array: ComponentSpec = pad_array_function,
     select_ports: Callable = select_ports_electrical,

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -19,7 +19,7 @@ from gdsfactory.types import (
 
 @gf.cell
 def add_fiber_array(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     bend: ComponentSpec = "bend_euler",
     gc_port_name: str = "o1",

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -23,7 +23,7 @@ from gdsfactory.types import (
 
 @cell
 def add_fiber_single(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight_function,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     layer_label: LayerSpec = "LABEL",
     fiber_spacing: float = TECH.fiber_spacing,

--- a/gdsfactory/routing/fanout2x2.py
+++ b/gdsfactory/routing/fanout2x2.py
@@ -4,13 +4,14 @@ import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
 from gdsfactory.components.bezier import bezier
+from gdsfactory.components.straight import straight
 from gdsfactory.port import select_ports_optical
 from gdsfactory.types import ComponentSpec, CrossSectionSpec
 
 
 @gf.cell
 def fanout2x2(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec = straight,
     port_spacing: float = 20.0,
     bend_length: Optional[float] = None,
     npoints: int = 101,

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_tapers_.yml
@@ -207,7 +207,8 @@ settings:
     name: straight_373b1ebb_add_t_0521a25f
   default:
     bend: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     gc_port_labels: null

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type0_.yml
@@ -71,7 +71,8 @@ settings:
     name: coupler_a078f3c8
   default:
     bend: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     gc_port_labels: null

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type1_.yml
@@ -71,7 +71,8 @@ settings:
     name: coupler_bcc4a0b5
   default:
     bend: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     gc_port_labels: null

--- a/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
+++ b/gdsfactory/routing/test_add_fiber_array/test_settings_test_type2_.yml
@@ -71,7 +71,8 @@ settings:
     name: coupler_a078f3c8
   default:
     bend: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     gc_port_labels: null

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_function_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_function_.yml
@@ -93,7 +93,8 @@ instances:
             name: ring_single_15a01d93
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -247,7 +248,8 @@ instances:
             name: ring_single_36bf9679
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -401,7 +403,8 @@ instances:
             name: ring_single_4f2b93e6
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -555,7 +558,8 @@ instances:
             name: ring_single_557cf3bf
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -709,7 +713,8 @@ instances:
             name: ring_single_5d6e411b
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -863,7 +868,8 @@ instances:
             name: ring_single_97963132
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1017,7 +1023,8 @@ instances:
             name: ring_single_b1b00c28
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1171,7 +1178,8 @@ instances:
             name: ring_single_b4c8763a
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1325,7 +1333,8 @@ instances:
             name: ring_single_b5de162f
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1479,7 +1488,8 @@ instances:
             name: ring_single_cb0f7119
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1633,7 +1643,8 @@ instances:
             name: ring_single_f56e8ae9
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null
@@ -1787,7 +1798,8 @@ instances:
             name: ring_single_f72b5eef
           default:
             bend: bend_euler
-            component: mmi2x2
+            component:
+              function: straight
             component_name: null
             cross_section: strip
             gc_port_labels: null

--- a/gdsfactory/tests/test_containers.py
+++ b/gdsfactory/tests/test_containers.py
@@ -5,7 +5,7 @@ import gdsfactory as gf
 from gdsfactory.containers import containers
 from gdsfactory.difftest import difftest
 
-component = gf.c.mzi2x2_2x2(straight_x_top="straight_heater_metal")
+component = gf.components.mzi2x2_2x2(straight_x_top="straight_heater_metal")
 
 skip_test = {
     "pack_doe",

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
@@ -127,7 +127,8 @@ settings:
     module: gdsfactory.components.mzi
     name: mzi_2e88f57c
   default:
-    component: mmi2x2
+    component:
+      function: straight
     layer: M3
     pad: pad
     pad_port_spacing: 50

--- a/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_electrical_pads_top_.yml
@@ -127,7 +127,8 @@ settings:
     module: gdsfactory.components.mzi
     name: mzi_2e88f57c
   default:
-    component: mmi2x2
+    component:
+      function: straight
     layer: M3
     pad_array:
       function: pad_array

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -128,7 +128,8 @@ settings:
     name: mzi_2e88f57c
   default:
     bend: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     gc_port_labels: null

--- a/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -275,7 +275,8 @@ settings:
   default:
     bend:
       function: bend_euler
-    component: mmi2x2
+    component:
+      function: straight
     component_name: null
     cross_section: strip
     fiber_spacing: 50

--- a/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/gdsfactory/tests/test_containers/test_settings_fanout2x2_.yml
@@ -128,7 +128,8 @@ settings:
     name: mzi_2e88f57c
   default:
     bend_length: null
-    component: mmi2x2
+    component:
+      function: straight
     cross_section: strip
     npoints: 101
     port_spacing: 20


### PR DESCRIPTION
- remove gf.set_active_pdk(), as we should only be using pdk.activate(), so there is only one way to activate a PDK.
- change default ComponentFactory from 'mmi2x2' string to straight componentFactory.