### PR TITLE
Fix mpirun path

### DIFF
--- a/gdsfactory/simulation/gmeep/write_sparameters_grating.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_grating.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 from gdsfactory.config import logger, sparameters_path
 from gdsfactory.serialization import clean_value_json, clean_value_name
+from gdsfactory.simulation.gmeep import _mpirun, _python
 from gdsfactory.simulation.gmeep.get_simulation_grating_fiber import (
     get_simulation_grating_fiber,
 )
@@ -286,7 +287,7 @@ def write_sparameters_grating_mpi(
     with open(script_file, "w") as script_file_obj:
         script_file_obj.writelines(script_lines)
     # Exec string
-    command = f"mpirun -np {cores} python {script_file}"
+    command = f"{_mpirun()} -np {cores} {_python()} {script_file}"
 
     # Launch simulation
     if verbosity:

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -1,8 +1,10 @@
 """Compute and write Sparameters using Meep in MPI."""
 
 import multiprocessing
+import os
 import pathlib
 import pickle
+import re
 import shlex
 import subprocess
 import sys
@@ -30,6 +32,21 @@ from gdsfactory.types import ComponentSpec, PathType
 ncores = multiprocessing.cpu_count()
 
 temp_dir_default = Path(sparameters_path) / "temp"
+
+
+def _python() -> str:
+    """select correct python executable from current activated environment"""
+    return sys.executable
+
+
+def _mpirun() -> str:
+    """select correct mpirun executable from current activated environment"""
+    python = _python()
+    path, ext = os.path.splitext(python)
+    mpirun = re.sub("python$", "mpirun", path) + ext
+    if not os.path.exists(mpirun):
+        return "mpirun"
+    return mpirun
 
 
 @pydantic.validate_arguments
@@ -180,7 +197,7 @@ def write_sparameters_meep_mpi(
     script_file = tempfile.with_suffix(".py")
     with open(script_file, "w") as script_file_obj:
         script_file_obj.writelines(script_lines)
-    command = f"mpirun -np {cores} python {script_file}"
+    command = f"{_mpirun()} -np {cores} {_python()} {script_file}"
     logger.info(command)
     logger.info(str(filepath))
 


### PR DESCRIPTION
Today, when I tried to use `write_s_parameters_meep_mpi`, I noticed that the generated python file was using the wrong `mpirun` and the wrong `python` variable. This is easily fixed by using absolute paths in stead.

If the absolute path in the current environment for mpirun does not exist, we'll fall back to the old behavior.