### PR TITLE
get_bundle improvements

### DIFF
--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -27,6 +27,7 @@ from gdsfactory.port import Port
 from gdsfactory.routing.get_bundle_corner import get_bundle_corner
 from gdsfactory.routing.get_bundle_from_steps import get_bundle_from_steps
 from gdsfactory.routing.get_bundle_from_waypoints import get_bundle_from_waypoints
+from gdsfactory.routing.get_bundle_sbend import get_bundle_sbend
 from gdsfactory.routing.get_bundle_u import get_bundle_udirect, get_bundle_uindirect
 from gdsfactory.routing.get_route import get_route, get_route_from_waypoints
 from gdsfactory.routing.manhattan import generate_manhattan_waypoints
@@ -51,6 +52,7 @@ def get_bundle(
     extension_length: float = 0.0,
     straight: ComponentSpec = straight_function,
     bend: ComponentSpec = bend_euler,
+    with_sbend: bool = False,
     sort_ports: bool = True,
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
     **kwargs,
@@ -66,6 +68,7 @@ def get_bundle(
         separation: bundle separation (center to center).
         extension_length: adds straight extension.
         bend: function for the bend. Defaults to euler.
+        with_sbend: use s_bend routing when there is no space for manhattan routing.
         sort_ports: sort port coordinates.
         cross_section: CrossSection or function that returns a cross_section.
 
@@ -210,6 +213,8 @@ def get_bundle(
         and y_start > y_end
     ):
         # print("get_bundle_same_axis")
+        if with_sbend:
+            return get_bundle_sbend(ports1, ports2, sort_ports, **kwargs)
         return get_bundle_same_axis(**params)
 
     elif start_angle == end_angle:


### PR DESCRIPTION
I have extended `get_bundle` to enable s_bend routing when there is no space for Manhattan routing. (https://github.com/gdsfactory/gdsfactory/issues/55)

Added:
- s_bend routing option for `get_bundle`

Modified:
- `get_bundle_sbend` now returns a list of Routes like all the other `get_bundle_*` functions, rather than a `Routes` object

Removed:
- None

```import gdsfactory as gf
c1 = gf.components.nxn(west=0, east=3)
c2 = gf.components.nxn(west=3, east=0, wg_margin=3)

c = gf.Component()
c1_ref = c.add_ref(c1)
c2_ref = c.add_ref(c2)
c2_ref.movex(100)
c2_ref.movey(-50)
routes = gf.routing.get_bundle(
    ports1=c1_ref.get_ports_list(), ports2=c2_ref.get_ports_list(), with_sbend=True
)

for route in routes:
    c.add(route. References)

c.show()
```

![image](https://user-images.githubusercontent.com/100642027/186947848-428af98c-e71c-474a-b13b-3aa6ffa36779.png)


Please let me know if you need me to change anything.