### PR TITLE
Integrate flayout

### DIFF
--- a/gdsfactory/klayout/pymacros/import_generic_pcells.lym
+++ b/gdsfactory/klayout/pymacros/import_generic_pcells.lym
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description/>
+ <version/>
+ <category>pymacros</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name/>
+ <menu-path/>
+ <interpreter>python</interpreter>
+ <dsl-interpreter-name/>
+ <text>
+
+import flayout as fl
+import gdsfactory.components as gfc
+from gdsfactory.types import ComponentOrReference
+
+# FIXME: Often, deleting KLayout cells imported this way will crash KLayout
+
+gf_pcells = []
+for name, cell in gfc.cells.items():
+    # Would be nice to add SiEPIC pins to all of these
+    try:
+      gf_pcells.append(fl.pcell(cell, on_error="ignore"))
+    except:
+      # Currently, pcells defined with partial don't work due to a missing __name__ attribute
+      pass
+
+# Cell
+generic_lib = fl.library(
+    "generic",
+    pcells=gf_pcells,
+    cells=[],
+    description="GDSFactory Generic PCell Library",
+)
+</text>
+</klayout-macro>

--- a/gdsfactory/klayout/pymacros/link_gdsfactory_python.lym
+++ b/gdsfactory/klayout/pymacros/link_gdsfactory_python.lym
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<klayout-macro>
+ <description/>
+ <version/>
+ <category>pymacros</category>
+ <prolog/>
+ <epilog/>
+ <doc/>
+ <autorun>false</autorun>
+ <autorun-early>false</autorun-early>
+ <shortcut/>
+ <show-in-menu>true</show-in-menu>
+ <group-name/>
+ <menu-path/>
+ <interpreter>python</interpreter>
+ <dsl-interpreter-name/>
+ <text>
+import pya
+import sys
+import json
+import importlib
+from pathlib import Path
+
+python_base_dir = pya.FileDialog.ask_existing_dir("Select directory of Python environment to link:", "")
+
+import_packages = [
+    'click',
+    'flatdict',
+    'gdspy',
+    'jsondiff',
+    'loguru',
+    'lxml',
+    'matplotlib',
+    'numpy',
+    'omegaconf',
+    'orjson',
+    'pandas',
+    'pydantic',
+    'pytest',
+    'pytest-regressions',
+    'pyyaml',
+    'qrcode',
+    'rectpack',
+    'scipy',
+    'shapely',
+    'toolz',
+    'tqdm',
+    'types-PyYAML',
+    'typing_extensions',
+    'watchdog',
+    'xmltodict',
+    'gdsfactory',
+    'flayout'
+]
+
+external_site_packages = list(Path(python_base_dir).glob("**/site-packages"))
+
+if len(external_site_packages) > 1 or len(external_site_packages) == 0:
+    raise ImportError("The specified directory should contain exactly one 'site-packages' folder.")
+
+python_lib_path = external_site_packages[0]
+
+# Add path to import all extra modules
+sys.path.append(str(python_lib_path))
+
+for package in import_packages:
+  package_info_dir =  list(python_lib_path.glob(f"{package}-*dist-info*"))
+
+  if len(package_info_dir) == 0:
+    continue
+
+  if len(package_info_dir) > 1:
+    print(f"Multiple info directories for {package} found! :\n{package_info_dir}")
+    continue
+
+  package_info_file = package_info_dir[0] / "direct_url.json"
+
+  if not package_info_file.exists():
+    continue
+
+  with open(package_info_file, 'r') as f:
+    # Should be in format: "file:///path/to/local/package"
+    try:
+        package_import_path = json.load(f)["url"][7:]
+        print("found package: ", package_import_path)
+    except Exception as err:
+        print(err)
+
+  if package_import_path not in sys.path:
+    sys.path.append(package_import_path)
+
+  # importlib.import_module(package)
+
+# sys.path.remove(package_import_path)
+
+</text>
+</klayout-macro>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e .
 click
 flatdict
+flayout
 gdspy
 jsondiff
 loguru


### PR DESCRIPTION
Using @flaport's [flayout](https://github.com/flaport/flayout) package, we can add all of our generic components into KLayout with just a couple of macros! 

The simplest way to make it work is to:
- Open any installed version of KLayout
- Run the `link_gdsfactory_python.lym` macro, which will open a file dialog where you can select the environment to link (this needs to have `gdsfactory` and `flayout` installed)
- Run the `import_generic_pcells.lym` macro, which will import all of the generic components as a library

The imported library isn't perfect though and deleting cells will (often) crash KLayout immediately..

This should work for packages installed with `pip install -e` as well as the standard pip install.

It also crashes when trying to load the first 'patch' macro at startup.

It would also be nice to automatically add SiEPIC pins to all of these GUI PCells