### PR TITLE
Simphony gdsfactory wrapper

### DIFF
--- a/gdsfactory/simulation/simphony/__init__.py
+++ b/gdsfactory/simulation/simphony/__init__.py
@@ -16,7 +16,9 @@ from gdsfactory.simulation.simphony import components
 from gdsfactory.simulation.simphony.add_gc import add_gc
 from gdsfactory.simulation.simphony.circuit import component_to_circuit
 from gdsfactory.simulation.simphony.components import model_factory
-from gdsfactory.simulation.simphony.model_from_gdsfactory import model_from_gdsfactory
+from gdsfactory.simulation.simphony.model_from_gdsfactory import (
+    GDSFactorySimphonyWrapper,
+)
 from gdsfactory.simulation.simphony.model_from_sparameters import (
     model_from_csv,
     model_from_filepath,
@@ -33,7 +35,7 @@ __all__ = [
     "component_to_circuit",
     "components",
     "model_factory",
-    "model_from_gdsfactory",
+    "GDSFactorySimphonyWrapper",
     "model_from_sparameters",
     "model_from_csv",
     "model_from_filepath",

--- a/gdsfactory/simulation/simphony/components/coupler_fdtd.py
+++ b/gdsfactory/simulation/simphony/components/coupler_fdtd.py
@@ -1,5 +1,7 @@
 import gdsfactory as gf
-from gdsfactory.simulation.simphony.model_from_gdsfactory import model_from_gdsfactory
+from gdsfactory.simulation.simphony.model_from_gdsfactory import (
+    GDSFactorySimphonyWrapper,
+)
 
 
 def coupler_fdtd(c=gf.c.coupler, width=0.5, length=20, gap=0.224):
@@ -25,7 +27,7 @@ def coupler_fdtd(c=gf.c.coupler, width=0.5, length=20, gap=0.224):
     """
     if callable(c):
         c = c(width=width, length=length, gap=gap)
-    return model_from_gdsfactory(c)
+    return GDSFactorySimphonyWrapper(component=c)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/simulation/simphony/components/coupler_ring_fdtd.py
+++ b/gdsfactory/simulation/simphony/components/coupler_ring_fdtd.py
@@ -1,7 +1,9 @@
 from simphony import Model
 
 import gdsfactory as gf
-from gdsfactory.simulation.simphony.model_from_gdsfactory import model_from_gdsfactory
+from gdsfactory.simulation.simphony.model_from_gdsfactory import (
+    GDSFactorySimphonyWrapper,
+)
 
 
 def coupler_ring_fdtd(
@@ -32,7 +34,7 @@ def coupler_ring_fdtd(
         if callable(factory)
         else factory
     )
-    return model_from_gdsfactory(coupler)
+    return GDSFactorySimphonyWrapper(component=coupler)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/simulation/simphony/components/mmi1x2.py
+++ b/gdsfactory/simulation/simphony/components/mmi1x2.py
@@ -1,5 +1,7 @@
 import gdsfactory as gf
-from gdsfactory.simulation.simphony.model_from_gdsfactory import model_from_gdsfactory
+from gdsfactory.simulation.simphony.model_from_gdsfactory import (
+    GDSFactorySimphonyWrapper,
+)
 
 
 def mmi1x2(**kwargs):
@@ -51,7 +53,7 @@ def mmi1x2(**kwargs):
         c = gc.mmi1x2()
         gs.plot_model(c)
     """
-    return model_from_gdsfactory(gf.components.mmi1x2)
+    return GDSFactorySimphonyWrapper(component=gf.components.mmi1x2)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/simulation/simphony/components/mmi2x2.py
+++ b/gdsfactory/simulation/simphony/components/mmi2x2.py
@@ -1,5 +1,7 @@
 import gdsfactory as gf
-from gdsfactory.simulation.simphony.model_from_gdsfactory import model_from_gdsfactory
+from gdsfactory.simulation.simphony.model_from_gdsfactory import (
+    GDSFactorySimphonyWrapper,
+)
 
 
 def mmi2x2(**kwargs):
@@ -52,7 +54,7 @@ def mmi2x2(**kwargs):
         c = gc.mmi2x2()
         gs.plot_model(c)
     """
-    return model_from_gdsfactory(gf.components.mmi2x2)
+    return GDSFactorySimphonyWrapper(component=gf.components.mmi2x2)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/simulation/simphony/model_from_gdsfactory.py
+++ b/gdsfactory/simulation/simphony/model_from_gdsfactory.py
@@ -1,3 +1,5 @@
+from typing import Any, List, Tuple
+
 import numpy as np
 from scipy.constants import speed_of_light
 from simphony import Model
@@ -9,42 +11,67 @@ import gdsfactory.simulation.lumerical as sim
 from gdsfactory.component import Component
 
 
-def model_from_gdsfactory(
-    component: Component, dirpath=gf.CONFIG["sparameters"], **kwargs
-) -> Model:
-    """Return simphony model from gdsfactory Component Sparameters.
+class GDSFactorySimphonyWrapper(Model):
+    """Take a GDSFactory component and convert it into a Simphony Model object."""
 
-    Args:
-        component: component factory or instance.
-        dirpath: sparameters directory.
-        kwargs: settings.
+    def __init__(
+        self,
+        name: str = "",
+        *,
+        component: Component,
+        dirpath=gf.CONFIG["sparameters"],
+        **kwargs
+    ) -> None:
+        """Take a GDSFactory component and convert it into a Simphony Model object.
 
-    """
-    kwargs.pop("function_name", "")
-    kwargs.pop("module", "")
-    component = gf.call_if_func(component, **kwargs)
-    pins, f, s = sim.read_sparameters_lumerical(component=component, dirpath=dirpath)
+        Args:
+            name: name of the model.
+            component: component factory or instance.
+            dirpath: sparameters directory.
+            kwargs: settings.
 
-    def interpolate_sp(freq):
-        return interpolate(freq, f, s)
+        """
+        pin_names, self.f, self.s = self._model_from_gdsfactory(
+            component=component, dirpath=dirpath, **kwargs
+        )
 
-    Model.pin_count = len(pins)
-    m = Model()
-    m.pins = PinList([Pin(component=m, name=pins[i]) for i, _ in enumerate(pins)])
-    m.__setattr__("sparams", (f, s))
-    m.s_parameters = interpolate_sp
-    m.freq_range = (m.sparams[0][0], m.sparams[0][-1])
-    m.wavelengths = speed_of_light / np.array(f)
-    m.s = s
-    return m
+        pins = PinList(
+            [Pin(component=self, name=pin_names[i]) for i in range(len(pin_names))]
+        )
+
+        freq_range = self.f[0], self.f[-1]
+
+        self.wavelengths = speed_of_light / np.array(self.f)
+
+        super().__init__(name, freq_range=freq_range, pins=pins)
+
+    def s_parameters(self, freqs: "np.array") -> "np.ndarray":
+        return interpolate(freqs, self.f, self.s)
+
+    def _model_from_gdsfactory(
+        self, component: Component, dirpath=gf.CONFIG["sparameters"], **kwargs
+    ) -> Tuple[List[str], Any, np.ndarray]:
+        """Return simphony model from gdsfactory Component Sparameters.
+
+        Args:
+            component: component factory or instance.
+            dirpath: sparameters directory.
+            kwargs: settings.
+
+        """
+        kwargs.pop("function_name", "")
+        kwargs.pop("module", "")
+        component = gf.call_if_func(component, **kwargs)
+
+        return sim.read_sparameters_lumerical(component=component, dirpath=dirpath)
 
 
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
-    c = model_from_gdsfactory(gf.c.mmi2x2())
-    # c = model_from_gdsfactory(gf.c.mmi2x2())
-    # c = model_from_gdsfactory(gf.c.bend_euler())
+    c = GDSFactorySimphonyWrapper(component=gf.c.mmi2x2())
+    # c = GDSFactorySimphonyWrapper(component=gf.c.mmi2x2())
+    # c = GDSFactorySimphonyWrapper(component=gf.c.bend_euler())
     # wav = np.linspace(1520, 1570, 1024) * 1e-9
     # f = speed_of_light / wav
     # s = c.s_parameters(freq=f)


### PR DESCRIPTION
Simphony `Model` does not take `Model().pin_count` (see here: https://github.com/BYUCamachoLab/simphony/issues/67). A better way to define a new Simphony Model object is using a new class derived from the base Model class (See: [SiPANN Wrapper](https://github.com/BYUCamachoLab/simphony/blob/5370dcbc33951f308c31df886af4aa1f736510fb/simphony/libraries/sipann.py#L29))

Added:
- Rewrote `model_from_gdsfactory` to `GDSFactorySimphonyWrapper`. Similar to Simphony's SiPANN wrapper
- Minor replacements so the rest of the plugin works with this

Removed:
- None