### PR TITLE
update  phidl to 1.6.2 and tidy3d to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.12.27](https://github.com/gdsfactory/gdsfactory/pull/546)
+
+- add min area and min_density rules to klayout write drc deck
+- upgrade phidl to 1.6.2
+- lazy load matplotlib and pandas
+
 ## [5.12.22](https://github.com/gdsfactory/gdsfactory/pull/545)
 
 - add xoffset1 and xoffset2 to straight_heater_doped_rib

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -122,6 +122,8 @@ Klayout DRC
    rule_space
    rule_separation
    rule_enclosing
+   rule_area
+   rule_density
 
 
 ************************

--- a/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
+++ b/docs/notebooks/plugins/tidy3d/00_tidy3d.ipynb
@@ -896,7 +896,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import gdspy
-import matplotlib.pyplot as plt
 import numpy as np
 import yaml
 from numpy import int64
@@ -267,12 +266,13 @@ class Component(Device):
         return snap_to_grid(ports_ccw[0].y - ports_cw[0].y)
 
     def plot_netlist(self, with_labels: bool = True, font_weight: str = "normal"):
-        """plots a netlist graph with networkx
+        """Plots a netlist graph with networkx.
 
         Args:
             with_labels: add label to each node.
             font_weight: normal, bold.
         """
+        import matplotlib.pyplot as plt
         import networkx as nx
 
         plt.figure()

--- a/gdsfactory/components/taper_from_csv.py
+++ b/gdsfactory/components/taper_from_csv.py
@@ -5,7 +5,6 @@ from functools import partial
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -24,8 +23,9 @@ def taper_from_csv(
     Args:
         filepath: for CSV file.
         cross_section: specification (CrossSection, string, CrossSectionFactory dict).
-
     """
+    import pandas as pd
+
     taper_data = pd.read_csv(filepath)
     xs = taper_data["x"].values * 1e6
     ys = np.round(taper_data["width"].values * 1e6 / 2.0, 3)

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -1,6 +1,5 @@
 from typing import Optional, Tuple
 
-import matplotlib.colors
 import shapely
 
 from gdsfactory.component import Component
@@ -28,6 +27,7 @@ def to_3d(
 
     """
     try:
+        import matplotlib.colors
         from trimesh.creation import extrude_polygon
         from trimesh.scene import Scene
     except ImportError as e:

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -1,9 +1,6 @@
 import pathlib
 from typing import Optional, Tuple
 
-import matplotlib.colors
-import shapely
-
 from gdsfactory.component import Component
 from gdsfactory.layers import LayerColors
 from gdsfactory.tech import LAYER_STACK, LayerStack
@@ -20,13 +17,15 @@ def to_stl(
     """Exports a Component into STL.
 
     Args:
-        component:
-        filepath:
-        layer_colors: layer colors from Klayout Layer Properties file
-        layer_stack: contains thickness and zmin for each layer
-        exclude_layers: layers to exclude
+        component: to export.
+        filepath: to write STL to.
+        layer_colors: layer colors from Klayout Layer Properties file.
+        layer_stack: contains thickness and zmin for each layer.
+        exclude_layers: layers to exclude.
 
     """
+    import matplotlib.colors
+    import shapely
     from trimesh.creation import extrude_polygon
 
     layer_to_thickness = layer_stack.get_layer_to_thickness()

--- a/gdsfactory/geometry/write_drc.py
+++ b/gdsfactory/geometry/write_drc.py
@@ -56,6 +56,59 @@ def rule_enclosing(
     )
 
 
+def rule_area(layer: str, min_area_um2: float = 2.0) -> str:
+    """Return script for min area checking.
+
+    based on https://github.com/klayoutmatthias/si4all
+    """
+    return f"""
+
+min_{layer}_a = {min_area_um2}.um2
+r_nwell_a = nwell.with_area(0, min_{layer}_a)
+r_nwell_a.output("{layer.upper()}_A: nwell area &lt; min_{layer}_a µm²")
+"""
+
+
+def rule_density(
+    layer: str = "metal1",
+    min_density=0.2,
+    max_density=0.8,
+) -> str:
+    """Return script to ensure density of layer is within min and max.
+
+    based on https://github.com/klayoutmatthias/si4all
+    """
+    return f"""
+min_density = {min_density}
+max_density = {max_density}
+
+area = {layer}.area
+border_area = border.area
+if border_area &gt;= 1.dbu * 1.dbu
+
+  r_min_dens = polygon_layer
+  r_max_dens = polygon_layer
+
+  dens = area / border_area
+
+  if dens &lt; min_density
+    # copy border as min density marker
+    r_min_dens = border
+  end
+
+  if dens &gt; max_density
+    # copy border as max density marker
+    r_max_dens = border
+  end
+
+  r_min_dens.output("{layer}_Xa: {layer} density below threshold of {min_density}")
+  r_max_dens.output("{layer}: {layer} density above threshold of {max_density}")
+
+end
+
+"""
+
+
 def write_layer_definition(layer_map: Dict[str, Layer]) -> List[str]:
     """Returns layer_map definition script for klayout
 

--- a/gdsfactory/simulation/gtidy3d/modes.py
+++ b/gdsfactory/simulation/gtidy3d/modes.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, Extra
 from scipy.constants import c as SPEED_OF_LIGHT
 from tidy3d.plugins.mode.solver import compute_modes
 from tqdm.auto import tqdm
+from typing_extensions import Literal
 
 from gdsfactory.config import CONFIG, logger
 from gdsfactory.serialization import get_hash
@@ -133,6 +134,8 @@ SETTINGS = [
 ]
 
 SETTINGS_COUPLER = set(SETTINGS + ["wg_width1", "wg_width2", "gap"])
+Precision = Literal["single", "double"]
+FilterPol = Literal["te", "tm"]
 
 
 class Waveguide(BaseModel):
@@ -152,6 +155,8 @@ class Waveguide(BaseModel):
         nmodes: number of modes to compute.
         bend_radius: optional bend radius (um).
         cache: filepath for caching modes. If None does not use file cache.
+        precision: single or double.
+        filter_pol: te, tm or None.
 
     ::
 
@@ -187,6 +192,8 @@ class Waveguide(BaseModel):
     nmodes: int = 4
     bend_radius: Optional[float] = None
     cache: Optional[PathType] = CONFIG["modes"]
+    precision: Precision = "single"
+    filter_pol: Optional[FilterPol] = None
 
     class Config:
         extra = Extra.allow
@@ -329,6 +336,8 @@ class Waveguide(BaseModel):
                     num_pml=(0, 0),
                     target_neff=self.get_ncore(wavelength),
                     sort_by="largest_neff",
+                    precision=self.precision,
+                    filter_pol=self.filter_pol,
                 ),
             )
         )

