### PR TITLE
Keep reference names on copy, and allow setting on init

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1871,9 +1871,8 @@ def copy(D: Component) -> Component:
             rotation=ref.rotation,
             magnification=ref.magnification,
             x_reflection=ref.x_reflection,
+            name=ref.name,
         )
-        new_ref.name = ref.name  # keep reference names
-        new_ref.owner = D_copy
         D_copy.add(new_ref)
 
     for port in D.ports.values():

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1872,7 +1872,7 @@ def copy(D: Component) -> Component:
             magnification=ref.magnification,
             x_reflection=ref.x_reflection,
         )
-        # new_ref.name = ref.name if hasattr(ref, "name") else ref.parent.name
+        new_ref.name = ref.name  # keep reference names
         new_ref.owner = D_copy
         D_copy.add(new_ref)
 

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -132,6 +132,8 @@ class ComponentReference(_GeometryHelper):
         x_reflection : bool
             If True, the reference is reflected parallel to the x direction
             before being rotated.
+        name : str (optional)
+            A name for the reference (if provided).
 
     """
 
@@ -146,6 +148,7 @@ class ComponentReference(_GeometryHelper):
         columns: int = 1,
         rows: int = 1,
         spacing=None,
+        name: Optional[str] = None,
     ) -> None:
         """Initialize the ComponentReference object."""
         self._reference = gdstk.Reference(
@@ -161,7 +164,7 @@ class ComponentReference(_GeometryHelper):
 
         self.ref_cell = component
         self._owner = None
-        self._name = None
+        self._name = name
 
         self.rows = rows
         self.columns = columns
@@ -360,9 +363,10 @@ class ComponentReference(_GeometryHelper):
                 raise ValueError(
                     f"This reference's owner already has a reference with name {value!r}. Please choose another name."
                 )
-            self.owner._named_references.pop(self._name, None)
+            if self.owner:
+                self.owner._named_references.pop(self._name, None)
+                self.owner._named_references[value] = self
             self._name = value
-            self.owner._named_references[value] = self
 
     def __repr__(self) -> str:
         """Return a string representation of the object."""

--- a/gdsfactory/tests/test_component_from_yaml.py
+++ b/gdsfactory/tests/test_component_from_yaml.py
@@ -597,6 +597,14 @@ def _demo_netlist() -> None:
     gf.show(c2)
 
 
+def test_ref_names_retained_on_copy():
+    c_orig = from_yaml(sample_connections)
+    c_copy = c_orig.copy()
+    orig_ref_names = set(c_orig.named_references.keys())
+    new_ref_names = set(c_copy.named_references.keys())
+    assert orig_ref_names == new_ref_names
+
+
 if __name__ == "__main__":
     # c = test_connections_different_factory()
     # c = test_sample()


### PR DESCRIPTION
This MR 
1. Ensures that reference names are retained when copying a component
2. Fixes an issue when a `ComponentReference`'s name is set before it has an `owner`
3. Adds `name` as a parameter to `ComponentReference`'s constructor, so it can be set on initialization