### PR TITLE
show_ports=False by default and use PORT layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
-## [5.8.9]
+## 5.8.9
 
-- add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
-- apply default_decorator before returning component if pdk.default_decorator is defined.
+- [PR](https://github.com/gdsfactory/gdsfactory/pull/440)
+    * add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
+    * apply default_decorator before returning component if pdk.default_decorator is defined.
+- [PR](https://github.com/gdsfactory/gdsfactory/pull/441) Component.show(show_ports=False) `show_ports=False` and use `LAYER.PORT`, fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/438)
 
 ## [5.8.8](https://github.com/gdsfactory/gdsfactory/pull/436)
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -911,9 +911,9 @@ class Component(Device):
 
     def show(
         self,
-        show_ports: bool = True,
+        show_ports: bool = False,
         show_subports: bool = False,
-        port_marker_layer: Layer = (1, 12),
+        port_marker_layer: Layer = "PORT",
     ) -> None:
         """Show component in klayout.
 

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -80,5 +80,5 @@ if __name__ == "__main__":
         # bbox_offsets=[3],
     )
     c.assert_ports_on_grid()
-    c.show()
+    c.show(show_ports=True)
     c.pprint()


### PR DESCRIPTION
Component.show(show_ports=False) `show_ports=False` and use `LAYER.PORT`, fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/438)