### PR TITLE
Improve netlist connection algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+*.obtained.*
 
 # Translations
 *.mo

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1532,7 +1532,7 @@ def test_netlist_simple() -> None:
     import gdsfactory as gf
 
     c = gf.Component()
-    c1 = c << gf.components.straight(length=1, width=1)
+    c1 = c << gf.components.straight(length=1, width=2)
     c2 = c << gf.components.straight(length=2, width=2)
     c2.connect(port="o1", destination=c1.ports["o2"])
     c.add_port("o1", port=c1.ports["o1"])
@@ -1540,6 +1540,21 @@ def test_netlist_simple() -> None:
     netlist = c.get_netlist()
     # print(netlist.pretty())
     assert len(netlist["instances"]) == 2
+
+
+def test_netlist_simple_width_mismatch_throws_error() -> None:
+    import pytest
+
+    import gdsfactory as gf
+
+    c = gf.Component()
+    c1 = c << gf.components.straight(length=1, width=1)
+    c2 = c << gf.components.straight(length=2, width=2)
+    c2.connect(port="o1", destination=c1.ports["o2"])
+    c.add_port("o1", port=c1.ports["o1"])
+    c.add_port("o2", port=c2.ports["o2"])
+    with pytest.raises(ValueError):
+        c.get_netlist()
 
 
 def test_netlist_complex() -> None:

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -457,7 +457,7 @@ class ComponentReference(DeviceReference):
     def rotate(
         self,
         angle: float = 45,
-        center: Coordinate = (0.0, 0.0),
+        center: Union[Coordinate, str, int] = (0.0, 0.0),
     ) -> "ComponentReference":
         """Return rotated ComponentReference.
 

--- a/gdsfactory/components/array_component.py
+++ b/gdsfactory/components/array_component.py
@@ -53,7 +53,6 @@ def array(
                 name = f"{port.name}_{row+1}_{col+1}"
                 c.add_port(name, port=port)
                 c.ports[name].move((col * spacing[0], row * spacing[1]))
-                ref.ports[name] = port
     return c
 
 

--- a/gdsfactory/conftest.py
+++ b/gdsfactory/conftest.py
@@ -25,6 +25,11 @@ def cleandir(request: SubRequest) -> None:
         shutil.rmtree(build_folder)
 
 
+@pytest.fixture
+def datadir(original_datadir, tmpdir):
+    return original_datadir
+
+
 @pytest.fixture(scope="session")
 def show_diffs(request: SubRequest) -> None:
     c = gf.read.from_gdspaths(diff_path.glob("*.gds"))

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -27,7 +27,7 @@ from gdsfactory import Port
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.name import clean_name
 from gdsfactory.pdk import get_layer
-from gdsfactory.serialization import clean_value_json
+from gdsfactory.serialization import clean_dict, clean_value_json
 from gdsfactory.snap import snap_to_grid
 from gdsfactory.types import LayerSpec
 
@@ -344,22 +344,23 @@ def _extract_connections_two_sweep(
             )
 
     critical_warnings = {
-        w: warnings[w] for w in raise_error_for_warnings if warnings[w]
+        w: warnings[w] for w in raise_error_for_warnings if w in warnings
     }
 
     if critical_warnings:
         raise ValueError(
             f"Found warnings while extracting netlist: {critical_warnings}"
         )
-    return connections, warnings
+    return connections, dict(warnings)
 
 
 def _make_warning(ports: List[str], values: Any, message: str) -> Dict[str, Any]:
-    return {
+    w = {
         "ports": ports,
         "values": values,
         "message": message,
     }
+    return clean_dict(w)
 
 
 def _null_validator(port1: Port, port2: Port, port_names, warnings):

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -87,6 +87,7 @@ valid_top_level_keys = [
     "settings",
     "info",
     "pdk",
+    "warnings",
 ]
 
 valid_anchor_point_keywords = [

--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -23,7 +23,14 @@ def assert_on_2nm_grid(x: float) -> None:
 def snap_to_grid(
     x: Union[float, Tuple, np.ndarray], nm: int = 1
 ) -> Union[float, Tuple, np.ndarray]:
-    y = nm * np.round(np.asarray(x, dtype=float) * 1e3 / nm) / 1e3
+    if nm == 0:
+        return x
+    elif nm < 0:
+        raise ValueError("nm must be an integer tolerance value greater than zero")
+    elif nm == 1:
+        y = np.round(np.asarray(x, dtype=float), 3)
+    else:
+        y = nm * np.round(np.asarray(x, dtype=float) * 1e3 / nm) / 1e3
     if isinstance(x, tuple):
         return tuple(y)
     elif isinstance(x, (int, float, str, np.float_)):

--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -1,4 +1,5 @@
 """snaps values and coordinates to the GDS grid in nm."""
+from typing import Tuple, Union
 
 import numpy as np
 
@@ -19,8 +20,10 @@ def assert_on_2nm_grid(x: float) -> None:
         raise ValueError(f"{x} needs to be on 2nm grid, try {x_grid}")
 
 
-def snap_to_grid(x: float, nm: int = 1) -> float:
-    y = nm * np.round(np.array(x, dtype=float) * 1e3 / nm) / 1e3
+def snap_to_grid(
+    x: Union[float, Tuple, np.ndarray], nm: int = 1
+) -> Union[float, Tuple, np.ndarray]:
+    y = nm * np.round(np.asarray(x, dtype=float) * 1e3 / nm) / 1e3
     if isinstance(x, tuple):
         return tuple(y)
     elif isinstance(x, (int, float, str, np.float_)):

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_connections_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_connections_.yml
@@ -28,3 +28,15 @@ placements:
     x: 0.5
     y: 0.0
 ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 2 unconnected optical ports!
+      ports:
+      - wgw,o2
+      - wgn,o1
+      values:
+      - - 1.5
+        - 0.0
+      - - 0.0
+        - 0.0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_.yml
@@ -679,3 +679,91 @@ placements:
     x: 900.0
     y: 600.0
 ports: {}
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 16 unconnected electrical ports!
+      ports:
+      - bl,e1
+      - bl,e2
+      - bl,e3
+      - bl,e4
+      - tl,e1
+      - tl,e2
+      - tl,e3
+      - tl,e4
+      - br,e1
+      - br,e2
+      - br,e3
+      - br,e4
+      - tr,e1
+      - tr,e2
+      - tr,e3
+      - tr,e4
+      values:
+      - - -50.0
+        - 0.0
+      - - 0.0
+        - 50.0
+      - - 50.0
+        - 0.0
+      - - 0.0
+        - -50.0
+      - - -50.0
+        - 200.0
+      - - 0.0
+        - 250.0
+      - - 50.0
+        - 200.0
+      - - 0.0
+        - 150.0
+      - - 850.0
+        - 400.0
+      - - 900.0
+        - 450.0
+      - - 950.0
+        - 400.0
+      - - 900.0
+        - 350.0
+      - - 850.0
+        - 600.0
+      - - 900.0
+        - 650.0
+      - - 950.0
+        - 600.0
+      - - 900.0
+        - 550.0
+  optical:
+    unconnected_ports:
+    - message: 4 unconnected optical ports!
+      ports:
+      - straight_1,o1
+      - straight_5,o2
+      - straight_6,o1
+      - straight_10,o2
+      values:
+      - - 50.0
+        - 0.0
+      - - 850.0
+        - 400.0
+      - - 50.0
+        - 200.0
+      - - 850.0
+        - 600.0
+  vertical_dc:
+    unconnected_ports:
+    - message: 4 unconnected vertical_dc ports!
+      ports:
+      - bl,pad
+      - tl,pad
+      - br,pad
+      - tr,pad
+      values:
+      - - 0.0
+        - 0.0
+      - - 0.0
+        - 200.0
+      - - 900.0
+        - 400.0
+      - - 900.0
+        - 600.0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_docstring_.yml
@@ -93,3 +93,21 @@ placements:
     x: 81.99
     y: -39.375
 ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 4 unconnected optical ports!
+      ports:
+      - mmi_bot,o2
+      - mmi_bot,o3
+      - mmi_top,o1
+      - mmi_top,o2
+      values:
+      - - 113.0
+        - -38.75
+      - - 113.0
+        - -40.0
+      - - 0.0
+        - 0.0
+      - - 42.0
+        - 0.625

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_.yml
@@ -150,3 +150,45 @@ placements:
     x: 0.0
     y: 0.0
 ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 12 unconnected optical ports!
+      ports:
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi10_0_o1
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi10_0_o2
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi10_0_o3
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi4_1_o1
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi4_1_o2
+      - mmi1x2_sweep,mmi1x2_length_mmi100_width_mmi4_1_o3
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi10_2_o1
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi10_2_o2
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi10_2_o3
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi4_3_o1
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi4_3_o2
+      - mmi1x2_sweep,mmi1x2_length_mmi2_width_mmi4_3_o3
+      values:
+      - - 50.5
+        - 55.5
+      - - 170.5
+        - 56.125
+      - - 170.5
+        - 54.875
+      - - 50.5
+        - 162.5
+      - - 170.5
+        - 163.125
+      - - 170.5
+        - 161.875
+      - - 50.5
+        - 269.5
+      - - 72.5
+        - 270.125
+      - - 72.5
+        - 268.875
+      - - 172.5
+        - 266.5
+      - - 194.5
+        - 267.125
+      - - 194.5
+        - 265.875

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_function_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_doe_function_.yml
@@ -1931,3 +1931,177 @@ placements:
     x: 44.953
     y: 0.0
 ports: {}
+warnings:
+  vertical_te:
+    unconnected_ports:
+    - message: 56 unconnected vertical_te ports!
+      ports:
+      - rings,ring_single_length_x1_r_60fdb14d_0_vertical_te_00
+      - rings,ring_single_length_x1_r_60fdb14d_0_vertical_te_01
+      - rings,ring_single_length_x1_r_60fdb14d_0_vertical_te_10
+      - rings,ring_single_length_x1_r_60fdb14d_0_vertical_te_20
+      - rings,ring_single_length_x2_r_edd7ea6f_1_vertical_te_00
+      - rings,ring_single_length_x2_r_edd7ea6f_1_vertical_te_01
+      - rings,ring_single_length_x2_r_edd7ea6f_1_vertical_te_10
+      - rings,ring_single_length_x2_r_edd7ea6f_1_vertical_te_20
+      - rings,ring_single_length_x3_r_96ab2414_2_vertical_te_00
+      - rings,ring_single_length_x3_r_96ab2414_2_vertical_te_01
+      - rings,ring_single_length_x3_r_96ab2414_2_vertical_te_10
+      - rings,ring_single_length_x3_r_96ab2414_2_vertical_te_20
+      - rings,ring_single_length_x1_r_07deb5f3_3_vertical_te_00
+      - rings,ring_single_length_x1_r_07deb5f3_3_vertical_te_01
+      - rings,ring_single_length_x1_r_07deb5f3_3_vertical_te_10
+      - rings,ring_single_length_x1_r_07deb5f3_3_vertical_te_20
+      - rings,ring_single_length_x2_r_2e5ac97f_4_vertical_te_00
+      - rings,ring_single_length_x2_r_2e5ac97f_4_vertical_te_01
+      - rings,ring_single_length_x2_r_2e5ac97f_4_vertical_te_10
+      - rings,ring_single_length_x2_r_2e5ac97f_4_vertical_te_20
+      - rings,ring_single_length_x3_r_29cfb0e4_5_vertical_te_00
+      - rings,ring_single_length_x3_r_29cfb0e4_5_vertical_te_01
+      - rings,ring_single_length_x3_r_29cfb0e4_5_vertical_te_10
+      - rings,ring_single_length_x3_r_29cfb0e4_5_vertical_te_20
+      - rings,ring_single_length_x1_r_78660d65_6_vertical_te_00
+      - rings,ring_single_length_x1_r_78660d65_6_vertical_te_01
+      - rings,ring_single_length_x1_r_78660d65_6_vertical_te_10
+      - rings,ring_single_length_x1_r_78660d65_6_vertical_te_20
+      - rings,ring_single_length_x2_r_faeb062b_7_vertical_te_00
+      - rings,ring_single_length_x2_r_faeb062b_7_vertical_te_01
+      - rings,ring_single_length_x2_r_faeb062b_7_vertical_te_10
+      - rings,ring_single_length_x2_r_faeb062b_7_vertical_te_20
+      - rings,ring_single_length_x3_r_5cb87802_8_vertical_te_00
+      - rings,ring_single_length_x3_r_5cb87802_8_vertical_te_01
+      - rings,ring_single_length_x3_r_5cb87802_8_vertical_te_10
+      - rings,ring_single_length_x3_r_5cb87802_8_vertical_te_20
+      - rings,ring_single_length_x1_r_554fe677_9_vertical_te_00
+      - rings,ring_single_length_x1_r_554fe677_9_vertical_te_01
+      - rings,ring_single_length_x1_r_554fe677_9_vertical_te_10
+      - rings,ring_single_length_x1_r_554fe677_9_vertical_te_20
+      - rings,ring_single_length_x2_r_3137a208_10_vertical_te_00
+      - rings,ring_single_length_x2_r_3137a208_10_vertical_te_01
+      - rings,ring_single_length_x2_r_3137a208_10_vertical_te_10
+      - rings,ring_single_length_x2_r_3137a208_10_vertical_te_20
+      - rings,ring_single_length_x3_r_f0c4c752_11_vertical_te_00
+      - rings,ring_single_length_x3_r_f0c4c752_11_vertical_te_01
+      - rings,ring_single_length_x3_r_f0c4c752_11_vertical_te_10
+      - rings,ring_single_length_x3_r_f0c4c752_11_vertical_te_20
+      - mzis,mzi_delta_length10_add__413018bb_(0,0)_vertical_te_00
+      - mzis,mzi_delta_length10_add__413018bb_(0,0)_vertical_te_01
+      - mzis,mzi_delta_length10_add__413018bb_(0,0)_vertical_te_10
+      - mzis,mzi_delta_length10_add__413018bb_(0,0)_vertical_te_20
+      - mzis,mzi_delta_length100_add_b6c954fc_(1,0)_vertical_te_00
+      - mzis,mzi_delta_length100_add_b6c954fc_(1,0)_vertical_te_01
+      - mzis,mzi_delta_length100_add_b6c954fc_(1,0)_vertical_te_10
+      - mzis,mzi_delta_length100_add_b6c954fc_(1,0)_vertical_te_20
+      values:
+      - - 189.973
+        - 24.58250000000004
+      - - 316.97299999999996
+        - 24.58250000000004
+      - - 62.97300000000001
+        - 24.58250000000004
+      - - 443.97299999999996
+        - 24.58250000000004
+      - - 189.973
+        - 398.6325
+      - - 316.97299999999996
+        - 398.6325
+      - - 62.97300000000001
+        - 398.6325
+      - - 443.97299999999996
+        - 398.6325
+      - - 189.973
+        - 772.6825000000001
+      - - 316.97299999999996
+        - 772.6825000000001
+      - - 62.97300000000001
+        - 772.6825000000001
+      - - 443.97299999999996
+        - 772.6825000000001
+      - - 189.973
+        - 1146.7325
+      - - 316.97299999999996
+        - 1146.7325
+      - - 62.97300000000001
+        - 1146.7325
+      - - 443.97299999999996
+        - 1146.7325
+      - - 606.913
+        - 24.58250000000004
+      - - 733.913
+        - 24.58250000000004
+      - - 479.913
+        - 24.58250000000004
+      - - 860.913
+        - 24.58250000000004
+      - - 606.913
+        - 378.6325
+      - - 733.913
+        - 378.6325
+      - - 479.913
+        - 378.6325
+      - - 860.913
+        - 378.6325
+      - - 606.913
+        - 732.6825000000001
+      - - 733.913
+        - 732.6825000000001
+      - - 479.913
+        - 732.6825000000001
+      - - 860.913
+        - 732.6825000000001
+      - - 606.913
+        - 1066.7325
+      - - 733.913
+        - 1066.7325
+      - - 479.913
+        - 1066.7325
+      - - 860.913
+        - 1066.7325
+      - - 1023.8530000000001
+        - 24.58250000000004
+      - - 1150.853
+        - 24.58250000000004
+      - - 896.8530000000001
+        - 24.58250000000004
+      - - 1277.853
+        - 24.58250000000004
+      - - 1023.8530000000001
+        - 358.6325
+      - - 1150.853
+        - 358.6325
+      - - 896.8530000000001
+        - 358.6325
+      - - 1277.853
+        - 358.6325
+      - - 1023.8530000000001
+        - 672.6825000000001
+      - - 1150.853
+        - 672.6825000000001
+      - - 896.8530000000001
+        - 672.6825000000001
+      - - 1277.853
+        - 672.6825000000001
+      - - 1023.8530000000001
+        - 986.7325000000001
+      - - 1150.853
+        - 986.7325000000001
+      - - 896.8530000000001
+        - 986.7325000000001
+      - - 1277.853
+        - 986.7325000000001
+      - - 1430.799
+        - -81.5685
+      - - 1557.799
+        - -81.5685
+      - - 1303.799
+        - -81.5685
+      - - 1684.799
+        - -81.5685
+      - - 1430.799
+        - -126.5685
+      - - 1557.799
+        - -126.5685
+      - - 1303.799
+        - -126.5685
+      - - 1684.799
+        - -126.5685

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mirror_simple_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mirror_simple_.yml
@@ -27,3 +27,15 @@ placements:
     x: 0.0
     y: 0.0
 ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 2 unconnected optical ports!
+      ports:
+      - s,o1
+      - b,o2
+      values:
+      - - 0.0
+        - 0.0
+      - - 20.0
+        - -10.0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_mmis_.yml
@@ -96,3 +96,12 @@ ports:
   o1: mmi_short,o1
   o2: mmi_long,o2
   o3: mmi_long,o3
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 1 unconnected optical ports!
+      ports:
+      - mmi_short,o3
+      values:
+      - - 15.0
+        - -0.625

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_rotation_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_rotation_.yml
@@ -26,3 +26,27 @@ placements:
     x: 4.0
     y: 2.0
 ports: {}
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 6 unconnected electrical ports!
+      ports:
+      - r1,e1
+      - r1,e2
+      - r1,e4
+      - r2,e1
+      - r2,e2
+      - r2,e3
+      values:
+      - - 0.0
+        - 1.0
+      - - 2.0
+        - 2.0
+      - - 2.0
+        - 0.0
+      - - 6.0
+        - 1.9999999999999996
+      - - 8.0
+        - 0.9999999999999993
+      - - 6.0
+        - -4.440892098500626e-16

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_sample_waypoints_.yml
@@ -528,3 +528,62 @@ placements:
     x: -250.0
     y: 1000.0
 ports: {}
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 12 unconnected electrical ports!
+      ports:
+      - t,e11
+      - t,e12
+      - t,e13
+      - t,e14
+      - t,e15
+      - t,e16
+      - b,e11
+      - b,e12
+      - b,e13
+      - b,e14
+      - b,e15
+      - b,e16
+      values:
+      - - -250.0
+        - 1000.0
+      - - -100.0
+        - 1000.0
+      - - 50.0
+        - 1000.0
+      - - 200.0
+        - 1000.0
+      - - 350.0
+        - 1000.0
+      - - 500.0
+        - 1000.0
+      - - 0.0
+        - 0.0
+      - - 150.0
+        - 0.0
+      - - 300.0
+        - 0.0
+      - - 450.0
+        - 0.0
+      - - 600.0
+        - 0.0
+      - - 750.0
+        - 0.0
+  optical:
+    unconnected_ports:
+    - message: 4 unconnected optical ports!
+      ports:
+      - straight_1,o1
+      - straight_5,o2
+      - straight_6,o1
+      - straight_10,o2
+      values:
+      - - 0.0
+        - 0.0
+      - - -249.99999999999997
+        - 1000.0
+      - - 150.0
+        - 0.0
+      - - -99.99999999999997
+        - 1000.0

--- a/gdsfactory/tests/test_component_from_yaml/test_netlists_yaml_anchor_.yml
+++ b/gdsfactory/tests/test_component_from_yaml/test_netlists_yaml_anchor_.yml
@@ -23,3 +23,27 @@ placements:
     x: -15.0
     y: 0.625
 ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 6 unconnected optical ports!
+      ports:
+      - mmi_long,o1
+      - mmi_long,o2
+      - mmi_long,o3
+      - mmi_short,o1
+      - mmi_short,o2
+      - mmi_short,o3
+      values:
+      - - 10.000999999999998
+        - 12.875
+      - - 40.001
+        - 13.5
+      - - 40.001
+        - 12.25
+      - - -25.0
+        - 0.625
+      - - 0.0
+        - 1.25
+      - - 0.0
+        - 0.0

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -10,18 +10,18 @@ def test_get_netlist_cell_array() -> None:
     n = c.get_netlist()
     assert len(c.ports) == 10
     assert not n["connections"]
-    assert len(n["instances"]) == 1
+    assert len(n["ports"]) == 10
+    assert len(n["instances"]) == 5
 
 
 def test_get_netlist_cell_array_connecting() -> None:
     c = gf.components.array(
         gf.components.straight(length=100), spacing=(100, 0), columns=5, rows=1
     )
-    c.show()
-    n = c.get_netlist()
-    assert len(c.ports) == 10
-    assert len(n["connections"]) == 4
-    assert len(n["instances"]) == 1
+    with pytest.raises(ValueError):
+        # because the component-array has automatic external ports, we assume no internal self-connections
+        # we expect a ValueError to be thrown where the serendipitous connections are
+        c.get_netlist()
 
 
 def test_get_netlist_simple():

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -45,6 +45,31 @@ def test_get_netlist_simple():
     assert len(unconnected_optical_port_warnings[0]["ports"]) == 4
 
 
+def test_get_netlist_promoted():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.straight(), "i1")
+    i2 = c.add_ref(gf.components.straight(), "i2")
+    i3 = c.add_ref(gf.components.straight(), "i3")
+    i2.connect("o2", i1.ports["o1"])
+    i3.movey(-100)
+    c.add_port("t1", port=i1.ports["o2"])
+    c.add_port("t2", port=i2.ports["o1"])
+    c.add_port("t3", port=i3.ports["o1"])
+    c.add_port("t4", port=i3.ports["o2"])
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    ports = netlist["ports"]
+    expected_ports = {"t1": "i1,o2", "t2": "i2,o1", "t3": "i3,o1", "t4": "i3,o2"}
+
+    assert len(connections) == 1
+    assert ports == expected_ports
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,o2", "i1,o1"}
+    assert extracted_port_pair == expected_port_pair
+    assert not netlist["warnings"]
+
+
 def test_get_netlist_close_enough():
     c = gf.Component()
     i1 = c.add_ref(gf.components.straight(), "i1")

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -7,6 +7,59 @@ def test_get_netlist_cell_array() -> None:
     assert len(n.keys()) == 5
 
 
+def test_get_netlist_simple():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.straight(), "i1")
+    i2 = c.add_ref(gf.components.straight(), "i2")
+    i3 = c.add_ref(gf.components.straight(), "i3")
+    i2.connect("o2", i1.ports["o1"])
+    i3.movey(-100)
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,o2", "i1,o1"}
+    assert extracted_port_pair == expected_port_pair
+
+
+def test_get_netlist_tiny():
+    c = gf.Component()
+    cc = gf.components.straight(length=0.002)
+    i1 = c.add_ref(cc, "i1")
+    i2 = c.add_ref(cc, "i2")
+    i3 = c.add_ref(cc, "i3")
+    i4 = c.add_ref(cc, "i4")
+
+    i2.connect("o2", i1.ports["o1"])
+    i3.connect("o2", i2.ports["o1"])
+    i4.connect("o2", i3.ports["o1"])
+
+    netlist = c.get_netlist(tolerance=5)
+    connections = netlist["connections"]
+    assert len(connections) == 3
+    # cpairs = list(connections.items())
+    # extracted_port_pair = set(cpairs[0])
+    # expected_port_pair = {'i2,o2', 'i1,o1'}
+    # assert extracted_port_pair == expected_port_pair
+
+
+def test_get_netlist_rotated():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.straight(), "i1")
+    i2 = c.add_ref(gf.components.straight(), "i2")
+    i1.rotate(35)
+    i2.connect("o2", i1.ports["o1"])
+
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,o2", "i1,o1"}
+    assert extracted_port_pair == expected_port_pair
+
+
 if __name__ == "__main__":
     c = gf.c.array()
     n = c.get_netlist()

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -67,7 +67,7 @@ def test_get_netlist_promoted():
     extracted_port_pair = set(cpairs[0])
     expected_port_pair = {"i2,o2", "i1,o1"}
     assert extracted_port_pair == expected_port_pair
-    assert not netlist["warnings"]
+    assert "warnings" not in netlist
 
 
 def test_get_netlist_close_enough():

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -38,6 +38,11 @@ def test_get_netlist_simple():
     extracted_port_pair = set(cpairs[0])
     expected_port_pair = {"i2,o2", "i1,o1"}
     assert extracted_port_pair == expected_port_pair
+    unconnected_optical_port_warnings = netlist["warnings"]["optical"][
+        "unconnected_ports"
+    ]
+    assert len(unconnected_optical_port_warnings) == 1
+    assert len(unconnected_optical_port_warnings[0]["ports"]) == 4
 
 
 def test_get_netlist_close_enough():
@@ -144,6 +149,52 @@ def test_get_netlist_rotated():
     cpairs = list(connections.items())
     extracted_port_pair = set(cpairs[0])
     expected_port_pair = {"i2,o2", "i1,o1"}
+    assert extracted_port_pair == expected_port_pair
+
+
+def test_get_netlist_electrical_simple():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.wire_straight(), "i1")
+    i2 = c.add_ref(gf.components.wire_straight(), "i2")
+    i3 = c.add_ref(gf.components.wire_straight(), "i3")
+    i2.connect("e2", i1.ports["e1"])
+    i3.movey(-100)
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,e2", "i1,e1"}
+    assert extracted_port_pair == expected_port_pair
+
+
+def test_get_netlist_electrical_rotated_joint():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.wire_straight(), "i1")
+    i2 = c.add_ref(gf.components.wire_straight(), "i2")
+    i2.connect("e2", i1.ports["e1"])
+    i2.rotate(45, "e2")
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,e2", "i1,e1"}
+    assert extracted_port_pair == expected_port_pair
+
+
+def test_get_netlist_electrical_allowable_offset():
+    c = gf.Component()
+    i1 = c.add_ref(gf.components.wire_straight(), "i1")
+    i2 = c.add_ref(gf.components.wire_straight(), "i2")
+    i2.connect("e2", i1.ports["e1"])
+    i2.move((0.001, 0.001))
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,e2", "i1,e1"}
     assert extracted_port_pair == expected_port_pair
 
 


### PR DESCRIPTION
Hi @joamatab , I rewrote the `get_netlist()` to be more robust and to warn about more issues in optical routing.

**Key changes and improvements:**
- we now do _two_ sweeps over the connections... first we try to connect everything assuming perfect connections at each port. Then we gather ports which did _not_ perfectly connect to anything and try to find imperfect connections, by grouping ports on a coarse grid. This approach does a much better job with such imperfect connections from my trials (and added tests)
- I added a bunch of tests, which should illustrate the new behavior (you can run them against the old algorithm also to see the differences)
- Netlisting with ComponentArray now behaves as you would expect... i.e. an array of 5 straights will show that there are 5 straights in the circuit at the lowest level
- warnings collected during netlisting are reported back into the netlist. These include warnings about mismatched port widths, orientations, shear angles, excessive offsets, etc. You can also configure warning types which should throw an error when encountered by modifying `DEFAULT_CRITICAL_CONNECTION_ERROR_TYPES`. Validators, which will produce warnings for each port type, can be overridden with `DEFAULT_CONNECTION_VALIDATORS`
- A key difference in this algorithm is that we group each port type independently. This allows us to use different logic to determine i.e. if an electrical port is properly connected vs an optical port. In this revision, the core logic is the same, but we employ extra validation for optical ports.
- `snap_to_grid()` now allows a value of 0, which will return the original value, is more efficient when the value is 1, and will throw a more descriptive error when the value is <0
- the signature to `get_netlist()` is exactly the same as it was before, and this should be a drop-in-replacement, however I increased the default value of `tolerance` to 5, because it should allow better performance with the two-grid-sweep approach, as described