### PR TITLE
Meep MPI output logging

### DIFF
--- a/gdsfactory/async_utils.py
+++ b/gdsfactory/async_utils.py
@@ -1,0 +1,41 @@
+import asyncio
+from pathlib import Path
+
+
+async def handle_return(
+    out_or_err: asyncio.streams.StreamReader,
+    log_file: Path = None,
+    to_console: bool = True,
+) -> None:
+    with open(log_file, "w") as f:
+        while True:
+            # Without this sleep, the program won't exit
+            await asyncio.sleep(0)
+            data = await out_or_err.readline()
+            line = data.decode().strip()
+            if line:
+                if to_console:
+                    print(line)
+                f.write(line + "\n")
+
+
+async def execute_and_stream_output(
+    command: str, log_file_dir: Path, log_file_str: str
+) -> asyncio.subprocess.Process:
+    # Best not to use shell, but I can't get create_subprocess_exec to work here
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    asyncio.create_task(
+        handle_return(proc.stdout, log_file=log_file_dir / f"{log_file_str}_out.log")
+    )
+    asyncio.create_task(
+        handle_return(proc.stderr, log_file=log_file_dir / f"{log_file_str}_err.log")
+    )
+
+    # This needs to also handle the "wait_to_finish" flag
+    await proc.wait()
+    return proc

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -41,7 +41,6 @@ def write_sparameters_meep_mpi(
     dirpath: Optional[PathType] = None,
     temp_dir: Path = temp_dir_default,
     temp_file_str: str = "write_sparameters_meep_mpi",
-    log_file_str: str = "write_sparameters_meep_mpi",
     live_output: bool = False,
     overwrite: bool = False,
     wait_to_finish: bool = True,
@@ -75,6 +74,8 @@ def write_sparameters_meep_mpi(
             Defaults to active pdk.layer_stack.
         temp_dir: temporary directory to hold simulation files.
         temp_file_str: names of temporary files in temp_dir.
+        live_output: stream output of mpirun command to file and print to console
+            (meep verbosity still needs to be set separately)
         overwrite: overwrites stored simulation results.
         wait_to_finish: if True makes the function call blocking.
 
@@ -190,7 +191,7 @@ def write_sparameters_meep_mpi(
 
         asyncio.run(
             execute_and_stream_output(
-                command, log_file_dir=temp_dir, log_file_str=log_file_str
+                command, log_file_dir=temp_dir, log_file_str=temp_file_str
             )
         )
     else:

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -41,6 +41,8 @@ def write_sparameters_meep_mpi(
     dirpath: Optional[PathType] = None,
     temp_dir: Path = temp_dir_default,
     temp_file_str: str = "write_sparameters_meep_mpi",
+    log_file_str: str = "write_sparameters_meep_mpi",
+    live_output: bool = False,
     overwrite: bool = False,
     wait_to_finish: bool = True,
     **kwargs,
@@ -181,25 +183,34 @@ def write_sparameters_meep_mpi(
     logger.info(command)
     logger.info(str(filepath))
 
-    with subprocess.Popen(
-        shlex.split(command),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    ) as proc:
-        print(proc.stdout.read().decode())
-        print(proc.stderr.read().decode())
-        sys.stdout.flush()
-        sys.stderr.flush()
+    if live_output:
+        import asyncio
 
-    if wait_to_finish and not proc.stderr:
-        while not filepath.exists():
+        from gdsfactory.async_utils import execute_and_stream_output
+
+        asyncio.run(
+            execute_and_stream_output(
+                command, log_file_dir=temp_dir, log_file_str=log_file_str
+            )
+        )
+    else:
+        with subprocess.Popen(
+            shlex.split(command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as proc:
             print(proc.stdout.read().decode())
             print(proc.stderr.read().decode())
             sys.stdout.flush()
             sys.stderr.flush()
-            time.sleep(1)
-
+        if wait_to_finish and not proc.stderr:
+            while not filepath.exists():
+                print(proc.stdout.read().decode())
+                print(proc.stderr.read().decode())
+                sys.stdout.flush()
+                sys.stderr.flush()
+                time.sleep(1)
     return filepath
 
 
@@ -224,6 +235,7 @@ if __name__ == "__main__":
         cores=2,
         run=True,
         overwrite=True,
+        live_output=True,
         # lazy_parallelism=True,
         lazy_parallelism=False,
         # filepath="instance_dict.csv",


### PR DESCRIPTION
Currently, using `get_sparameters_meep_mpi` doesn't show real-time simulation progress, even if `mp.verbosity` is not set. Instead, Meep's output is only shown at the end of the simulation, making debugging more difficult. 

This PR provides the option to
- Run the mpirun command asynchronously
- Direct stdout and stderr to a log file and console

It can't replace the current Popen call, as it doesn't handle the case of `wait_to_finish=False`, so it won't work with the `get_sparameters_meep_batch` code as-is.