### PR TITLE
51017

### DIFF
--- a/.github/workflows/test_plugins_conda.yml
+++ b/.github/workflows/test_plugins_conda.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          make meep
           make install
           pip install -r requirements_full.txt
       - name: Test with pytest
@@ -37,5 +38,4 @@ jobs:
         run: |
           mkdir -p $HOME/.tidy3d
           echo ${{ secrets.TIDY3D_AUTH }} > $HOME/.tidy3d/auth.json
-          make meep
           make test-plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/478) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/474)
     - Use snap.snap_to_grid() to snap cross section points
     - Warning was not being raised if only one coordinate was off-grid
-- [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476)
+- [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476) offgrid manhattan connection gaps
+- remove unused cache setting from Component.copy()
 
 ## [5.10.16](https://github.com/gdsfactory/gdsfactory/pull/477)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.10.17](https://github.com/gdsfactory/gdsfactory/pull/480)
+
+- [PR](https://github.com/gdsfactory/gdsfactory/pull/478) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/474)
+    - Use snap.snap_to_grid() to snap cross section points
+    - Warning was not being raised if only one coordinate was off-grid
+- [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476)
+
 ## [5.10.16](https://github.com/gdsfactory/gdsfactory/pull/477)
 
 - rename triangle to triangles, to avoid conflict names with triangle module [PR](https://github.com/gdsfactory/gdsfactory/pull/475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476) offgrid manhattan connection gaps
 - remove unused cache setting from Component.copy()
 - fix phidl [issue](https://github.com/amccaugh/phidl/issues/154)
+- make lytest as an optional dependency
 
 ## [5.10.16](https://github.com/gdsfactory/gdsfactory/pull/477)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Warning was not being raised if only one coordinate was off-grid
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476) offgrid manhattan connection gaps
 - remove unused cache setting from Component.copy()
+- fix phidl [issue](https://github.com/amccaugh/phidl/issues/154)
 
 ## [5.10.16](https://github.com/gdsfactory/gdsfactory/pull/477)
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -922,17 +922,26 @@ class Component(Device):
         show_ports: bool = False,
         show_subports: bool = False,
         port_marker_layer: Layer = "SHOW_PORTS",
+        **kwargs,
     ) -> None:
         """Show component in klayout.
 
-        returns a copy of the Component, so the original component remains intact.
-        with pins markers on each port show_ports = True, and optionally also
-        the ports from the references (show_subports=True)
+            returns a copy of the Component, so the original component remains intact.
+            with pins markers on each port show_ports = True, and optionally also
+            the ports from the references (show_subports=True)
 
-        Args:
-            show_ports: shows component with port markers and labels.
-            show_subports: add ports markers and labels to references.
-            port_marker_layer: for the ports.
+            Args:
+                show_ports: shows component with port markers and labels.
+                show_subports: add ports markers and labels to references.
+                port_marker_layer: for the ports.
+
+        Keyword Args:
+            gdspath: GDS file path to write to.
+            gdsdir: directory for the GDS file. Defaults to /tmp/.
+            unit: unit size for objects in library. 1um by default.
+            precision: for object dimensions in the library (m). 1nm by default.
+            timestamp: Defaults to 2019-10-25. If None uses current time.
+
         """
         from gdsfactory.add_pins import add_pins_triangle
         from gdsfactory.show import show
@@ -952,7 +961,7 @@ class Component(Device):
         else:
             component = self
 
-        show(component)
+        show(component, **kwargs)
 
     def to_3d(self, *args, **kwargs):
         """Return Component 3D trimesh Scene.

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -109,6 +109,10 @@ class Component(Device):
         self.version = version
         self.changelog = changelog
 
+    def __lshift__(self, element):
+        """Convenience operator equivalent to add_ref()"""
+        return self.add_ref(element)
+
     def unlock(self) -> None:
         """I recommend doing this only if you know what you are doing."""
         self._locked = False

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -756,6 +756,7 @@ class Component(Device):
         if not isinstance(component, Device):
             raise TypeError(f"type = {type(Component)} needs to be a Component.")
         ref = ComponentReference(component)
+        ref.owner = self
         self.add(ref)
 
         if alias is not None:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -627,12 +627,10 @@ class Component(Device):
 
         return super().add_polygon(points=points, layer=get_layer(layer))
 
-    def copy(
-        self, prefix: str = "", suffix: str = "_copy", cache: bool = True
-    ) -> Device:
+    def copy(self, prefix: str = "", suffix: str = "_copy") -> "Component":
         from gdsfactory.copy import copy
 
-        return copy(self, prefix=prefix, suffix=suffix, cache=cache)
+        return copy(self, prefix=prefix, suffix=suffix)
 
     def copy_child_info(self, component: "Component") -> None:
         """Copy info from child component into parent.
@@ -765,7 +763,7 @@ class Component(Device):
         return ref
 
     def get_layers(self) -> Union[Set[Tuple[int, int]], Set[Tuple[int64, int64]]]:
-        """Return a set of (layer, datatype)
+        """Return a set of (layer, datatype).
 
         .. code ::
 
@@ -930,14 +928,14 @@ class Component(Device):
     ) -> None:
         """Show component in klayout.
 
-            returns a copy of the Component, so the original component remains intact.
-            with pins markers on each port show_ports = True, and optionally also
-            the ports from the references (show_subports=True)
+        returns a copy of the Component, so the original component remains intact.
+        with pins markers on each port show_ports = True, and optionally also
+        the ports from the references (show_subports=True)
 
-            Args:
-                show_ports: shows component with port markers and labels.
-                show_subports: add ports markers and labels to references.
-                port_marker_layer: for the ports.
+        Args:
+            show_ports: shows component with port markers and labels.
+            show_subports: add ports markers and labels to references.
+            port_marker_layer: for the ports.
 
         Keyword Args:
             gdspath: GDS file path to write to.
@@ -951,7 +949,7 @@ class Component(Device):
         from gdsfactory.show import show
 
         if show_subports:
-            component = self.copy(suffix="", cache=False)
+            component = self.copy(suffix="")
             for reference in component.references:
                 add_pins_triangle(
                     component=component,
@@ -960,7 +958,7 @@ class Component(Device):
                 )
 
         elif show_ports:
-            component = self.copy(suffix="", cache=False)
+            component = self.copy(suffix="")
             add_pins_triangle(component=component, layer=port_marker_layer)
         else:
             component = self

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -110,11 +110,11 @@ class Component(Device):
         self.changelog = changelog
 
     def __lshift__(self, element):
-        """Convenience operator equivalent to add_ref()"""
+        """Convenience operator equivalent to add_ref()."""
         return self.add_ref(element)
 
     def unlock(self) -> None:
-        """I recommend doing this only if you know what you are doing."""
+        """only do this if you know what you are doing."""
         self._locked = False
 
     def lock(self) -> None:

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -138,7 +138,7 @@ class ComponentReference(DeviceReference):
 
     def __repr__(self) -> str:
         return (
-            'DeviceReference (parent Device "%s", ports %s, origin %s, rotation %s,'
+            'ComponentReference (parent Component "%s", ports %s, origin %s, rotation %s,'
             " x_reflection %s)"
             % (
                 self.parent.name,

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
+from gdspy import CellReference
 from numpy import cos, float64, int64, mod, ndarray, pi, sin
 from phidl.device_layout import Device, DeviceReference
 
@@ -119,22 +120,32 @@ class ComponentReference(DeviceReference):
         x_reflection: bool = False,
         visual_label: str = "",
     ) -> None:
-        super().__init__(
-            device=component,
+        CellReference.__init__(
+            self,
+            ref_cell=component,
             origin=origin,
             rotation=rotation,
             magnification=magnification,
             x_reflection=x_reflection,
+            ignore_missing=False,
         )
-        self.parent = component
-        # The ports of a DeviceReference have their own unique id (uid),
-        # since two DeviceReferences of the same parent Device can be
+        self.owner = None
+        # The ports of a ComponentReference have their own unique id (uid),
+        # since two ComponentReferences of the same parent Component can be
         # in different locations and thus do not represent the same port
         self._local_ports = {
             name: port._copy(new_uid=True) for name, port in component.ports.items()
         }
         self.visual_label = visual_label
         # self.uid = str(uuid.uuid4())[:8]
+
+    @property
+    def parent(self):
+        return self.ref_cell
+
+    @parent.setter
+    def parent(self, value):
+        self.ref_cell = value
 
     def __repr__(self) -> str:
         return (

--- a/gdsfactory/components/spiral_circular.py
+++ b/gdsfactory/components/spiral_circular.py
@@ -164,8 +164,6 @@ def spiral_circular(
     # thickness = outer_radius - mid_radius
     # r = gds.Round((0.,0.), outer_radius, inner_radius, layer=1, max_points=1000)
 
-    ps = gds.boolean(ps, None, "or")
-
     c = gf.Component()
     c.info["length"] = snap_to_grid(length)
     c.add_polygon(ps, layer=layer)

--- a/gdsfactory/components/spiral_circular.py
+++ b/gdsfactory/components/spiral_circular.py
@@ -164,6 +164,8 @@ def spiral_circular(
     # thickness = outer_radius - mid_radius
     # r = gds.Round((0.,0.), outer_radius, inner_radius, layer=1, max_points=1000)
 
+    ps = gds.boolean(ps, None, "or")
+
     c = gf.Component()
     c.info["length"] = snap_to_grid(length)
     c.add_polygon(ps, layer=layer)

--- a/gdsfactory/copy.py
+++ b/gdsfactory/copy.py
@@ -7,10 +7,16 @@ from gdsfactory.component import Component, ComponentReference
 
 
 def copy(
-    D: Component, prefix: str = "", suffix: str = "_copy", cache: bool = True
+    D: Component,
+    prefix: str = "",
+    suffix: str = "_copy",
 ) -> Component:
-    """returns a deep copy of a Component.
-    based on phidl.geometry with CellArray support
+    """Returns a deep copy of a Component.
+
+    Args:
+        D: component.
+        prefix: to add to new component name.
+        suffix: to add to new component name.
     """
     D_copy = Component(name=f"{prefix}{D.name}{suffix}")
     D_copy.info = python_copy.deepcopy(D.info)

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -22,8 +22,6 @@ import pathlib
 import shutil
 from typing import Optional
 
-from lytest.kdb_xor import GeometryDifference, run_xor
-
 from gdsfactory.component import Component
 from gdsfactory.config import CONFIG, logger
 from gdsfactory.gdsdiff.gdsdiff import gdsdiff
@@ -50,6 +48,7 @@ def difftest(
         xor: runs xor if there is difference.
         dirpath: defaults to cwd refers to where the test is being invoked.
     """
+    from lytest.kdb_xor import GeometryDifference, run_xor
 
     # containers function_name is different from component.name
     # we store the container with a different name from original component

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -770,8 +770,8 @@ if __name__ == "__main__":
     # c3.show()
 
     c = gf.Component("bend")
-    b = c << gf.components.bend_circular(angle=30)
+    b = c << gf.components.bend_circular(angle=40)
     s = c << gf.components.straight(length=5)
     s.connect("o1", b.ports["o2"])
     # c = c.flatten()
-    c.show(show_ports=True, precision=1e-10)
+    c.show(show_ports=True, precision=1e-9)

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -774,4 +774,4 @@ if __name__ == "__main__":
     s = c << gf.components.straight(length=5)
     s.connect("o1", b.ports["o2"])
     # c = c.flatten()
-    c.show(show_ports=True)
+    c.show(show_ports=True, precision=1e-10)

--- a/gdsfactory/tests/test_labels.py
+++ b/gdsfactory/tests/test_labels.py
@@ -25,7 +25,7 @@ def test_add_labels_optical() -> Component:
         port=c.ports["o2"], gc=gc, gc_index=1, layer_label=gf.LAYER.LABEL
     )
 
-    c = c.copy(cache=False, suffix="")
+    c = c.copy(suffix="")
     add_labels(c, get_label_function=get_input_label, gc=gc)
     labels_text = [c.labels[0].text, c.labels[1].text]
     # print(label1)
@@ -45,7 +45,7 @@ def test_add_labels_electrical() -> Component:
         port=c.ports["e2"], layer_label=gf.LAYER.LABEL, gc_index=1
     )
 
-    c = c.copy(cache=False, suffix="")
+    c = c.copy(suffix="")
     add_labels(component=c, get_label_function=get_input_label_electrical)
     labels_text = [c.labels[0].text, c.labels[1].text]
 

--- a/gdsfactory/tests/test_paths.py
+++ b/gdsfactory/tests/test_paths.py
@@ -126,7 +126,6 @@ def transition():
 
     wg2_ref = c << wg2
     wg2_ref.connect("in1", wgt_ref.ports["out1"])
-    print(wg2_ref.parent.name)
     return c
 
 
@@ -158,7 +157,7 @@ def test_settings(component: Component, data_regression: DataRegressionFixture) 
 def test_layers1():
     P = gf.path.straight(length=10.001)
     X = gf.CrossSection(
-        width=0.5, offset=0, layer=gf.LAYER.SLAB90, port_names=["in", "out"]
+        width=0.5, offset=0, layer=gf.LAYER.SLAB90, port_names=("in", "out")
     )
     c = gf.path.extrude(P, X, simplify=5e-3)
     assert c.ports["in"].layer == gf.LAYER.SLAB90
@@ -177,7 +176,7 @@ def test_layers2():
 
 def test_copy() -> None:
     x1 = gf.CrossSection(
-        width=0.5, offset=0, layer=gf.LAYER.SLAB90, port_names=["in", "out"]
+        width=0.5, offset=0, layer=gf.LAYER.SLAB90, port_names=("in", "out")
     )
     x2 = x1.copy()
 
@@ -187,7 +186,6 @@ def test_copy() -> None:
 
 if __name__ == "__main__":
     c = transition()
-    print(c.references)
     c.show()
 
     # c = test_path()

--- a/gdsfactory/tests/test_paths.py
+++ b/gdsfactory/tests/test_paths.py
@@ -104,6 +104,7 @@ def transition():
     )
 
     Xtrans = gf.path.transition(cross_section1=X1, cross_section2=X2, width_type="sine")
+    # Xtrans = gf.cross_section.strip(port_names=('in1', 'out1'))
 
     P1 = gf.path.straight(length=5)
     P2 = gf.path.straight(length=5)
@@ -125,6 +126,7 @@ def transition():
 
     wg2_ref = c << wg2
     wg2_ref.connect("in1", wgt_ref.ports["out1"])
+    print(wg2_ref.parent.name)
     return c
 
 
@@ -184,11 +186,14 @@ def test_copy() -> None:
 
 
 if __name__ == "__main__":
-    # c = transition()
+    c = transition()
+    print(c.references)
+    c.show()
+
     # c = test_path()
     # print(c.name)
 
-    test_copy()
+    # test_copy()
     # c = test_layers2()
     # c = transition()
     # c = double_loop()

--- a/gdsfactory/tests/test_paths.py
+++ b/gdsfactory/tests/test_paths.py
@@ -115,11 +115,6 @@ def transition():
     P4 = gf.path.euler(radius=25, angle=45, p=0.5, use_eff=False)
     wg_trans = gf.path.extrude(P4, Xtrans)
 
-    # print("wg1", wg1)
-    # print("wg2", wg2)
-    # print("wg3", wg_trans)
-    # wg_trans.pprint()
-
     wg1_ref = c << wg1
     wgt_ref = c << wg_trans
     wgt_ref.connect("in1", wg1_ref.ports["out1"])
@@ -186,7 +181,8 @@ def test_copy() -> None:
 
 if __name__ == "__main__":
     c = transition()
-    c.show()
+    # c.plot()
+    c.show(show_ports=False)
 
     # c = test_path()
     # print(c.name)


### PR DESCRIPTION
- [PR](https://github.com/gdsfactory/gdsfactory/pull/478) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/474)
    - Use snap.snap_to_grid() to snap cross section points
    - Warning was not being raised if only one coordinate was off-grid
- [PR](https://github.com/gdsfactory/gdsfactory/pull/479) fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/476) offgrid manhattan connection gaps
- remove unused cache setting from Component.copy()
- fix phidl [issue](https://github.com/amccaugh/phidl/issues/154)
- make lytest as an optional dependency