### PR TITLE
fix (and deprecate?) ComponentReference.translate()

### DIFF
--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -318,7 +318,9 @@ class ComponentReference(_GeometryHelper):
         return self._reference.get_paths(depth=depth)
 
     def translate(self, dx, dy):
-        return self._reference.translate(dx, dy)
+        x0, y0 = self._reference.origin
+        self._reference.origin = (x0 + dx, y0 + dy)
+        return self
 
     def area(self, by_spec=False):
         """Calculate total area.


### PR DESCRIPTION
hi @joamatab , this MR fixes `ComponentReference.translate()`. However, it should probably also be deprecated, with a warning that suggests using `ComponentReference.move()` instead. What do you think?