--- a/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
@@ -13,7 +13,7 @@ def test_simulation_hash() -> None:
     sim = gt.get_simulation(component=component)
     sim_hash = get_sim_hash(sim)
 
-    sim_hash_reference = "c7b3965312e6cf47faaef6ffcb0bbde9"
+    sim_hash_reference = "c118b7ae64eeffb55021a3553979aee8"
 
     # print(f"assert hash == {sim_hash!r}")
     assert sim_hash == sim_hash_reference, f"sim_hash_reference = {sim_hash!r}"
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     test_simulation_hash()
     # test_simulation(overwrite=True)
 
-    test_simulation()
+    # test_simulation()
     # component = gf.components.straight(length=3)
     # sim = gt.get_simulation(component=component)
     # sim.to_file("sim_ref.yaml")

--- a/gdsfactory/simulation/simphony/circuit.py
+++ b/gdsfactory/simulation/simphony/circuit.py
@@ -66,7 +66,7 @@ def component_to_circuit(
     a = 0
     for name, metadata in instances.items():
         component_type = metadata["component"]
-        component_settings = metadata["settings"]
+        component_settings = metadata.get("settings", {})
 
         if component_type is None:
             raise ValueError(f"instance {name!r} has no component_type")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ numpy
 omegaconf
 orjson
 pandas
-phidl==1.6.1
+phidl==1.6.2
 picwriter==0.5
 pydantic
 pytest

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -10,6 +10,6 @@ sax
 scikit-image
 simphony==0.6.1
 sklearn
-tidy3d-beta==1.4.1
+tidy3d-beta==1.5.0
 triangle
 trimesh


### PR DESCRIPTION
- add min area and min_density rules to klayout write drc deck
- upgrade phidl to 1.6.2
- lazy load matplotlib and pandas
- update tidy3d-beta from 1.4.2 to 1.5.0.
    - mode_solver has
        - precision: single or double.
        - filter_pol: te, tm or None.
