### PR TITLE
Fix show ports shear

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -36,6 +36,7 @@ def _rotate(v: ndarray, m: ndarray) -> ndarray:
 def get_pin_triangle_polygon_tip(port: Port) -> Tuple[List[float], Tuple[float, float]]:
     """Returns triangle polygon and tip position"""
     p = port
+    port_face = p.info.get("face", None)
 
     orientation = p.orientation
 
@@ -51,11 +52,14 @@ def get_pin_triangle_polygon_tip(port: Port) -> Tuple[List[float], Tuple[float, 
     dtop = np.array([0, d])
     dtip = np.array([d, 0])
 
-    p0 = p.center + _rotate(dbot, rot_mat)
-    p1 = p.center + _rotate(dtop, rot_mat)
+    if not port_face:
+        p0 = p.center + _rotate(dbot, rot_mat)
+        p1 = p.center + _rotate(dtop, rot_mat)
+        port_face = [p0, p1]
+
     ptip = p.center + _rotate(dtip, rot_mat)
 
-    polygon = [p0, p1, ptip]
+    polygon = list(port_face) + [ptip]
     polygon = np.stack(polygon)
     return polygon, ptip
 

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -48,14 +48,18 @@ def get_pin_triangle_polygon_tip(port: Port) -> Tuple[List[float], Tuple[float, 
     rot_mat = np.array([[ca, -sa], [sa, ca]])
     d = p.width / 2
 
-    dbot = np.array([0, -d])
-    dtop = np.array([0, d])
     dtip = np.array([d, 0])
 
-    if not port_face:
-        p0 = p.center + _rotate(dbot, rot_mat)
-        p1 = p.center + _rotate(dtop, rot_mat)
-        port_face = [p0, p1]
+    if port_face:
+        dtop = port_face[0]
+        dbot = port_face[-1]
+    else:
+        dbot = np.array([0, -d])
+        dtop = np.array([0, d])
+
+    p0 = p.center + _rotate(dbot, rot_mat)
+    p1 = p.center + _rotate(dtop, rot_mat)
+    port_face = [p0, p1]
 
     ptip = p.center + _rotate(dtip, rot_mat)
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -445,7 +445,7 @@ def extrude(
             port_width = width if np.isscalar(width) else width[0]
             port_orientation = (p.start_angle + 180) % 360
             center = points[0]
-            face = [points1[0], points2[0]]
+            face = [points1[0] - center, points2[0] - center]
 
             if warn_off_grid_ports:
                 center_snap = snap.snap_to_grid(center, snap_to_grid_nm)
@@ -471,7 +471,7 @@ def extrude(
             port_width = width if np.isscalar(width) else width[-1]
             port_orientation = (p.end_angle) % 360
             center = points[-1]
-            face = [points1[-1], points2[-1]]
+            face = [points1[-1] - center, points2[-1] - center]
 
             if warn_off_grid_ports:
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -445,7 +445,8 @@ def extrude(
             port_width = width if np.isscalar(width) else width[0]
             port_orientation = (p.start_angle + 180) % 360
             center = points[0]
-            face = [points1[0] - center, points2[0] - center]
+            face = [points1[0], points2[0]]
+            face = [_rotated_delta(point, center, port_orientation) for point in face]
 
             if warn_off_grid_ports:
                 center_snap = snap.snap_to_grid(center, snap_to_grid_nm)
@@ -471,7 +472,8 @@ def extrude(
             port_width = width if np.isscalar(width) else width[-1]
             port_orientation = (p.end_angle) % 360
             center = points[-1]
-            face = [points1[-1] - center, points2[-1] - center]
+            face = [points1[-1], points2[-1]]
+            face = [_rotated_delta(point, center, port_orientation) for point in face]
 
             if warn_off_grid_ports:
 
@@ -504,6 +506,26 @@ def extrude(
         c = x.add_pins(c) or c
 
     return c
+
+
+def _rotated_delta(
+    point: np.ndarray, center: np.ndarray, orientation: float
+) -> np.ndarray:
+    """Gets the rotated distance of a point from a center
+
+    Args:
+        point: the initial point
+        center: a center point to use as a reference
+        orientation: the rotation, in degrees
+
+     Returns: the normalized delta between the point and center, accounting for rotation
+    """
+    ca = np.cos(orientation * np.pi / 180)
+    sa = np.sin(orientation * np.pi / 180)
+    rot_mat = np.array([[ca, -sa], [sa, ca]])
+    delta = point - center
+    rotated_delta = np.dot(delta, rot_mat)
+    return rotated_delta
 
 
 def _cut_path_with_ray(

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -445,13 +445,14 @@ def extrude(
             port_width = width if np.isscalar(width) else width[0]
             port_orientation = (p.start_angle + 180) % 360
             center = points[0]
+            face = [points1[0], points2[0]]
 
             if warn_off_grid_ports:
                 center_snap = snap.snap_to_grid(center, snap_to_grid_nm)
                 if center[0] != center_snap[0] or center[1] != center_snap[1]:
                     warnings.warn(f"Port center {center} has off-grid ports")
 
-            c.add_port(
+            port1 = c.add_port(
                 port=Port(
                     name=port_names[0],
                     layer=get_layer(layers[0]),
@@ -465,10 +466,12 @@ def extrude(
                     shear_angle=shear_angle_start,
                 )
             )
+            port1.info["face"] = face
         if port_names[1] is not None:
             port_width = width if np.isscalar(width) else width[-1]
             port_orientation = (p.end_angle) % 360
             center = points[-1]
+            face = [points1[-1], points2[-1]]
 
             if warn_off_grid_ports:
 
@@ -476,7 +479,7 @@ def extrude(
 
                 if center[0] != center_snap[0] or center[1] != center_snap[1]:
                     warnings.warn(f"Port center {center} has off-grid ports")
-            c.add_port(
+            port2 = c.add_port(
                 port=Port(
                     name=port_names[1],
                     layer=get_layer(layers[1]),
@@ -490,6 +493,7 @@ def extrude(
                     shear_angle=shear_angle_end,
                 )
             )
+            port2.info["face"] = face
 
     c.info["length"] = float(np.round(p.length(), 3))
 


### PR DESCRIPTION
Hi @joamatab ,

This PR fixes issues with visualizing the port face in complex scenarios, particularly when a non-zero `shear_angle` is set. The fix sets the attribute  `Port.info["face"]` to the normalized delta of waveguide face from its center point. In this way, we can retain a definition of the face which is robust to arbitrary transformations of the cell reference later on. I think this solution should be robust to other complex "non-normal face" situations in the future, should there be any, as long as they are created via `extrude()`.

Complex example behavior:
```python
import gdsfactory as gf

if __name__ == "__main__":
    P = gf.path.euler()

    s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
    X1 = gf.CrossSection(
        width=1,
        offset=0,
        layer=gf.LAYER.WG,
        name="core",
        port_names=("o1", "o2"),
        sections=[s],
    )
    s2 = gf.Section(width=2, offset=0, layer=gf.LAYER.SLAB90, name="slab")
    X2 = gf.CrossSection(
        width=0.5,
        offset=0,
        layer=gf.LAYER.WG,
        name="core",
        port_names=("o1", "o2"),
        sections=[s2],
    )
    t = gf.path.transition(X1, X2, width_type="linear")
    c = gf.path.extrude(P, t, shear_angle_start=10, shear_angle_end=45)
    c2 = gf.Component()
    r = c2 << c
    r.movey(-100)
    r.rotate(30)
    c2.add_ports(r.ports)
    c2 = c2.flatten()
    c2.show(show_ports=True)
```

![image](https://user-images.githubusercontent.com/3070522/184564763-629b0997-affb-4bdb-b622-f9581e9d42cf.png)

Fixes #483 