### PR TITLE
Fix shortcut installation script

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -10,10 +10,10 @@ call conda activate
 call conda install -c conda-forge git -y
 if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-call git clone https://github.com/SkandanC/gdsfactory.git -b Add-shortcut-during-installation
-
-cd gdsfactory
-python shortcuts.py
+call git clone https://github.com/gdsfactory/gdsfactory.git
 
 :SKIP_INSTALL
 echo gdsfactory installed
+
+cd gdsfactory
+python shortcuts.py

--- a/install.bat
+++ b/install.bat
@@ -4,17 +4,15 @@ pip install lytest simphony sax jax sklearn klayout devsim
 pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
 pip install gdsfactory==5.54.0
 gf tool install
-cd ..
-set GF_PATH=%cd%
 
+call ..\condabin\conda activate
+call ..\conda install -c conda-forge git -y
 if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-call %GF_PATH%\condabin\conda activate
-call conda install -c conda-forge git -y
 call git clone https://github.com/gdsfactory/gdsfactory.git
 
 cd gdsfactory
-%GF_PATH%\python shortcuts.py %GF_PATH%
+python shortcuts.py
 
 :SKIP_INSTALL
 echo gdsfactory installed

--- a/install.bat
+++ b/install.bat
@@ -1,15 +1,23 @@
 
-set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
-pip install lytest simphony sax jax sklearn klayout devsim
-pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
-pip install gdsfactory==5.54.0
-gf tool install
-cd ..
+@REM set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
+@REM pip install lytest simphony sax jax sklearn klayout devsim
+@REM pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
+@REM pip install gdsfactory==5.54.0
+@REM gf tool install
+@REM cd ..
 set GF_PATH=%cd%
+echo %GF_PATH%
 
-if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
+@REM if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-git clone https://github.com/gdsfactory/gdsfactory.git
+@REM pause
+call %GF_PATH%\condabin\conda activate
+@REM pause
+call conda install -c conda-forge git -y
+@REM pause
+call git clone https://github.com/gdsfactory/gdsfactory.git
+@REM pause
+echo %GF_PATH%
 
 cd gdsfactory
 %GF_PATH%\python shortcuts.py %GF_PATH%

--- a/install.bat
+++ b/install.bat
@@ -1,23 +1,17 @@
 
-@REM set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
-@REM pip install lytest simphony sax jax sklearn klayout devsim
-@REM pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
-@REM pip install gdsfactory==5.54.0
-@REM gf tool install
-@REM cd ..
+set PIP_FIND_LINKS="https://whls.blob.core.windows.net/unstable/index.html"
+pip install lytest simphony sax jax sklearn klayout devsim
+pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/index.html --use-deprecated legacy-resolver
+pip install gdsfactory==5.54.0
+gf tool install
+cd ..
 set GF_PATH=%cd%
-echo %GF_PATH%
 
-@REM if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
+if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-@REM pause
 call %GF_PATH%\condabin\conda activate
-@REM pause
 call conda install -c conda-forge git -y
-@REM pause
 call git clone https://github.com/gdsfactory/gdsfactory.git
-@REM pause
-echo %GF_PATH%
 
 cd gdsfactory
 %GF_PATH%\python shortcuts.py %GF_PATH%

--- a/install.bat
+++ b/install.bat
@@ -10,7 +10,7 @@ call conda activate
 call conda install -c conda-forge git -y
 if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-call git clone https://github.com/SkandanC/gdsfactory.git
+call git clone https://github.com/SkandanC/gdsfactory.git -b Add-shortcut-during-installation
 
 cd gdsfactory
 python shortcuts.py

--- a/install.bat
+++ b/install.bat
@@ -5,11 +5,12 @@ pip install "jaxlib[cuda111]" -f https://whls.blob.core.windows.net/unstable/ind
 pip install gdsfactory==5.54.0
 gf tool install
 
-call ..\condabin\conda activate
-call ..\conda install -c conda-forge git -y
+cd ..\condabin
+call conda activate
+call conda install -c conda-forge git -y
 if exist "%USERPROFILE%\Desktop\gdsfactory" (goto SKIP_INSTALL)
 cd %USERPROFILE%\Desktop
-call git clone https://github.com/gdsfactory/gdsfactory.git
+call git clone https://github.com/SkandanC/gdsfactory.git
 
 cd gdsfactory
 python shortcuts.py

--- a/shortcuts.py
+++ b/shortcuts.py
@@ -44,7 +44,7 @@ jupyter_lab_settings = """
 
 anaconda_navigator_settings = """
 {
-    "menu_name": "gdsfactory Anaconda Navigator",
+    "menu_name": "gdsfactory Navigator",
     "menu_items":
         [
             {

--- a/shortcuts.py
+++ b/shortcuts.py
@@ -62,9 +62,9 @@ anaconda_navigator_settings = """
 
 
 def shortcuts(settings: str):
-    with open(f"{sys.argv[1]}/settings.json", "w") as f:
+    with open("settings.json", "w") as f:
         json.dump(json.loads(settings), f)
-    menuinst.install(f"{sys.argv[1]}/settings.json", prefix=f"{sys.argv[1]}")
+    menuinst.install("settings.json", prefix=sys.executable.strip("python.exe"))
 
 
 if __name__ == "__main__":

--- a/shortcuts.py
+++ b/shortcuts.py
@@ -50,7 +50,7 @@ anaconda_navigator_settings = """
             {
                 "script": "${PREFIX}/Scripts/anaconda-navigator.exe",
                 "scriptarguments": [],
-                "name": "gdsfactory Anaconda Navigator",
+                "name": "gdsfactory Navigator",
                 "workdir": "${PREFIX}",
                 "icon": "${MENU_DIR}/anaconda-navigator.ico",
                 "desktop": true,


### PR DESCRIPTION
If git is not installed, the install script fails to clone gdsfactory and install the shortcuts. Minor fix.