### PR TITLE
reduce spurious vtk text output in devsim notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ devsim:
 	python devsim/devsim_linux_v2.1.0/install.py
 	pip install -e devsim/devsim_linux_v2.1.0/lib # Works in this specific way
 	pip install mkl
+	pip install wurlitzer
 	mamba install pyvista -y
 
 .PHONY: gdsdiff build conda

--- a/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
+++ b/docs/notebooks/plugins/devsim/01_pin_waveguide.ipynb
@@ -44,7 +44,8 @@
     "    !python ~/devsim/devsim_linux_v2.1.0/install.py\n",
     "    import sys\n",
     "    !{sys.executable} -m pip install -e ~/devsim/devsim_linux_v2.1.0/lib # Works in this specific way\n",
-    "    %conda install --yes -c conda-forge pyvista"
+    "    %conda install --yes -c conda-forge pyvista\n",
+    "    %conda install -c conda-forge wurlitzer"
    ]
   },
   {
@@ -72,6 +73,7 @@
    "source": [
     "%%capture\n",
     "from gdsfactory.simulation.devsim import get_simulation_xsection\n",
+    "from wurlitzer import pipes # To suppress some vtk output\n",
     "\n",
     "nm = 1E-9\n",
     "\n",

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -5,6 +5,7 @@ import numpy as np
 import pyvista as pv
 from devsim.python_packages import model_create, simple_physics
 from pydantic import BaseModel, Extra
+from wurlitzer import pipes
 
 nm = 1e-9
 um = 1e-6
@@ -346,7 +347,8 @@ class PINWaveguide(BaseModel):
         )  # , scalar_bar_args=sargs)
         _ = plotter.show_grid()
         _ = plotter.camera_position = "xy"
-        _ = plotter.show(jupyter_backend=jupyter_backend)
+        with pipes() as (out, err):
+            _ = plotter.show(jupyter_backend=jupyter_backend)
 
     def list_fields(self, tempfile="temp.dat"):
         devsim.write_devices(file=tempfile, type="tecplot")


### PR DESCRIPTION
import wurlitzer (also added to Makefile for DEVSIM) to greatly reduce spurious text output when plotting unstructures DEVSIM meshes

Before:

<img width="671" alt="Capture_bad" src="https://user-images.githubusercontent.com/46427609/184570458-0d951929-148f-430b-8ff2-92edfb9591f2.PNG">

After

<img width="456" alt="Capture_better" src="https://user-images.githubusercontent.com/46427609/184570463-7b5a071c-0988-4030-9b8b-332fc727f483.PNG">
: