### PR TITLE
Klayout tech

### DIFF
--- a/gdsfactory/tests/test_klayout_tech.py
+++ b/gdsfactory/tests/test_klayout_tech.py
@@ -1,41 +1,15 @@
 from pytest_regressions.data_regression import DataRegressionFixture
 
-from gdsfactory.klayout_tech import (
-    KLayoutGroupProperty,
-    KLayoutLayerProperties,
-    KLayoutLayerProperty,
-)
-from gdsfactory.layers import LAYER_COLORS, LayerColors
+from gdsfactory.config import PATH
+from gdsfactory.klayout_tech import KLayoutLayerProperties
 
 
 def test_klayout_tech_create(
     data_regression: DataRegressionFixture, check: bool = True
 ) -> KLayoutLayerProperties:
 
-    lc: LayerColors = LAYER_COLORS
+    lyp = KLayoutLayerProperties.from_lyp(str(PATH.klayout_lyp))
 
-    lyp = KLayoutLayerProperties(
-        layers={
-            layer.name: KLayoutLayerProperty(
-                layer=(layer.gds_layer, layer.gds_datatype),
-                name=layer.name,
-                fill_color=layer.color,
-                frame_color=layer.color,
-                dither_pattern=layer.dither,
-            )
-            for layer in lc.layers.values()
-        },
-        groups={
-            "Doping": KLayoutGroupProperty(
-                members=["N", "NP", "NPP", "P", "PP", "PPP", "PDPP", "GENPP", "GEPPP"]
-            ),
-            "Simulation": KLayoutGroupProperty(
-                members=["SIM_REGION", "MONITOR", "SOURCE"]
-            ),
-        },
-    )
-
-    # lyp.to_lyp("test_lyp")
     if check:
         data_regression.check(lyp.dict())
 


### PR DESCRIPTION
More refactoring of the KLayout technology module. Aside from the layer numbers appended to the layer names and the layers without names, the module can read our current layer properties (layers.lyp) into a KLayoutLayerProperties object and write to a new .lyp file. 

Still need to fix the test and figure out what to do with the layer names that have layer numbers on them. Also might be worth naming the unnamed layers.

@joamatab how can I regenerate the yaml file that's used in the test?