### PR TITLE
Fix multilayer routing

### DIFF
--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -1057,14 +1057,14 @@ def route_manhattan(
             end_straight_length=end_straight_length,
             min_straight_length=min_straight_length,
             bend=bend,
-            cross_section=x,
+            cross_section=cross_section,
         )
         route = round_corners(
             points=points,
             straight=straight,
             taper=taper,
             bend=bend,
-            cross_section=x,
+            cross_section=cross_section,
             with_point_markers=with_point_markers,
             with_sbend=with_sbend,
         )

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -58,13 +58,13 @@ def _get_unique_port_facing(
     if isinstance(layer, list):
         for _layer in layer:
             ports_selected = select_ports_list(
-                ports=ports, orientation=orientation, layer=_layer
+                ports=ports, orientation=orientation, layer=gf.get_layer(_layer)
             )
             if ports_selected:
                 break
     else:
         ports_selected = select_ports_list(
-            ports=ports, orientation=orientation, layer=layer
+            ports=ports, orientation=orientation, layer=gf.get_layer(layer)
         )
 
     if len(ports_selected) > 1:


### PR DESCRIPTION
Fixes #706

- `MultiCrossSectionAngle`s weren't being passed into `generate_manhattan_waypoints` and `round_corners` as tuples of `CrossSection`, `(angle, angle)` pairs, but instead as lists of `CrossSections`, which is now fixed.

- `_get_unique_port_facing` now calls `get_layer` in case the layer is a string rather than a tuple.