### PR TITLE
fixing the port cross sections of an extruded transition and adding test

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -883,8 +883,8 @@ def extrude(
                     width=port_width,
                     orientation=port_orientation,
                     center=center,
-                    cross_section=x.cross_sections[0]
-                    if hasattr(x, "cross_sections")
+                    cross_section=x.cross_section1
+                    if hasattr(x, "cross_section1")
                     else x,
                     shear_angle=shear_angle_start,
                 )
@@ -911,8 +911,8 @@ def extrude(
                     width=port_width,
                     center=center,
                     orientation=port_orientation,
-                    cross_section=x.cross_sections[1]
-                    if hasattr(x, "cross_sections")
+                    cross_section=x.cross_section2
+                    if hasattr(x, "cross_section2")
                     else x,
                     shear_angle=shear_angle_end,
                 )

--- a/gdsfactory/tests/test_paths_extrude.py
+++ b/gdsfactory/tests/test_paths_extrude.py
@@ -23,6 +23,25 @@ def test_path_extrude_multiple_ports() -> gf.Component:
     return c
 
 
+def test_extrude_transition():
+    w1 = 1
+    w2 = 5
+    length = 10
+    cs1 = gf.get_cross_section("strip", width=w1)
+    cs2 = gf.get_cross_section("strip", width=w2)
+    transition = gf.path.transition(cs1, cs2)
+    p = gf.path.straight(length)
+    c = gf.path.extrude(p, transition)
+    assert c.ports["o1"].cross_section == cs1
+    assert c.ports["o2"].cross_section == cs2
+    assert c.ports["o1"].width == w1
+    assert c.ports["o2"].width == w2
+
+    expected_area = (w1 + w2) / 2 * length
+    actual_area = c._cell.area(True)[(1, 0)]
+    assert actual_area == expected_area
+
+
 if __name__ == "__main__":
     c = test_path_extrude_multiple_ports()
     c.show(show_ports=True)


### PR DESCRIPTION
hi @joamatab, this fix is unrelated to the gdstk transition... the bug existed before as well. extruded transitions were not getting the correct ports. i fixed and added a test