### PR TITLE
reduce unnecessary usage of deepcopy

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -1,5 +1,4 @@
 """Cell decorator for functions that return a Component."""
-import copy
 import functools
 import hashlib
 import inspect
@@ -83,7 +82,7 @@ def cell_without_validator(func):
 
         sig = inspect.signature(func)
         args_as_kwargs = dict(zip(sig.parameters.keys(), args))
-        args_as_kwargs.update(**copy.deepcopy(kwargs))
+        args_as_kwargs.update(kwargs)
 
         default = {
             p.name: p.default
@@ -92,11 +91,11 @@ def cell_without_validator(func):
         }
 
         changed = args_as_kwargs
-        full = copy.deepcopy(default)
+        full = default.copy()
         full.update(**args_as_kwargs)
 
-        default2 = copy.deepcopy(default)
-        changed2 = copy.deepcopy(changed)
+        default2 = default.copy()
+        changed2 = changed.copy()
 
         # list of default args as strings
         default_args_list = [

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1,4 +1,3 @@
-import copy as python_copy
 import datetime
 import hashlib
 import itertools
@@ -701,7 +700,7 @@ class Component(Device):
 
         self.get_child_name = True
         self.child = component
-        self.info.update(python_copy.deepcopy(component.info))
+        self.info.update(component.info)
 
     @property
     def size_info(self) -> SizeInfo:


### PR DESCRIPTION
Hi @joamatab , I've found some components spend as much as 86% of their time just in calls to `deepcopy()`, primarily within the cell decorator. This MR replaces these unnecessary calls to deepcopy with simple copies.