### PR TITLE
Experimental Tcad crosssection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: 6cddcde8aeebdf97a9cb649c1d5fc70d520dd417
     hooks:
       - id: codespell
-        args: ["-L TE,TE/TM,te,ba,FPR,fpr_spacing,ro,nd,Synopsys"]
+        args: ["-L TE,TE/TM,te,ba,FPR,fpr_spacing,ro,nd"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: ff37419597c6dcb0a9e705067d3ac44d7543eb53

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: 6cddcde8aeebdf97a9cb649c1d5fc70d520dd417
     hooks:
       - id: codespell
-        args: ["-L TE,TE/TM,te,ba,FPR,fpr_spacing,ro,nd"]
+        args: ["-L TE,TE/TM,te,ba,FPR,fpr_spacing,ro,nd,Synopsys"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: ff37419597c6dcb0a9e705067d3ac44d7543eb53

--- a/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
+++ b/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "[DEVSIM](https://devsim.org/) is an open-source semiconductor device simulator; also see [publication](https://joss.theoj.org/papers/10.21105/joss.03898). \n",
     "\n",
-    "It compares in solving capabilities to Sentaurus Device (Synopsis) or Victory Device Simulator (Silvaco). Some of its features include:\n",
+    "It compares in solving capabilities for propietary tools. Some of its features include:\n",
     "* Sharfetter-Gummel discretization of the electron and hole continuity equations\n",
     "* DC, transient, small-signal AC, and noise solution algorithms\n",
     "* Solution of 1D, 2D, and 3D unstructured meshes\n",

--- a/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
+++ b/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DEVSIM circuit simulator (experimental)\n",
+    "\n",
+    "[DEVSIM](https://devsim.org/) is an open-source semiconductor device simulator; also see [publication](https://joss.theoj.org/papers/10.21105/joss.03898). \n",
+    "\n",
+    "It compares in solving capabilities to Sentaurus Device (Synopsis) or Victory Device Simulator (Silvaco). Some of its features include:\n",
+    "* Sharfetter-Gummel discretization of the electron and hole continuity equations\n",
+    "* DC, transient, small-signal AC, and noise solution algorithms\n",
+    "* Solution of 1D, 2D, and 3D unstructured meshes\n",
+    "* Advanced models for mobility and semiclassical approaches for quantum effects\n",
+    "In addition, it operates with a symbolic model evaluation interface, easily allowing new models and their derivatives to be scripted.\n",
+    "\n",
+    "There is an active community over at the [DEVSIM forums](https://forum.devsim.org/).\n",
+    "\n",
+    "## Meshing\n",
+    "\n",
+    "DEVSIM solves equations on unstructured meshes. It has a built-in 1D and 2D meshing interface, currently used in gdsfactory to solve for carrier distributions in waveguide cross-sections. It also interfaces with GMSH for arbitrary 2D and 3D meshes, which we will use in the future to perform semiconductor simulations of gdsfactory components.\n",
+    "\n",
+    "## Installing DEVSIM and visualization dependencies\n",
+    "\n",
+    "To run the below notebook, you will need to install DEVSIM in your notebook's Python environment. The easiest way to do so is to [download the binary from Github](https://github.com/devsim/devsim/releases), unzip, and `pip install` the package. There are also dependencies to load and display mesh files. For the simplest install, you will need to use `conda` (`mamba` for speed) instead of `pip` to get the binaries for `vtk`.\n",
+    "\n",
+    "Here is an example on Ubuntu (you may need to restart your notebook after running this cell)\n",
+    "\n",
+    "In a fresh conda environment on Ubuntu, I am able to run this notebook after running the following commands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "install = False # Set True to perform\n",
+    "\n",
+    "if install:\n",
+    "    !mkdir ~/devsim\n",
+    "    !wget -P ~/devsim https://github.com/devsim/devsim/releases/download/v2.1.0/devsim_linux_v2.1.0.tgz\n",
+    "    !tar --directory ~/devsim zxvf ~/devsim/devsim_linux_v2.1.0.tgz\n",
+    "    !tar zxvf ~/devsim/devsim_linux_v2.1.0.tgz --directory ~/devsim\n",
+    "    !python ~/devsim/devsim_linux_v2.1.0/install.py\n",
+    "    import sys\n",
+    "    !{sys.executable} -m pip install -e ~/devsim/devsim_linux_v2.1.0/lib # Works in this specific way\n",
+    "    %conda install --yes -c conda-forge pyvista"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DC Drift-diffusion simulation\n",
+    "\n",
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We setup the simulation by defining a strip waveguide cross-section. As per the docstring, we can change waveguide geometry (core thickness, slab thickness, core width), doping configuration (dopant level, dopant positions), as well as hyperparameters like adaptive mesh resolution at all the interfaces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "from gdsfactory.simulation.devsim import get_simulation_xsection\n",
+    "\n",
+    "nm = 1E-9\n",
+    "\n",
+    "c = get_simulation_xsection.PINWaveguide(\n",
+    "    wg_width=500 * nm,\n",
+    "    wg_thickness=220 * nm,\n",
+    "    slab_thickness=90 * nm,\n",
+    ")\n",
+    "\n",
+    "# Initialize mesh and solver\n",
+    "c.ddsolver()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The device can be saved to a tecplot file named `filename.dat` with `c.save_device(filename=filename.dat)`, and can then be opened by an appropriate software such as [Paraview](https://www.paraview.org/). \n",
+    "\n",
+    "(Experimental) It is also possible to visualize the mesh in the Notebook with the `plot` method. By default it shows the geometry. We can also pass a string to `scalars` to plot a field as color over the mesh. For instance, acceptor concentration and donor concentration for the PN junction. The method `c.list_fields()` returns the header of the mesh, which lists all possible fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.list_fields()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.plot(scalars='NetDoping')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.plot(scalars='Electrons', log_scale=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Solve\n",
+    "\n",
+    "We iteratively solve for the self-consistent carrier distribution for 0.5V of applied forward voltage, iterating with 0.1V steps, and then visualize the electron concentration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find a solution with 1V across the junction, ramping by 0.1V steps\n",
+    "c.ramp_voltage(0.5, 0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.plot(scalars='Electrons', log_scale=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and similarly for reverse-bias: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.ramp_voltage(-0.5, -0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.plot(scalars='Electrons', log_scale=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('devsimscratch': conda)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "64c133f3a1967b296905f90b4858707aa8b6457960082c15c2ca47266618a04c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -1,0 +1,306 @@
+"""Returns simulation from cross-section."""
+import pathlib
+from typing import Optional
+
+# import matplotlib.pyplot as plt
+import numpy as np
+
+# TCAD imports
+from devsim import (
+    add_2d_contact,
+    add_2d_interface,
+    add_2d_mesh_line,
+    add_2d_region,
+    create_2d_mesh,
+    create_device,
+    finalize_mesh,
+    get_contact_list,
+    get_interface_list,
+    get_region_list,
+    set_node_values,
+    set_parameter,
+    solve,
+    write_devices,
+)
+from devsim.python_packages.model_create import CreateNodeModel, CreateSolution
+from devsim.python_packages.simple_physics import (
+    CreateSiliconDriftDiffusion,
+    CreateSiliconDriftDiffusionAtContact,
+    CreateSiliconPotentialOnly,
+    CreateSiliconPotentialOnlyContact,
+    CreateSiliconSiliconInterface,
+    GetContactBiasName,
+    PrintCurrents,
+    SetSiliconParameters,
+)
+from pydantic import BaseModel, Extra
+
+from gdsfactory.config import CONFIG
+from gdsfactory.serialization import get_hash
+from gdsfactory.types import PathType
+
+nm = 1e-9
+um = 1e-6
+
+
+class PINWaveguide(BaseModel):
+    """Silicon PIN junction waveguide Model.
+
+    Parameters:
+        wg_width: waveguide width.
+        wg_thickness: thickness waveguide (um).
+        p_offset: offset between waveguide center and P-doping (um, negative to push toward n-side)
+        n_offset: offset between waveguide center and N-doping (um, negative to push toward p-side)
+        slab_thickness: thickness slab (um).
+        t_box: thickness BOX (um).
+        t_clad: thickness cladding (um).
+        xmargin: margin from waveguide edge to each side (um).
+        cache: filepath for caching modes. If None does not use file cache.
+    ::
+
+            xmargin          width            xmargin
+           <------>       <---------->        <------>
+                     ppp_offset     nnn_offset
+                     <---------> <---------->
+                        p_offset n_offset
+                             <-> <->
+                           _____|_____ _ _ _ _ _ _ _ _ _
+                          |  |     |  |                |
+          =====___________|  |     |  |___________=====|
+          |          |       |     |         |         | wg_thickness
+          |   ppp    |   p   |  i  |    n    |   nnn   |
+          |__________|_______|_____|_________|_________|
+          <-------------------------------------------->
+                               w_sim
+
+    """
+
+    wg_width: float
+    wg_thickness: float
+    p_offset: float = 0.0
+    n_offset: float = 0.0
+    slab_thickness: float
+    t_box: float = 2.0 * um
+    t_clad: float = 2.0 * um
+    xmargin: float = 1.0 * um
+    cache: Optional[PathType] = CONFIG["modes"]
+
+    class Config:
+        extra = Extra.allow
+
+    @property
+    def t_sim(self):
+        return self.t_box + self.wg_thickness + self.t_clad
+
+    @property
+    def w_sim(self):
+        return self.wg_width + 2 * self.xmargin
+
+    @property
+    def filepath(self) -> Optional[pathlib.Path]:
+        if self.cache is None:
+            return
+        cache = pathlib.Path(self.cache)
+        cache.mkdir(exist_ok=True, parents=True)
+        settings = {setting: getattr(self, setting) for setting in self.settings}
+        return cache / f"{get_hash(settings)}.npz"
+
+    def Create2DMesh(self, device):
+        xmin = -self.xmargin - self.wg_width / 2
+        xmax = self.xmargin + self.wg_width / 2
+        ymin = 0
+        ymax = self.wg_thickness
+        xmin_waveguide = -self.wg_width / 2
+        xmax_waveguide = self.wg_width / 2
+        yslab = self.slab_thickness
+
+        create_2d_mesh(mesh="dio")
+        add_2d_mesh_line(mesh="dio", dir="x", pos=xmin, ps=100 * nm)
+        add_2d_mesh_line(mesh="dio", dir="x", pos=0, ps=1 * nm)
+        add_2d_mesh_line(mesh="dio", dir="x", pos=xmax, ps=100 * nm)
+        add_2d_mesh_line(mesh="dio", dir="y", pos=ymin, ps=10 * nm)
+        add_2d_mesh_line(mesh="dio", dir="y", pos=ymax, ps=10 * nm)
+
+        add_2d_region(
+            mesh="dio",
+            material="Si",
+            region="slab",
+            xl=xmin,
+            xh=xmax,
+            yl=ymin,
+            yh=yslab,
+            bloat=5 * nm,
+        )
+        add_2d_region(
+            mesh="dio",
+            material="Si",
+            region="core",
+            xl=xmin_waveguide,
+            xh=xmax_waveguide,
+            yl=yslab,
+            yh=ymax,
+            bloat=5 * nm,
+        )
+        # add_2d_region(mesh="dio", material="Oxide", region="left_clad", xl=xmin, xh=xmin_waveguide, yl=yslab, yh=ymax, bloat=10*nm)
+        # add_2d_region(mesh="dio", material="Oxide", region="right_clad", xl=xmax_waveguide, xh=xmax, yl=yslab, yh=ymax, bloat=10*nm)
+
+        add_2d_interface(
+            mesh="dio",
+            name="i0",
+            region0="core",
+            region1="slab",
+            xl=xmin_waveguide,
+            xh=xmax_waveguide,
+            yl=yslab,
+            yh=yslab,
+            bloat=5 * nm,
+        )
+
+        add_2d_contact(
+            mesh="dio",
+            name="left",
+            material="metal",
+            region="slab",
+            yl=ymin,
+            yh=yslab,
+            xl=xmin,
+            xh=xmin,
+            bloat=1 * um,
+        )
+        add_2d_contact(
+            mesh="dio",
+            name="right",
+            material="metal",
+            region="slab",
+            yl=ymin,
+            yh=yslab,
+            xl=xmax,
+            xh=xmax,
+            bloat=1 * um,
+        )
+        finalize_mesh(mesh="dio")
+        create_device(mesh="dio", device=device)
+
+    def SetParameters(self, device):
+        """
+        Set parameters for 300 K
+        """
+        SetSiliconParameters(device, "slab", 300)
+        SetSiliconParameters(device, "core", 300)
+        # SetOxideParameters(device, "left_clad", 300)
+        # SetOxideParameters(device, "right_clad", 300)
+
+    def SetNetDoping(self, device):
+        """
+        NetDoping
+        """
+        CreateNodeModel(device, "core", "Acceptors", "1.0e18*step(-x)")
+        CreateNodeModel(device, "core", "Donors", "1.0e18*step(x)")
+        CreateNodeModel(device, "core", "NetDoping", "Donors-Acceptors")
+        CreateNodeModel(device, "slab", "Acceptors", "1.0e18*step(-x)")
+        CreateNodeModel(device, "slab", "Donors", "1.0e18*step(x)")
+        CreateNodeModel(device, "slab", "NetDoping", "Donors-Acceptors")
+
+    def InitialSolution(self, device, region, circuit_contacts=None):
+        # Create Potential, Potential@n0, Potential@n1
+        CreateSolution(device, region, "Potential")
+
+        # Create potential only physical models
+        CreateSiliconPotentialOnly(device, region)
+
+        # Set up the contacts applying a bias
+        for i in get_contact_list(device=device):
+            if circuit_contacts and i in circuit_contacts:
+                CreateSiliconPotentialOnlyContact(device, region, i, True)
+            else:
+                # it is more correct for the bias to be 0, and it looks like there is side effects
+                set_parameter(device=device, name=GetContactBiasName(i), value=0.0)
+                CreateSiliconPotentialOnlyContact(device, region, i)
+
+    def DriftDiffusionInitialSolution(self, device, region, circuit_contacts=None):
+        # drift diffusion solution variables
+        CreateSolution(device, region, "Electrons")
+        CreateSolution(device, region, "Holes")
+
+        # create initial guess from dc only solution
+        set_node_values(
+            device=device,
+            region=region,
+            name="Electrons",
+            init_from="IntrinsicElectrons",
+        )
+        set_node_values(
+            device=device, region=region, name="Holes", init_from="IntrinsicHoles"
+        )
+
+        # Set up equations
+        CreateSiliconDriftDiffusion(device, region)
+        for i in get_contact_list(device=device):
+            if circuit_contacts and i in circuit_contacts:
+                CreateSiliconDriftDiffusionAtContact(device, region, i, True)
+            else:
+                CreateSiliconDriftDiffusionAtContact(device, region, i)
+
+    def initialize_solver(self):
+        device = "MyDevice"
+        self.Create2DMesh(device)
+        self.SetParameters(device=device)
+        self.SetNetDoping(device=device)
+
+        CreateSolution(device, "core", "Potential")
+        CreateSiliconPotentialOnly(device, "core")
+        self.InitialSolution(device=device, region="slab")
+
+        # CreateSolution(device, "left_clad", "Potential")
+        # CreateOxidePotentialOnly(device, "left_clad")
+        # self.InitialSolution(device=device, region="left_clad")
+
+        # CreateSolution(device, "right_clad", "Potential")
+        # CreateOxidePotentialOnly(device, "right_clad")
+        # self.InitialSolution(device=device, region="right_clad")
+
+        for region in get_region_list(device=device):
+            self.DriftDiffusionInitialSolution(device=device, region=region)
+        for interface in get_interface_list(device=device):
+            CreateSiliconSiliconInterface(device=device, interface=interface)
+
+        solve(
+            type="dc", absolute_error=1e10, relative_error=1e-8, maximum_iterations=30
+        )
+
+    def ramp_voltage(self, V, dV):
+        device = "MyDevice"
+        v = 0.0
+        while np.abs(v) < np.abs(V):
+            set_parameter(device=device, name=GetContactBiasName("left"), value=v)
+            solve(
+                type="dc",
+                absolute_error=1e10,
+                relative_error=1e-10,
+                maximum_iterations=30,
+            )
+            PrintCurrents(device, "left")
+            PrintCurrents(device, "right")
+            v += dV
+
+    # def get_field_density(self, field_name="Electrons"):
+    #     device = "MyDevice"
+    #     region = "MyRegion"
+    #     y = get_node_model_values(device=device, region=region, name=field_name)
+    #     return y
+
+    def save_device(self, filepath):
+        write_devices(file=filepath, type="tecplot")
+
+
+if __name__ == "__main__":
+    c = PINWaveguide(
+        wg_width=500 * nm,
+        wg_thickness=220 * nm,
+        slab_thickness=90 * nm,
+    )
+    c.initialize_solver()
+    c.ramp_voltage(1, 0.1)
+
+    # print(c.get_field_density(field_name="Holes"))
+    c.save_device("./test")

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -1,43 +1,10 @@
 """Returns simulation from cross-section."""
-import pathlib
-from typing import Optional
 
-# import matplotlib.pyplot as plt
+import devsim
 import numpy as np
-
-# TCAD imports
-from devsim import (
-    add_2d_contact,
-    add_2d_interface,
-    add_2d_mesh_line,
-    add_2d_region,
-    create_2d_mesh,
-    create_device,
-    finalize_mesh,
-    get_contact_list,
-    get_interface_list,
-    get_region_list,
-    set_node_values,
-    set_parameter,
-    solve,
-    write_devices,
-)
-from devsim.python_packages.model_create import CreateNodeModel, CreateSolution
-from devsim.python_packages.simple_physics import (
-    CreateSiliconDriftDiffusion,
-    CreateSiliconDriftDiffusionAtContact,
-    CreateSiliconPotentialOnly,
-    CreateSiliconPotentialOnlyContact,
-    CreateSiliconSiliconInterface,
-    GetContactBiasName,
-    PrintCurrents,
-    SetSiliconParameters,
-)
+import pyvista as pv
+from devsim.python_packages import model_create, simple_physics
 from pydantic import BaseModel, Extra
-
-from gdsfactory.config import CONFIG
-from gdsfactory.serialization import get_hash
-from gdsfactory.types import PathType
 
 nm = 1e-9
 um = 1e-6
@@ -51,24 +18,31 @@ class PINWaveguide(BaseModel):
         wg_thickness: thickness waveguide (um).
         p_offset: offset between waveguide center and P-doping (um, negative to push toward n-side)
         n_offset: offset between waveguide center and N-doping (um, negative to push toward p-side)
+        ppp_offset: offset between waveguide center and Ppp-doping (um, negative to push toward n-side) NOT IMPLEMENTED
+        npp_offset: offset between waveguide center and Npp-doping (um, negative to push toward p-side) NOT IMPLEMENTED
         slab_thickness: thickness slab (um).
         t_box: thickness BOX (um).
         t_clad: thickness cladding (um).
-        xmargin: margin from waveguide edge to each side (um).
-        cache: filepath for caching modes. If None does not use file cache.
+        p_conc: low-doping acceptor concentration (/cm3)
+        n_conc: low-doping donor concentration (/cm3)
+        ppp_conc: high-doping acceptor concentration (/cm3)
+        nnn_conc: high-doping donor concentration (/cm3)
+        xmargin: margin from waveguide edge to low doping regions
+        contact_bloat: controls which nodes are considered contacts; adjust if contacts are not found
+
     ::
 
             xmargin          width            xmargin
            <------>       <---------->        <------>
-                     ppp_offset     nnn_offset
-                     <---------> <---------->
+                   ppp_offset        npp_offset
+                     <--->             <---->
                         p_offset n_offset
                              <-> <->
                            _____|_____ _ _ _ _ _ _ _ _ _
                           |  |     |  |                |
-          =====___________|  |     |  |___________=====|
+          ________________|  |     |  |___________=====|
           |          |       |     |         |         | wg_thickness
-          |   ppp    |   p   |  i  |    n    |   nnn   |
+          |   Ppp    |   P   |  i  |    N    |   Npp   |
           |__________|_______|_____|_________|_________|
           <-------------------------------------------->
                                w_sim
@@ -79,11 +53,17 @@ class PINWaveguide(BaseModel):
     wg_thickness: float
     p_offset: float = 0.0
     n_offset: float = 0.0
+    ppp_offset: float = 0.5 * um
+    npp_offset: float = 0.5 * um
     slab_thickness: float
     t_box: float = 2.0 * um
     t_clad: float = 2.0 * um
-    xmargin: float = 1.0 * um
-    cache: Optional[PathType] = CONFIG["modes"]
+    p_conc: float = 1e17
+    n_conc: float = 1e17
+    ppp_conc: float = 1e18
+    nnn_conc: float = 1e18
+    xmargin: float = 0.5 * um
+    contact_bloat: float = 1 * um
 
     class Config:
         extra = Extra.allow
@@ -94,34 +74,25 @@ class PINWaveguide(BaseModel):
 
     @property
     def w_sim(self):
-        return self.wg_width + 2 * self.xmargin
-
-    @property
-    def filepath(self) -> Optional[pathlib.Path]:
-        if self.cache is None:
-            return
-        cache = pathlib.Path(self.cache)
-        cache.mkdir(exist_ok=True, parents=True)
-        settings = {setting: getattr(self, setting) for setting in self.settings}
-        return cache / f"{get_hash(settings)}.npz"
+        return 2 * self.xmargin + self.ppp_offset + self.npp_offset
 
     def Create2DMesh(self, device):
-        xmin = -self.xmargin - self.wg_width / 2
-        xmax = self.xmargin + self.wg_width / 2
+        xmin = -self.xmargin - self.ppp_offset - self.wg_width / 2
+        xmax = self.xmargin + self.npp_offset + self.wg_width / 2
         ymin = 0
         ymax = self.wg_thickness
         xmin_waveguide = -self.wg_width / 2
         xmax_waveguide = self.wg_width / 2
         yslab = self.slab_thickness
 
-        create_2d_mesh(mesh="dio")
-        add_2d_mesh_line(mesh="dio", dir="x", pos=xmin, ps=100 * nm)
-        add_2d_mesh_line(mesh="dio", dir="x", pos=0, ps=1 * nm)
-        add_2d_mesh_line(mesh="dio", dir="x", pos=xmax, ps=100 * nm)
-        add_2d_mesh_line(mesh="dio", dir="y", pos=ymin, ps=10 * nm)
-        add_2d_mesh_line(mesh="dio", dir="y", pos=ymax, ps=10 * nm)
+        devsim.create_2d_mesh(mesh="dio")
+        devsim.add_2d_mesh_line(mesh="dio", dir="x", pos=xmin, ps=20 * nm)
+        devsim.add_2d_mesh_line(mesh="dio", dir="x", pos=0, ps=1 * nm)
+        devsim.add_2d_mesh_line(mesh="dio", dir="x", pos=xmax, ps=20 * nm)
+        devsim.add_2d_mesh_line(mesh="dio", dir="y", pos=ymin, ps=10 * nm)
+        devsim.add_2d_mesh_line(mesh="dio", dir="y", pos=ymax, ps=10 * nm)
 
-        add_2d_region(
+        devsim.add_2d_region(
             mesh="dio",
             material="Si",
             region="slab",
@@ -131,7 +102,7 @@ class PINWaveguide(BaseModel):
             yh=yslab,
             bloat=5 * nm,
         )
-        add_2d_region(
+        devsim.add_2d_region(
             mesh="dio",
             material="Si",
             region="core",
@@ -141,10 +112,10 @@ class PINWaveguide(BaseModel):
             yh=ymax,
             bloat=5 * nm,
         )
-        # add_2d_region(mesh="dio", material="Oxide", region="left_clad", xl=xmin, xh=xmin_waveguide, yl=yslab, yh=ymax, bloat=10*nm)
-        # add_2d_region(mesh="dio", material="Oxide", region="right_clad", xl=xmax_waveguide, xh=xmax, yl=yslab, yh=ymax, bloat=10*nm)
+        # devsim.add_2d_region(mesh="dio", material="Oxide", region="left_clad", xl=xmin, xh=xmin_waveguide, yl=yslab, yh=ymax, bloat=10*nm)
+        # devsim.add_2d_region(mesh="dio", material="Oxide", region="right_clad", xl=xmax_waveguide, xh=xmax, yl=yslab, yh=ymax, bloat=10*nm)
 
-        add_2d_interface(
+        devsim.add_2d_interface(
             mesh="dio",
             name="i0",
             region0="core",
@@ -156,7 +127,7 @@ class PINWaveguide(BaseModel):
             bloat=5 * nm,
         )
 
-        add_2d_contact(
+        devsim.add_2d_contact(
             mesh="dio",
             name="left",
             material="metal",
@@ -165,9 +136,9 @@ class PINWaveguide(BaseModel):
             yh=yslab,
             xl=xmin,
             xh=xmin,
-            bloat=1 * um,
+            bloat=self.contact_bloat,
         )
-        add_2d_contact(
+        devsim.add_2d_contact(
             mesh="dio",
             name="right",
             material="metal",
@@ -176,17 +147,17 @@ class PINWaveguide(BaseModel):
             yh=yslab,
             xl=xmax,
             xh=xmax,
-            bloat=1 * um,
+            bloat=self.contact_bloat,
         )
-        finalize_mesh(mesh="dio")
-        create_device(mesh="dio", device=device)
+        devsim.finalize_mesh(mesh="dio")
+        devsim.create_device(mesh="dio", device=device)
 
     def SetParameters(self, device):
         """
         Set parameters for 300 K
         """
-        SetSiliconParameters(device, "slab", 300)
-        SetSiliconParameters(device, "core", 300)
+        simple_physics.SetSiliconParameters(device, "slab", 300)
+        simple_physics.SetSiliconParameters(device, "core", 300)
         # SetOxideParameters(device, "left_clad", 300)
         # SetOxideParameters(device, "right_clad", 300)
 
@@ -194,77 +165,99 @@ class PINWaveguide(BaseModel):
         """
         NetDoping
         """
-        CreateNodeModel(device, "core", "Acceptors", "1.0e18*step(-x)")
-        CreateNodeModel(device, "core", "Donors", "1.0e18*step(x)")
-        CreateNodeModel(device, "core", "NetDoping", "Donors-Acceptors")
-        CreateNodeModel(device, "slab", "Acceptors", "1.0e18*step(-x)")
-        CreateNodeModel(device, "slab", "Donors", "1.0e18*step(x)")
-        CreateNodeModel(device, "slab", "NetDoping", "Donors-Acceptors")
+        model_create.CreateNodeModel(
+            device,
+            "slab",
+            "Acceptors",
+            f"{self.p_conc:1.1e}*step(-x) + {self.ppp_conc:1.1e}*step(-{self.ppp_offset:1.1e}-x)",
+        )
+        model_create.CreateNodeModel(
+            device,
+            "slab",
+            "Donors",
+            f"{self.n_conc:1.1e}*step(x) + {self.nnn_conc:1.1e}*step(x-{self.npp_offset:1.1e})",
+        )
+        model_create.CreateNodeModel(device, "slab", "NetDoping", "Donors-Acceptors")
+        model_create.CreateNodeModel(
+            device, "core", "Acceptors", f"{self.p_conc:1.1e}*step(-x)"
+        )
+        model_create.CreateNodeModel(
+            device, "core", "Donors", f"{self.n_conc:1.1e}*step(x)"
+        )
+        model_create.CreateNodeModel(device, "core", "NetDoping", "Donors-Acceptors")
 
     def InitialSolution(self, device, region, circuit_contacts=None):
         # Create Potential, Potential@n0, Potential@n1
-        CreateSolution(device, region, "Potential")
+        model_create.CreateSolution(device, region, "Potential")
 
         # Create potential only physical models
-        CreateSiliconPotentialOnly(device, region)
+        simple_physics.CreateSiliconPotentialOnly(device, region)
 
         # Set up the contacts applying a bias
-        for i in get_contact_list(device=device):
+        for i in devsim.get_contact_list(device=device):
             if circuit_contacts and i in circuit_contacts:
-                CreateSiliconPotentialOnlyContact(device, region, i, True)
+                simple_physics.CreateSiliconPotentialOnlyContact(
+                    device, region, i, True
+                )
             else:
                 # it is more correct for the bias to be 0, and it looks like there is side effects
-                set_parameter(device=device, name=GetContactBiasName(i), value=0.0)
-                CreateSiliconPotentialOnlyContact(device, region, i)
+                devsim.set_parameter(
+                    device=device, name=simple_physics.GetContactBiasName(i), value=0.0
+                )
+                simple_physics.CreateSiliconPotentialOnlyContact(device, region, i)
 
     def DriftDiffusionInitialSolution(self, device, region, circuit_contacts=None):
         # drift diffusion solution variables
-        CreateSolution(device, region, "Electrons")
-        CreateSolution(device, region, "Holes")
+        model_create.CreateSolution(device, region, "Electrons")
+        model_create.CreateSolution(device, region, "Holes")
 
         # create initial guess from dc only solution
-        set_node_values(
+        devsim.set_node_values(
             device=device,
             region=region,
             name="Electrons",
             init_from="IntrinsicElectrons",
         )
-        set_node_values(
+        devsim.set_node_values(
             device=device, region=region, name="Holes", init_from="IntrinsicHoles"
         )
 
         # Set up equations
-        CreateSiliconDriftDiffusion(device, region)
-        for i in get_contact_list(device=device):
+        simple_physics.CreateSiliconDriftDiffusion(device, region)
+        for i in devsim.get_contact_list(device=device):
             if circuit_contacts and i in circuit_contacts:
-                CreateSiliconDriftDiffusionAtContact(device, region, i, True)
+                simple_physics.CreateSiliconDriftDiffusionAtContact(
+                    device, region, i, True
+                )
             else:
-                CreateSiliconDriftDiffusionAtContact(device, region, i)
+                simple_physics.CreateSiliconDriftDiffusionAtContact(device, region, i)
 
-    def initialize_solver(self):
+    def ddsolver(self):
         device = "MyDevice"
         self.Create2DMesh(device)
         self.SetParameters(device=device)
         self.SetNetDoping(device=device)
 
-        CreateSolution(device, "core", "Potential")
-        CreateSiliconPotentialOnly(device, "core")
+        model_create.CreateSolution(device, "core", "Potential")
+        simple_physics.CreateSiliconPotentialOnly(device, "core")
         self.InitialSolution(device=device, region="slab")
 
-        # CreateSolution(device, "left_clad", "Potential")
+        # model_create.CreateSolution(device, "left_clad", "Potential")
         # CreateOxidePotentialOnly(device, "left_clad")
         # self.InitialSolution(device=device, region="left_clad")
 
-        # CreateSolution(device, "right_clad", "Potential")
+        # model_create.CreateSolution(device, "right_clad", "Potential")
         # CreateOxidePotentialOnly(device, "right_clad")
         # self.InitialSolution(device=device, region="right_clad")
 
-        for region in get_region_list(device=device):
+        for region in devsim.get_region_list(device=device):
             self.DriftDiffusionInitialSolution(device=device, region=region)
-        for interface in get_interface_list(device=device):
-            CreateSiliconSiliconInterface(device=device, interface=interface)
+        for interface in devsim.get_interface_list(device=device):
+            simple_physics.CreateSiliconSiliconInterface(
+                device=device, interface=interface
+            )
 
-        solve(
+        devsim.solve(
             type="dc", absolute_error=1e10, relative_error=1e-8, maximum_iterations=30
         )
 
@@ -272,15 +265,17 @@ class PINWaveguide(BaseModel):
         device = "MyDevice"
         v = 0.0
         while np.abs(v) < np.abs(V):
-            set_parameter(device=device, name=GetContactBiasName("left"), value=v)
-            solve(
+            devsim.set_parameter(
+                device=device, name=simple_physics.GetContactBiasName("left"), value=v
+            )
+            devsim.solve(
                 type="dc",
                 absolute_error=1e10,
                 relative_error=1e-10,
                 maximum_iterations=30,
             )
-            PrintCurrents(device, "left")
-            PrintCurrents(device, "right")
+            simple_physics.PrintCurrents(device, "left")
+            simple_physics.PrintCurrents(device, "right")
             v += dV
 
     # def get_field_density(self, field_name="Electrons"):
@@ -290,7 +285,26 @@ class PINWaveguide(BaseModel):
     #     return y
 
     def save_device(self, filepath):
-        write_devices(file=filepath, type="tecplot")
+        devsim.write_devices(file=filepath, type="tecplot")
+
+    def plot(self, tempfile="temp.dat", scalars=None, log_scale=False, cmap="RdBu"):
+        devsim.write_devices(file=tempfile, type="tecplot")
+        reader = pv.get_reader(tempfile)
+        mesh = reader.read()
+        # sargs = dict(height=0.25, vertical=True, position_x=0.05, position_y=0.05)
+        plotter = pv.Plotter(notebook=True)
+        _ = plotter.add_mesh(
+            mesh, scalars=scalars, log_scale=log_scale, cmap=cmap
+        )  # , scalar_bar_args=sargs)
+        _ = plotter.show_grid()
+        _ = plotter.camera_position = "xy"
+        _ = plotter.show(jupyter_backend="None")
+
+    def list_fields(self, tempfile="temp.dat"):
+        devsim.write_devices(file=tempfile, type="tecplot")
+        reader = pv.get_reader(tempfile)
+        mesh = reader.read()
+        return mesh[0]
 
 
 if __name__ == "__main__":
@@ -299,8 +313,9 @@ if __name__ == "__main__":
         wg_thickness=220 * nm,
         slab_thickness=90 * nm,
     )
-    c.initialize_solver()
+    c.ddsolver()
+    # c.save_device("./test.dat")
     c.ramp_voltage(1, 0.1)
 
-    # print(c.get_field_density(field_name="Holes"))
-    c.save_device("./test")
+    # # print(c.get_field_density(field_name="Holes"))
+    c.save_device("./test.dat")


### PR DESCRIPTION
- Experimental tcad cross-section simulation using DEVSIM
  - fully parametrized ridge PIN waveguide cross-section
  - basic DC simulation and visualization
  - example notebook, with DEVSIM installation instructions
  - works pretty well, good qualitative results
- Current limitations (TODO: fixme)
  - Only drift-diffusion in silicon: no surface recombination, oxide, etc.
  - Only manual waveguide cross-section: next step is to generate 3D meshes from components
  - Only DC simulations: add AC, transient, etc.
  - needs benchmarking and tests
  - Pyvista/vtk has lots of warning text outputs in notebook, need to toggle off
  - change DEVSIM verbosity
  - Synopsys mispelled because I couldn't successfully change the codespell hook


