### PR TITLE
klayout_tech improvements

### DIFF
--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -640,14 +640,15 @@ class KLayoutTechnology(BaseModel):
         # Specify relative file name for layer properties file
         self.technology.layer_properties_file = lyp_filename
 
+        if not self.technology.name:
+            self.technology.name = self.name
+
         # TODO: Also interop with xs scripts?
 
         # Write lyp to file
         self.layer_properties.to_lyp(lyp_path)
 
         root = etree.XML(self.technology.to_xml().encode("utf-8"))
-        subelement = etree.SubElement(root, "name")
-        subelement.text = self.name
 
         if layer_stack is not None:
             # KLayout 0.27.x won't have a way to read/write the 2.5D info for technologies, so add manually
@@ -729,7 +730,7 @@ if __name__ == "__main__":
 
     lyp = LayerDisplayProperties.from_lyp(str(PATH.klayout_lyp))
 
-    yaml_test()
+    # yaml_test()
     # str_xml = open(PATH.klayout_tech / "tech.lyt").read()
     # new_tech = db.Technology.technology_from_xml(str_xml)
     # generic_tech = KLayoutTechnology(layer_properties=lyp)

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -695,7 +695,9 @@ class KLayoutTechnology(BaseModel):
             src_element = src_element[0]
 
             for layer_level in layer_stack.layers.values():
-                src_element.text += f"{layer_level.layer[0]}/{layer_level.layer[1]}: {layer_level.zmin} {layer_level.thickness}\n"
+                # Round the float based on the database unit (dbu) to not end up with numbers like: 2.0700000000000003
+                rounding_place = len(str(self.technology.dbu).split(".")[-1])
+                src_element.text += f"{layer_level.layer[0]}/{layer_level.layer[1]}: {round(layer_level.zmin, rounding_place)} {round(layer_level.thickness, rounding_place)}\n"
 
         # root['connectivity']['connection']= '41/0,44/0,45/0'
         if connectivity is not None:

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -653,22 +653,22 @@ class KLayoutTechnology(BaseModel):
         root = etree.XML(self.technology.to_xml().encode("utf-8"))
 
         # KLayout tech doesn't include mebes config, so add it after lefdef config:
-        # if not mebes_config:
-        mebes_config = {
-            "invert": False,
-            "subresolution": True,
-            "produce-boundary": True,
-            "num-stripes-per-cell": 64,
-            "num-shapes-per-cell": 0,
-            "data-layer": 1,
-            "data-datatype": 0,
-            "data-name": "DATA",
-            "boundary-layer": 0,
-            "boundary-datatype": 0,
-            "boundary-name": "BORDER",
-            "layer-map": "layer_map()",
-            "create-other-layers": True,
-        }
+        if not mebes_config:
+            mebes_config = {
+                "invert": False,
+                "subresolution": True,
+                "produce-boundary": True,
+                "num-stripes-per-cell": 64,
+                "num-shapes-per-cell": 0,
+                "data-layer": 1,
+                "data-datatype": 0,
+                "data-name": "DATA",
+                "boundary-layer": 0,
+                "boundary-datatype": 0,
+                "boundary-name": "BORDER",
+                "layer-map": "layer_map()",
+                "create-other-layers": True,
+            }
         mebes = etree.Element("mebes")
         for k, v in mebes_config.items():
             if isinstance(v, bool):

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 from lxml import etree
 from pydantic import BaseModel, Field, validator
-from typing_extensions import Literal
 
 from gdsfactory.config import PATH
 from gdsfactory.tech import LayerStack
@@ -694,10 +693,10 @@ class KLayoutTechnology(BaseModel):
             encoding="utf-8",
             pretty_print=True,
             xml_declaration=True,
-        ).decode("utf8")
+        )
 
         # Write lyt to file
-        lyt_path.write_text(script)
+        lyt_path.write_bytes(script)
 
     class Config:
         """Allow db.Technology type."""
@@ -730,7 +729,7 @@ if __name__ == "__main__":
 
     lyp = LayerDisplayProperties.from_lyp(str(PATH.klayout_lyp))
 
-    # yaml_test()
+    yaml_test()
     # str_xml = open(PATH.klayout_tech / "tech.lyt").read()
     # new_tech = db.Technology.technology_from_xml(str_xml)
     # generic_tech = KLayoutTechnology(layer_properties=lyp)

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -707,21 +707,22 @@ class KLayoutTechnology(BaseModel):
                 layer_c1 = self.layer_properties.layer_views[layer_name_c1].layer
                 layer_via = self.layer_properties.layer_views[layer_name_via].layer
                 layer_c2 = self.layer_properties.layer_views[layer_name_c2].layer
-                connection = (
-                    ",".join(
-                        [
-                            f"{layer[0]}/{layer[1]}"
-                            for layer in [layer_c1, layer_via, layer_c2]
-                        ]
-                    )
-                    + "\n"
+                connection = ",".join(
+                    [
+                        f"{layer[0]}/{layer[1]}"
+                        for layer in [layer_c1, layer_via, layer_c2]
+                    ]
                 )
 
-                subelement = etree.SubElement(src_element, "connection")
-                subelement.text = connection
+                etree.SubElement(src_element, "connection").text = connection
+
+        # The indentation can easily get messed up when adding elements to existing XML objects, so we need to filter it
+        # by passing it through another parser that strips it of any whitespace and then using pretty_print to re-format
+        # the indentation.
+        parser = etree.XMLParser(remove_blank_text=True)
 
         script = etree.tostring(
-            root,
+            etree.XML(etree.tostring(root), parser),
             encoding="utf-8",
             pretty_print=True,
             xml_declaration=True,

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -607,6 +607,7 @@ class KLayoutTechnology(BaseModel):
         connectivity: List of layer names connectivity for netlist tracing.
     """
 
+    # TODO: Add import method
     import klayout.db as db
 
     name: str
@@ -697,7 +698,11 @@ class KLayoutTechnology(BaseModel):
             for layer_level in layer_stack.layers.values():
                 # Round the float based on the database unit (dbu) to not end up with numbers like: 2.0700000000000003
                 rounding_place = len(str(self.technology.dbu).split(".")[-1])
-                src_element.text += f"{layer_level.layer[0]}/{layer_level.layer[1]}: {round(layer_level.zmin, rounding_place)} {round(layer_level.thickness, rounding_place)}\n"
+                zmin = round(layer_level.zmin, rounding_place)
+                zmax = round(zmin + layer_level.thickness, rounding_place)
+                src_element.text += (
+                    f"{layer_level.layer[0]}/{layer_level.layer[1]}: {zmin} {zmax}\n"
+                )
 
         # root['connectivity']['connection']= '41/0,44/0,45/0'
         if connectivity is not None:


### PR DESCRIPTION
A couple of changes to the KLayout technology module:
- Added CustomPatterns class, which contains lists of CustomDitherPatterns and CustomLineStyles
- Added yaml import/export for CustomPatterns and LayerDisplayProperties
- LayerView group members are stored in a list rather than a dict
- Added mebes reader options to KLayoutTechnology export since they aren't created by the KLayout API
- Fixed some formatting issues when writing .lyt files
- 2.5D section of .lyt now uses zmin, zmax as it should, rather than zmin, thickness as it did