### PR TITLE
rename `gdsfactory/flatten_invalid_refs.py` to `gdsfactory/decorators.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## [5.16.0](https://github.com/gdsfactory/gdsfactory/pull/580)
+
+- rename `gdsfactory/flatten_invalid_refs.py` to `gdsfactory/decorators.py`
+- add test to flatten_invalid_refs and include documentation in the [PDK docs](https://gdsfactory.github.io/gdsfactory/notebooks/08_pdk.html#)
+
 ## [5.15.3](https://github.com/gdsfactory/gdsfactory/pull/579)
 
 - [PR](https://github.com/gdsfactory/gdsfactory/pull/576)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also access:
 gdsfactory provides you with functions that you can use to:
 
 - define Pcells in python or YAML.
-- define route between components.
+- define routes between components.
 - test settings, ports and geometry for components to avoid regressions.
 
 
@@ -84,6 +84,5 @@ Open source heroes:
 
 ## Links
 
-- [gdsfactory github repo](https://github.com/gdsfactory/gdsfactory) and [docs](https://gdsfactory.github.io/gdsfactory/)
-- [ubc PDK](https://github.com/gdsfactory/ubc): sample open source PDK from edx course.
+- [gdsfactory GitHub repo](https://github.com/gdsfactory/gdsfactory), [docs](https://gdsfactory.github.io/gdsfactory/) and [general updates](https://github.com/gdsfactory/gdsfactory/discussions/547)
 - [awesome photonics list](https://github.com/joamatab/awesome_photonics)

--- a/docs/notebooks/08_pdk.ipynb
+++ b/docs/notebooks/08_pdk.ipynb
@@ -260,9 +260,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## LayerSpec, ComponentSpec, CrossSectionSpec\n",
+    "## PDK\n",
     "\n",
-    "When you register Layers, ComponentFactories (cells) and CrossSectionFactories (cross_sections), you can access them by a string.\n",
+    "You can register Layers, ComponentFactories (Parametric cells) and CrossSectionFactories (cross_sections) into a PDK. Then you can access them by a string after you activate the pdk `PDK.activate()`.\n",
     "\n",
     "### LayerSpec\n",
     "\n",
@@ -900,11 +900,11 @@
    "source": [
     "## PDK Testing\n",
     "\n",
-    "To make sure all your PDK Pcells produce the components that you want, it's important to test your PDK.\n",
+    "To make sure all your PDK Pcells produce the components that you want, it's important to test your PDK cells.\n",
     "\n",
-    "As you write your own cell functions you want to make sure you do not break them later on. You can write tests to avoid unwanted regressions.\n",
+    "As you write your own cell functions you want to make sure you do not break or produced unwanted regressions later on. You should write tests for this.\n",
     "\n",
-    "Make sure you create a test like this an name it with `test_` prefix so Pytest can find it.\n"
+    "Make sure you create a `test_components.py` file for pytest to test your PDK.\n"
    ]
   },
   {
@@ -966,6 +966,71 @@
     "    \"\"\"Ensures all ports are on grid to avoid 1nm gaps\"\"\"\n",
     "    component = factory[component_name]()\n",
     "    component.assert_ports_on_grid()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PDK decorator\n",
+    "\n",
+    "You can also define a PDK decorator (function) that runs over every PDK PCell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from gdsfactory.pdk import GENERIC\n",
+    "from gdsfactory.decorators import flatten_invalid_refs, has_valid_transformations\n",
+    "\n",
+    "GENERIC.activate()\n",
+    "\n",
+    "@gf.cell\n",
+    "def _demo_non_manhattan():\n",
+    "    c = gf.Component(\"bend\")\n",
+    "    b = c << gf.components.bend_circular(angle=30)\n",
+    "    s = c << gf.components.straight(length=5)\n",
+    "    s.connect(\"o1\", b.ports[\"o2\"])\n",
+    "    return c\n",
+    "\n",
+    "c1 = _demo_non_manhattan()\n",
+    "print(has_valid_transformations(c1))\n",
+    "c1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "if you zoom in between the bends you will see a notch between waveguides due to non-manhattan connection between the bends.\n",
+    "\n",
+    "![](https://i.imgur.com/jBEwy9T.png)\n",
+    "\n",
+    "You an fix it with the `flatten_invalid_refs` decorator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2 = _demo_non_manhattan(decorator=flatten_invalid_refs)\n",
+    "print(has_valid_transformations(c2))\n",
+    "c2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you zoom in the connection the decorator you can see it fixed the issue.\n",
+    "\n",
+    "![](https://i.imgur.com/VbSgIjP.png)"
    ]
   },
   {

--- a/gdsfactory/decorators.py
+++ b/gdsfactory/decorators.py
@@ -31,7 +31,7 @@ def has_valid_transformations(component: Component) -> bool:
 
 
 def flatten_invalid_refs(component: Component, grid_size: Optional[float] = None):
-    """Flattens all references of the component with invalid GDS transformations
+    """Flattens component references component with invalid GDS transformations.
 
     (i.e. non-90 deg rotations or sub-grid translations).
 
@@ -56,15 +56,16 @@ def flatten_invalid_refs(component: Component, grid_size: Optional[float] = None
 
 
 @gf.cell
-def _demo_non_manhattan():
-    c = gf.Component("bend")
+def _demo_non_manhattan() -> Component:
+    """Returns component with Manhattan snapping issues."""
+    c = Component("bend")
     b = c << gf.components.bend_circular(angle=30)
     s = c << gf.components.straight(length=5)
     s.connect("o1", b.ports["o2"])
     return c
 
 
-def test_invalid_refs():
+def test_flatten_invalid_refs():
     c1 = _demo_non_manhattan()
     assert not has_valid_transformations(c1)
 
@@ -73,6 +74,6 @@ def test_invalid_refs():
 
 
 if __name__ == "__main__":
-    test_invalid_refs()
+    test_flatten_invalid_refs()
     # c = _demo_non_manhattan(decorator=flatten_invalid_refs)
     # c.show()

--- a/gdsfactory/flatten_invalid_refs.py
+++ b/gdsfactory/flatten_invalid_refs.py
@@ -1,19 +1,78 @@
-from gdsfactory import Component
+import gdsfactory as gf
+from gdsfactory.pdk import get_grid_size
 from gdsfactory.snap import is_on_grid
+from gdsfactory.types import Component, ComponentReference, Optional
 
 
-def flatten_invalid_refs(component: Component, grid_size: int = 1):
-    """
-    Flattens all references of the component with invalid GDS transformations (i.e. non-90 deg rotations or sub-grid translations). This is an in-place operation.
+def is_valid_transformation(
+    ref: ComponentReference, grid_size: Optional[float] = None
+) -> bool:
+    """Returns True if the component has valid transformations.
 
     Args:
-        component: the component to fix (in place)
-        grid_size: the GDS grid size, in nm (any translations with higher resolution than this are considered invalid)
+        component: the component reference to check.
+        grid_size: the GDS grid size, in um, defaults to active PDK.get_grid_size()
+            any translations with higher resolution than this are considered invalid.
     """
+    grid_size = grid_size or get_grid_size()
+    nm = int(grid_size * 1e3)
+    origin_is_on_grid = all(is_on_grid(x, nm) for x in ref.origin)
+    rotation_is_regular = ref.rotation is None or ref.rotation % 90 == 0
+    return origin_is_on_grid and rotation_is_regular
+
+
+def has_valid_transformations(component: Component) -> bool:
+    """Returns True if the component has valid transformations."""
+    refs = component.references
+    for ref in refs:
+        if not is_valid_transformation(ref):
+            return False
+    return True
+
+
+def flatten_invalid_refs(component: Component, grid_size: Optional[float] = None):
+    """Flattens all references of the component with invalid GDS transformations
+
+    (i.e. non-90 deg rotations or sub-grid translations).
+
+    This is an in-place operation, so you should use it as a decorator.
+    flattens only individual references with invalid transformations.
+
+    Args:
+        component: the component to fix (in place).
+        grid_size: the GDS grid size, in um, defaults to active PDK.get_grid_size()
+            any translations with higher resolution than this are considered invalid.
+    """
+    grid_size = grid_size or get_grid_size()
+    nm = int(grid_size * 1e3)
+
     refs = component.references.copy()
     for ref in refs:
-        origin_is_on_grid = all(is_on_grid(x, grid_size) for x in ref.origin)
+        origin_is_on_grid = all(is_on_grid(x, nm) for x in ref.origin)
         rotation_is_regular = ref.rotation is None or ref.rotation % 90 == 0
         if not origin_is_on_grid or not rotation_is_regular:
             component.flatten_reference(ref)
     return component
+
+
+@gf.cell
+def _demo_non_manhattan():
+    c = gf.Component("bend")
+    b = c << gf.components.bend_circular(angle=30)
+    s = c << gf.components.straight(length=5)
+    s.connect("o1", b.ports["o2"])
+    return c
+
+
+def test_invalid_refs():
+    c1 = _demo_non_manhattan()
+    assert not has_valid_transformations(c1)
+
+    c2 = _demo_non_manhattan(decorator=flatten_invalid_refs)
+    assert has_valid_transformations(c2)
+
+
+if __name__ == "__main__":
+    test_invalid_refs()
+    # c = _demo_non_manhattan(decorator=flatten_invalid_refs)
+    # c.show()

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -39,6 +39,7 @@ layers_required = ["DEVREC", "PORT", "PORTE"]
 
 class Pdk(BaseModel):
     """Store layers, cross_sections, cell functions, simulation_settings ...
+
     only one Pdk can be active at a given time.
 
     Parameters:
@@ -48,9 +49,11 @@ class Pdk(BaseModel):
         containers: dict of pcells that contain other cells.
         base_pdk: a pdk to copy from and extend.
         default_decorator: decorate all cells, if not otherwise defined on the cell.
-        layers: maps name to gdslayer/datatype. For example dict(si=(1, 0), sin=(34, 0)).
+        layers: maps name to gdslayer/datatype.
+            For example dict(si=(1, 0), sin=(34, 0)).
         layer_stack: maps name to layer numbers, thickness, zmin, sidewall_angle.
-            if can also contain material properties (refractive index, nonlinear coefficient, sheet resistance ...).
+            if can also contain material properties
+            (refractive index, nonlinear coefficient, sheet resistance ...).
         layer_colors: includes layer name to color, opacity and pattern.
         sparameters_path: to store Sparameters simulations.
         interconnect_cml_path: path to interconnect CML (optional).
@@ -95,6 +98,10 @@ class Pdk(BaseModel):
 
     def activate(self) -> None:
         """Set current pdk to as the active pdk."""
+        from gdsfactory.cell import clear_cache
+
+        clear_cache()
+
         if self.base_pdk:
             cross_sections = self.base_pdk.cross_sections
             cross_sections.update(self.cross_sections)


### PR DESCRIPTION
- rename `gdsfactory/flatten_invalid_refs.py` to `gdsfactory/decorators.py`
- add test to flatten_invalid_refs and include documentation in the [PDK docs](https://gdsfactory.github.io/gdsfactory/notebooks/08_pdk.html#)
- pdk.activate clears cache
