### PR TITLE
589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.8.9]
+
+- add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
+- apply default_decorator before returning component if pdk.default_decorator is defined.
+
 ## [5.8.8](https://github.com/gdsfactory/gdsfactory/pull/436)
 
 - assert ports on grid works with None orientation ports.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ gdsfactory top contributors:
 - Simon Bilodeau (Princeton): Meep FDTD write Sparameters
 - Thomas Dorch (Freedom Photonics): for Meep's material database access, MPB sidewall angles, and add_pin_path
 - Igal Bayn (Google): for documentation improvements and suggestions.
+- Alex Sludds (MIT): for tiling fixes.
 
 Open source heroes:
 
@@ -74,6 +75,4 @@ Open source heroes:
 
 - [gdsfactory github repo](https://github.com/gdsfactory/gdsfactory) and [docs](https://gdsfactory.github.io/gdsfactory/)
 - [ubc PDK](https://github.com/gdsfactory/ubc): sample open source PDK from edx course.
-- [miniforge install instructions](https://github.com/conda-forge/miniforge#mambaforge)
-- [SAX](https://flaport.github.io/sax): separate package for circuit simulations
 - [awesome photonics list](https://github.com/joamatab/awesome_photonics)


### PR DESCRIPTION
- add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
- apply default_decorator before returning component if pdk.default_decorator is defined.