### PR TITLE
Fix oddly transformed refs via optional decorator and prevent side effects with copy/flatten

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -770,6 +770,13 @@ class Component(Device):
 
         return component_flat
 
+    def flatten_reference(self, ref: ComponentReference):
+        from gdsfactory.functions import transformed
+
+        self.remove(ref)
+        new_component = transformed(ref, decorator=None)
+        self.add_ref(new_component)
+
     def add_ref(
         self, component: "Component", alias: Optional[str] = None
     ) -> "ComponentReference":

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -768,7 +768,6 @@ class Component(Device):
         for layer, polys in poly_dict.items():
             component_flat.add_polygon(polys, layer=single_layer or layer)
 
-        component_flat.name = f"{self.name}_flat"
         return component_flat
 
     def add_ref(

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -501,7 +501,6 @@ class ComponentReference(DeviceReference):
         Returns:
             ComponentReference: with correct rotation to connect to destination.
         """
-        from gdsfactory.functions import mirror, rotate
 
         # port can either be a string with the name or an actual Port
         if port in self.ports:  # Then ``port`` is a key for the ports dict
@@ -516,17 +515,8 @@ class ComponentReference(DeviceReference):
 
         angle = 180 + destination.orientation - p.orientation
         angle = angle % 360
-        parent = self.parent
 
-        if angle not in (0, 90, 180, 270):
-            if self.x_reflection:
-                self.mirror()
-                parent = mirror(parent)
-            new = rotate(parent, angle=angle).flatten()
-            self.parent = new
-            p = new.ports[port]
-        else:
-            self.rotate(angle=angle, center=p.center)
+        self.rotate(angle=angle, center=p.center)
 
         self.move(origin=p, destination=destination)
         self.move(
@@ -538,14 +528,6 @@ class ComponentReference(DeviceReference):
                 ]
             )
         )
-
-        if angle not in (0, 90, 180, 270):
-            origin_snapped = np.round(self.origin, 3)
-            shift = origin_snapped - self.origin
-            if any(shift):
-                self.origin = origin_snapped
-                for e in new.polygons:
-                    e.translate(*-shift)
 
         return self
 

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -501,7 +501,7 @@ class ComponentReference(DeviceReference):
         Returns:
             ComponentReference: with correct rotation to connect to destination.
         """
-        from gdsfactory.functions import rotate
+        from gdsfactory.functions import mirror, rotate
 
         # port can either be a string with the name or an actual Port
         if port in self.ports:  # Then ``port`` is a key for the ports dict
@@ -516,12 +516,15 @@ class ComponentReference(DeviceReference):
 
         angle = 180 + destination.orientation - p.orientation
         angle = angle % 360
+        parent = self.parent
 
         if angle not in (0, 90, 180, 270):
-            new = rotate(self.parent, angle=angle).flatten()
+            if self.x_reflection:
+                self.mirror()
+                parent = mirror(parent)
+            new = rotate(parent, angle=angle).flatten()
             self.parent = new
             p = new.ports[port]
-
         else:
             self.rotate(angle=angle, center=p.center)
 

--- a/gdsfactory/copy.py
+++ b/gdsfactory/copy.py
@@ -18,7 +18,7 @@ def copy(
         prefix: to add to new component name.
         suffix: to add to new component name.
     """
-    D_copy = Component(name=f"{prefix}{D.name}{suffix}")
+    D_copy = Component()
     D_copy.info = python_copy.deepcopy(D.info)
     for ref in D.references:
         if isinstance(ref, DeviceReference):

--- a/gdsfactory/flatten_invalid_refs.py
+++ b/gdsfactory/flatten_invalid_refs.py
@@ -9,6 +9,13 @@ from gdsfactory.snap import is_on_grid
 
 
 def flatten_invalid_refs(component: Component, grid_size: int = 1):
+    """
+    Flattens all references of the component with invalid GDS transformations (i.e. non-90 deg rotations or sub-grid translations). This is an in-place operation.
+
+    Args:
+        component: the component to fix (in place)
+        grid_size: the GDS grid size, in nm (any translations with higher resolution than this are considered invalid)
+    """
     refs = component.references.copy()
     for ref in refs:
         origin_is_on_grid = all([is_on_grid(x, grid_size) for x in ref.origin])

--- a/gdsfactory/flatten_invalid_refs.py
+++ b/gdsfactory/flatten_invalid_refs.py
@@ -1,9 +1,3 @@
-###################################################################################################################
-# PROPRIETARY AND CONFIDENTIAL
-# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
-# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
-# RPLTD NOTICE VERSION: 1.1.1
-###################################################################################################################
 from gdsfactory import Component
 from gdsfactory.snap import is_on_grid
 

--- a/gdsfactory/flatten_invalid_refs.py
+++ b/gdsfactory/flatten_invalid_refs.py
@@ -1,0 +1,20 @@
+###################################################################################################################
+# PROPRIETARY AND CONFIDENTIAL
+# THIS SOFTWARE IS THE SOLE PROPERTY AND COPYRIGHT (c) 2021 OF ROCKLEY PHOTONICS LTD.
+# USE OR REPRODUCTION IN PART OR AS A WHOLE WITHOUT THE WRITTEN AGREEMENT OF ROCKLEY PHOTONICS LTD IS PROHIBITED.
+# RPLTD NOTICE VERSION: 1.1.1
+###################################################################################################################
+from gdsfactory import Component
+from gdsfactory.snap import is_on_grid
+
+
+def flatten_invalid_refs(component: Component, grid_size: int = 1):
+    refs = component.references.copy()
+    for ref in refs:
+        origin_is_on_grid = all([is_on_grid(x, grid_size) for x in ref.origin])
+        rotation_is_regular = ref.rotation is None or ref.rotation % 90 == 0
+        if origin_is_on_grid and rotation_is_regular:
+            pass
+        else:
+            component.flatten_reference(ref)
+    return component

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -125,7 +125,7 @@ def rotate(
         )
 
     component_new.add_ports(ref.ports)
-    component_new.copy_child_info(component)
+    component_new.info = component.info.copy()
     return component_new
 
 
@@ -153,7 +153,7 @@ def mirror(
     ref = component_new.add_ref(component)
     ref.mirror(p1=p1, p2=p2)
     component_new.add_ports(ref.ports)
-    component_new.copy_child_info(component)
+    component_new.info = component.info.copy()
     return component_new
 
 

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -12,6 +12,7 @@ import numpy as np
 from omegaconf import OmegaConf
 from pydantic import validate_arguments
 
+from gdsfactory import ComponentReference
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight
@@ -88,7 +89,7 @@ def add_texts(
         text_factory: function to add text labels.
     """
     return [
-        add_text(component, text=f"{prefix}{i+index0}", **kwargs)
+        add_text(component, text=f"{prefix}{i + index0}", **kwargs)
         for i, component in enumerate(components)
     ]
 
@@ -181,6 +182,21 @@ def move(
     return component_new
 
 
+@cell
+def transformed(ref: ComponentReference):
+    """
+    Takes a reference and returns a flattened cell with all transformations from the reference applied
+
+    Args:
+        ref: the reference to flatten into a new cell
+
+    """
+    c = Component()
+    c.add(ref)
+    c.info = ref.info.copy()
+    return c.flatten()
+
+
 def move_port_to_zero(component: Component, port_name: str = "o1"):
     """Return a container that contains a reference to the original component.
 
@@ -240,7 +256,6 @@ __all__ = (
     "rotate",
     "update_info",
 )
-
 
 if __name__ == "__main__":
     import gdsfactory as gf

--- a/gdsfactory/tests/test_copy.py
+++ b/gdsfactory/tests/test_copy.py
@@ -1,5 +1,31 @@
 import gdsfactory as gf
 
+
+def test_two_copies_in_one():
+    c = gf.Component()
+    c1 = gf.components.straight()
+    c2 = c1.copy()
+    c3 = c1.copy()
+    c3.add_label("I'm different")
+
+    c << c1
+    r2 = c << c2
+    r3 = c << c3
+    r2.movey(-100)
+    r3.movey(-200)
+    c.write_gds("two_copies_in_one.gds")
+    assert c2.name != c3.name
+
+
+def test_copied_cell_keeps_info():
+    c1 = gf.components.straight()
+    c2 = c1.copy()
+    assert (
+        len(c1.info) > 0
+    ), "This test doesn't make any sense unless there is some info to copy"
+    assert c1.info == c2.info
+
+
 if __name__ == "__main__":
     c = gf.Component()
     c1 = gf.components.straight()

--- a/gdsfactory/tests/test_flatten.py
+++ b/gdsfactory/tests/test_flatten.py
@@ -10,6 +10,30 @@ def test_flatten() -> None:
     assert c1.name != c2.name, f"{c1.name} must be different from {c2.name}"
 
 
+def test_two_flats_in_one():
+    c = gf.Component()
+    c1 = gf.components.straight()
+    c2 = c1.flatten()
+    c3 = c1.flatten()
+    c3.add_label("I'm different")
+
+    c << c1
+    r2 = c << c2
+    r3 = c << c3
+    r2.movey(-100)
+    r3.movey(-200)
+    assert c2.name != c3.name
+
+
+def test_flattened_cell_keeps_info():
+    c1 = gf.components.straight()
+    c2 = c1.flatten()
+    assert (
+        len(c1.info) > 0
+    ), "This test doesn't make any sense unless there is some info to copy"
+    assert c1.info == c2.info
+
+
 if __name__ == "__main__":
     c1 = gf.components.mzi()
     c2 = c1.flatten(single_layer=(2, 0))


### PR DESCRIPTION
This MR changes a recently implemented strategy to deal with odd transformations. Instead of applying directly in the connect() function, which is unreliable and covers only a sliver of cases, we add a new decorator which scans for any refs with sub-grid shifts or non-90 rotations and fixes them by replacing the ref with a flattened copy with transformations embedded.
There are a few key benefits

- fixes will be applied regardless of how the transformation was applied, as long as the parent cell is being wrapped with `@cell`
- the PDK creator can decide whether or not to apply this decorator
- no redundant operations... this only happens once at the time of finalizing the cell

Additionally, I fixed a few potential bugs, in that previously `Component.copy()` and `Component.flatten()` were assigning fixed names to the output cell which could create name collisions. It is safer to keep the new cell's default name (with UID) to prevent this. The thought is that even a copied or flattened cell should be eventually placed inside a cell function with `@cell` decorator, which will remove the anonymous and unpredictable names (for those of us who care). And for those who don't care as much, at least they won't get dangerous side effects!