### PR TITLE
Fix windows install script

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,7 @@
 
 set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
-pip install lytest simphony sax jax jaxlib sklearn klayout
+pip install lytest simphony sax jax sklearn klayout
+pip install "jax[cpu]===0.3.7" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
 pip install gdsfactory==5.38.0
 gf tool install
 

--- a/install.bat
+++ b/install.bat
@@ -1,7 +1,7 @@
 
 set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
 pip install lytest simphony sax jax sklearn klayout
-pip install "jax[cpu]===0.3.7" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
+pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
 pip install gdsfactory==5.38.0
 gf tool install
 


### PR DESCRIPTION
Fixed jaxlib installation (cuda111 version is installed by default, jax falls back to cpu if gpu is not found).

https://github.com/gdsfactory/gdsfactory/issues/723