### PR TITLE
document layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,26 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.8.10]
+
+- add `SHOW_PORTS = (1, 12)` layer.
+- document needed layers for the pdk.
+
+| Layer          | Purpose                                                      |
+| -------------- | ------------------------------------------------------------ |
+| PORT           | optical port pins. For connectivity checks.                  |
+| PORTE          | electrical port pins. For connectivity checks.               |
+| DEVREC         | device recognition layer. For connectivity checks.           |
+| SHOW_PORTS     | add port pin markers when `Component.show(show_ports=True)`  |
+| LABEL_INSTANCE | for adding instance labels on `gf.read.from_yaml`            |
+| LABEL          | for adding labels to grating couplers for automatic testing. |
+| TE             | for TE polarization fiber marker.                            |
+| TM             | for TM polarization fiber marker.                            |
+
 ## 5.8.9
 
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/440)
-    * add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
-    * apply default_decorator before returning component if pdk.default_decorator is defined.
+  - add default layers to pdk. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/437)
+  - apply default_decorator before returning component if pdk.default_decorator is defined.
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/441) Component.show(show_ports=False) `show_ports=False` and use `LAYER.PORT`, fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/438)
 
 ## [5.8.8](https://github.com/gdsfactory/gdsfactory/pull/436)
@@ -53,17 +69,17 @@
 ## 5.8.0
 
 - works with siepic verification [PR](https://github.com/gdsfactory/gdsfactory/pull/410)
-    - cross_section has optional add_pins and add_bbox, which can be used for verification.
-        - add `cladding_layers` and `cladding_offset`.
-        - cladding_layers follow path shape, while bbox_layers are rectangular.
-    - add 2nm siepic pins and siepic DeviceRecognition layer in cladding_layers, to allow SiEPIC verification scripts.
-    - add `with_two_ports` to taper. False for edge couplers and terminators.
-    - fix ring_double_heater open in the heater top waveguide.
+  - cross_section has optional add_pins and add_bbox, which can be used for verification.
+    - add `cladding_layers` and `cladding_offset`.
+    - cladding_layers follow path shape, while bbox_layers are rectangular.
+  - add 2nm siepic pins and siepic DeviceRecognition layer in cladding_layers, to allow SiEPIC verification scripts.
+  - add `with_two_ports` to taper. False for edge couplers and terminators.
+  - fix ring_double_heater open in the heater top waveguide.
 - Make pdk from existing pdk [PR](https://github.com/gdsfactory/gdsfactory/pull/406)
 - add events module and events relating to Pdk modifications [PR](https://github.com/gdsfactory/gdsfactory/pull/412)
-    - add default_decorator attribute to Pdk. adding pdk argument to pdk-related events
-- add LayerSpec as Union[int, Tuple[int,int], str, None] [PR](https://github.com/gdsfactory/gdsfactory/pull/413/)
-    - add layers dict to Pdk(layers=LAYER.dict()), and `pdk.get_layer`
+  - add default_decorator attribute to Pdk. adding pdk argument to pdk-related events
+- add LayerSpec as Union[int, Tuple[int,int], str, None][pr](https://github.com/gdsfactory/gdsfactory/pull/413/)
+  - add layers dict to Pdk(layers=LAYER.dict()), and `pdk.get_layer`
 
 ## [5.7.1](https://github.com/gdsfactory/gdsfactory/pull/403)
 
@@ -78,9 +94,9 @@
 - clean cross-sections [PR](https://github.com/gdsfactory/gdsfactory/pull/398/files)
 - fix N/S routing in route_ports_to_side [PR](https://github.com/gdsfactory/gdsfactory/pull/395)
 - Add basic multilayer electrical routing to most routing functions [PR](https://github.com/gdsfactory/gdsfactory/pull/392)
-   - Use via_corner instead of wire_corner for bend function
-   - Use MultiCrossSectionAngleSpec instead of CrossSectionSpec to define multiple cross sections
-   - Avoids refactoring as much as possible so it doesn't interfere with current single-layer routing
+  - Use via_corner instead of wire_corner for bend function
+  - Use MultiCrossSectionAngleSpec instead of CrossSectionSpec to define multiple cross sections
+  - Avoids refactoring as much as possible so it doesn't interfere with current single-layer routing
 
 ## [5.6.12](https://github.com/gdsfactory/gdsfactory/pull/397)
 
@@ -99,7 +115,7 @@
 
 ## [5.6.9](https://github.com/gdsfactory/gdsfactory/pull/389)
 
--  add_port_from_marker function only allows for ports to be created parallel to the long side of the pin marker. [PR](https://github.com/gdsfactory/gdsfactory/pull/386)
+- add_port_from_marker function only allows for ports to be created parallel to the long side of the pin marker. [PR](https://github.com/gdsfactory/gdsfactory/pull/386)
 
 ## [5.6.7](https://github.com/gdsfactory/gdsfactory/pull/385)
 
@@ -107,7 +123,6 @@
 - write_gds creates a new file per save
 - improve filewatcher for YAML files
 - add python_requires = >= 3.7 in setup.cfg
-
 
 ## [5.6.6](https://github.com/gdsfactory/gdsfactory/pull/382)
 
@@ -161,7 +176,6 @@
 - expose `gf.add_pins` module instead of `add_pins` function. So you can use any of the functions inside the module.
 - improve tutorial
 
-
 ## [5.5.5](https://github.com/gdsfactory/gdsfactory/pull/360)
 
 - add `gdsdir` to write_cells CLI command
@@ -206,7 +220,7 @@
 
 - bring back python3.7 compatibility [PR](https://github.com/gdsfactory/gdsfactory/pull/338)
 - rename `vars` to `settings` in `read.from_yaml` [PR](https://github.com/gdsfactory/gdsfactory/pull/339)
-    - use settings combined with kwargs for getting component name
+  - use settings combined with kwargs for getting component name
 - fix mirror isse in `gf.read.from_yaml` [PR](https://github.com/gdsfactory/gdsfactory/pull/341)
 
 ## [5.4.0](https://github.com/gdsfactory/gdsfactory/pull/337)
@@ -219,9 +233,9 @@
 - update netlist driven flow tutorial with ipywidgets, so you can live update the YAML and see it in matplotlib and Klayout [PR](https://github.com/gdsfactory/gdsfactory/pull/329)
 - [PR fixes problem with showing new layers, not in the previous layer props](https://github.com/gdsfactory/gdsfactory/pull/328)
 - [fix show](https://github.com/gdsfactory/gdsfactory/pull/326)
- - Fixes gf.show() when gdsdir is passed as a kwarg (for cases when the user wants to retain the output gds file at a specific directory)
- - Changes the default behavior to use a context manager to clean up the temp directory after it is created
- - Adds tests for the two different invocation types
+- Fixes gf.show() when gdsdir is passed as a kwarg (for cases when the user wants to retain the output gds file at a specific directory)
+- Changes the default behavior to use a context manager to clean up the temp directory after it is created
+- Adds tests for the two different invocation types
 
 ## [5.3.7](https://github.com/gdsfactory/gdsfactory/pull/325)
 
@@ -255,8 +269,8 @@
 - enable Component.plot() with ports with orientation = None
 - add gf.routing.get_route_from_steps_electrical
 - rename ComponentFactory to ComponentSpec and ComponentOrFactory to ComponentSpec [PR](https://github.com/gdsfactory/gdsfactory/pull/313)
-    * replace callable(component) with gf.get_component(component)
-    * replace some call_if_func(component) with gf.get_component(component)
+  - replace callable(component) with gf.get_component(component)
+  - replace some call_if_func(component) with gf.get_component(component)
 
 ## [5.2.9](https://github.com/gdsfactory/gdsfactory/pull/308)
 
@@ -266,7 +280,6 @@
 
 - add more type annotations. To reduce the number of mypy errors.
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/306)
-
 
 ## [5.2.7](https://github.com/gdsfactory/gdsfactory/pull/305)
 
@@ -300,16 +313,15 @@
 ## [5.2.1](https://github.com/gdsfactory/gdsfactory/pull/289)
 
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/289)
-    * rename cladding_offsets as bbox_offsets
-    * copy_child_info propagates polarization and wavelength info
+
+  - rename cladding_offsets as bbox_offsets
+  - copy_child_info propagates polarization and wavelength info
 
 - make sure 0 or None is 0 in `xmin` or `xmax` keys from component_from_yaml
-
 
 ## [5.2.0](https://github.com/gdsfactory/gdsfactory/pull/287)
 
 - rename `contact` to `via_stack`
-
 
 ## [5.1.2](https://github.com/gdsfactory/gdsfactory/pull/286)
 
@@ -324,6 +336,7 @@
 ## [5.1.0](https://github.com/gdsfactory/gdsfactory/pull/284)
 
 - improve shear angle algorithm to work with waveguides at any angle [PR](https://github.com/gdsfactory/gdsfactory/pull/283)
+
   - add examples in notebooks
   - add tests
   - add shear_angle attribute to Port

--- a/docs/notebooks/08_pdk.ipynb
+++ b/docs/notebooks/08_pdk.ipynb
@@ -9,9 +9,9 @@
     "gdsfactory includes a generic PDK class. Only one PDK can be active at a time.\n",
     "\n",
     "The PDK allows you to register:\n",
-    "- `cell` functions that return Components from a ComponentSpec (string, Component, ComponentFactory or dict)\n",
-    "- `cross_section` functions that return CrossSection from a CrossSection Spec (string, CrossSection, CrossSectionFactory or dict)\n",
-    "- `layers` that returns a GDS Layer from a string, an int or a Tuple[int, int]\n",
+    "- `cell` functions that return Components from a ComponentSpec (string, Component, ComponentFactory or dict). Also known as PCells (parametric cells).\n",
+    "- `cross_section` functions that return CrossSection from a CrossSection Spec (string, CrossSection, CrossSectionFactory or dict).\n",
+    "- `layers` that return a GDS Layer from a string, an int or a Tuple[int, int].\n",
     "\n",
     "\n",
     "You can only have one active PDK at a time.\n",
@@ -32,7 +32,13 @@
     "\n",
     "GDS layers are a tuple of two integer number `gdslayer/gdspurpose`\n",
     "\n",
-    "The easiest way to define your layermap is using a Klayout `lyp` file to generate the layers code."
+    "You can define all the layers from your PDK:\n",
+    "\n",
+    "1. From a Klayout `lyp` (layer properties file).\n",
+    "2. From scratch, adding all your layers into a class.\n",
+    "\n",
+    "\n",
+    "Lets generate the layers definition code from a klayout `lyp` file."
    ]
   },
   {
@@ -107,6 +113,39 @@
     "\n",
     "\n",
     "LAYER = LayerMap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are some default layers in some generic components and cross_sections, that it may be convenient adding.\n",
+    "\n",
+    "| Layer          | Purpose                                                      |\n",
+    "| -------------- | ------------------------------------------------------------ |\n",
+    "| DEVREC         | device recognition layer. For connectivity checks.           |\n",
+    "| PORT           | optical port pins. For connectivity checks.                  |\n",
+    "| PORTE          | electrical port pins. For connectivity checks.               |\n",
+    "| SHOW_PORTS     | add port pin markers when `Component.show(show_ports=True)`  |\n",
+    "| LABEL          | for adding labels to grating couplers for automatic testing. |\n",
+    "| LABEL_INSTANCE | for adding instance labels on `gf.read.from_yaml`            |\n",
+    "| TE             | for TE polarization fiber marker.                            |\n",
+    "| TM             | for TM polarization fiber marker.                            |\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "class LayersConvenient(BaseModel):\n",
+    "    DEVREC: Layer = (68, 0)\n",
+    "    PORT: Layer = (1, 10)  # PinRec optical\n",
+    "    PORTE: Layer = (1, 11)  # PinRec electrical\n",
+    "    SHOW_PORTS: Layer = (1, 12) \n",
+    "\n",
+    "    LABEL: Layer = (201, 0)\n",
+    "    LABEL_INSTANCE: Layer = (66, 0)\n",
+    "    TE: Layer = (203, 0)\n",
+    "    TM: Layer = (204, 0)\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -195,8 +234,9 @@
    "source": [
     "## cells\n",
     "\n",
-    "Cells are functions that return Components. You can customize the function default arguments easily thanks to `functools.partial`\n",
+    "Cells are functions that return Components. They are parametrized and accept also cells as parameters, so you can build many levels of complexity. Cells are also known as PCells or parametric cells.\n",
     "\n",
+    "You can customize the function default arguments easily thanks to `functools.partial`\n",
     "Lets customize the default arguments of a library of cells.\n",
     "\n",
     "For example, you can make some wide MMIs for a particular technology. Lets say the best MMI width you found it to be 9um."
@@ -719,9 +759,9 @@
     "\n",
     "To make sure all your PDK Pcells produce the components that you want, it's important to test your PDK.\n",
     "\n",
-    "As you write your own component factories you want to make sure you do not break them later on. You can write tests to avoid unwanted regressions.\n",
+    "As you write your own cell functions you want to make sure you do not break them later on. You can write tests to avoid unwanted regressions.\n",
     "\n",
-    "Make sure you create a test like this an name it with test_ prefix so Pytest can find it.\n"
+    "Make sure you create a test like this an name it with `test_` prefix so Pytest can find it.\n"
    ]
   },
   {

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -76,6 +76,16 @@ import gdsfactory as gf
 class LayerMap(BaseModel):
     WGCORE = (3, 0)
     LABEL = (100, 0)
+    DEVREC: Layer = (68, 0)
+    LABEL: Layer = (10, 0)
+    PORT: Layer = (1, 10)  # PinRec
+    PORTE: Layer = (1, 11)  # PinRecM
+    FLOORPLAN: Layer = (99, 0)
+
+    TE: Layer = (203, 0)
+    TM: Layer = (204, 0)
+    TEXT: Layer = (66, 0)
+    LABEL_INSTANCE: Layer = (66, 0)
 
 
 LAYER = LayerMap()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -913,12 +913,13 @@ class Component(Device):
         self,
         show_ports: bool = False,
         show_subports: bool = False,
-        port_marker_layer: Layer = "PORT",
+        port_marker_layer: Layer = "SHOW_PORTS",
     ) -> None:
         """Show component in klayout.
 
-        show_subports = True adds pins to a component copy for klayout show.
-        so the original component remains intact.
+        returns a copy of the Component, so the original component remains intact.
+        with pins markers on each port show_ports = True, and optionally also
+        the ports from the references (show_subports=True)
 
         Args:
             show_ports: shows component with port markers and labels.

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -15,21 +15,22 @@ Assumes two ports are connected when they have same width, x, y
 
 """
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict
 
 import omegaconf
 
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.name import clean_name
+from gdsfactory.pdk import get_layer
 from gdsfactory.serialization import clean_value_json
 from gdsfactory.snap import snap_to_grid
-from gdsfactory.tech import LAYER
+from gdsfactory.types import LayerSpec
 
 
 def get_instance_name(
     component: Component,
     reference: ComponentReference,
-    layer_label: Tuple[int, int] = LAYER.LABEL_INSTANCE,
+    layer_label: LayerSpec = "LABEL_INSTANCE",
 ) -> str:
     """Returns the instance name from the label.
     If no label returns to instanceName_x_y
@@ -39,6 +40,8 @@ def get_instance_name(
         reference: reference that needs naming.
         layer_label: ignores layer_label[1].
     """
+
+    layer_label = get_layer(layer_label)
 
     x = snap_to_grid(reference.x)
     y = snap_to_grid(reference.y)
@@ -64,7 +67,7 @@ def get_instance_name(
 def get_netlist(
     component: Component,
     full_settings: bool = False,
-    layer_label: Tuple[int, int] = LAYER.LABEL_INSTANCE,
+    layer_label: LayerSpec = "LABEL_INSTANCE",
     tolerance: int = 1,
 ) -> omegaconf.DictConfig:
     """From a component returns instances, connections and placements dict. It
@@ -87,6 +90,7 @@ def get_netlist(
     instances = {}
     connections = {}
     top_ports = {}
+    layer_label = get_layer(layer_label)
 
     for reference in component.references:
         c = reference.parent

--- a/gdsfactory/layers.py
+++ b/gdsfactory/layers.py
@@ -89,7 +89,7 @@ class LayerSet(LayerSetPhidl):
         alpha: float = 0.6,
         dither: bool = None,
     ) -> None:
-        """Adds a layer to an existing LayerSet object for nice colors.
+        """Adds a layer to LayerSet object for nice colors.
 
         Args:
             name: Name of the Layer.

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -56,6 +56,7 @@ class LayerMap(BaseModel):
     PORT: Layer = (1, 10)
     PORTE: Layer = (1, 11)
     PORTH: Layer = (70, 0)
+    SHOW_PORTS: Layer = (1, 12)
     LABEL: Layer = (201, 0)
     LABEL_SETTINGS: Layer = (202, 0)
     TE: Layer = (203, 0)


### PR DESCRIPTION
- add `SHOW_PORTS = (1, 12)` layer.
- document needed layers for the pdk.

| Layer          | Purpose                                                      |
| -------------- | ------------------------------------------------------------ |
| PORT           | optical port pins. For connectivity checks.                  |
| PORTE          | electrical port pins. For connectivity checks.               |
| DEVREC         | device recognition layer. For connectivity checks.           |
| SHOW_PORTS     | add port pin markers when `Component.show(show_ports=True)`  |
| LABEL_INSTANCE | for adding instance labels on `gf.read.from_yaml`            |
| LABEL          | for adding labels to grating couplers for automatic testing. |
| TE             | for TE polarization fiber marker.                            |
| TM             | for TM polarization fiber marker.                            |


https://github.com/gdsfactory/gdsfactory/issues/438
