### PR TITLE
5106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
     - add `gf.add_labels.add_labels_to_ports_electrical`
     - add `gf.add_labels.add_labels_to_ports_optical`
     - add `gf.add_labels.add_labels_to_ports_vertical_dc` for pads
+- fix colors in Component.plot()
+- add `Component.plotqt()`
+- add add_port_markers and read_labels_yaml to gf.read.labels
 
 ## [5.10.5](https://github.com/gdsfactory/gdsfactory/pull/457)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.10.6](https://github.com/gdsfactory/gdsfactory/pull/457)
+
+- raise ValueError if no polygons to render in 3D.
+
 ## [5.10.5](https://github.com/gdsfactory/gdsfactory/pull/457)
 
 - quickplotter picks a random color if layer not defined in pdk.get_layer_color(). Before it was raising a ValueError.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [5.10.6](https://github.com/gdsfactory/gdsfactory/pull/457)
 
 - raise ValueError if no polygons to render in 3D.
+- add pad ports to functions that route to electrical pads, so new Component can still access the pad ports.
+    - `gf.routing.add_electrical_pads_shortest`
+    - `gf.routing.add_electrical_pads_top`
+    - `gf.routing.add_electrical_pads_top_dc`
+- add `gf.add_labels.add_labels_to_ports`
+    - add `gf.add_labels.add_labels_to_ports_electrical`
+    - add `gf.add_labels.add_labels_to_ports_optical`
+    - add `gf.add_labels.add_labels_to_ports_vertical_dc` for pads
 
 ## [5.10.5](https://github.com/gdsfactory/gdsfactory/pull/457)
 

--- a/docs/notebooks/07_mask.ipynb
+++ b/docs/notebooks/07_mask.ipynb
@@ -846,6 +846,56 @@
     "\n",
     "display(x, out)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a998fea-911f-4dc6-85d6-56fce034785f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "\n",
+    "def mzi_te(**kwargs):\n",
+    "    gc = gf.c.grating_coupler_elliptical_tm()\n",
+    "    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)\n",
+    "    c = gf.routing.add_fiber_single(\n",
+    "        c, get_input_label_text_function=None, grating_coupler=gc\n",
+    "    )\n",
+    "    gf.dft.add_label_yaml(c)\n",
+    "    c = c.rotate(-90)\n",
+    "    return c\n",
+    "\n",
+    " \n",
+    "# Lets write a mask\n",
+    "c = gf.grid(\n",
+    "    [\n",
+    "        mzi_te(),\n",
+    "        mzi_te(),\n",
+    "        gf.functions.rotate(mzi_te),\n",
+    "        gf.dft.add_label_yaml(\n",
+    "            gf.functions.mirror(gf.routing.add_fiber_single(gf.components.mmi1x2))\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "gdspath = c.write_gds(\"mask.gds\")\n",
+    "csvpath = gf.mask.write_labels_gdspy(gdspath, prefix=\"component_name\")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0512badf-7a0d-4201-a1ec-89a7b05a7ead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.read.labels import read_labels_yaml, add_port_markers\n",
+    "\n",
+    "# You can make sure that all the ports will be tested by adding port markers\n",
+    "add_port_markers(gdspath=gdspath, csvpath=csvpath, marker_size=40)"
+   ]
   }
  ],
  "metadata": {

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -946,7 +946,7 @@ class Component(Device):
 
         show(component)
 
-    def to_3d(self, **kwargs):
+    def to_3d(self, *args, **kwargs):
         """Return Component 3D trimesh Scene.
 
         Keyword Args:
@@ -960,7 +960,7 @@ class Component(Device):
         """
         from gdsfactory.export.to_3d import to_3d
 
-        return to_3d(self, **kwargs)
+        return to_3d(self, *args, **kwargs)
 
     def write_gds(
         self,

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -148,7 +148,7 @@ class Component(Device):
         anchor: str = "o",
         layer="TEXT",
     ) -> Label:
-        """Adds a Label to the Device.
+        """Adds Label to the Component.
 
         Args:
             text: Label text.

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -818,6 +818,11 @@ class Component(Device):
 
             return quickplot2(self)
 
+    def plotqt(self):
+        from gdsfactory.quickplotter import quickplot2
+
+        return quickplot2(self)
+
     def ploth(
         self,
         layers_excluded: Optional[Layers] = None,

--- a/gdsfactory/dft/add_label_yaml.py
+++ b/gdsfactory/dft/add_label_yaml.py
@@ -8,7 +8,8 @@ import pydantic
 
 import gdsfactory as gf
 from gdsfactory.name import clean_name
-from gdsfactory.types import Layer
+from gdsfactory.pdk import get_layer
+from gdsfactory.types import LayerSpec
 
 ignore = [
     "cross_section",
@@ -32,12 +33,12 @@ port_types_to_label = [
 def add_label_yaml(
     component: gf.Component,
     port_types: List[str] = port_types_to_label,
-    layer: Layer = (66, 0),
+    layer: LayerSpec = "TEXT",
     metadata_ignore: Optional[List[str]] = ignore,
     metadata_include_parent: Optional[List[str]] = None,
     metadata_include_child: Optional[List[str]] = None,
 ) -> gf.Component:
-    """Returns Component with measurement labels.
+    """Returns Component with measurement label.
 
     Args:
         component: to add labels to.
@@ -59,6 +60,7 @@ wavelength: {component.metadata.get('wavelength')}
 settings:
 """
     info = []
+    layer = get_layer(layer)
 
     # metadata = component.metadata_child.changed
     metadata = component.metadata_child.get("changed")

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -41,6 +41,8 @@ def to_3d(
     layer_to_zmin = layer_stack.get_layer_to_zmin()
     exclude_layers = exclude_layers or []
 
+    has_polygons = False
+
     for layer, polygons in component.get_polygons(by_spec=True).items():
         if (
             layer not in exclude_layers
@@ -49,7 +51,8 @@ def to_3d(
         ):
             height = layer_to_thickness[layer]
             zmin = layer_to_zmin[layer]
-            color_hex = layer_colors.get_from_tuple(layer).color
+            layer_color = layer_colors.get_from_tuple(layer)
+            color_hex = layer_color.color
             color_rgb = matplotlib.colors.to_rgb(color_hex)
 
             for polygon in polygons:
@@ -58,6 +61,13 @@ def to_3d(
                 mesh.apply_translation((0, 0, zmin))
                 mesh.visual.face_colors = (*color_rgb, 0.5)
                 scene.add_geometry(mesh)
+                has_polygons = True
+
+    if not has_polygons:
+        raise ValueError(
+            f"{component.name!r} does not have polygons defined in the "
+            "layer_stack or layer_colors for the active Pdk {get_active_pdk().name!r}"
+        )
     return scene
 
 

--- a/gdsfactory/klayout/tech/layers.lyp
+++ b/gdsfactory/klayout/tech/layers.lyp
@@ -609,23 +609,6 @@
   <marked>false</marked>
   <xfill>false</xfill>
   <animation>0</animation>
-  <name>TEXT 66/0</name>
-  <source>66/0@1</source>
- </properties>
- <properties>
-  <frame-color>#0000ff</frame-color>
-  <fill-color>#0000ff</fill-color>
-  <frame-brightness>0</frame-brightness>
-  <fill-brightness>0</fill-brightness>
-  <dither-pattern>I1</dither-pattern>
-  <line-style/>
-  <valid>true</valid>
-  <visible>true</visible>
-  <transparent>false</transparent>
-  <width>1</width>
-  <marked>false</marked>
-  <xfill>false</xfill>
-  <animation>0</animation>
   <name>LABEL OPTICAL IO 201/0</name>
   <source>201/0@1</source>
  </properties>
@@ -967,7 +950,7 @@
   <xfill>false</xfill>
   <animation>0</animation>
   <name>Errors</name>
-  <source>66/0@1</source>
+  <source>69/0@1</source>
  </properties>
  <properties>
   <frame-color>#004080</frame-color>

--- a/gdsfactory/layers.py
+++ b/gdsfactory/layers.py
@@ -26,9 +26,7 @@ layer_path = module_path / "klayout" / "tech" / "layers.lyp"
 
 
 def preview_layerset(ls, size: float = 100.0, spacing: float = 100.0) -> object:
-    """Generates a preview Device with representations of all the layers,
-    used for previewing LayerColors color schemes in quickplot or saved .gds
-    files
+    """Generates a Component with all the layers.
 
     Args:
         ls: LayerColors.
@@ -185,7 +183,7 @@ class LayerColors(BaseModel):
             return self.layers[name]
 
     def __getitem__(self, val):
-        """allows access to the layer names like ls['gold2'].
+        """Allows accessing to the layer names like ls['gold2'].
 
         Args:
             val: Layer name to access within the LayerColors.
@@ -207,14 +205,14 @@ class LayerColors(BaseModel):
         }
         if layer_tuple not in tuple_to_name:
             raise ValueError(
-                f"Layer color from {layer_tuple} not in {list(tuple_to_name.keys())}"
+                f"Layer color {layer_tuple} not in {list(tuple_to_name.keys())}"
             )
 
         name = tuple_to_name[layer_tuple]
         return self.layers[name]
 
     def clear(self) -> None:
-        """Deletes all entries in the LayerColors"""
+        """Deletes all layers in the LayerColors."""
         self.layers = {}
 
     def preview(self):

--- a/gdsfactory/layers.py
+++ b/gdsfactory/layers.py
@@ -211,6 +211,9 @@ class LayerColors(BaseModel):
         name = tuple_to_name[layer_tuple]
         return self.layers[name]
 
+    def get_layer_tuples(self):
+        return {(layer.gds_layer, layer.gds_datatype) for layer in self.layers.values()}
+
     def clear(self) -> None:
         """Deletes all layers in the LayerColors."""
         self.layers = {}

--- a/gdsfactory/mask/write_labels.py
+++ b/gdsfactory/mask/write_labels.py
@@ -87,10 +87,11 @@ def write_labels(
 
 def write_labels_gdspy(
     gdspath: Path,
+    prefix: str = "opt_",
     layer_label: Optional[Tuple[int, int]] = LAYER.TEXT,
     filepath: Optional[PathType] = None,
-    prefix: str = "opt_",
     debug: bool = False,
+    set_transform: bool = True,
 ) -> Path:
     """Load GDS and extracts label text and coordinates.
 
@@ -98,10 +99,13 @@ def write_labels_gdspy(
 
     Args:
         gdspath: for the mask.
+        prefix: for the labels to write.
         layer_label: for labels to write.
         filepath: for CSV file. Defaults to gdspath with CSV suffix.
-        prefix: for the labels to write.
         debug: prints the label.
+        set_transform: bool
+            If True, labels will include the transformations from
+            the references they are from.
     """
 
     gdspath = pathlib.Path(gdspath)
@@ -111,7 +115,7 @@ def write_labels_gdspy(
 
     labels = []
 
-    for label in c.get_labels(set_transform=True):
+    for label in c.get_labels(set_transform=set_transform):
         if (
             layer_label
             and label.layer == layer_label[0]

--- a/gdsfactory/quickplotter.py
+++ b/gdsfactory/quickplotter.py
@@ -189,12 +189,13 @@ def quickplot(items):  # noqa: C901
 
     Examples
     --------
-    >>> R = pg.rectangle()
-    >>> quickplot(R)
+    >>> import gdsfactory as gf
+    >>> R = gf.components.rectangle()
+    >>> gf.plot(R)
 
-    >>> R = pg.rectangle()
-    >>> E = pg.ellipse()
-    >>> quickplot([R, E])
+    >>> R = gf.components.rectangle()
+    >>> E = gf.components.ellipse()
+    >>> gf.plot([R, E])
     """
 
     # Override default options with _quickplot_options
@@ -367,7 +368,7 @@ def _get_layerprop(layer, datatype):
     LAYER_COLORS = get_layer_colors()
     _layer = (
         LAYER_COLORS.get_from_tuple((layer, datatype))
-        if (layer, datatype) in LAYER_COLORS.layers.values()
+        if (layer, datatype) in LAYER_COLORS.get_layer_tuples()
         else None
     )
     if _layer is not None:
@@ -991,3 +992,10 @@ def quickplot2(item_list, *args, **kwargs):
     viewer_window.show()
     viewer_window.raise_()
     return viewer
+
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    c = gf.components.straight()
+    c.plotqt()

--- a/gdsfactory/read/labels.py
+++ b/gdsfactory/read/labels.py
@@ -1,0 +1,111 @@
+from typing import Dict, Optional
+
+import numpy as np
+import pandas as pd
+from omegaconf import DictConfig, OmegaConf
+from phidl.device_layout import _rotate_points
+
+import gdsfactory as gf
+from gdsfactory.name import clean_name
+from gdsfactory.types import PathType
+
+
+def read_labels_yaml(
+    csvpath: PathType, prefix: Optional[str] = None
+) -> Dict[str, DictConfig]:
+    """Read labels from csvfile in YAML format."""
+    labels = pd.read_csv(csvpath)
+    cells = OmegaConf.create()
+
+    for label in labels.iterrows():
+        label = label[1]
+        if prefix and not label[0].startswith(prefix):
+            continue
+
+        d = OmegaConf.create(label[0])
+        x = label[1]
+        y = label[2]
+        rotation = label[3]
+        cell_name = d["component_name"]
+        instance_name = clean_name(f"{cell_name}_{x}_{y}")
+        # wavelength = d.get("wavelength", 1.55)
+        # polarization = d["polarization"]
+        # ports = d["ports"]
+
+        d["x"] = x
+        d["y"] = y
+        d["rotation"] = rotation
+        cells[instance_name] = d
+    return cells
+
+
+def overlay_ports(gdspath, csvpath, marker_size=20, marker_layer=(203, 0)):
+    """Overlay ports extracted from a csvpath into a gdspath."""
+    c = gf.Component("overlay")
+    c << gf.import_gds(gdspath)
+    cells = read_labels_yaml(csvpath=csvpath)
+
+    for cell in cells.values():
+        for port in cell["ports"].values():
+            r = c << gf.components.rectangle(
+                size=(marker_size, marker_size), layer=marker_layer
+            )
+
+            x = port["midpoint"][0]
+            y = port["midpoint"][1]
+            rotation = cell["rotation"]
+            x, y = np.array(_rotate_points((x, y), angle=rotation)).flatten()
+
+            r.x = x + cell["x"]
+            r.y = y + cell["y"]
+    return c
+
+
+if __name__ == "__main__":
+    # c = read_labels_yaml(csvpath="/home/jmatres/mask.csv", prefix="component_name")
+    # csvpath = "/home/jmatres/mask.csv"
+    # prefix = "component_name"
+
+    # labels = pd.read_csv(csvpath)
+    # cells = OmegaConf.create()
+
+    # for label in labels.iterrows():
+    #     label = label[1]
+    #     if prefix and not label[0].startswith(prefix):
+    #         continue
+
+    #     d = OmegaConf.create(label[0])
+    #     x = label[1]
+    #     y = label[2]
+    #     rotation = label[3]
+    #     cell_name = d["component_name"]
+    #     wavelength = d.get("wavelength", 1.55)
+    #     polarization = d["polarization"]
+    #     ports = d["ports"]
+    #     instance_name = clean_name(f"{cell_name}_{x}_{y}")
+    #     cells[instance_name] = d
+
+    csvpath = "/home/jmatres/mask.csv"
+    gdspath = "/home/jmatres/mask.gds"
+    marker_size = 40
+    marker_layer = (203, 0)
+
+    c = gf.Component("overlay")
+    c << gf.import_gds(gdspath)
+    cells = read_labels_yaml(csvpath=csvpath)
+
+    for cell in cells.values():
+        for port in cell["ports"].values():
+            r = c << gf.components.rectangle(
+                size=(marker_size, marker_size), layer=marker_layer
+            )
+
+            x = port["midpoint"][0]
+            y = port["midpoint"][1]
+            rotation = cell["rotation"]
+            x, y = np.array(_rotate_points((x, y), angle=rotation)).flatten()
+
+            r.x = x + cell["x"]
+            r.y = y + cell["y"]
+
+    c.show()

--- a/gdsfactory/read/labels.py
+++ b/gdsfactory/read/labels.py
@@ -39,8 +39,8 @@ def read_labels_yaml(
     return cells
 
 
-def overlay_ports(gdspath, csvpath, marker_size=20, marker_layer=(203, 0)):
-    """Overlay ports extracted from a csvpath into a gdspath."""
+def add_port_markers(gdspath, csvpath, marker_size=20, marker_layer=(203, 0)):
+    """Add port markers from port info extracted from a gdspath and csvpath."""
     c = gf.Component("overlay")
     c << gf.import_gds(gdspath)
     cells = read_labels_yaml(csvpath=csvpath)

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -26,7 +26,6 @@ def add_electrical_pads_shortest(
         port_orientation: in degrees.
         layer: for the routing.
         kwargs: pad_settings.
-
     """
     c = Component()
     component = gf.get_component(component)

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -39,8 +39,9 @@ def add_electrical_pads_shortest(
 
     pad_port_spacing += pad.metadata_child["full"]["size"][0] / 2
 
-    for port in ports:
+    for i, port in enumerate(ports):
         p = c << pad
+
         if port_orientation == 0:
             p.x = port.x + pad_port_spacing
             p.y = port.y
@@ -58,7 +59,13 @@ def add_electrical_pads_shortest(
             p.x = port.x
             c.add(route_quad(port, p.ports["e2"], layer=layer))
 
+        # add pad ports
+        c.add_ports(p.ports, prefix=f"pad{i+1}_")
+
+    # add component ports
     c.add_ports(ref.ports)
+
+    # remove electrical ports
     for port in ports:
         c.ports.pop(port.name)
     c.copy_child_info(component)
@@ -72,4 +79,4 @@ if __name__ == "__main__":
     c = add_electrical_pads_shortest(component=c)
 
     # c = add_electrical_pads_shortest()
-    c.show()
+    c.show(show_ports=True)

--- a/gdsfactory/routing/add_electrical_pads_top.py
+++ b/gdsfactory/routing/add_electrical_pads_top.py
@@ -29,23 +29,30 @@ def add_electrical_pads_top(
 
     c.component = component
     ref = c << component
-    ports = select_ports(ref.ports)
-    ports = list(ports.values())
-    pads = c << gf.get_component(pad_array, columns=len(ports), orientation=270)
+    ports_electrical = select_ports(ref.ports)
+    ports_electrical = list(ports_electrical.values())
+    pads = c << gf.get_component(
+        pad_array, columns=len(ports_electrical), orientation=270
+    )
     pads.x = ref.x + spacing[0]
     pads.ymin = ref.ymax + spacing[1]
     ports_pads = list(pads.ports.values())
 
     ports_pads = gf.routing.sort_ports.sort_ports_x(ports_pads)
-    ports_component = gf.routing.sort_ports.sort_ports_x(ports)
+    ports_component = gf.routing.sort_ports.sort_ports_x(ports_electrical)
 
     for p1, p2 in zip(ports_component, ports_pads):
         c << route_quad(p1, p2, layer=layer)
 
     c.add_ports(ref.ports)
-    for port in ports:
+
+    # remove electrical ports
+    for port in ports_electrical:
         c.ports.pop(port.name)
+
+    c.add_ports(pads.ports)
     c.copy_child_info(component)
+    c.auto_rename_ports()
     return c
 
 
@@ -59,4 +66,4 @@ if __name__ == "__main__":
     c = gf.components.straight_heater_metal()
     c = gf.components.mzi_phase_shifter_top_heater_metal()
     cc = add_electrical_pads_top(component=c, spacing=(-150, 30))
-    cc.show()
+    cc.show(show_ports=True)

--- a/gdsfactory/routing/add_electrical_pads_top_dc.py
+++ b/gdsfactory/routing/add_electrical_pads_top_dc.py
@@ -20,7 +20,7 @@ def add_electrical_pads_top_dc(
     get_bundle_function: Callable = get_bundle_electrical,
     **kwargs,
 ) -> Component:
-    """connects component electrical ports with pad array at the top
+    """Returns new component with electrical ports connected to a pad array at the top.
 
     Args:
         component: to connect to.
@@ -55,9 +55,12 @@ def add_electrical_pads_top_dc(
         c.add(route.references)
 
     c.add_ports(cref.ports)
+
+    # remove electrical ports
     for port in ports_component:
         c.ports.pop(port.name)
 
+    c.add_ports(pads.ports)
     c.copy_child_info(component)
     return c
 
@@ -65,4 +68,4 @@ def add_electrical_pads_top_dc(
 if __name__ == "__main__":
     c = gf.components.straight_heater_metal(length=100.0)
     cc = add_electrical_pads_top_dc(component=c, width=10)
-    cc.show()
+    cc.show(show_ports=True)

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -237,7 +237,6 @@ def add_fiber_single(
         gco.connect(gc_port_name, wg.ports["o2"])
 
         port = wg.ports["o2"]
-
         ports = gc.get_ports_list(prefix="vertical") or gc.get_ports_list()
         pname = ports[0].name
         p1 = c.add_port(name="loopback1", port=gci.ports[pname])

--- a/gdsfactory/samples/23_reticle.py
+++ b/gdsfactory/samples/23_reticle.py
@@ -33,14 +33,21 @@ def mzi_te_pads3(**kwargs):
 
 
 if __name__ == "__main__":
-    c = mzi_te_pads3()
-    c.show()
-
-    # c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
-    # c = gf.routing.add_fiber_single(c)
-    # c = c.rotate(-90)
-    # c = gf.routing.add_electrical_pads_top(c)
-    # gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}")
+    # c = mzi_te_pads3()
     # c.show()
-    print(c.get_labels())
-    # print(c.get_ports_dict(port_type="electrical").keys())
+
+    gc = gf.c.grating_coupler_elliptical_tm()
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = gf.routing.add_fiber_single(
+        c, get_input_label_text_function=None, grating_coupler=gc
+    )
+    c = c.rotate(-90)
+    c = gf.routing.add_electrical_pads_top(c)
+    gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}-")
+    gf.add_labels.add_labels_to_ports(
+        component=c, port_type="loopback", prefix=f"opttm1500-{c.name}-"
+    )
+    gf.add_labels.add_labels_to_ports(
+        component=c, port_type="vertical_tm", prefix=f"opttm1500-{c.name}-"
+    )
+    c.show()

--- a/gdsfactory/samples/23_reticle.py
+++ b/gdsfactory/samples/23_reticle.py
@@ -5,21 +5,42 @@ Sample of a reticle
 import gdsfactory as gf
 
 
-def mzi_te_pads(**kwargs):
-    c = gf.c.mzi_phase_shifter_top_heater_metal(**kwargs)
-    c_te = gf.routing.add_fiber_single(c)
-    c_te_pads = gf.routing.add_electrical_pads_top(c_te)
-    return c_te_pads
+def mzi_te_pads1(**kwargs):
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = gf.routing.add_fiber_single(c)
+    c = c.rotate(-90)
+    c = gf.routing.add_electrical_pads_top(c)
+    gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}-")
+    return c
+
+
+def mzi_te_pads2(**kwargs):
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = gf.routing.add_fiber_single(c)
+    c = c.rotate(-90)
+    c = gf.routing.add_electrical_pads_top_dc(c)
+    gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}-")
+    return c
+
+
+def mzi_te_pads3(**kwargs):
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = gf.routing.add_fiber_single(c)
+    c = c.rotate(-90)
+    c = gf.routing.add_electrical_pads_shortest(c)
+    gf.add_labels.add_labels_to_ports_vertical_dc(component=c, prefix=f"elec-{c.name}-")
+    return c
 
 
 if __name__ == "__main__":
-    # c = mzi_te_pads()
-    # c.show()
-    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = mzi_te_pads3()
+    c.show()
+
+    # c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
     # c = gf.routing.add_fiber_single(c)
     # c = c.rotate(-90)
-    c = gf.routing.add_electrical_pads_top(c)
-    gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}")
-    c.show()
+    # c = gf.routing.add_electrical_pads_top(c)
+    # gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}")
+    # c.show()
     print(c.get_labels())
-    print(c.get_ports_dict(port_type="electrical").keys())
+    # print(c.get_ports_dict(port_type="electrical").keys())

--- a/gdsfactory/samples/23_reticle.py
+++ b/gdsfactory/samples/23_reticle.py
@@ -1,6 +1,4 @@
-"""
-Sample of a reticle
-"""
+"""Sample of a reticle top level Component."""
 
 import gdsfactory as gf
 

--- a/gdsfactory/samples/23_reticle.py
+++ b/gdsfactory/samples/23_reticle.py
@@ -1,0 +1,25 @@
+"""
+Sample of a reticle
+"""
+
+import gdsfactory as gf
+
+
+def mzi_te_pads(**kwargs):
+    c = gf.c.mzi_phase_shifter_top_heater_metal(**kwargs)
+    c_te = gf.routing.add_fiber_single(c)
+    c_te_pads = gf.routing.add_electrical_pads_top(c_te)
+    return c_te_pads
+
+
+if __name__ == "__main__":
+    # c = mzi_te_pads()
+    # c.show()
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    # c = gf.routing.add_fiber_single(c)
+    # c = c.rotate(-90)
+    c = gf.routing.add_electrical_pads_top(c)
+    gf.add_labels.add_labels_to_ports_electrical(component=c, prefix=f"elec-{c.name}")
+    c.show()
+    print(c.get_labels())
+    print(c.get_ports_dict(port_type="electrical").keys())

--- a/gdsfactory/samples/23_reticle_passives.py
+++ b/gdsfactory/samples/23_reticle_passives.py
@@ -1,6 +1,4 @@
-"""
-Sample of a reticle
-"""
+"""Write a sample reticle together with GDS file."""
 
 import gdsfactory as gf
 
@@ -17,6 +15,7 @@ def mzi_te(**kwargs):
 
 
 if __name__ == "__main__":
+    # Lets write a mask
     c = gf.grid(
         [
             mzi_te(),
@@ -29,4 +28,9 @@ if __name__ == "__main__":
     )
     gdspath = c.write_gds("mask.gds")
     csvpath = gf.mask.write_labels_gdspy(gdspath, prefix="component_name")
-    c.show()
+
+    from gdsfactory.read.labels import add_port_markers
+
+    # You can make sure that all the ports will be tested by adding port markers
+    c2 = add_port_markers(gdspath=gdspath, csvpath=csvpath, marker_size=40)
+    c2.show()

--- a/gdsfactory/samples/23_reticle_passives.py
+++ b/gdsfactory/samples/23_reticle_passives.py
@@ -1,0 +1,32 @@
+"""
+Sample of a reticle
+"""
+
+import gdsfactory as gf
+
+
+def mzi_te(**kwargs):
+    gc = gf.c.grating_coupler_elliptical_tm()
+    c = gf.c.mzi_phase_shifter_top_heater_metal(delta_length=40)
+    c = gf.routing.add_fiber_single(
+        c, get_input_label_text_function=None, grating_coupler=gc
+    )
+    gf.dft.add_label_yaml(c)
+    c = c.rotate(-90)
+    return c
+
+
+if __name__ == "__main__":
+    c = gf.grid(
+        [
+            mzi_te(),
+            mzi_te(),
+            gf.functions.rotate(mzi_te),
+            gf.dft.add_label_yaml(
+                gf.functions.mirror(gf.routing.add_fiber_single(gf.components.mmi1x2))
+            ),
+        ]
+    )
+    gdspath = c.write_gds("mask.gds")
+    csvpath = gf.mask.write_labels_gdspy(gdspath, prefix="component_name")
+    c.show()

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -98,8 +98,8 @@ class LayerLevel(BaseModel):
 
     Attributes:
         layer: (GDSII Layer number, GDSII datatype).
-        thickness: layer thickness.
-        zmin: height position where material starts.
+        thickness: layer thickness in um.
+        zmin: height position where material starts in um.
         material: material name.
         sidewall_angle: in degrees with respect to normal.
     """


### PR DESCRIPTION

- raise ValueError if no polygons to render in 3D.
- add pad ports to functions that route to electrical pads, so new Component can still access the pad ports.
    - `gf.routing.add_electrical_pads_shortest`
    - `gf.routing.add_electrical_pads_top`
    - `gf.routing.add_electrical_pads_top_dc`
- add `gf.add_labels.add_labels_to_ports`
    - add `gf.add_labels.add_labels_to_ports_electrical`
    - add `gf.add_labels.add_labels_to_ports_optical`
    - add `gf.add_labels.add_labels_to_ports_vertical_dc` for pads
- fix colors in Component.plot()
- add `Component.plotqt()`
- add add_port_markers and read_labels_yaml to gf.read.labels