### PR TITLE
get_bundle has `with_sbend` kwarg

### DIFF
--- a/docs/notebooks/04_routing.ipynb
+++ b/docs/notebooks/04_routing.ipynb
@@ -1194,17 +1194,16 @@
     "routes = gf.routing.get_bundle_sbend(\n",
     "    c1.get_ports_list(orientation=0), c2.get_ports_list(orientation=180)\n",
     ")\n",
-    "c.add(routes.references)\n",
+    "for route in routes:\n",
+    "    c.add(route.references)\n",
     "c"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "routes"
+    "You can also `get_bundle` adding `with_sbend=True`"
    ]
   },
   {
@@ -1213,9 +1212,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = gf.Component(\"route_solution_2_get_bundle_sbend\")\n",
-    "route = gf.routing.get_bundle_sbend(right_ports, left_ports)\n",
-    "c.add(route.references)"
+    "c = gf.Component(\"route_solution_2_get_bundle\")\n",
+    "c1 = c << gf.components.nxn(east=3, ysize=20)\n",
+    "c2 = c << gf.components.nxn(west=3)\n",
+    "c2.move((80, 0))\n",
+    "routes = gf.routing.get_bundle(\n",
+    "    c1.get_ports_list(orientation=0), c2.get_ports_list(orientation=180), with_sbend=True\n",
+    ")\n",
+    "for route in routes:\n",
+    "    c.add(route.references)\n",
+    "c"
    ]
   },
   {

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -214,7 +214,7 @@ def get_bundle(
     ):
         # print("get_bundle_same_axis")
         if with_sbend:
-            return get_bundle_sbend(ports1, ports2, sort_ports, **kwargs)
+            return get_bundle_sbend(ports1, ports2, sort_ports=sort_ports, **kwargs)
         return get_bundle_same_axis(**params)
 
     elif start_angle == end_angle:

--- a/gdsfactory/routing/get_bundle_sbend.py
+++ b/gdsfactory/routing/get_bundle_sbend.py
@@ -50,17 +50,25 @@ if __name__ == "__main__":
     pitch = 2.0
     ys_left = [0, 10, 20]
     N = len(ys_left)
-    ys_right = [(i - N / 2) * pitch for i in range(N)]
+    y0 = -10
+    ys_right = [(i - N / 2) * pitch + y0 for i in range(N)]
 
     layer = (1, 0)
     right_ports = [
-        gf.Port(f"R_{i}", (0, ys_right[i]), 0.5, 180, layer=layer) for i in range(N)
+        gf.Port(
+            f"R_{i}", center=(0, ys_right[i]), width=0.5, orientation=180, layer=layer
+        )
+        for i in range(N)
     ]
     left_ports = [
-        gf.Port(f"L_{i}", (-50, ys_left[i]), 0.5, 0, layer=layer) for i in range(N)
+        gf.Port(
+            f"L_{i}", center=(-50, ys_left[i]), width=0.5, orientation=0, layer=layer
+        )
+        for i in range(N)
     ]
     left_ports.reverse()
 
-    routes = get_bundle_sbend(right_ports, left_ports)
-    c.add(routes.references)
+    routes = gf.routing.get_bundle(right_ports, left_ports, with_sbend=False)
+    for route in routes:
+        c.add(route.references)
     c.show(show_ports=True)


### PR DESCRIPTION
-  extended get_bundle to enable s_bend routing when there is no space for Manhattan routing. fixes [issue](https://github.com/gdsfactory/gdsfactory/issues/55) [PR](https://github.com/gdsfactory/gdsfactory/pull/639)
