### PR TITLE
don't cache import_gds in read.from_phidl

### DIFF
--- a/gdsfactory/geometry/outline.py
+++ b/gdsfactory/geometry/outline.py
@@ -48,6 +48,8 @@ def outline(elements, **kwargs) -> Component:
             Specific layer(s) to put polygon geometry on.)
 
     """
+    if "layer" in kwargs:
+        kwargs["layer"] = gf.get_layer(kwargs["layer"])
     return gf.read.from_phidl(component=pg.outline(elements, **kwargs))
 
 

--- a/gdsfactory/read/from_phidl.py
+++ b/gdsfactory/read/from_phidl.py
@@ -57,7 +57,7 @@ def from_phidl(component: Device, port_layer: Layer = (1, 0), **kwargs) -> Compo
         gdspath = gdsdir / f"{device.name}.gds"
         filepath = device.write_gds(gdspath, cellname=device.name)
 
-        component = import_gds(filepath, **kwargs)
+        component = import_gds(filepath, cache=False, **kwargs)
         component.unlock()
 
     for p in device.ports.values():


### PR DESCRIPTION
Hi @joamatab , in the new implementation of read.from_phidl(), there can be issues related to caching when importing the gds. `cache=False` should be set to prevent subsequent calls to the same phidl function from being shadowed by the cell already in the cache with the same name. I also added capability to pass a layer as a string to `outline()`