### PR TITLE
don't re-apply PDK decorator in get_component

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -314,11 +314,6 @@ class Pdk(BaseModel):
                 else self.containers[cell_name]
             )
             component = cell(**settings)
-            component = (
-                self.default_decorator(component) or component
-                if self.default_decorator
-                else component
-            )
             return component
         else:
             raise ValueError(


### PR DESCRIPTION
The `default_decorator` of a pdk gets applied to components within the `@cell` decorator, unless the component is explicitly called with another decorator. Inside the `get_component()` function, however, it is redundantly being applied. This is not only bad because it is redundant and will double-apply the decorator to each cell in this case, but it also occurs _after_ the cell is locked, which should generally be forbidden, and, depending on the nature of the decorator, will throw an error. Thirdly, it is bad because it will apply inconsistently (only when the component is retrieved via `get_component()`). We can see correct behaviour when these lines are removed.