### PR TITLE
recursively netlist transformed (flattened) references

### DIFF
--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -199,6 +199,7 @@ def transformed(ref: ComponentReference):
     c.add(ref)
     c.copy_child_info(ref.ref_cell)
     c.add_ports(ref.ports)
+    c.info["transformed_cell"] = ref.ref_cell.name
     return c.flatten()
 
 

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -1,6 +1,8 @@
 import pytest
 
 import gdsfactory as gf
+from gdsfactory.decorators import flatten_invalid_refs
+from gdsfactory.get_netlist import get_netlist_recursive
 
 
 def test_get_netlist_cell_array() -> gf.Component:
@@ -295,6 +297,44 @@ def test_get_netlist_electrical_different_widths() -> gf.Component:
     expected_port_pair = {"i2,e2", "i1,e1"}
     assert extracted_port_pair == expected_port_pair
     return c
+
+
+def test_get_netlist_transformed():
+    rotation_value = 35
+    cname = "test_get_netlist_transformed"
+    c = gf.Component(cname)
+    i1 = c.add_ref(gf.components.straight(), "i1")
+    i2 = c.add_ref(gf.components.straight(), "i2")
+    i1.rotate(rotation_value)
+    i2.connect("o2", i1.ports["o1"])
+
+    # flatten the oddly rotated refs
+    c = flatten_invalid_refs(c)
+
+    # perform the initial sanity checks on the netlist
+    netlist = c.get_netlist()
+    connections = netlist["connections"]
+    assert len(connections) == 1
+    cpairs = list(connections.items())
+    extracted_port_pair = set(cpairs[0])
+    expected_port_pair = {"i2,o2", "i1,o1"}
+    assert extracted_port_pair == expected_port_pair
+
+    recursive_netlist = get_netlist_recursive(c)
+    top_netlist = recursive_netlist[cname]
+    # the recursive netlist should have 3 entries, for the top level and two rotated straights
+    assert len(recursive_netlist) == 3
+    # confirm that the child netlists have reference attributes properly set
+
+    i1_cell_name = top_netlist["instances"]["i1"]["component"]
+    i1_netlist = recursive_netlist[i1_cell_name]
+    # currently for transformed netlists, the instance name of the inner cell is None
+    assert i1_netlist["placements"][None]["rotation"] == rotation_value
+
+    i2_cell_name = top_netlist["instances"]["i2"]["component"]
+    i2_netlist = recursive_netlist[i2_cell_name]
+    # currently for transformed netlists, the instance name of the inner cell is None
+    assert i2_netlist["placements"][None]["rotation"] == rotation_value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This MR enables recursive netlisting of references which have been transformed and flattened via the `flatten_invalid_refs` decorator, such that they can be properly simulated, i.e. with sax.