### PR TITLE
Fix is_on_grid

### DIFF
--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def is_on_grid(x: float, nm: int = 1) -> bool:
-    return np.isclose(snap_to_grid(x, nm=nm), x)
+    return np.array_equal(snap_to_grid(x, nm=nm), np.round(x, 6))
 
 
 def assert_on_1nm_grid(x: float) -> None:

--- a/gdsfactory/tests/test_snap.py
+++ b/gdsfactory/tests/test_snap.py
@@ -21,6 +21,16 @@ def test_is_on_2nm_grid() -> None:
     assert gf.snap.is_on_grid(2e-3, 2)
 
 
+def test_point_is_on_grid() -> None:
+    assert gf.snap.is_on_grid([0.5555, 0]) is False
+    assert gf.snap.is_on_grid([0.555, 0]) is True
+
+
+def test_point_is_on_2nm_grid() -> None:
+    assert gf.snap.is_on_grid([0.555, 0], nm=2) is False
+    assert gf.snap.is_on_grid([0.556, 0], nm=2) is True
+
+
 if __name__ == "__main__":
     test_is_on_2nm_grid()
     # print(snap_to_grid(1.1e-3))


### PR DESCRIPTION
Hi @joamatab , the `gf.snap.is_on_grid()` function does not work as expected when given an iterable argument, such as a point. This patch fixes the bug and provides two tests which demonstrate the expected behaviour (fails on current master, passes on this branch).