### PR TITLE
`gf.routing.get_route()` has `with_sbend` that allows failing routes to route using Sbend.

### DIFF
--- a/docs/notebooks/plugins/sax/sax.ipynb
+++ b/docs/notebooks/plugins/sax/sax.ipynb
@@ -325,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tqdm.auto as tqdm\n",
+    "from tqdm.auto import tqdm\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
     "import jax.example_libraries.optimizers as opt\n",
@@ -1601,7 +1601,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tqdm.auto as tqdm\n",
     "\n",
     "range_ = tqdm.trange(300)\n",
     "for step in range_:\n",

--- a/docs/notebooks/plugins/sax/sax.ipynb
+++ b/docs/notebooks/plugins/sax/sax.ipynb
@@ -325,7 +325,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm.auto import tqdm\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
     "import jax.example_libraries.optimizers as opt\n",

--- a/fixme/routing/fixed/route_sbend.py
+++ b/fixme/routing/fixed/route_sbend.py
@@ -10,12 +10,12 @@ from gdsfactory.routing.manhattan import route_manhattan
 
 
 if __name__ == "__main__":
-    c = gf.Component()
+    c = gf.Component("demo")
     length = 10
     c1 = c << gf.components.straight(length=length)
     c2 = c << gf.components.straight(length=length)
 
-    dy = 4.0
+    dy = 10.0
     c2.y = dy
     c2.movex(length + dy)
 
@@ -23,10 +23,7 @@ if __name__ == "__main__":
         input_port=c1.ports["o2"],
         output_port=c2.ports["o1"],
         radius=5.0,
-        with_point_markers=True,
-        s_bend=gf.routing.get_route_sbend,
     )
 
     c.add(route.references)
-
     c.show(show_ports=True)

--- a/fixme/routing/fixed/route_sbend2.py
+++ b/fixme/routing/fixed/route_sbend2.py
@@ -11,7 +11,7 @@ from gdsfactory.routing.manhattan import route_manhattan
 
 
 if __name__ == "__main__":
-    c = gf.Component()
+    c = gf.Component("demo_sbend")
     length = 10
     c1 = c << gf.components.straight(length=length)
     c2 = c << gf.components.straight(length=length)
@@ -24,8 +24,7 @@ if __name__ == "__main__":
         input_port=c1.ports["o2"],
         output_port=c2.ports["o1"],
         radius=5.0,
-        with_point_markers=True,
-        s_bend=gf.routing.get_route_sbend,
+        with_sbend=False,
     )
 
     c.add(route.references)

--- a/fixme/routing/fixed/route_sbend3.py
+++ b/fixme/routing/fixed/route_sbend3.py
@@ -24,8 +24,7 @@ if __name__ == "__main__":
         input_port=c1.ports["o2"],
         output_port=c2.ports["o1"],
         radius=5.0,
-        with_point_markers=True,
-        s_bend=gf.routing.get_route_sbend,
+        with_sbend=True,
     )
 
     c.add(route.references)

--- a/gdsfactory/routing/test_manhattan.py
+++ b/gdsfactory/routing/test_manhattan.py
@@ -4,7 +4,6 @@ import pytest
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.port import Port
-from gdsfactory.routing.get_route_sbend import get_route_sbend
 from gdsfactory.routing.manhattan import RouteWarning, round_corners, route_manhattan
 
 TOLERANCE = 0.001
@@ -47,52 +46,6 @@ def test_manhattan() -> Component:
         route = route_manhattan(
             input_port=input_port,
             output_port=output_port,
-            radius=5.0,
-            auto_widen=True,
-            width_wide=2,
-            layer=layer
-            # width=0.2,
-        )
-
-        top_cell.add(route.references)
-        assert np.isclose(route.length, length), route.length
-    return top_cell
-
-
-@cell
-def test_manhattan_sbend() -> Component:
-    top_cell = Component()
-    layer = (1, 0)
-
-    inputs = [
-        Port("in1", center=(10, 5), width=0.5, orientation=90, layer=layer),
-        # Port("in2",center= (-10, 20), width=0.5, 0),
-        # Port("in3",center= (10, 30), width=0.5, 0),
-        # Port("in4",center= (-10, -5), width=0.5, 90),
-        # Port("in5",center= (0, 0), width=0.5, 0),
-        # Port("in6",center= (0, 0), width=0.5, 0),
-    ]
-
-    outputs = [
-        Port("in1", center=(290, -60), width=0.5, orientation=180, layer=layer),
-        # Port("in2", (-100, 20), 0.5, 0),
-        # Port("in3", (100, -25), 0.5, 0),
-        # Port("in4", (-150, -65), 0.5, 270),
-        # Port("in5", (25, 3), 0.5, 180),
-        # Port("in6", (0, 10), 0.5, 0),
-    ]
-
-    lengths = [290.38]
-
-    for input_port, output_port, length in zip(inputs, outputs, lengths):
-        # input_port = Port("input_port", (10,5), 0.5, 90)
-        # output_port = Port("output_port", (90,-60), 0.5, 180)
-        # bend = bend_circular(radius=5.0)
-
-        route = route_manhattan(
-            input_port=input_port,
-            output_port=output_port,
-            s_bend=get_route_sbend,
             radius=5.0,
             auto_widen=True,
             width_wide=2,
@@ -155,8 +108,7 @@ def _demo_manhattan_fail() -> Component:
 
 
 if __name__ == "__main__":
-    c = test_manhattan_sbend()
-    # c = test_manhattan_fail()
+    c = test_manhattan_fail()
     # c = test_manhattan_pass()
     # c = _demo_manhattan_fail()
     # c = gf.components.straight()

--- a/gdsfactory/routing/test_manhattan_sbend.py
+++ b/gdsfactory/routing/test_manhattan_sbend.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+import gdsfactory as gf
+from gdsfactory.cell import cell
+from gdsfactory.component import Component
+from gdsfactory.routing.manhattan import RouteWarning, route_manhattan
+
+TOLERANCE = 0.001
+DEG2RAD = np.pi / 180
+RAD2DEG = 1 / DEG2RAD
+
+O2D = {0: "East", 180: "West", 90: "North", 270: "South"}
+
+
+@cell
+def test_manhattan_sbend_pass() -> Component:
+    c = gf.Component("demo_sbend")
+    length = 10
+    c1 = c << gf.components.straight(length=length)
+    c2 = c << gf.components.straight(length=length)
+
+    dy = 4.0
+    c2.y = dy
+    c2.movex(length + 20)
+
+    route = route_manhattan(
+        input_port=c1.ports["o2"],
+        output_port=c2.ports["o1"],
+        radius=5.0,
+        with_sbend=True,
+    )
+
+    c.add(route.references)
+    return c
+
+
+@cell
+def test_manhattan_sbend_fail() -> Component:
+    with pytest.warns(RouteWarning):
+        c = gf.Component("demo_sbend")
+        length = 10
+        c1 = c << gf.components.straight(length=length)
+        c2 = c << gf.components.straight(length=length)
+
+        dy = 4.0
+        c2.y = dy
+        c2.movex(length + 20)
+
+        route = route_manhattan(
+            input_port=c1.ports["o2"],
+            output_port=c2.ports["o1"],
+            radius=5.0,
+            with_sbend=False,
+        )
+
+        c.add(route.references)
+    return c
+
+
+if __name__ == "__main__":
+    c = test_manhattan_sbend_pass()
+    c.show(show_ports=True)


### PR DESCRIPTION
- `gf.routing.get_route()` has `with_sbend` that allows failing routes to route using Sbend.

Based on Skandan's PR #615  #616 

@SkandanC 
@tvt173 
