### PR TITLE
straight propagates to route filter in get_bundle

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   sphinx_docs_to_gh-pages:
-    needs: [pre-commit]
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
     steps:

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -218,7 +218,7 @@ def get_bundle(
         return get_bundle_udirect(**params)
 
     elif end_angle == (start_angle + 180) % 360:
-        # print('get_bundle_uindirect')
+        # print("get_bundle_uindirect")
         return get_bundle_uindirect(extension_length=extension_length, **params)
     else:
         raise NotImplementedError("This should never happen")
@@ -712,33 +712,31 @@ if __name__ == "__main__":
 
     import gdsfactory as gf
 
-    c = gf.Component("get_bundle_none_orientation")
-    pt = c << gf.components.pad_array(orientation=None, columns=3)
-    pb = c << gf.components.pad_array(orientation=None, columns=3)
-    pt.move((100, 200))
-
-    routes = gf.routing.get_bundle_electrical_multilayer(
-        pb.ports,
-        pt.ports,
-        start_straight_length=1,
-        end_straight_length=10,
-        separation=30,
-    )
-
-    for route in routes:
-        c.add(route.references)
-
-    c.show(show_ports=True)
-
-    # c = gf.Component()
-    # c1 = c << gf.components.mmi2x2()
-    # c2 = c << gf.components.mmi2x2()
-    # c2.move((100, 40))
-    # routes = get_bundle(
-    #     [c1.ports['o2'], c1.ports["E1"]],
-    #     [c2.ports['o1'], c2.ports['o2']],
-    #     radius=5,
+    # c = gf.Component("get_bundle_none_orientation")
+    # pt = c << gf.components.pad_array(orientation=None, columns=3)
+    # pb = c << gf.components.pad_array(orientation=None, columns=3)
+    # pt.move((100, 200))
+    # routes = gf.routing.get_bundle_electrical_multilayer(
+    #     pb.ports,
+    #     pt.ports,
+    #     start_straight_length=1,
+    #     end_straight_length=10,
+    #     separation=30,
     # )
     # for route in routes:
-    #     assert np.isclose(route.length, 111.3) ,route.length
     #     c.add(route.references)
+
+    c = gf.Component("demo")
+    c1 = c << gf.components.mmi2x2()
+    c2 = c << gf.components.mmi2x2()
+    c2.move((100, 40))
+    routes = get_bundle(
+        [c1.ports["o2"], c1.ports["o1"]],
+        [c2.ports["o1"], c2.ports["o2"]],
+        radius=5,
+        # layer=(2, 0),
+        straight=gf.partial(gf.components.straight, layer=(1, 0), width=1),
+    )
+    for route in routes:
+        c.add(route.references)
+    c.show(show_ports=True)

--- a/gdsfactory/routing/get_bundle_u.py
+++ b/gdsfactory/routing/get_bundle_u.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy import float64, ndarray
 
 from gdsfactory.components.bend_euler import bend_euler
+from gdsfactory.components.straight import straight as straight_function
 from gdsfactory.geometry.functions import remove_identicals
 from gdsfactory.port import Port
 from gdsfactory.routing.get_route import get_route_from_waypoints
@@ -95,8 +96,7 @@ def get_bundle_udirect(
                                   |
                            X------/
     """
-    if "straight" in kwargs:
-        _ = kwargs.pop("straight")
+    straight = kwargs.pop("straight", straight_function)
     routes = _get_bundle_udirect_waypoints(
         ports1,
         ports2,
@@ -119,7 +119,9 @@ def get_bundle_udirect(
             **kwargs,
         )
 
-    return [route_filter(route, bend=bend, **kwargs) for route in routes]
+    return [
+        route_filter(route, bend=bend, straight=straight, **kwargs) for route in routes
+    ]
 
 
 def _get_bundle_udirect_waypoints(

--- a/gdsfactory/routing/get_route.py
+++ b/gdsfactory/routing/get_route.py
@@ -44,7 +44,7 @@ from gdsfactory.components.straight import straight as straight_function
 from gdsfactory.components.taper import taper as taper_function
 from gdsfactory.components.via_corner import via_corner
 from gdsfactory.components.wire import wire_corner
-from gdsfactory.cross_section import metal2, metal3, strip
+from gdsfactory.cross_section import metal2, metal3
 from gdsfactory.port import Port
 from gdsfactory.routing.manhattan import round_corners, route_manhattan
 from gdsfactory.types import (
@@ -176,7 +176,7 @@ def get_route_from_waypoints(
     bend: Callable = bend_euler,
     straight: Callable = straight_function,
     taper: Optional[Callable] = taper_function,
-    cross_section: CrossSectionSpec = strip,
+    cross_section: CrossSectionSpec = "strip",
     **kwargs,
 ) -> Route:
     """Returns a route formed by the given waypoints with bends instead of \

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -882,6 +882,7 @@ def round_corners(
             )
         if straight_ports is None:
             straight_ports = [p.name for p in _get_straight_ports(wg, layer=layer)]
+
         pname_west, pname_east = straight_ports
 
         wg_ref = wg.ref()

--- a/gdsfactory/routing/path_length_matching.py
+++ b/gdsfactory/routing/path_length_matching.py
@@ -5,7 +5,6 @@ from numpy import ndarray
 
 import gdsfactory as gf
 from gdsfactory.components.bend_euler import bend_euler
-from gdsfactory.cross_section import strip
 from gdsfactory.geometry.functions import path_length
 from gdsfactory.routing.manhattan import (
     _is_horizontal,
@@ -22,7 +21,7 @@ def path_length_matched_points(
     extra_length: float = 0.0,
     nb_loops: int = 1,
     bend: ComponentSpec = bend_euler,
-    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
     **kwargs,
 ) -> List[ndarray]:
     """Several types of paths won't match correctly. We do not try to handle all the corner cases here. You will need to modify the input list of waypoints in some cases.
@@ -147,7 +146,7 @@ def path_length_matched_points_add_waypoints(
     margin: float = 0.0,
     extra_length: float = 0.0,
     nb_loops: int = 1,
-    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
+    cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
     **kwargs,
 ) -> List[ndarray]:
     """Args are the following.


### PR DESCRIPTION
Now we also allow to use custom straight functions in get_bundle

```
    c = gf.Component("demo")
    c1 = c << gf.components.mmi2x2()
    c2 = c << gf.components.mmi2x2()
    c2.move((100, 40))
    routes = get_bundle(
        [c1.ports["o2"], c1.ports["o1"]],
        [c2.ports["o1"], c2.ports["o2"]],
        radius=5,
        # layer=(2, 0),
        straight=gf.partial(gf.components.straight, layer=(1, 0), width=1),
    )
    for route in routes:
        c.add(route.references)
    c.show(show_ports=True)
```

fixes #910 