### PR TITLE
Fix devsim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,13 +175,5 @@ link:
 
 spell:
 	codespell -i 3 -w -L TE,TE/TM,te,ba,FPR,fpr_spacing
-
-devsim:
-	wget -P devsim https://github.com/devsim/devsim/releases/download/v2.1.0/devsim_linux_v2.1.0.tgz
-	tar zxvf devsim/devsim_linux_v2.1.0.tgz --directory devsim
-	python devsim/devsim_linux_v2.1.0/install.py
-	pip install -e devsim/devsim_linux_v2.1.0/lib # Works in this specific way
-	pip install mkl
-	mamba install -c conda-forge pyvista -y
-
+	
 .PHONY: gdsdiff build conda

--- a/gdsfactory/simulation/devsim/__init__.py
+++ b/gdsfactory/simulation/devsim/__init__.py
@@ -1,0 +1,12 @@
+from gdsfactory.config import logger
+from gdsfactory.simulation import plot, port_symmetries
+import devsim as tcad
+from gdsfactory.simulation.get_sparameters_path import get_sparameters_data_meep
+from gdsfactory.simulation.devsim.get_simulation_xsection import get_simulation_xsection
+
+logger.info(f"DEVSIM {tcad.__version__!r} installed at {tcad.__path__!r}")
+
+__all__ = [
+    "get_simulation_xsection",
+]
+__version__ = "0.0.1"

--- a/gdsfactory/simulation/devsim/__init__.py
+++ b/gdsfactory/simulation/devsim/__init__.py
@@ -1,12 +1,15 @@
-from gdsfactory.config import logger
-from gdsfactory.simulation import plot, port_symmetries
 import devsim as tcad
-from gdsfactory.simulation.get_sparameters_path import get_sparameters_data_meep
-from gdsfactory.simulation.devsim.get_simulation_xsection import get_simulation_xsection
+
+from gdsfactory.config import logger
+from gdsfactory.simulation.devsim.get_simulation_xsection import (
+    PINWaveguide,
+    alpha_to_k,
+    dalpha_carriers,
+    dn_carriers,
+    k_to_alpha,
+)
 
 logger.info(f"DEVSIM {tcad.__version__!r} installed at {tcad.__path__!r}")
 
-__all__ = [
-    "get_simulation_xsection",
-]
+__all__ = ["dn_carriers", "dalpha_carriers", "alpha_to_k", "k_to_alpha", "PINWaveguide"]
 __version__ = "0.0.1"

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -50,7 +50,7 @@ def dn_carriers(wavelength: float, dN: float, dP: float) -> float:
         wavelength *= 1e-6
         return (
             -3.64 * 1e-10 * wavelength**2 * dN
-            - 3.51 * 1e-6 * wavelength**2 * np.poewr(dP, 0.8)
+            - 3.51 * 1e-6 * wavelength**2 * np.power(dP, 0.8)
         )
 
 

--- a/requirements_devsim.txt
+++ b/requirements_devsim.txt
@@ -1,0 +1,4 @@
+devsim
+mkl
+pyvista
+tidy3d-beta==1.7.1

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -14,6 +14,7 @@ nlopt
 phidl
 pyglet
 pygmsh
+pyvista
 sax==0.8.4
 scikit-fem
 scikit-image

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,6 +1,5 @@
 autograd
 bokeh
-devsim
 freetype-py
 holoviews
 ipympl
@@ -8,13 +7,11 @@ ipywidgets
 klayout
 lytest==0.0.20
 mapbox_earcut
-mkl
 networkx
 nlopt
 phidl
 pyglet
 pygmsh
-pyvista
 sax==0.8.4
 scikit-fem
 scikit-image

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ with open("requirements_tidy3d.txt") as f:
         line.strip() for line in f.readlines() if not line.strip().startswith("-")
     ]
 
+with open("requirements_devsim.txt") as f:
+    requirements_devsim = [
+        line.strip() for line in f.readlines() if not line.strip().startswith("-")
+    ]
+
 with open("README.md") as f:
     long_description = f.read()
 
@@ -55,6 +60,7 @@ setup(
         "full": list(set(requirements + requirements_full)),
         "sipann": requirements_sipann,
         "tidy3d": requirements_tidy3d,
+        "devsim": requirements_devsim,
         "dev": list(set(requirements + requirements_dev)),
         "exp": list(set(requirements + requirements_exp)),
     },


### PR DESCRIPTION
DEVSIM can now be imported properly from scripts
Due to large requirements, there is now a requirements_file for DEVSIM, and it can be installed as
`pip install gdsfactory[devsim]`

