### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/notebooks/04_routing.ipynb
+++ b/docs/notebooks/04_routing.ipynb
@@ -514,7 +514,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The resolution decides how many \"leaps/hops\" the algorithm has to do. For a layout like this, where the default resolution (1 micron) is much larger than the distance between the obstacles (~15+ microns), it has to step through too many points and that takes a long time. Increasing the resolution to about 5 microns fixes it (for this layout)."
+    "The resolution decides how many \"leaps/hops\" the algorithm has to do. For a layout like this, where the default resolution (1 micron) is much smaller than the distance between the obstacles (~15+ microns), it has to step through too many points and that takes a long time. Increasing the resolution to about 5 microns fixes it (for this layout)."
    ]
   },
   {
@@ -2113,7 +2113,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.13 ('routing')",
    "language": "python",
    "name": "python3"
   },
@@ -2127,7 +2127,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4c65519349bbd7dc27568363a5ce836ca72144fe928137f523d4439572f11a58"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Small typo in the `astar_routing` section of the doc.