### PR TITLE
5125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - improve meep plugin.
     - remove port_field_monitor_name parameter (no longer needed) thanks to meep 1.23 introduced to use the energy in the whole simulation to determine when to terminate, which is a better termination condition than the energy at the ports. [PR](https://github.com/gdsfactory/gdsfactory/pull/495/files). Requires meep 1.23 or newer.
     - update termination condition for grating_coupler simulations.
+    - rename effective permitivity to get_effective index. Change units from meters to um, and permitivities to refractive_index to be consistent with gdsfactory units in um.
+- add `gf.generate_doe` [PR](https://github.com/gdsfactory/gdsfactory/pull/508/files)
+- add add_center_section to CrossSection and cross_section for slot cross_section [PR](https://github.com/gdsfactory/gdsfactory/pull/509) [fixes](https://github.com/gdsfactory/gdsfactory/issues/506)
 
 ## [5.12.4](https://github.com/gdsfactory/gdsfactory/pull/502)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.12.5](https://github.com/gdsfactory/gdsfactory/pull/502)
+
+- better docstrings with autodoc_typehints = "description"
+- improve meep plugin.
+    - remove port_field_monitor_name parameter (no longer needed) thanks to meep 1.23 introduced to use the energy in the whole simulation to determine when to terminate, which is a better termination condition than the energy at the ports. [PR](https://github.com/gdsfactory/gdsfactory/pull/495/files). Requires meep 1.23 or newer.
+    - update termination condition for grating_coupler simulations.
+
 ## [5.12.4](https://github.com/gdsfactory/gdsfactory/pull/502)
 
 - function to calculate_effective_permittivity [PR](https://github.com/gdsfactory/gdsfactory/pull/501)
@@ -8,7 +15,7 @@
 ## [5.12.2](https://github.com/gdsfactory/gdsfactory/pull/498)
 
 - extract generating component list for doe into a separate function for use in pack_doe and elsewhere [fixes issue](https://github.com/gdsfactory/gdsfactory/issues/496)
-- meep 1.23 introduced to use the energy in the whole simulation to determine when to terminate, which is a better termination condition than the energy at the ports. [PR](https://github.com/gdsfactory/gdsfactory/issues/496). Requires meep 1.23 or newer.
+- meep 1.23 introduced to use the energy in the whole simulation to determine when to terminate, which is a better termination condition than the energy at the ports. [PR](https://github.com/gdsfactory/gdsfactory/pull/495/files). Requires meep 1.23 or newer.
 
 ## [5.12.1](https://github.com/gdsfactory/gdsfactory/pull/494)
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,16 @@
+/* Newlines (\a) and spaces (\20) before each parameter */
+.sig-param::before {
+    content: "\a\20\20\20\20\20\20\20\20\20\20\20\20\20\20\20\20";
+    white-space: pre;
+}
+
+/* Newline after the last parameter (so the closing bracket is on a new line) */
+dt em.sig-param:last-of-type::after {
+    content: "\a";
+    white-space: pre;
+}
+
+/* To have blue background of width of the block (instead of width of content) */
+dl.class > dt:first-of-type {
+    display: block !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ autodoc_pydantic_model_show_config_member = False
 autodoc_pydantic_model_show_config_summary = False
 autodoc_pydantic_model_show_validator_summary = False
 autodoc_pydantic_model_show_validator_members = False
+autodoc_typehints = "description"
 
 
 autodoc_default_options = {

--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -70,14 +70,14 @@ def get_index(
     """Returns refractive index from Meep's material database.
 
     Args:
-        name: material name
-        wavelength: wavelength (um)
+        name: material name.
+        wavelength: wavelength (um).
         dispersive: True for built-in Meep index model,
-            False for simple, non-dispersive model
+            False for simple, non-dispersive model.
 
     Note:
         Using the built-in models can be problematic at low resolution.
-        If fields are NaN or Inf, increase resolution or use a non-dispersive model
+        If fields are NaN or Inf, increase resolution or use a non-dispersive model.
 
     """
     medium = get_material(name=name, wavelength=wavelength, dispersive=dispersive)

--- a/gdsfactory/simulation/gmeep/get_simulation.py
+++ b/gdsfactory/simulation/gmeep/get_simulation.py
@@ -37,7 +37,6 @@ def get_simulation(
     wavelength_points: int = 50,
     dfcen: float = 0.2,
     port_source_name: str = "o1",
-    port_field_monitor_name: str = "o2",
     port_margin: float = 3,
     distance_source_to_monitors: float = 0.2,
     port_source_offset: float = 0,
@@ -104,14 +103,13 @@ def get_simulation(
         wavelength_points: wavelength steps.
         dfcen: delta frequency.
         port_source_name: input port name.
-        port_field_monitor_name: for component port.
         port_margin: margin on each side of the port.
         distance_source_to_monitors: in (um) source goes before.
         port_source_offset: offset between source GDS port and source MEEP port.
         port_monitor_offset: offset between monitor GDS port and monitor MEEP port.
         dispersive: use dispersive material models (requires higher resolution).
-        material_name_to_meep: dispersive materials have a wavelength
-            dependent index. Maps layer_stack names with meep material database names.
+        material_name_to_meep: map layer_stack names with meep material database name
+            or refractive index. dispersive materials have a wavelength dependent index.
 
     Keyword Args:
         settings: other parameters for sim object (resolution, symmetries, etc.)
@@ -153,20 +151,6 @@ def get_simulation(
         port_source = component_ref.get_ports_list()[0]
         port_source_name = port_source.name
         warnings.warn(f"Selecting port_source_name={port_source_name!r} instead.")
-
-    if port_field_monitor_name not in component_ref.ports:
-        warnings.warn(
-            f"port_field_monitor_name={port_field_monitor_name!r} not in {port_names}"
-        )
-        port_field_monitor = (
-            component_ref.get_ports_list()[0]
-            if len(component.ports) < 2
-            else component.get_ports_list()[1]
-        )
-        port_field_monitor_name = port_field_monitor.name
-        warnings.warn(
-            f"Selecting port_field_monitor_name={port_field_monitor_name!r} instead."
-        )
 
     assert isinstance(
         component, Component
@@ -235,9 +219,6 @@ def get_simulation(
         np.array(port.center), angle=angle_rad, length=port_source_offset
     )
     center = xy_shifted.tolist() + [0]  # (x, y, z=0)
-
-    field_monitor_port = component_ref.ports[port_field_monitor_name]
-    field_monitor_point = field_monitor_port.center.tolist() + [0]  # (x, y, z=0)
 
     if np.isclose(port.orientation, 0):
         direction = mp.X
@@ -312,7 +293,6 @@ def get_simulation(
         freqs=freqs,
         monitors=monitors,
         sources=sources,
-        field_monitor_point=field_monitor_point,
         port_source_name=port_source_name,
         initialized=False,
     )

--- a/gdsfactory/simulation/gmeep/get_simulation_grating_fiber.py
+++ b/gdsfactory/simulation/gmeep/get_simulation_grating_fiber.py
@@ -66,37 +66,37 @@ def get_simulation_grating_fiber(
     ncore = sqrt(na**2 + ncore**2)
 
     Args:
-        period: fiber grating period
+        period: fiber grating period.
         fill_factor: fraction of the grating period filled with the grating material.
-        n_periods: number of periods
-        widths: Optional list of widths. Overrides period, fill_factor, n_periods
-        gaps: Optional list of gaps. Overrides period, fill_factor, n_periods
-        fiber_angle_deg: fiber angle in degrees
-        fiber_xposition: xposition
-        fiber_core_diameter: fiber diameter
-        fiber_numerical_aperture: NA
+        n_periods: number of periods.
+        widths: Optional list of widths. Overrides period, fill_factor, n_periods.
+        gaps: Optional list of gaps. Overrides period, fill_factor, n_periods.
+        fiber_angle_deg: fiber angle in degrees.
+        fiber_xposition: xposition.
+        fiber_core_diameter: fiber diameter.
+        fiber_numerical_aperture: NA.
         fiber_nclad: fiber cladding index.
-        fiber_ncore: fiber core index
+        fiber_ncore: fiber core index.
         nwg: waveguide index.
         nclad: top cladding index.
         nbox: box index bottom.
         nsubstrate: index substrate.
-        pml_thickness: pml_thickness (um)
-        substrate_thickness: substrate_thickness (um)
-        box_thickness: thickness for bottom cladding (um)
-        wg_thickness: wg_thickness (um)
+        pml_thickness: pml_thickness (um).
+        substrate_thickness: substrate_thickness (um).
+        box_thickness: thickness for bottom cladding (um).
+        wg_thickness: wg_thickness (um).
         top_clad_thickness: thickness of the top cladding.
         air_gap_thickness: air gap thickness.
-        fiber_thickness: fiber_thickness
-        resolution: resolution pixels/um
-        wavelength_start: min wavelength (um)
-        wavelength_stop: max wavelength (um)
+        fiber_thickness: fiber_thickness.
+        resolution: resolution pixels/um.
+        wavelength_start: min wavelength (um).
+        wavelength_stop: max wavelength (um).
         wavelength_points: wavelength points.
         eps_averaging: epsilon averaging.
         fiber_port_y_offset_from_air: y_offset from fiber to air (um).
-        waveguide_port_x_offset_from_grating_start:
-        fiber_port_x_size:
-        xmargin: margin from PML to grating end
+        waveguide_port_x_offset_from_grating_start: in um.
+        fiber_port_x_size: in um.
+        xmargin: margin from PML to grating end in um.
 
 
     .. code::

--- a/gdsfactory/simulation/gmeep/test_eigenmode.py
+++ b/gdsfactory/simulation/gmeep/test_eigenmode.py
@@ -16,17 +16,17 @@ from gdsfactory.simulation.modes.types import Mode
 
 
 def lumerical_parser(E_1D, H_1D, y_1D, z_1D, res=50, z_offset=0.11 * 1e-6):
-    """
+    """Converts 1D arrays of fields to 2D arrays according to positions.
+
     Lumerical data is in 1D arrays, and over a nonregular mesh
-    Converts 1D arrays of fields to 2D arrays according to positions
 
     Args
-        E_1D: E array from Lumerical
-        H_1D: H array from Lumerical
-        y_1D: y array from Lumerical
-        z_1D: z array from Lumerical
-        res: desired resolution
-        z_offset: z offset to move the fields
+        E_1D: E array from Lumerical.
+        H_1D: H array from Lumerical.
+        y_1D: y array from Lumerical.
+        z_1D: z array from Lumerical.
+        res: desired resolution.
+        z_offset: z offset to move the fields.
     """
     # Make regular grid from resolution and range of domain
     y_1D = y_1D[...].flatten()

--- a/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
@@ -132,8 +132,8 @@ def test_sparameters_straight_batch(dataframe_regression) -> None:
 
 
 if __name__ == "__main__":
-    # test_sparameters_straight(None)
+    test_sparameters_straight(None)
     # test_sparameters_straight_symmetric(False)
-    test_sparameters_straight_batch(None)
+    # test_sparameters_straight_batch(None)
     # test_sparameters_straight_mpi(None)
     # test_sparameters_crossing_symmetric(False)

--- a/gdsfactory/simulation/gmeep/write_sparameters_grating.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_grating.py
@@ -122,15 +122,7 @@ def write_sparameters_grating(
         plt.show()
         return
 
-    termination = [
-        mp.stop_when_fields_decayed(
-            dt=50,
-            c=mp.Ez,
-            pt=monitor.regions[0].center,
-            decay_by=decay_by,
-        )
-        for monitor in [sim_dict["waveguide_monitor"], sim_dict["fiber_monitor"]]
-    ]
+    termination = [mp.stop_when_energy_decayed(dt=50, decay_by=1e-3)]
 
     if animate:
         # Run while saving fields

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -254,17 +254,16 @@ def write_sparameters_meep(
         wavelength_points: wavelength steps.
         dfcen: delta frequency.
         port_source_name: input port name.
-        port_field_monitor_name:
         port_margin: margin on each side of the port (um).
         distance_source_to_monitors: in (um).
         port_source_offset: offset between source Component port and source MEEP port.
-        port_monitor_offset: offset between monitor Component port and monitor MEEP port.
-        material_name_to_meep: dispersive materials have a wavelength
-            dependent index. Maps layer_stack names with meep material database names.
+        port_monitor_offset: offset between Component and MEEP port monitor.
+        material_name_to_meep: map layer_stack names with meep material database name
+            or refractive index. dispersive materials have a wavelength dependent index.
 
     Returns:
         sparameters in a pandas Dataframe (wavelengths, s11a, s12m, ...)
-            where `a` is the angle in radians and `m` the module
+            where `a` is the angle in radians and `m` the module.
 
     """
     component = gf.get_component(component)
@@ -273,7 +272,7 @@ def write_sparameters_meep(
 
     for setting in settings.keys():
         if setting not in settings_get_simulation:
-            raise ValueError(f"{setting} not in {settings_get_simulation}")
+            raise ValueError(f"{setting!r} not in {settings_get_simulation}")
 
     port_symmetries = port_symmetries or {}
 

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
@@ -91,7 +91,6 @@ def write_sparameters_meep_batch(
         wavelength_points: wavelength steps.
         dfcen: delta frequency.
         port_source_name: input port name.
-        port_field_monitor_name: from component port.
         port_margin: margin on each side of the port.
         distance_source_to_monitors: in (um) source goes before.
         port_source_offset: offset between source GDS port and source MEEP port.

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -106,7 +106,6 @@ def write_sparameters_meep_mpi(
         wavelength_points: wavelength steps.
         dfcen: delta frequency.
         port_source_name: input port name.
-        port_field_monitor_name: for monitor field decay.
         port_margin: margin on each side of the port.
         distance_source_to_monitors: in (um) source goes before.
         port_source_offset: offset between source GDS port and source MEEP port.
@@ -121,7 +120,7 @@ def write_sparameters_meep_mpi(
     """
     for setting in kwargs.keys():
         if setting not in settings_write_sparameters_meep:
-            raise ValueError(f"{setting} not in {settings_write_sparameters_meep}")
+            raise ValueError(f"{setting!r} not in {settings_write_sparameters_meep}")
 
     component = gf.get_component(component)
     assert isinstance(component, Component)


### PR DESCRIPTION
- better docstrings with autodoc_typehints = "description"
- improve meep plugin.
    - remove port_field_monitor_name parameter (no longer needed) thanks to meep 1.23 introduced to use the energy in the whole simulation to determine when to terminate, which is a better termination condition than the energy at the ports. [PR](https://github.com/gdsfactory/gdsfactory/pull/495/files). Requires meep 1.23 or newer.
    - update termination condition for grating_coupler simulations.
    - rename effective permitivity to get_effective index. Change units from meters to um, and permitivities to refractive_index to be consistent with gdsfactory units in um.
- add `gf.generate_doe` [PR](https://github.com/gdsfactory/gdsfactory/pull/508/files)
- add add_center_section to CrossSection and cross_section for slot cross_section [PR](https://github.com/gdsfactory/gdsfactory/pull/509) [fixes](https://github.com/gdsfactory/gdsfactory/issues/506)