### PR TITLE
fail difftest when passing n to reject changes

### DIFF
--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -99,7 +99,7 @@ def difftest(
                 "Would you like to save current GDS as the new reference? [Y/n] "
             )
             if val.upper().startswith("N"):
-                return
+                raise
             logger.info(f"deleting file {str(ref_file)!r}")
             ref_file.unlink()
             shutil.copy(run_file, ref_file)


### PR DESCRIPTION
Hi @joamatab , there's a bit of a bug in difftest right now... When the `-s` flag is set to step through failures and the user presses `n` to reject the changes, pytest logs the test as passed. We should fail the test in this case.