### PR TITLE
Trim component

### DIFF
--- a/gdsfactory/geometry/__init__.py
+++ b/gdsfactory/geometry/__init__.py
@@ -11,6 +11,7 @@ from gdsfactory.geometry.check_width import check_width
 from gdsfactory.geometry.invert import invert
 from gdsfactory.geometry.offset import offset
 from gdsfactory.geometry.outline import outline
+from gdsfactory.geometry.trim import trim
 from gdsfactory.geometry.union import union
 from gdsfactory.geometry.xor_diff import xor_diff
 
@@ -28,4 +29,5 @@ __all__ = (
     "union",
     "xor_diff",
     "functions",
+    "trim",
 )

--- a/gdsfactory/geometry/trim.py
+++ b/gdsfactory/geometry/trim.py
@@ -1,0 +1,71 @@
+from typing import List, Optional, Tuple
+
+import gdstk
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.component_layout import _parse_layer
+
+
+@gf.cell
+def trim(
+    component: Component,
+    domain: List[Tuple[int, int]],
+    precision: float = 1e-4,
+    return_ports: Optional[bool] = False,
+) -> Component:
+    """Trim a component by another geometry, preserving the component's layers and ports.
+
+    Useful to get a smaller component from a larger one for simulation.
+
+    Args:
+        component: Component(/Reference)
+        domain: list of array-like[N][2] representing the boundary of the component to keep.
+        precision: float Desired precision for rounding vertex coordinates.
+        return_ports: whether to return the included ports or not. Ports are always renamed to avoid inheritance conflicts.
+
+    Returns: All layers (and possibly ports) of the component restricted to the domain polygon.
+    """
+    domain_shape = gdstk.Polygon(domain)
+    c = Component()
+
+    for layer, layer_polygons in component.get_polygons(by_spec=True).items():
+        gds_layer, gds_datatype = _parse_layer(layer)
+        for layer_polygon in layer_polygons:
+            p = gdstk.boolean(
+                operand1=gdstk.Polygon(layer_polygon),
+                operand2=domain_shape,
+                operation="and",
+                precision=precision,
+                layer=gds_layer,
+                datatype=gds_datatype,
+            )
+            if p:
+                c.add_polygon(p, layer=layer)
+
+    if return_ports:
+        ports = []
+        i = 0
+        print(len(component.get_ports()))
+        for port in component.get_ports():
+            print(
+                port.name,
+                [port.center],
+                domain_shape,
+                gdstk.inside([port.center], domain_shape),
+            )
+            if gdstk.inside([port.center], domain_shape):
+                new_name = f"{port.name[:1]}{i}"
+                ports.append(port.copy(new_name))
+                i += 1
+
+        c.add_ports(ports)
+        c.auto_rename_ports_layer_orientation()
+
+    return c
+
+
+if __name__ == "__main__":
+    c = gf.components.straight_pin(length=10, taper=None)
+    trimmed_c = trim(component=c, domain=[[0, -5], [0, 5], [5, 5], [5, -5]])
+    trimmed_c.show(show_ports=True)

--- a/gdsfactory/tests/test_geometry.py
+++ b/gdsfactory/tests/test_geometry.py
@@ -49,8 +49,16 @@ def test_boolean_and_klayout() -> None:
     assert int(c3.area()) == 113
 
 
+def test_trim() -> None:
+    c = gf.components.straight_pin(length=10, taper=None)
+    rectangle = [[0, -5], [0, 5], [5, 5], [5, -5]]
+    trimmed_c = gf.geometry.trim(component=c, domain=rectangle)
+    assert trimmed_c.area() < c.area() and len(trimmed_c.get_layers()) > 1
+
+
 if __name__ == "__main__":
-    test_boolean_xor()
+    # test_boolean_xor()
+    test_trim()
     # c3 = gf.geometry.boolean_klayout(c1, c2, operation="and", layer3=(1, 0))
     # c4 = gf.geometry.boolean(c1, c2, operation="and", layer=(1, 0))
     # print(int(c3.area()))


### PR DESCRIPTION
New function in `geometry` that given a component and a polygonal domain, returns the portion of that component within that domain, but unlike existing functions preserves all layers and (possibly) ports. 

It's like the opposite of "add_padding", and also allows non-rectangular shapes for the padding removal.

There is also an accompanying test.

Very useful when resizing an existing component for simulations

Example:

```
    c = gf.components.straight_pin(length=10, taper=None)
    trimmed_c = trim(component=c, domain=[[0, -5], [0, 5], [5, 5], [5, -5]])
```

![image](https://user-images.githubusercontent.com/46427609/201501023-ba619508-d5e0-481a-97af-8c0992e30c95.png)
