### PR TITLE
fix get_netlist_recursive and expose get_netlist_dict as individual function

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -302,9 +302,10 @@ class Component(Device):
         )
         return G
 
-    def get_netlist_yaml(self) -> str:
-        """Return YAML netlist."""
-        return OmegaConf.to_yaml(self.get_netlist())
+    def get_netlist_yaml(self, **kwargs) -> Dict[str, Any]:
+        from gdsfactory.get_netlist import get_netlist_yaml
+
+        return get_netlist_yaml(**kwargs)
 
     def write_netlist(self, filepath: str) -> None:
         """Write netlist in YAML."""
@@ -343,7 +344,9 @@ class Component(Device):
         return get_netlist(component=self, **kwargs)
 
     def get_netlist_dict(self, **kwargs) -> Dict[str, Any]:
-        return OmegaConf.to_container(self.get_netlist(**kwargs))
+        from gdsfactory.get_netlist import get_netlist_dict
+
+        return get_netlist_dict(**kwargs)
 
     def get_netlist_recursive(self, **kwargs) -> Dict[str, DictConfig]:
         """Returns recursive netlist for a component and subcomponents.

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -305,7 +305,7 @@ class Component(Device):
     def get_netlist_yaml(self, **kwargs) -> Dict[str, Any]:
         from gdsfactory.get_netlist import get_netlist_yaml
 
-        return get_netlist_yaml(**kwargs)
+        return get_netlist_yaml(self, **kwargs)
 
     def write_netlist(self, filepath: str) -> None:
         """Write netlist in YAML."""
@@ -346,7 +346,7 @@ class Component(Device):
     def get_netlist_dict(self, **kwargs) -> Dict[str, Any]:
         from gdsfactory.get_netlist import get_netlist_dict
 
-        return get_netlist_dict(**kwargs)
+        return get_netlist_dict(dict, **kwargs)
 
     def get_netlist_recursive(self, **kwargs) -> Dict[str, DictConfig]:
         """Returns recursive netlist for a component and subcomponents.

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -66,6 +66,44 @@ def get_instance_name(
     return text
 
 
+def get_netlist_dict(
+    component: Component,
+    full_settings: bool = False,
+    layer_label: LayerSpec = "LABEL_INSTANCE",
+    tolerance: int = 1,
+    exclude_port_types: Optional[List] = None,
+) -> Dict:
+    """From a component returns instances, connections and placements dict."""
+    return omegaconf.OmegaConf.to_container(
+        get_netlist(
+            component=component,
+            full_settings=full_settings,
+            layer_label=layer_label,
+            tolerance=tolerance,
+            exclude_port_types=exclude_port_types,
+        )
+    )
+
+
+def get_netlist_yaml(
+    component: Component,
+    full_settings: bool = False,
+    layer_label: LayerSpec = "LABEL_INSTANCE",
+    tolerance: int = 1,
+    exclude_port_types: Optional[List] = None,
+) -> Dict:
+    """From a component returns instances, connections and placements yaml string content."""
+    return omegaconf.OmegaConf.to_yaml(
+        get_netlist(
+            component=component,
+            full_settings=full_settings,
+            layer_label=layer_label,
+            tolerance=tolerance,
+            exclude_port_types=exclude_port_types,
+        )
+    )
+
+
 def get_netlist(
     component: Component,
     full_settings: bool = False,
@@ -201,7 +239,7 @@ def get_netlist(
 
 def get_netlist_recursive(
     component: Component,
-    component_suffix: str = ".ba",
+    component_suffix: str = "",
     get_netlist_func: Callable = get_netlist,
     **kwargs,
 ) -> Dict[str, omegaconf.DictConfig]:
@@ -232,7 +270,12 @@ def get_netlist_recursive(
         # for each reference, expand the netlist
         for ref in component.references:
             rcell = ref.parent
-            grandchildren = get_netlist_recursive(rcell)
+            grandchildren = get_netlist_recursive(
+                component=rcell,
+                component_suffix=component_suffix,
+                get_netlist_func=get_netlist_func,
+                **kwargs,
+            )
             all_netlists.update(grandchildren)
             if ref.ref_cell.references:
                 inst_name = get_instance_name(component, ref)


### PR DESCRIPTION
The main thing this MR fixes is the recursive get_netlist_recursive call: the parameters were not given to the deeper calls.

Also, exposing get_netlist_dict as a separate function (not only method) is convenient for sax interop.