### PR TITLE
access reference ports more easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 5.46.0
 
+- meep plot2D improvements [PR](https://github.com/gdsfactory/gdsfactory/pull/792)
+
+## 5.45.1
+
 - add spiral heater phase shifter [PR](https://github.com/gdsfactory/gdsfactory/pull/786)
 
 ## 5.45.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 5.46.0
 
 - meep plot2D improvements [PR](https://github.com/gdsfactory/gdsfactory/pull/792)
+- fix show_subports causes error with CellArray references [issue](https://github.com/gdsfactory/gdsfactory/issues/791)
+- access reference ports more easily [PR]()
 
 ## 5.45.1
 

--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -461,6 +461,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also access the ports directly from the references"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component(\"sample_reference_connect_simpler\")\n",
+    "\n",
+    "mmi = c << gf.components.mmi1x2()\n",
+    "b = c << gf.components.bend_circular()\n",
+    "b.connect(\"o1\", destination=mmi[\"o2\"])\n",
+    "\n",
+    "c.add_port(\"o1\", port=mmi[\"o1\"])\n",
+    "c.add_port(\"o2\", port=b[\"o2\"])\n",
+    "c.add_port(\"o3\", port=mmi[\"o3\"])\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Port naming\n",
     "\n",
     "You have the freedom to name the ports as you want, and you can use `gf.port.auto_rename_ports(prefix='o')` to rename them later on.\n",

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1229,11 +1229,12 @@ class Component(gdspy.Cell, _GeometryHelper):
             component = self.copy()
             component.name = self.name
             for reference in component.references:
-                add_pins_triangle(
-                    component=component,
-                    reference=reference,
-                    layer=port_marker_layer,
-                )
+                if isinstance(component, ComponentReference):
+                    add_pins_triangle(
+                        component=component,
+                        reference=reference,
+                        layer=port_marker_layer,
+                    )
 
         elif show_ports:
             component = self.copy()

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -526,7 +526,7 @@ class ComponentReference(CellReference, _GeometryHelper):
 
     def connect(
         self,
-        port: Union[str, int, Port],
+        port: Union[str, Port],
         destination: Port,
         overlap: float = 0.0,
     ) -> "ComponentReference":

--- a/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
@@ -13,7 +13,7 @@ def test_simulation_hash() -> None:
     sim = gt.get_simulation(component=component)
     sim_hash = get_sim_hash(sim)
 
-    sim_hash_reference = "c74de15b5bc67d44c1a92168b43b6e7e"
+    sim_hash_reference = "4b0cd0b69d0e1c32a1bf30e1f1ea5b27"
 
     # print(f"assert hash == {sim_hash!r}")
     assert sim_hash == sim_hash_reference, f"sim_hash_reference = {sim_hash!r}"


### PR DESCRIPTION
Allows to access reference ports more easily

requested by @sequoiap  and @HelgeGehring 

```
import gdsfactory as gf

c = gf.Component()
w1 = c <<gf.c.straight()
w2 = c <<gf.c.straight(width=1)
w2.connect('o1', w1['o2'])
c.show()
```

Let me know what you think

@tvt173 
