### PR TITLE
Using tidy3d.webapi.Batch instead of pool executor

### DIFF
--- a/gdsfactory/simulation/gtidy3d/get_results.py
+++ b/gdsfactory/simulation/gtidy3d/get_results.py
@@ -10,7 +10,7 @@ from tidy3d.log import WebError
 
 import gdsfactory as gf
 from gdsfactory.config import PATH, logger
-from gdsfactory.types import PathType
+from gdsfactory.types import PathType, List
 
 _executor = concurrent.futures.ThreadPoolExecutor()
 
@@ -21,10 +21,10 @@ def get_sim_hash(sim: td.Simulation) -> str:
 
 
 def _get_results(
-    sim: td.Simulation,
+    sims: List[td.Simulation],
     dirpath: PathType = PATH.results_tidy3d,
     overwrite: bool = False,
-) -> td.SimulationData:
+) -> web.BatchData:
     """Return SimulationData results from simulation.
 
     Only submits simulation if results not found locally or remotely.
@@ -37,50 +37,54 @@ def _get_results(
         dirpath: to store results locally.
         overwrite: overwrites the data even when path exists.
     """
-    task_name = sim_hash = get_sim_hash(sim)
-    sim_path = dirpath / f"{sim_hash}.hdf5"
-    logger.info(f"running simulation {sim_hash!r}")
+    # task_name = sim_hash = get_sim_hash(sim)
+    # sim_path = dirpath / f"{sim_hash}.hdf5"
+    # logger.info(f"running simulation {sim_hash!r}")
 
-    hash_to_id = {d["task_name"][:32]: d["task_id"] for d in web.get_tasks()}
-    filepath = str(dirpath / f"{sim_hash}.hdf5")
-    job = web.Job(simulation=sim, task_name=task_name)
+    # hash_to_id = {d["task_name"][:32]: d["task_id"] for d in web.get_tasks()}
+    # filepath = str(dirpath / f"{sim_hash}.hdf5")
+    # job = web.Job(simulation=sim, task_name=task_name)
 
-    # Results in local storage
-    if sim_path.exists():
-        task_id = hash_to_id[sim_hash]
-        logger.info(f"{sim_path!r} for task_id {task_id!r} found in local storage")
-        return td.SimulationData.from_file(filepath)
+    # # Results in local storage
+    # if sim_path.exists():
+    #     task_id = hash_to_id[sim_hash]
+    #     logger.info(f"{sim_path!r} for task_id {task_id!r} found in local storage")
+    #     return td.SimulationData.from_file(filepath)
 
-    # Results in server storage
-    if sim_hash in hash_to_id:
-        task_id = hash_to_id[sim_hash]
-        web.monitor(task_id)
+    # # Results in server storage
+    # if sim_hash in hash_to_id:
+    #     task_id = hash_to_id[sim_hash]
+    #     web.monitor(task_id)
 
-        try:
-            return web.load(task_id=task_id, path=filepath, replace_existing=overwrite)
-        except WebError:
-            logger.info(f"task_id {task_id!r} exists but no results found.")
-        except Exception:
-            logger.info(f"task_id {task_id!r} exists but unexpected error encountered.")
+    #     try:
+    #         return web.load(task_id=task_id, path=filepath, replace_existing=overwrite)
+    #     except WebError:
+    #         logger.info(f"task_id {task_id!r} exists but no results found.")
+    #     except Exception:
+    #         logger.info(f"task_id {task_id!r} exists but unexpected error encountered.")
 
-    # Run simulation if results not found in local or server storage
-    logger.info(f"sending task_name {task_name!r} to tidy3d server.")
-    return job.run(path=filepath)
+    # # Run simulation if results not found in local or server storage
+    # logger.info(f"sending task_name {task_name!r} to tidy3d server.")
+    # return job.run(path=filepath)
+
+    task_names = [get_sim_hash(sim) for sim in sims]
+    batch = web.Batch(simulations=dict(zip(task_names, sims)))
+    return batch.run(path_dir=dirpath)
 
 
 def get_results(
-    sim: td.Simulation,
+    sims: List[td.Simulation],
     dirpath=PATH.results_tidy3d,
     overwrite: bool = True,
-) -> Awaitable[td.SimulationData]:
-    """Return a SimulationData from Simulation.
+) -> web.BatchData:
+    """Return a List of SimulationData from a list of Simulation.
 
     Works with Pool of threads.
     Each thread can run in paralell and only becomes blocking when you ask
     for .result()
 
     Args:
-        sim: Simulation
+        sims: List[Simulation]
         dirpath: to store results locally
         overwrite: overwrites the data even if path exists. Keep True.
 
@@ -90,11 +94,10 @@ def get_results(
 
         component = gf.components.straight(length=3)
         sim = gt.get_simulation(component=component)
-        sim_data = gt.get_results(sim) # threaded
-        sim_data = sim_data.result() # waits for results
+        sim_data = gt.get_results([sim])
 
     """
-    return _executor.submit(_get_results, sim, dirpath, overwrite)
+    return _get_results(sims, dirpath, overwrite)
 
 
 if __name__ == "__main__":

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -8,5 +8,6 @@ pyyaml
 simphony==0.6.1
 SiPANN==1.4.0
 sklearn
-tidy3d-beta==1.4.0
+shapely==1.7.1
+tidy3d-beta
 triangle


### PR DESCRIPTION
This PR is a WIP to illustrate how the Tidy3D native Batch can be used instead of a pool executor. It seems that our `web.monitor` function does not interact well with the executor. In the future, we could instead introduce a `web.wait()` function that does not show any output and this *may* fix the current issues. Generally though I would recommend rewriting everything using the Batch functionality rather than the executor.

With this batch rewrite, tidy3d 1.4.1 works well, so I removed the restriction to 1.4.0.

Additionally, all the shapely warnings come from shapely 1.8.0 or higher. I added shapely restriction to 1.7.1. We are thinking of waiting for shapely 2.0 before doing modifications to our current code that uses it.