### PR TITLE
S bend manhattan routing

### DIFF
--- a/gdsfactory/routing/get_route.py
+++ b/gdsfactory/routing/get_route.py
@@ -62,6 +62,7 @@ def get_route(
     bend: ComponentSpec = bend_euler,
     straight: ComponentSpec = straight_function,
     taper: Optional[ComponentSpec] = None,
+    s_bend: Optional[Route] = None,
     start_straight_length: float = 0.01,
     end_straight_length: float = 0.01,
     min_straight_length: float = 0.01,
@@ -124,18 +125,27 @@ def get_route(
             **kwargs,
         )
 
-    return route_manhattan(
-        input_port=input_port,
-        output_port=output_port,
-        straight=straight,
-        taper=taper,
-        start_straight_length=start_straight_length,
-        end_straight_length=end_straight_length,
-        min_straight_length=min_straight_length,
-        bend=bend90,
-        cross_section=cross_section,
-        **kwargs,
-    )
+    if s_bend:
+        return route_manhattan(
+            input_port=input_port,
+            output_port=output_port,
+            s_bend=s_bend,
+            cross_section=cross_section,
+            **kwargs,
+        )
+    else:
+        return route_manhattan(
+            input_port=input_port,
+            output_port=output_port,
+            straight=straight,
+            taper=taper,
+            start_straight_length=start_straight_length,
+            end_straight_length=end_straight_length,
+            min_straight_length=min_straight_length,
+            bend=bend90,
+            cross_section=cross_section,
+            **kwargs,
+        )
 
 
 get_route_electrical = partial(

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -994,6 +994,7 @@ def route_manhattan(
     end_straight_length: Optional[float] = None,
     min_straight_length: Optional[float] = None,
     bend: ComponentSpec = bend_euler,
+    s_bend: Optional[Route] = None,
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
     with_point_markers: bool = False,
     **kwargs,
@@ -1001,7 +1002,7 @@ def route_manhattan(
     """Generates the Manhattan waypoints for a route.
 
     Then creates the straight, taper and bend references that define the
-    route.
+    route, or create an SBend route.
 
     """
     if isinstance(cross_section, list):
@@ -1015,23 +1016,26 @@ def route_manhattan(
         end_straight_length = end_straight_length or x.min_length
         min_straight_length = min_straight_length or x.min_length
 
-    points = generate_manhattan_waypoints(
-        input_port,
-        output_port,
-        start_straight_length=start_straight_length,
-        end_straight_length=end_straight_length,
-        min_straight_length=min_straight_length,
-        bend=bend,
-        cross_section=x,
-    )
-    return round_corners(
-        points=points,
-        straight=straight,
-        taper=taper,
-        bend=bend,
-        cross_section=x,
-        with_point_markers=with_point_markers,
-    )
+    if not s_bend:
+        points = generate_manhattan_waypoints(
+            input_port,
+            output_port,
+            start_straight_length=start_straight_length,
+            end_straight_length=end_straight_length,
+            min_straight_length=min_straight_length,
+            bend=bend,
+            cross_section=x,
+        )
+        return round_corners(
+            points=points,
+            straight=straight,
+            taper=taper,
+            bend=bend,
+            cross_section=x,
+            with_point_markers=with_point_markers,
+        )
+    else:
+        return s_bend(input_port, output_port, cross_section=x)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/routing/test_manhattan.py
+++ b/gdsfactory/routing/test_manhattan.py
@@ -4,6 +4,7 @@ import pytest
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.port import Port
+from gdsfactory.routing.get_route_sbend import get_route_sbend
 from gdsfactory.routing.manhattan import RouteWarning, round_corners, route_manhattan
 
 TOLERANCE = 0.001
@@ -46,6 +47,52 @@ def test_manhattan() -> Component:
         route = route_manhattan(
             input_port=input_port,
             output_port=output_port,
+            radius=5.0,
+            auto_widen=True,
+            width_wide=2,
+            layer=layer
+            # width=0.2,
+        )
+
+        top_cell.add(route.references)
+        assert np.isclose(route.length, length), route.length
+    return top_cell
+
+
+@cell
+def test_manhattan_sbend() -> Component:
+    top_cell = Component()
+    layer = (1, 0)
+
+    inputs = [
+        Port("in1", center=(10, 5), width=0.5, orientation=90, layer=layer),
+        # Port("in2",center= (-10, 20), width=0.5, 0),
+        # Port("in3",center= (10, 30), width=0.5, 0),
+        # Port("in4",center= (-10, -5), width=0.5, 90),
+        # Port("in5",center= (0, 0), width=0.5, 0),
+        # Port("in6",center= (0, 0), width=0.5, 0),
+    ]
+
+    outputs = [
+        Port("in1", center=(290, -60), width=0.5, orientation=180, layer=layer),
+        # Port("in2", (-100, 20), 0.5, 0),
+        # Port("in3", (100, -25), 0.5, 0),
+        # Port("in4", (-150, -65), 0.5, 270),
+        # Port("in5", (25, 3), 0.5, 180),
+        # Port("in6", (0, 10), 0.5, 0),
+    ]
+
+    lengths = [290.38]
+
+    for input_port, output_port, length in zip(inputs, outputs, lengths):
+        # input_port = Port("input_port", (10,5), 0.5, 90)
+        # output_port = Port("output_port", (90,-60), 0.5, 180)
+        # bend = bend_circular(radius=5.0)
+
+        route = route_manhattan(
+            input_port=input_port,
+            output_port=output_port,
+            s_bend=get_route_sbend,
             radius=5.0,
             auto_widen=True,
             width_wide=2,


### PR DESCRIPTION
Add s_bend option for Manhattan routing. We can pass an s_bend function optionally to use it instead of waypoints when there is not enough space for manhattan routing.

Add tests too.

Closes https://github.com/gdsfactory/gdsfactory/issues/51.

Please let me know if there is anything you want me to modify.