### PR TITLE
Future type annotations and cleaner docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,13 @@ autodoc_pydantic_model_show_config_summary = False
 autodoc_pydantic_model_show_validator_summary = False
 autodoc_pydantic_model_show_validator_members = False
 autodoc_typehints = "description"
+autodoc_typehints_format = "short"
 
+autodoc_type_aliases = {
+    "ComponentSpec": "ComponentSpec",
+    "LayerSpec": "LayerSpec",
+    "CrossSectionSpec": "CrossSectionSpec",
+}
 
 autodoc_default_options = {
     "member-order": "bysource",

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -16,6 +16,7 @@ modules:
 
 isort:skip_file
 """
+from __future__ import annotations
 from functools import partial
 from toolz import compose
 from gdsfactory.component_layout import Group

--- a/gdsfactory/add_keepout.py
+++ b/gdsfactory/add_keepout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.component_layout import _parse_layer

--- a/gdsfactory/add_labels.py
+++ b/gdsfactory/add_labels.py
@@ -1,5 +1,7 @@
 """Add Label to each component port."""
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable, Dict, List, Optional, Union
 

--- a/gdsfactory/add_loopback.py
+++ b/gdsfactory/add_loopback.py
@@ -1,4 +1,6 @@
 """Add reference for a grating coupler array."""
+from __future__ import annotations
+
 from typing import List, Optional
 
 import gdsfactory as gf
@@ -18,7 +20,7 @@ def add_loopback(
     bend: ComponentSpec = gf.components.bend_euler,
     south_waveguide_spacing: Optional[float] = None,
     inside: bool = True,
-    **kwargs
+    **kwargs,
 ) -> List[ComponentReference]:
     """Return loopback (grating coupler align reference) references.
 

--- a/gdsfactory/add_padding.py
+++ b/gdsfactory/add_padding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -7,6 +7,8 @@ Some functions modify a component without changing its name.
 Make sure these functions are inside a new Component or called as a decorator
 They without modifying the cell name
 """
+from __future__ import annotations
+
 import json
 from functools import partial
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
@@ -35,7 +37,7 @@ def _rotate(v: ndarray, m: ndarray) -> ndarray:
 
 
 def get_pin_triangle_polygon_tip(
-    port: "Port",
+    port: Port,
 ) -> Tuple[List[float], Tuple[float, float]]:
     """Returns triangle polygon and tip position."""
     p = port
@@ -72,8 +74,8 @@ def get_pin_triangle_polygon_tip(
 
 
 def add_pin_triangle(
-    component: "Component",
-    port: "Port",
+    component: Component,
+    port: Port,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = "TEXT",
 ) -> None:
@@ -98,8 +100,8 @@ def add_pin_triangle(
 
 
 def add_pin_rectangle_inside(
-    component: "Component",
-    port: "Port",
+    component: Component,
+    port: Port,
     pin_length: float = 0.1,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = "TEXT",
@@ -153,8 +155,8 @@ def add_pin_rectangle_inside(
 
 
 def add_pin_rectangle_double(
-    component: "Component",
-    port: "Port",
+    component: Component,
+    port: Port,
     pin_length: float = 0.1,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = "TEXT",
@@ -224,8 +226,8 @@ def add_pin_rectangle_double(
 
 
 def add_pin_rectangle(
-    component: "Component",
-    port: "Port",
+    component: Component,
+    port: Port,
     pin_length: float = 0.1,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = "TEXT",
@@ -283,8 +285,8 @@ def add_pin_rectangle(
 
 
 def add_pin_path(
-    component: "Component",
-    port: "Port",
+    component: Component,
+    port: Port,
     pin_length: float = 2 * nm,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = None,
@@ -346,8 +348,8 @@ def add_pin_path(
 
 
 def add_outline(
-    component: "Component",
-    reference: Optional["ComponentReference"] = None,
+    component: Component,
+    reference: Optional[ComponentReference] = None,
     layer: LayerSpec = "DEVREC",
     **kwargs,
 ) -> None:
@@ -375,12 +377,12 @@ def add_outline(
 
 
 def add_pins_siepic(
-    component: "Component",
+    component: Component,
     function: Callable = add_pin_path,
     port_type: str = "optical",
     layer_pin: LayerSpec = "PORT",
     pin_length: float = 10 * nm,
-) -> "Component":
+) -> Component:
     """Add pins.
 
     Enables you to run SiEPIC verification tools:
@@ -410,10 +412,10 @@ add_pins_siepic_electrical = partial(
 
 
 def add_bbox_siepic(
-    component: "Component",
+    component: Component,
     bbox_layer: LayerSpec = "DEVREC",
     remove_layers: LayerSpecs = ("PORT", "PORTE"),
-) -> "Component":
+) -> Component:
     """Add bounding box device recognition layer.
 
     Args:
@@ -442,14 +444,14 @@ def add_bbox_siepic(
 
 
 def add_pins_bbox_siepic(
-    component: "Component",
+    component: Component,
     function: Callable = add_pin_path,
     port_type: str = "optical",
     layer_pin: LayerSpec = "PORT",
     pin_length: float = 10 * nm,
     bbox_layer: LayerSpec = "DEVREC",
     padding: float = 0,
-) -> "Component":
+) -> Component:
     """Add bounding box device recognition layer.
 
     Args:
@@ -485,12 +487,12 @@ add_pins_bbox_siepic_2nm = partial(add_pins_bbox_siepic, pin_length=2 * nm)
 
 
 def add_pins(
-    component: "Component",
-    reference: Optional["ComponentReference"] = None,
+    component: Component,
+    reference: Optional[ComponentReference] = None,
     function: Callable = add_pin_rectangle_inside,
     select_ports: Optional[Callable] = None,
     **kwargs,
-) -> "Component":
+) -> Component:
     """Add Pin port markers.
 
     Be careful with this function as it modifies the component.
@@ -518,8 +520,8 @@ add_pins_center = partial(add_pins, function=add_pin_rectangle)
 
 
 def add_settings_label(
-    component: "Component",
-    reference: "ComponentReference",
+    component: Component,
+    reference: ComponentReference,
     layer_label: LayerSpec = "LABEL_SETTINGS",
 ) -> None:
     """Add settings in label.
@@ -543,8 +545,8 @@ def add_settings_label(
 
 
 def add_instance_label(
-    component: "Component",
-    reference: "ComponentReference",
+    component: Component,
+    reference: ComponentReference,
     instance_name: Optional[str] = None,
     layer: LayerSpec = "LABEL_INSTANCE",
 ) -> None:
@@ -564,8 +566,8 @@ def add_instance_label(
 
 
 def add_pins_and_outline(
-    component: "Component",
-    reference: Optional["ComponentReference"] = None,
+    component: Component,
+    reference: Optional[ComponentReference] = None,
     add_outline_function: Optional[Callable] = add_outline,
     add_pins_function: Optional[Callable] = add_pins,
     add_settings_function: Optional[Callable] = add_settings_label,

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -1,4 +1,6 @@
 """Add ports from pin markers or labels."""
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/gdsfactory/add_tapers.py
+++ b/gdsfactory/add_tapers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/add_tapers_cross_section.py
+++ b/gdsfactory/add_tapers_cross_section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Optional
 
 import gdsfactory as gf
@@ -17,7 +19,7 @@ def add_tapers(
     taper_port_name1: str = "o1",
     taper_port_name2: str = "o2",
     cross_section2: CrossSectionSpec = strip,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns new component with taper in all optical ports.
 
@@ -45,7 +47,7 @@ def add_tapers(
             taper_ref = c << taper(
                 cross_section1=port.cross_section,
                 cross_section2=cross_section2,
-                **kwargs
+                **kwargs,
             )
             taper_ref.connect(taper_ref.ports[taper_port_name1].name, port)
             c.add_port(name=port_name, port=taper_ref.ports[taper_port_name2])

--- a/gdsfactory/add_termination.py
+++ b/gdsfactory/add_termination.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import List, Optional
 
@@ -18,7 +20,7 @@ def add_termination(
     terminator: ComponentSpec = terminator_function,
     port_name: Optional[str] = None,
     port_type: str = "optical",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns component with terminator on some ports.
 

--- a/gdsfactory/asserts.py
+++ b/gdsfactory/asserts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 from gdsfactory.component import Component

--- a/gdsfactory/async_utils.py
+++ b/gdsfactory/async_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -1,4 +1,6 @@
 """Cell decorator for functions that return a Component."""
+from __future__ import annotations
+
 import functools
 import hashlib
 import inspect

--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -1,5 +1,7 @@
 """Command line interface. Type `gf` into a terminal."""
 
+from __future__ import annotations
+
 import pathlib
 from typing import Optional
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import hashlib
 import itertools
@@ -221,7 +223,7 @@ class Component(_GeometryHelper):
             as_array=as_array,
         )
 
-    def get_dependencies(self, recursive: bool = False) -> List["Component"]:
+    def get_dependencies(self, recursive: bool = False) -> List[Component]:
         """Return a set of the cells included in this cell as references.
 
         Args:
@@ -588,7 +590,7 @@ class Component(_GeometryHelper):
         rotation: float = 0,
         h_mirror: bool = False,
         v_mirror: bool = False,
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Returns Component reference.
 
         Args:
@@ -754,7 +756,7 @@ class Component(_GeometryHelper):
         include_labels: bool = True,
         invert_selection: bool = False,
         recursive: bool = True,
-    ) -> "Component":
+    ) -> Component:
         """Remove a list of layers and returns the same Component.
 
         Args:
@@ -781,7 +783,7 @@ class Component(_GeometryHelper):
     def extract(
         self,
         layers: List[Union[Tuple[int, int], str]],
-    ) -> "Component":
+    ) -> Component:
         """Extract polygons from a Component and returns a new Component.
 
         based on phidl.geometry.
@@ -879,10 +881,10 @@ class Component(_GeometryHelper):
         self.is_unlocked()
         self._cell.add(*polygons)
 
-    def copy(self) -> "Component":
+    def copy(self) -> Component:
         return copy(self)
 
-    def copy_child_info(self, component: "Component") -> None:
+    def copy_child_info(self, component: Component) -> None:
         """Copy info from child component into parent.
 
         Parent components can access child cells settings.
@@ -952,7 +954,7 @@ class Component(_GeometryHelper):
 
     def add_array(
         self,
-        component: "Component",
+        component: Component,
         columns: int = 2,
         rows: int = 2,
         spacing: Tuple[float, float] = (100, 100),
@@ -1079,8 +1081,8 @@ class Component(_GeometryHelper):
         self.add_ref(new_component, alias=ref.name)
 
     def add_ref(
-        self, component: "Component", alias: Optional[str] = None, **kwargs
-    ) -> "ComponentReference":
+        self, component: Component, alias: Optional[str] = None, **kwargs
+    ) -> ComponentReference:
         """Add ComponentReference to the current Component.
 
         Args:
@@ -1660,7 +1662,7 @@ class Component(_GeometryHelper):
         origin: Float2 = (0, 0),
         destination: Optional[Float2] = None,
         axis: Optional[Axis] = None,
-    ) -> "Component":
+    ) -> Component:
         """Returns new Component with a moved reference to the original.
 
         component.
@@ -1678,7 +1680,7 @@ class Component(_GeometryHelper):
         self,
         p1: Float2 = (0, 1),
         p2: Float2 = (0, 0),
-    ) -> "Component":
+    ) -> Component:
         """Returns new Component with a mirrored reference.
 
         Args:
@@ -1689,7 +1691,7 @@ class Component(_GeometryHelper):
 
         return mirror(component=self, p1=p1, p2=p2)
 
-    def rotate(self, angle: float = 90) -> "Component":
+    def rotate(self, angle: float = 90) -> Component:
         """Returns new component with a rotated reference to the original.
 
         Args:
@@ -1699,7 +1701,7 @@ class Component(_GeometryHelper):
 
         return rotate(component=self, angle=angle)
 
-    def add_padding(self, **kwargs) -> "Component":
+    def add_padding(self, **kwargs) -> Component:
         """Returns new component with padding.
 
         Keyword Args:
@@ -1716,7 +1718,7 @@ class Component(_GeometryHelper):
 
         return add_padding(component=self, **kwargs)
 
-    def absorb(self, reference) -> "Component":
+    def absorb(self, reference) -> Component:
         """Absorbs polygons from ComponentReference into Component.
 
         Destroys the reference in the process but keeping the polygon geometry.
@@ -1838,7 +1840,7 @@ class Component(_GeometryHelper):
 
     def remap_layers(
         self, layermap, include_labels: bool = True, include_paths: bool = True
-    ) -> "Component":
+    ) -> Component:
         """Moves all polygons in the Component from one layer to another according to the layermap argument.
 
         Args:

--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
@@ -300,7 +302,7 @@ class Group(_GeometryHelper):
         """Returns the number of elements in the Group."""
         return len(self.elements)
 
-    def __iadd__(self, element) -> "Group":
+    def __iadd__(self, element) -> Group:
         """Adds an element to the Group.
 
         Args:
@@ -325,7 +327,7 @@ class Group(_GeometryHelper):
         )
         return np.array(bbox)
 
-    def add(self, element) -> "Group":
+    def add(self, element) -> Group:
         """Adds an element to the Group.
 
         Args:
@@ -356,7 +358,7 @@ class Group(_GeometryHelper):
         ]
         return self
 
-    def rotate(self, angle: float = 45, center=(0, 0)) -> "Group":
+    def rotate(self, angle: float = 45, center=(0, 0)) -> Group:
         """Rotates all elements in a Group around the specified centerpoint.
 
         Args:
@@ -369,7 +371,7 @@ class Group(_GeometryHelper):
             e.rotate(angle=angle, center=center)
         return self
 
-    def move(self, origin=(0, 0), destination=None, axis=None) -> "Group":
+    def move(self, origin=(0, 0), destination=None, axis=None) -> Group:
         """Moves the Group from the origin point to the destination.
 
         Both origin and destination can be 1x2 array-like, Port, or a key
@@ -387,7 +389,7 @@ class Group(_GeometryHelper):
             e.move(origin=origin, destination=destination, axis=axis)
         return self
 
-    def mirror(self, p1=(0, 1), p2=(0, 0)) -> "Group":
+    def mirror(self, p1=(0, 1), p2=(0, 0)) -> Group:
         """Mirrors a Group across the line formed between the two specified points.
 
         ``points`` may be input as either single points
@@ -405,7 +407,7 @@ class Group(_GeometryHelper):
 
     def distribute(
         self, direction="x", spacing=100, separation=True, edge="center"
-    ) -> "Group":
+    ) -> Group:
         """Distributes the elements in the Group.
 
         Args:
@@ -430,7 +432,7 @@ class Group(_GeometryHelper):
         )
         return self
 
-    def align(self, alignment="ymax") -> "Group":
+    def align(self, alignment="ymax") -> Group:
         """Aligns the elements in the Group.
 
         Args:

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -138,7 +140,7 @@ class ComponentReference(_GeometryHelper):
 
     def __init__(
         self,
-        component: "Component",
+        component: Component,
         origin: Coordinate = (0, 0),
         rotation: float = 0,
         magnification: float = 1,
@@ -527,7 +529,7 @@ class ComponentReference(_GeometryHelper):
         origin: Union[Port, Coordinate, str] = (0, 0),
         destination: Optional[Union[Port, Coordinate, str]] = None,
         axis: Optional[str] = None,
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Move the ComponentReference from origin point to destination.
 
         Both origin and destination can be 1x2 array-like, Port, or a key
@@ -601,7 +603,7 @@ class ComponentReference(_GeometryHelper):
         self,
         angle: float = 45,
         center: Union[Coordinate, str, int] = (0.0, 0.0),
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Return rotated ComponentReference.
 
         Args:
@@ -623,7 +625,7 @@ class ComponentReference(_GeometryHelper):
 
     def mirror_x(
         self, port_name: Optional[str] = None, x0: Optional[Coordinate] = None
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Perform horizontal mirror using x0 or port as axis (default, x0=0).
 
         This is the default for mirror along X=x0 axis
@@ -639,7 +641,7 @@ class ComponentReference(_GeometryHelper):
 
     def mirror_y(
         self, port_name: Optional[str] = None, y0: Optional[float] = None
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Perform vertical mirror using y0 as axis (default, y0=0)."""
         if port_name is None and y0 is None:
             y0 = 0.0
@@ -654,7 +656,7 @@ class ComponentReference(_GeometryHelper):
         self,
         p1: Coordinate = (0.0, 1.0),
         p2: Coordinate = (0.0, 0.0),
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Mirrors.
 
         Args:
@@ -695,7 +697,7 @@ class ComponentReference(_GeometryHelper):
         port: Union[str, Port],
         destination: Port,
         overlap: float = 0.0,
-    ) -> "ComponentReference":
+    ) -> ComponentReference:
         """Return ComponentReference where port connects to a destination.
 
         Args:

--- a/gdsfactory/components/C.py
+++ b/gdsfactory/components/C.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/L.py
+++ b/gdsfactory/components/L.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple, Union
 
 import gdsfactory as gf

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -3,6 +3,8 @@
 Make sure your components get imported here so the PDK registers them.
 """
 
+from __future__ import annotations
+
 import sys
 
 from gdsfactory.components.add_fiducials import add_fiducials, add_fiducials_offsets

--- a/gdsfactory/components/add_fiducials.py
+++ b/gdsfactory/components/add_fiducials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
@@ -14,7 +16,7 @@ def add_fiducials(
     top: Optional[ComponentSpec] = None,
     bottom: Optional[ComponentSpec] = None,
     offset: Float2 = (0, 0),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Return component with fiducials.
 

--- a/gdsfactory/components/add_grating_couplers.py
+++ b/gdsfactory/components/add_grating_couplers.py
@@ -1,4 +1,6 @@
 """Add grating_couplers to a component."""
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/components/align.py
+++ b/gdsfactory/components/align.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/array_component.py
+++ b/gdsfactory/components/array_component.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/array_with_fanout.py
+++ b/gdsfactory/components/array_with_fanout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/array_with_via.py
+++ b/gdsfactory/components/array_with_via.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/awg.py
+++ b/gdsfactory/components/awg.py
@@ -1,4 +1,6 @@
 """Sample AWG."""
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/bbox.py
+++ b/gdsfactory/components/bbox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple, Union
 
 from numpy import array

--- a/gdsfactory/components/bend_circular.py
+++ b/gdsfactory/components/bend_circular.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
@@ -12,7 +14,7 @@ def bend_circular(
     npoints: int = 720,
     with_bbox: bool = True,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a radial arc.
 

--- a/gdsfactory/components/bend_circular_heater.py
+++ b/gdsfactory/components/bend_circular_heater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
@@ -16,7 +18,7 @@ def bend_circular_heater(
     layer_heater: LayerSpec = "HEATER",
     with_bbox: bool = True,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Creates an arc of arclength `theta` starting at angle `start_angle`.
 

--- a/gdsfactory/components/bend_euler.py
+++ b/gdsfactory/components/bend_euler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
@@ -18,7 +20,7 @@ def bend_euler(
     direction: str = "ccw",
     with_bbox: bool = True,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns an euler bend that transitions from straight to curved.
 
@@ -122,7 +124,7 @@ def bend_straight_bend(
     npoints: int = 720,
     direction: str = "ccw",
     cross_section: CrossSectionSpec = strip,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Sbend made of 2 euler bends and straight section in between.
 
@@ -146,7 +148,7 @@ def bend_straight_bend(
         npoints=npoints,
         direction=direction,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
     b1 = c.add_ref(b)
     b2 = c.add_ref(b)

--- a/gdsfactory/components/bend_port.py
+++ b/gdsfactory/components/bend_port.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/bend_s.py
+++ b/gdsfactory/components/bend_s.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.bezier import bezier
@@ -9,7 +11,7 @@ def bend_s(
     size: Float2 = (10.0, 2.0),
     nb_points: int = 99,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Return S bend with bezier curve.
 
@@ -29,7 +31,7 @@ def bend_s(
         control_points=((0, 0), (dx / 2, 0), (dx / 2, dy), (dx, dy)),
         npoints=nb_points,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
     bend_ref = c << bend
     c.add_ports(bend_ref.ports)

--- a/gdsfactory/components/bezier.py
+++ b/gdsfactory/components/bezier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np
@@ -40,7 +42,7 @@ def bezier(
     end_angle: Optional[int] = None,
     cross_section: CrossSectionSpec = "strip",
     with_bbox: bool = True,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Bezier bend.
 

--- a/gdsfactory/components/cavity.py
+++ b/gdsfactory/components/cavity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
@@ -11,7 +13,7 @@ def cavity(
     coupler: ComponentSpec = "coupler",
     length: float = 0.1,
     gap: float = 0.2,
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Returns  cavity from a coupler and a mirror.
 

--- a/gdsfactory/components/cdc.py
+++ b/gdsfactory/components/cdc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf
@@ -108,7 +110,7 @@ def cdc(
     fins: bool = False,
     fin_size: Tuple[float, float] = (0.2, 0.05),
     cross_section: CrossSectionSpec = strip,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Grating-Assisted Contra-Directional Coupler.
 

--- a/gdsfactory/components/cdsem_all.py
+++ b/gdsfactory/components/cdsem_all.py
@@ -1,4 +1,6 @@
 """CD SEM structures."""
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/gdsfactory/components/cdsem_bend180.py
+++ b/gdsfactory/components/cdsem_bend180.py
@@ -1,4 +1,6 @@
 """CD SEM structures."""
+from __future__ import annotations
+
 from functools import partial
 
 import gdsfactory as gf

--- a/gdsfactory/components/cdsem_coupler.py
+++ b/gdsfactory/components/cdsem_coupler.py
@@ -1,4 +1,6 @@
 """CD SEM structures."""
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/gdsfactory/components/cdsem_straight.py
+++ b/gdsfactory/components/cdsem_straight.py
@@ -1,4 +1,6 @@
 """CD SEM structures."""
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/gdsfactory/components/cdsem_straight_density.py
+++ b/gdsfactory/components/cdsem_straight_density.py
@@ -1,4 +1,6 @@
 """CD SEM structures."""
+from __future__ import annotations
+
 from functools import partial
 
 import gdsfactory as gf

--- a/gdsfactory/components/circle.py
+++ b/gdsfactory/components/circle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from numpy import cos, pi, sin
 

--- a/gdsfactory/components/coh_rx_dual_pol.py
+++ b/gdsfactory/components/coh_rx_dual_pol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/coh_rx_single_pol.py
+++ b/gdsfactory/components/coh_rx_single_pol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/components/coh_tx_dual_pol.py
+++ b/gdsfactory/components/coh_tx_dual_pol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf
@@ -17,7 +19,7 @@ def coh_tx_dual_pol(
     input_coupler: Optional[ComponentSpec] = None,
     output_coupler: Optional[ComponentSpec] = None,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Dual polarization coherent transmitter.
 
@@ -67,7 +69,7 @@ def coh_tx_dual_pol(
         single_tx_1.ports["o1"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 
@@ -76,7 +78,7 @@ def coh_tx_dual_pol(
         single_tx_2.ports["o1"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 
@@ -93,7 +95,7 @@ def coh_tx_dual_pol(
             single_tx_1.ports["o2"],
             cross_section=cross_section,
             with_sbend=False,
-            **kwargs
+            **kwargs,
         )
         c.add(route.references)
 
@@ -102,7 +104,7 @@ def coh_tx_dual_pol(
             single_tx_2.ports["o2"],
             cross_section=cross_section,
             with_sbend=False,
-            **kwargs
+            **kwargs,
         )
         c.add(route.references)
 
@@ -135,7 +137,7 @@ def coh_tx_dual_pol(
                 out_coup.ports["o1"],
                 cross_section=cross_section,
                 with_sbend=False,
-                **kwargs
+                **kwargs,
             )
             c.add(route.references)
 
@@ -144,7 +146,7 @@ def coh_tx_dual_pol(
                 out_coup.ports["o2"],
                 cross_section=cross_section,
                 with_sbend=False,
-                **kwargs
+                **kwargs,
             )
             c.add(route.references)
     else:

--- a/gdsfactory/components/coh_tx_single_pol.py
+++ b/gdsfactory/components/coh_tx_single_pol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional
 
@@ -35,7 +37,7 @@ def coh_tx_single_pol(
     output_coupler: Optional[ComponentSpec] = None,
     pad_array: ComponentSpec = "pad_array",
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """MZM-based single polarization coherent transmitter.
 
@@ -153,7 +155,7 @@ def coh_tx_single_pol(
         mzm_i.ports["o1"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 
@@ -162,7 +164,7 @@ def coh_tx_single_pol(
         mzm_q.ports["o1"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 
@@ -178,7 +180,7 @@ def coh_tx_single_pol(
         ps_i.ports["o2"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 
@@ -187,7 +189,7 @@ def coh_tx_single_pol(
         ps_q.ports["o2"],
         cross_section=cross_section,
         with_sbend=False,
-        **kwargs
+        **kwargs,
     )
     c.add(route.references)
 

--- a/gdsfactory/components/compass.py
+++ b/gdsfactory/components/compass.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/component_lattice.py
+++ b/gdsfactory/components/component_lattice.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from typing import Dict, List, Tuple
 

--- a/gdsfactory/components/component_sequence.py
+++ b/gdsfactory/components/component_sequence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import Counter
 from typing import Dict, Optional, Tuple
 

--- a/gdsfactory/components/copy_layers.py
+++ b/gdsfactory/components/copy_layers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.cross import cross

--- a/gdsfactory/components/coupler.py
+++ b/gdsfactory/components/coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.coupler_straight import (
@@ -18,7 +20,7 @@ def coupler(
     dy: float = 5.0,
     dx: float = 10.0,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Symmetric coupler.
 

--- a/gdsfactory/components/coupler90.py
+++ b/gdsfactory/components/coupler90.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_circular import bend_circular
@@ -14,7 +16,7 @@ def coupler90(
     straight: ComponentSpec = straight,
     cross_section: CrossSectionSpec = "strip",
     bend_cross_section: Optional[CrossSectionSpec] = None,
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Straight coupled to a bend.
 
@@ -49,7 +51,7 @@ def coupler90(
         straight,
         cross_section=cross_section,
         length=bend90.ports["o2"].center[0] - bend90.ports["o1"].center[0],
-        **kwargs
+        **kwargs,
     )
 
     wg_ref = c << straight_component

--- a/gdsfactory/components/coupler90bend.py
+++ b/gdsfactory/components/coupler90bend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler

--- a/gdsfactory/components/coupler_adiabatic.py
+++ b/gdsfactory/components/coupler_adiabatic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bezier import bezier
@@ -14,7 +16,7 @@ def coupler_adiabatic(
     output_wg_sep: float = 3.0,
     dw: float = 0.1,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns 50/50 adiabatic coupler.
 

--- a/gdsfactory/components/coupler_asymmetric.py
+++ b/gdsfactory/components/coupler_asymmetric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_s import bend_s
@@ -13,7 +15,7 @@ def coupler_asymmetric(
     dy: float = 5.0,
     dx: float = 10.0,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Bend coupled to straight waveguide.
 

--- a/gdsfactory/components/coupler_full.py
+++ b/gdsfactory/components/coupler_full.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components import bend_s

--- a/gdsfactory/components/coupler_ring.py
+++ b/gdsfactory/components/coupler_ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf
@@ -20,7 +22,7 @@ def coupler_ring(
     coupler_straight: ComponentSpec = coupler_straight,
     cross_section: CrossSectionSpec = "strip",
     bend_cross_section: Optional[CrossSectionSpec] = None,
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Coupler for ring.
 
@@ -57,14 +59,14 @@ def coupler_ring(
         bend=bend,
         cross_section=cross_section,
         bend_cross_section=bend_cross_section,
-        **kwargs
+        **kwargs,
     )
     coupler_straight_component = gf.get_component(
         coupler_straight,
         gap=gap,
         length=length_x,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
 
     # add references to subcells

--- a/gdsfactory/components/coupler_straight.py
+++ b/gdsfactory/components/coupler_straight.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight as straight_function
@@ -9,7 +11,7 @@ def coupler_straight(
     length: float = 10.0,
     gap: float = 0.27,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Coupler_straight with two parallel straights.
 

--- a/gdsfactory/components/coupler_symmetric.py
+++ b/gdsfactory/components/coupler_symmetric.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_s import bend_s

--- a/gdsfactory/components/cross.py
+++ b/gdsfactory/components/cross.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/cutback_2x2.py
+++ b/gdsfactory/components/cutback_2x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.component_sequence import component_sequence

--- a/gdsfactory/components/cutback_bend.py
+++ b/gdsfactory/components/cutback_bend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from numpy import float64
 
 import gdsfactory as gf
@@ -24,7 +26,7 @@ def cutback_bend(
     rows: int = 6,
     columns: int = 5,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Deprecated.
 
@@ -81,7 +83,7 @@ def cutback_bend90(
     columns: int = 6,
     spacing: int = 5,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns bend90 cutback.
 
@@ -135,7 +137,7 @@ def staircase(
     length_h: float = 5.0,
     rows: int = 4,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns staircase.
 
@@ -179,7 +181,7 @@ def cutback_bend180(
     columns: int = 6,
     spacing: int = 3,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns cutback to measure u bend loss.
 
@@ -206,7 +208,7 @@ def cutback_bend180(
     wg_vertical = get_component(
         straight,
         length=2 * bend180.size_info.width + straight_length + spacing,
-        **kwargs
+        **kwargs,
     )
 
     # Define a map between symbols and (component, input port, output port)

--- a/gdsfactory/components/cutback_component.py
+++ b/gdsfactory/components/cutback_component.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler180
@@ -20,7 +22,7 @@ def cutback_component(
     mirror: bool = False,
     straight_length: Optional[float] = None,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a daisy chain of components for measuring their loss.
 

--- a/gdsfactory/components/cutback_splitter.py
+++ b/gdsfactory/components/cutback_splitter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler180
@@ -20,7 +22,7 @@ def cutback_splitter(
     mirror: bool = False,
     straight_length: Optional[float] = None,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a daisy chain of splitters for measuring their loss.
 

--- a/gdsfactory/components/dbr.py
+++ b/gdsfactory/components/dbr.py
@@ -8,6 +8,8 @@ https://open.library.ubc.ca/cIRcle/collections/ubctheses/24/items/1.0388871
 
 Period: 318nm, width: 500nm, dw: 20 ~ 120 nm.
 """
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
@@ -28,7 +30,7 @@ def dbr_cell(
     l1: float = period / 2,
     l2: float = period / 2,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Distributed Bragg Reflector unit cell.
 
@@ -73,7 +75,7 @@ def dbr(
     l2: float = period / 2,
     n: int = 10,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Distributed Bragg Reflector.
 

--- a/gdsfactory/components/dbr_tapered.py
+++ b/gdsfactory/components/dbr_tapered.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf
@@ -61,7 +63,7 @@ def dbr_tapered(
     fins: bool = False,
     fin_size: Tuple[float, float] = (0.2, 0.05),
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Distributed Bragg Reflector Cell class.
 

--- a/gdsfactory/components/delay_snake.py
+++ b/gdsfactory/components/delay_snake.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf
@@ -13,7 +15,7 @@ def delay_snake(
     n: int = 2,
     bend: ComponentSpec = "bend_euler",
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Snake with a starting straight and 90 bends.
 

--- a/gdsfactory/components/delay_snake2.py
+++ b/gdsfactory/components/delay_snake2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 import gdsfactory as gf

--- a/gdsfactory/components/delay_snake3.py
+++ b/gdsfactory/components/delay_snake3.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 
 import gdsfactory as gf

--- a/gdsfactory/components/delay_snake_sbend.py
+++ b/gdsfactory/components/delay_snake_sbend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight

--- a/gdsfactory/components/dicing_lane.py
+++ b/gdsfactory/components/dicing_lane.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.rectangle import rectangle

--- a/gdsfactory/components/die.py
+++ b/gdsfactory/components/die.py
@@ -1,5 +1,7 @@
 """based on phidl.geometry."""
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/components/die_bbox.py
+++ b/gdsfactory/components/die_bbox.py
@@ -1,4 +1,6 @@
 """based on phidl.geometry."""
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/die_bbox_frame.py
+++ b/gdsfactory/components/die_bbox_frame.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple, Union
 
 import numpy as np

--- a/gdsfactory/components/disk.py
+++ b/gdsfactory/components/disk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf
@@ -101,7 +103,7 @@ def disk(
     wrap_angle_deg: float = 180.0,
     parity: int = 1,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Disk Resonator.
 

--- a/gdsfactory/components/edge_coupler_array.py
+++ b/gdsfactory/components/edge_coupler_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/ellipse.py
+++ b/gdsfactory/components/ellipse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/components/extend_ports_list.py
+++ b/gdsfactory/components/extend_ports_list.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/extension.py
+++ b/gdsfactory/components/extension.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from typing import List, Optional, Tuple, Union
 

--- a/gdsfactory/components/fiber.py
+++ b/gdsfactory/components/fiber.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.circle import circle

--- a/gdsfactory/components/fiber_array.py
+++ b/gdsfactory/components/fiber_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.fiber import circle

--- a/gdsfactory/components/fiducial_squares.py
+++ b/gdsfactory/components/fiducial_squares.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/ge_detector_straight_si_contacts.py
+++ b/gdsfactory/components/ge_detector_straight_si_contacts.py
@@ -1,4 +1,6 @@
 """Straight Ge photodetector."""
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional
 

--- a/gdsfactory/components/grating_coupler_array.py
+++ b/gdsfactory/components/grating_coupler_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.grating_coupler_elliptical import grating_coupler_elliptical

--- a/gdsfactory/components/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_coupler_dual_pol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional
 

--- a/gdsfactory/components/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_coupler_elliptical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_coupler_elliptical_lumerical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Any, Dict, Optional
 

--- a/gdsfactory/components/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_coupler_elliptical_trenches.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/grating_coupler_functions.py
+++ b/gdsfactory/components/grating_coupler_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from numpy import pi, sin, sqrt

--- a/gdsfactory/components/grating_coupler_loss.py
+++ b/gdsfactory/components/grating_coupler_loss.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from typing import List, Tuple
 
@@ -19,7 +21,7 @@ def connect_loopback(
     b: float,
     y_bot_align_route: float,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> List[ComponentReference]:
     p0 = port0.center
     p1 = port1.center
@@ -46,7 +48,7 @@ def loss_deembedding_ch13_24(
     grating_coupler: ComponentSpec = grating_coupler_te,
     input_port_indexes: Tuple[int, ...] = (0, 1),
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -74,7 +76,7 @@ def loss_deembedding_ch13_24(
             start_straight_length=40.0,
             taper=None,
             cross_section=cross_section,
-            **kwargs
+            **kwargs,
         ).references
     )
 
@@ -108,7 +110,7 @@ def loss_deembedding_ch12_34(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = grating_coupler_te,
     input_port_indexes: Tuple[int, ...] = (0, 2),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -156,7 +158,7 @@ def loss_deembedding_ch14_23(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = grating_coupler_te,
     input_port_indexes: Tuple[int, ...] = (0, 1),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -204,7 +206,7 @@ def grating_coupler_loss_fiber_array(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = grating_coupler_te,
     input_port_indexes: Tuple[int, ...] = (0, 1),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Grating coupler fiber array loopback.
 

--- a/gdsfactory/components/grating_coupler_loss_fiber_single.py
+++ b/gdsfactory/components/grating_coupler_loss_fiber_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
@@ -9,7 +11,7 @@ from gdsfactory.types import ComponentSpec, CrossSectionSpec
 def grating_coupler_loss_fiber_single(
     grating_coupler: ComponentSpec = grating_coupler_te,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns grating coupler test structure.
 
@@ -37,7 +39,7 @@ def grating_coupler_loss_fiber_single(
         cross_section=cross_section,
         with_loopback=False,
         component_name=grating_coupler.name,
-        **kwargs
+        **kwargs,
     )
 
     c.copy_child_info(grating_coupler)

--- a/gdsfactory/components/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_coupler_rectangular.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_rectangular_arbitrary.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/grating_coupler_rectangular_arbitrary_slab.py
+++ b/gdsfactory/components/grating_coupler_rectangular_arbitrary_slab.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_coupler_tree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.grating_coupler_elliptical import (
@@ -16,7 +18,7 @@ def grating_coupler_tree(
     bend: ComponentSpec = "bend_euler",
     fanout_length: float = 0.0,
     layer_label: LayerSpec = "TEXT",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Array of straights connected with grating couplers.
 

--- a/gdsfactory/components/hline.py
+++ b/gdsfactory/components/hline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import LayerSpec

--- a/gdsfactory/components/litho_calipers.py
+++ b/gdsfactory/components/litho_calipers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/litho_ruler.py
+++ b/gdsfactory/components/litho_ruler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/litho_steps.py
+++ b/gdsfactory/components/litho_steps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/logo.py
+++ b/gdsfactory/components/logo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component

--- a/gdsfactory/components/loop_mirror.py
+++ b/gdsfactory/components/loop_mirror.py
@@ -1,5 +1,7 @@
 """Sagnac loop_mirror."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.mmi1x2 import mmi1x2

--- a/gdsfactory/components/marker_vertical.py
+++ b/gdsfactory/components/marker_vertical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.circle import circle

--- a/gdsfactory/components/mmi1x2.py
+++ b/gdsfactory/components/mmi1x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component

--- a/gdsfactory/components/mmi2x2.py
+++ b/gdsfactory/components/mmi2x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component

--- a/gdsfactory/components/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmi_90degree_hybrid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component

--- a/gdsfactory/components/mzi.py
+++ b/gdsfactory/components/mzi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional
 

--- a/gdsfactory/components/mzi_arm.py
+++ b/gdsfactory/components/mzi_arm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/mzi_arms.py
+++ b/gdsfactory/components/mzi_arms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/mzi_lattice.py
+++ b/gdsfactory/components/mzi_lattice.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/mzi_pads_center.py
+++ b/gdsfactory/components/mzi_pads_center.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.mzi import mzi as mzi_function
 from gdsfactory.components.pad import pad as pad_function

--- a/gdsfactory/components/mzi_phase_shifter.py
+++ b/gdsfactory/components/mzi_phase_shifter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.mzi import mzi
 from gdsfactory.components.straight_heater_metal import straight_heater_metal

--- a/gdsfactory/components/mzit.py
+++ b/gdsfactory/components/mzit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/mzit_lattice.py
+++ b/gdsfactory/components/mzit_lattice.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/nxn.py
+++ b/gdsfactory/components/nxn.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/optimal_90deg.py
+++ b/gdsfactory/components/optimal_90deg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/optimal_hairpin.py
+++ b/gdsfactory/components/optimal_hairpin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/optimal_step.py
+++ b/gdsfactory/components/optimal_step.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/pack_doe.py
+++ b/gdsfactory/components/pack_doe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools as it
 from typing import Any, Dict, List, Tuple
 

--- a/gdsfactory/components/pad.py
+++ b/gdsfactory/components/pad.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional, Tuple
 

--- a/gdsfactory/components/pad_gsg.py
+++ b/gdsfactory/components/pad_gsg.py
@@ -1,5 +1,7 @@
 """High speed GSG pads."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.pad import pad as pad_function
 from gdsfactory.components.rectangle import rectangle

--- a/gdsfactory/components/pads_shorted.py
+++ b/gdsfactory/components/pads_shorted.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.pad import pad as pad_function

--- a/gdsfactory/components/ramp.py
+++ b/gdsfactory/components/ramp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/rectangle.py
+++ b/gdsfactory/components/rectangle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/rectangle_with_slits.py
+++ b/gdsfactory/components/rectangle_with_slits.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/components/resistance_meander.py
+++ b/gdsfactory/components/resistance_meander.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/components/resistance_sheet.py
+++ b/gdsfactory/components/resistance_sheet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/ring.py
+++ b/gdsfactory/components/ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from numpy import cos, pi, sin
 

--- a/gdsfactory/components/ring_double.py
+++ b/gdsfactory/components/ring_double.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
@@ -16,7 +18,7 @@ def ring_double(
     straight: ComponentSpec = straight_function,
     bend: ComponentSpec = bend_euler,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a double bus ring.
 
@@ -54,7 +56,7 @@ def ring_double(
         bend=bend,
         straight=straight,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
     straight_component = gf.get_component(
         straight, length=length_y, cross_section=cross_section, **kwargs

--- a/gdsfactory/components/ring_double_heater.py
+++ b/gdsfactory/components/ring_double_heater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
@@ -24,7 +26,7 @@ def ring_double_heater(
     via_stack: gf.types.ComponentSpec = via_stack_heater_m3_mini,
     port_orientation: float = 90,
     via_stack_offset: Float2 = (0, 0),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a double bus ring with heater on top.
 
@@ -67,13 +69,13 @@ def ring_double_heater(
         bend=bend,
         cross_section=cross_section,
         bend_cross_section=cross_section_waveguide_heater,
-        **kwargs
+        **kwargs,
     )
     straight_component = gf.get_component(
         straight,
         length=length_y,
         cross_section=cross_section_waveguide_heater,
-        **kwargs
+        **kwargs,
     )
 
     c = Component()

--- a/gdsfactory/components/ring_single.py
+++ b/gdsfactory/components/ring_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.coupler_ring import coupler_ring as coupler_ring_function
@@ -15,7 +17,7 @@ def ring_single(
     straight: ComponentSpec = straight_function,
     bend: ComponentSpec = bend_euler,
     cross_section: ComponentSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> gf.Component:
     """Returns a single ring.
 
@@ -53,7 +55,7 @@ def ring_single(
         radius=radius,
         length_x=length_x,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
     sy = straight(length=length_y, cross_section=cross_section, **kwargs)
     b = gf.get_component(bend, cross_section=cross_section, radius=radius, **kwargs)

--- a/gdsfactory/components/ring_single_array.py
+++ b/gdsfactory/components/ring_single_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional, Tuple
 
 import gdsfactory as gf
@@ -18,7 +20,7 @@ def ring_single_array(
     spacing: float = 5.0,
     list_of_dicts: Optional[Tuple[Dict[str, float], ...]] = None,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Ring of single bus connected with straights.
 

--- a/gdsfactory/components/ring_single_dut.py
+++ b/gdsfactory/components/ring_single_dut.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
@@ -22,7 +24,7 @@ def ring_single_dut(
     bend: ComponentSpec = bend_euler,
     with_component: bool = True,
     port_name: str = "o1",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Single bus ring made of two couplers (ct: top, cb: bottom) connected.
 

--- a/gdsfactory/components/ring_single_heater.py
+++ b/gdsfactory/components/ring_single_heater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf
@@ -24,7 +26,7 @@ def ring_single_heater(
     via_stack: ComponentSpec = via_stack_heater_m3_mini,
     port_orientation: Optional[float] = 90,
     via_stack_offset: Float2 = (0, 0),
-    **kwargs
+    **kwargs,
 ) -> gf.Component:
     """Returns a single ring with heater on top.
 
@@ -66,20 +68,20 @@ def ring_single_heater(
         length_x=length_x,
         cross_section=cross_section,
         bend_cross_section=cross_section_waveguide_heater,
-        **kwargs
+        **kwargs,
     )
 
     straight_side = gf.get_component(
         straight,
         length=length_y,
         cross_section=cross_section_waveguide_heater,
-        **kwargs
+        **kwargs,
     )
     straight_top = gf.get_component(
         straight,
         length=length_x,
         cross_section=cross_section_waveguide_heater,
-        **kwargs
+        **kwargs,
     )
 
     bend = gf.get_component(

--- a/gdsfactory/components/seal_ring.py
+++ b/gdsfactory/components/seal_ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple, Union
 
 import gdsfactory as gf

--- a/gdsfactory/components/snspd.py
+++ b/gdsfactory/components/snspd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/spiral_double.py
+++ b/gdsfactory/components/spiral_double.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components import bend_circular
 from gdsfactory.path import spiral_archimedean

--- a/gdsfactory/components/spiral_external_io.py
+++ b/gdsfactory/components/spiral_external_io.py
@@ -2,6 +2,8 @@
 
 maybe: need to add grating coupler loopback as well
 """
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np
@@ -31,7 +33,7 @@ def spiral_external_io(
     bend: ComponentSpec = bend_euler,
     length: Optional[float] = None,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns spiral with input and output ports outside the spiral.
 

--- a/gdsfactory/components/spiral_heater.py
+++ b/gdsfactory/components/spiral_heater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/components/spiral_inner_io.py
+++ b/gdsfactory/components/spiral_inner_io.py
@@ -1,4 +1,6 @@
 """Spiral with grating couplers inside to save space."""
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np
@@ -32,7 +34,7 @@ def spiral_inner_io(
     length: Optional[float] = None,
     cross_section: CrossSectionSpec = "strip",
     cross_section_bend: Optional[CrossSectionSpec] = None,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Spiral with ports inside the spiral loop.
 
@@ -166,7 +168,7 @@ def spiral_inner_io_fiber_single(
     y_straight_inner_top: float = 10.0,
     y_straight_inner_bottom: float = 0.0,
     grating_spacing: float = 200.0,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Spiral with 90 and 270 degree ports.
 
@@ -201,7 +203,7 @@ def spiral_inner_io_fiber_single(
         y_straight_inner_top=y_straight_inner_top,
         y_straight_inner_bottom=y_straight_inner_bottom,
         grating_spacing=grating_spacing,
-        **kwargs
+        **kwargs,
     )
     ref = c << spiral
     ref.rotate(90)

--- a/gdsfactory/components/splitter_chain.py
+++ b/gdsfactory/components/splitter_chain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_s import bend_s

--- a/gdsfactory/components/splitter_tree.py
+++ b/gdsfactory/components/splitter_tree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -1,4 +1,6 @@
 """Straight waveguide."""
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
@@ -12,7 +14,7 @@ def straight(
     npoints: int = 2,
     with_bbox: bool = True,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns a Straight waveguide.
 

--- a/gdsfactory/components/straight_array.py
+++ b/gdsfactory/components/straight_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight as straight_function
@@ -9,7 +11,7 @@ def straight_array(
     n: int = 4,
     spacing: float = 4.0,
     straight: ComponentSpec = straight_function,
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Array of straights connected with grating couplers.
 

--- a/gdsfactory/components/straight_heater_doped_rib.py
+++ b/gdsfactory/components/straight_heater_doped_rib.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import gdsfactory as gf
@@ -29,7 +31,7 @@ def straight_heater_doped_rib(
     width: float = 0.5,
     xoffset_tip1: float = 0.2,
     xoffset_tip2: float = 0.4,
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Returns a doped thermal phase shifter.
 
@@ -99,7 +101,7 @@ def straight_heater_doped_rib(
         heater_width=heater_width,
         heater_gap=heater_gap,
         width=width,
-        **kwargs
+        **kwargs,
     )
 
     if taper:

--- a/gdsfactory/components/straight_heater_doped_strip.py
+++ b/gdsfactory/components/straight_heater_doped_strip.py
@@ -34,6 +34,8 @@ cross_section
 """
 
 
+from __future__ import annotations
+
 from functools import partial
 
 from gdsfactory.components.straight_heater_doped_rib import straight_heater_doped_rib

--- a/gdsfactory/components/straight_heater_meander.py
+++ b/gdsfactory/components/straight_heater_meander.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.via_stack import via_stack_heater_m3

--- a/gdsfactory/components/straight_heater_metal.py
+++ b/gdsfactory/components/straight_heater_metal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/straight_pin.py
+++ b/gdsfactory/components/straight_pin.py
@@ -1,4 +1,6 @@
 """Straight Doped PIN waveguide."""
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/straight_pin_slot.py
+++ b/gdsfactory/components/straight_pin_slot.py
@@ -1,4 +1,6 @@
 """Straight Doped PIN waveguide."""
+from __future__ import annotations
+
 from typing import Optional
 
 import gdsfactory as gf

--- a/gdsfactory/components/straight_rib.py
+++ b/gdsfactory/components/straight_rib.py
@@ -1,5 +1,7 @@
 """Straight Doped PIN waveguide."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.extension import extend_ports
 from gdsfactory.components.straight import straight

--- a/gdsfactory/components/switch_tree.py
+++ b/gdsfactory/components/switch_tree.py
@@ -14,6 +14,8 @@ _|  |__          |dy
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.components.mmi2x2 import mmi2x2
 from gdsfactory.components.mzi import mzi1x2_2x2

--- a/gdsfactory/components/taper.py
+++ b/gdsfactory/components/taper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional
 
 import gdsfactory as gf
@@ -17,7 +19,7 @@ def taper(
     with_bbox: bool = True,
     with_two_ports: bool = True,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Linear taper.
 

--- a/gdsfactory/components/taper_adiabatic.py
+++ b/gdsfactory/components/taper_adiabatic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 import numpy as np

--- a/gdsfactory/components/taper_cross_section.py
+++ b/gdsfactory/components/taper_cross_section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component
@@ -13,7 +15,7 @@ def taper_cross_section(
     npoints: int = 100,
     linear: bool = False,
     width_type: str = "sine",
-    **kwargs
+    **kwargs,
 ) -> Component:
     r"""Returns taper transition between cross_section1 and cross_section2.
 

--- a/gdsfactory/components/taper_from_csv.py
+++ b/gdsfactory/components/taper_from_csv.py
@@ -1,4 +1,6 @@
 """Adiabatic tapers from CSV files."""
+from __future__ import annotations
+
 import pathlib
 from functools import partial
 from pathlib import Path

--- a/gdsfactory/components/taper_parabolic.py
+++ b/gdsfactory/components/taper_parabolic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/components/text.py
+++ b/gdsfactory/components/text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/components/text_freetype.py
+++ b/gdsfactory/components/text_freetype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import warnings
 

--- a/gdsfactory/components/text_rectangular.py
+++ b/gdsfactory/components/text_rectangular.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/text_rectangular_font.py
+++ b/gdsfactory/components/text_rectangular_font.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 from typing import Dict
 

--- a/gdsfactory/components/triangles.py
+++ b/gdsfactory/components/triangles.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 
 from gdsfactory.cell import cell

--- a/gdsfactory/components/verniers.py
+++ b/gdsfactory/components/verniers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import Floats, LayerSpec
@@ -9,7 +11,7 @@ def verniers(
     gap: float = 0.1,
     xsize: int = 100,
     layer_label: LayerSpec = "LABEL",
-    **kwargs
+    **kwargs,
 ) -> Component:
     c = gf.Component()
     y = 0

--- a/gdsfactory/components/version_stamp.py
+++ b/gdsfactory/components/version_stamp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import platform
 from typing import Optional, Tuple

--- a/gdsfactory/components/via.py
+++ b/gdsfactory/components/via.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/components/via_corner.py
+++ b/gdsfactory/components/via_corner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from numpy import floor

--- a/gdsfactory/components/via_cutback.py
+++ b/gdsfactory/components/via_cutback.py
@@ -1,5 +1,7 @@
 """Via cutback."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_pins import LayerSpec
 from gdsfactory.component import Component

--- a/gdsfactory/components/via_stack.py
+++ b/gdsfactory/components/via_stack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 from numpy import floor

--- a/gdsfactory/components/via_stack_slot.py
+++ b/gdsfactory/components/via_stack_slot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from numpy import floor

--- a/gdsfactory/components/via_stack_with_offset.py
+++ b/gdsfactory/components/via_stack_with_offset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 from numpy import floor

--- a/gdsfactory/components/wafer.py
+++ b/gdsfactory/components/wafer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.types import Component, ComponentSpec, Optional, Tuple
 

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -1,5 +1,7 @@
 """Wires for electrical manhattan routes."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight

--- a/gdsfactory/components/wire_sbend.py
+++ b/gdsfactory/components/wire_sbend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.wire import wire_corner, wire_straight

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -12,6 +12,8 @@ PATH has all your computer specific paths that we do not care to store
 
 """
 
+from __future__ import annotations
+
 import io
 import json
 import os

--- a/gdsfactory/conftest.py
+++ b/gdsfactory/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from _pytest.fixtures import SubRequest
 

--- a/gdsfactory/containers.py
+++ b/gdsfactory/containers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from gdsfactory.add_padding import add_padding_container

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -2,11 +2,14 @@
 
 To create a component you need to extrude the path with a cross-section.
 """
+from __future__ import annotations
+
+import inspect
 import sys
 from collections.abc import Iterable
 from functools import partial
 from inspect import getmembers
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, get_type_hints
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pydantic
 from pydantic import BaseModel, Field
@@ -1364,8 +1367,10 @@ def get_cross_section_factories(
         for t in getmembers(module):
             if callable(t[1]) and t[0] != "partial":
                 try:
-                    r = get_type_hints(t[1]).get("return")
-                    if r == CrossSection:
+                    r = inspect.signature(t[1]).return_annotation
+                    if r == CrossSection or (
+                        isinstance(r, str) and r.endswith("CrossSection")
+                    ):
                         xs[t[0]] = t[1]
                 except ValueError:
                     if verbose:

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -2,12 +2,11 @@
 
 To create a component you need to extrude the path with a cross-section.
 """
-import inspect
 import sys
 from collections.abc import Iterable
 from functools import partial
 from inspect import getmembers
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, get_type_hints
 
 import pydantic
 from pydantic import BaseModel, Field
@@ -1365,7 +1364,7 @@ def get_cross_section_factories(
         for t in getmembers(module):
             if callable(t[1]) and t[0] != "partial":
                 try:
-                    r = inspect.signature(t[1]).return_annotation
+                    r = get_type_hints(t[1]).get("return")
                     if r == CrossSection:
                         xs[t[0]] = t[1]
                 except ValueError:

--- a/gdsfactory/decorators.py
+++ b/gdsfactory/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.pdk import get_grid_size
 from gdsfactory.snap import is_on_grid

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -1,6 +1,7 @@
 """GDS regression test. Adapted from lytest.
 
 TODO: adapt it into pytest_regressions
+from __future__ import annotations
 from pytest_regressions.file_regression import FileRegressionFixture
 class GdsRegressionFixture(FileRegressionFixture):
     def check(self,

--- a/gdsfactory/events.py
+++ b/gdsfactory/events.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 

--- a/gdsfactory/export/__init__.py
+++ b/gdsfactory/export/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.export.to_3d import to_3d
 from gdsfactory.export.to_np import to_np
 from gdsfactory.export.to_stl import to_stl

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import shapely

--- a/gdsfactory/export/to_np.py
+++ b/gdsfactory/export/to_np.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from typing import Optional, Tuple
 

--- a/gdsfactory/filestorage.py
+++ b/gdsfactory/filestorage.py
@@ -1,5 +1,7 @@
 """Store files."""
 
+from __future__ import annotations
+
 from io import BytesIO
 
 import numpy as np

--- a/gdsfactory/fill.py
+++ b/gdsfactory/fill.py
@@ -1,4 +1,6 @@
 """Dummy fill to keep density constant."""
+from __future__ import annotations
+
 import itertools
 from typing import Optional, Union
 

--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -1,6 +1,8 @@
 """Support for font rendering in GDS files."""
 
 
+from __future__ import annotations
+
 import gdstk
 import numpy as np
 from matplotlib import font_manager

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -6,6 +6,8 @@ There are two types of functions:
 - containers: return a new component
 
 """
+from __future__ import annotations
+
 from functools import lru_cache, partial
 
 import numpy as np

--- a/gdsfactory/gdsdiff/gds_diff_git.py
+++ b/gdsfactory/gdsdiff/gds_diff_git.py
@@ -6,6 +6,8 @@ The function needs to take the arguments as described in
 https://git-scm.com/docs/git/2.18.0#git-codeGITEXTERNALDIFFcode
 
 """
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/gdsfactory/gdsdiff/gdsdiff.py
+++ b/gdsfactory/gdsdiff/gdsdiff.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import pathlib
 from pathlib import Path

--- a/gdsfactory/gdsdiff/install.py
+++ b/gdsfactory/gdsdiff/install.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import pathlib
 import shutil

--- a/gdsfactory/gdsdiff/sample.py
+++ b/gdsfactory/gdsdiff/sample.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.gdsdiff.gdsdiff import gdsdiff
 

--- a/gdsfactory/gdsdiff/test_xor.py
+++ b/gdsfactory/gdsdiff/test_xor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.gdsdiff.gdsdiff import xor_polygons
 

--- a/gdsfactory/geometry/__init__.py
+++ b/gdsfactory/geometry/__init__.py
@@ -1,5 +1,7 @@
 """Geometric operations: Booleans, DRC checks."""
 
+from __future__ import annotations
+
 from gdsfactory.geometry import functions
 from gdsfactory.geometry.boolean import boolean
 from gdsfactory.geometry.boolean_klayout import boolean_klayout

--- a/gdsfactory/geometry/boolean.py
+++ b/gdsfactory/geometry/boolean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple, Union
 
 import gdstk

--- a/gdsfactory/geometry/boolean_klayout.py
+++ b/gdsfactory/geometry/boolean_klayout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 import uuid

--- a/gdsfactory/geometry/check_duplicated_cells.py
+++ b/gdsfactory/geometry/check_duplicated_cells.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union
 

--- a/gdsfactory/geometry/check_exclusion.py
+++ b/gdsfactory/geometry/check_exclusion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from gdsfactory.types import ComponentOrPath

--- a/gdsfactory/geometry/check_inclusion.py
+++ b/gdsfactory/geometry/check_inclusion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from gdsfactory.types import ComponentOrPath

--- a/gdsfactory/geometry/check_space.py
+++ b/gdsfactory/geometry/check_space.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from gdsfactory.component import Component

--- a/gdsfactory/geometry/check_width.py
+++ b/gdsfactory/geometry/check_width.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Tuple, Union
 

--- a/gdsfactory/geometry/functions.py
+++ b/gdsfactory/geometry/functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Union
 
 import numpy as np

--- a/gdsfactory/geometry/get_xsection_script.py
+++ b/gdsfactory/geometry/get_xsection_script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from gdsfactory.tech import LAYER

--- a/gdsfactory/geometry/invert.py
+++ b/gdsfactory/geometry/invert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.geometry.boolean import boolean

--- a/gdsfactory/geometry/offset.py
+++ b/gdsfactory/geometry/offset.py
@@ -1,5 +1,7 @@
 """Based on phidl.geometry."""
 
+from __future__ import annotations
+
 import gdstk
 
 import gdsfactory as gf

--- a/gdsfactory/geometry/outline.py
+++ b/gdsfactory/geometry/outline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union
 
 import gdsfactory as gf

--- a/gdsfactory/geometry/trim.py
+++ b/gdsfactory/geometry/trim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 import gdstk

--- a/gdsfactory/geometry/union.py
+++ b/gdsfactory/geometry/union.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdstk
 
 import gdsfactory as gf

--- a/gdsfactory/geometry/write_drc.py
+++ b/gdsfactory/geometry/write_drc.py
@@ -10,6 +10,8 @@ More DRC examples:
 - https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/tree/main/rules/klayout
 """
 
+from __future__ import annotations
+
 import pathlib
 from dataclasses import asdict, is_dataclass
 from typing import List, Optional

--- a/gdsfactory/geometry/xor_diff.py
+++ b/gdsfactory/geometry/xor_diff.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdstk
 
 import gdsfactory as gf

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
-from inspect import getmembers
-from typing import get_type_hints
+from inspect import getmembers, signature
 
 from gdsfactory.types import Component, ComponentFactory, Dict
 
@@ -20,8 +21,10 @@ def get_cells(modules, verbose: bool = False) -> Dict[str, ComponentFactory]:
         for t in getmembers(module):
             if callable(t[1]) and t[0] != "partial":
                 try:
-                    r = get_type_hints(t[1]).get("return")
-                    if r == Component:
+                    r = signature(t[1]).return_annotation
+                    if r == Component or (
+                        isinstance(r, str) and r.endswith("Component")
+                    ):
                         cells[t[0]] = t[1]
                 except ValueError:
                     if verbose:

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -1,6 +1,6 @@
-import inspect
 from collections.abc import Iterable
 from inspect import getmembers
+from typing import get_type_hints
 
 from gdsfactory.types import Component, ComponentFactory, Dict
 
@@ -20,7 +20,7 @@ def get_cells(modules, verbose: bool = False) -> Dict[str, ComponentFactory]:
         for t in getmembers(module):
             if callable(t[1]) and t[0] != "partial":
                 try:
-                    r = inspect.signature(t[1]).return_annotation
+                    r = get_type_hints(t[1]).get("return")
                     if r == Component:
                         cells[t[0]] = t[1]
                 except ValueError:

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -16,6 +16,8 @@ Assumes two ports are connected when they have same width, x, y
 
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 

--- a/gdsfactory/get_netlist_klayout.py
+++ b/gdsfactory/get_netlist_klayout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.types import ComponentOrPath
 
 

--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -1,4 +1,6 @@
 """pack a list of components into a grid."""
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/install.py
+++ b/gdsfactory/install.py
@@ -1,4 +1,6 @@
 """Install Klayout and GIT plugins."""
+from __future__ import annotations
+
 import configparser
 import os
 import pathlib

--- a/gdsfactory/klayout/drc/errors.py
+++ b/gdsfactory/klayout/drc/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import Float2, Layer

--- a/gdsfactory/klayout/drc/write_drc.py
+++ b/gdsfactory/klayout/drc/write_drc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gdsfactory as gf

--- a/gdsfactory/klayout/python/kgdsfactory/__init__.py
+++ b/gdsfactory/klayout/python/kgdsfactory/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from kgdsfactory.shortcuts import set_shortcuts
 
 __all__ = ("set_shortcuts",)

--- a/gdsfactory/klayout/python/kgdsfactory/shortcuts.py
+++ b/gdsfactory/klayout/python/kgdsfactory/shortcuts.py
@@ -1,5 +1,7 @@
 """Keybindings inspired by SiEPIC tools."""
 
+from __future__ import annotations
+
 import pya
 
 

--- a/gdsfactory/klayout/tech/write_klayout_pyxs.py
+++ b/gdsfactory/klayout/tech/write_klayout_pyxs.py
@@ -4,6 +4,8 @@ https://gdsfactory.github.io/klayout_pyxs/DocGrow.html
 
 """
 
+from __future__ import annotations
+
 import pathlib
 
 from gdsfactory.geometry.get_xsection_script import get_xsection_script

--- a/gdsfactory/klayout_tech.py
+++ b/gdsfactory/klayout_tech.py
@@ -3,6 +3,8 @@
 This module will enable conversion between gdsfactory settings and KLayout technology.
 """
 
+from __future__ import annotations
+
 import os
 import pathlib
 import re
@@ -77,7 +79,7 @@ class LayerView(BaseModel):
     marked: bool = False
     xfill: bool = False
     animation: int = 0
-    group_members: Dict[str, "LayerView"] = Field(default_factory=dict)
+    group_members: Dict[str, LayerView] = Field(default_factory=dict)
 
     def __init__(self, **data):
         """Initialize LayerView object."""
@@ -246,7 +248,7 @@ class CustomPatterns(BaseModel):
             file.write(yaml.safe_dump_all([self.dict()], indent=2, sort_keys=False))
 
     @staticmethod
-    def from_yaml(filename: str) -> "CustomPatterns":
+    def from_yaml(filename: str) -> CustomPatterns:
         """Import a CustomPatterns object from a yaml file.
 
         Args:
@@ -484,7 +486,7 @@ class LayerDisplayProperties(BaseModel):
     @staticmethod
     def from_lyp(
         filepath: str, layer_pattern: Optional[Union[str, re.Pattern]] = None
-    ) -> "LayerDisplayProperties":
+    ) -> LayerDisplayProperties:
         r"""Write all layer properties to a KLayout .lyp file.
 
         Args:
@@ -561,7 +563,7 @@ class LayerDisplayProperties(BaseModel):
     @staticmethod
     def from_yaml(
         layer_file: str = None, pattern_file: Optional[str] = None
-    ) -> "LayerDisplayProperties":
+    ) -> LayerDisplayProperties:
         """Import layer properties from two yaml files.
 
         Args:

--- a/gdsfactory/klive.py
+++ b/gdsfactory/klive.py
@@ -6,6 +6,8 @@ You can install gdsfactory klayout integration:
 - install the Klayout plugin through klayout package manager.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/gdsfactory/labels/__init__.py
+++ b/gdsfactory/labels/__init__.py
@@ -1,5 +1,7 @@
 """Design For Testing module includes test protocols."""
 
+from __future__ import annotations
+
 from gdsfactory.labels import ehva, siepic, write_labels
 from gdsfactory.labels.add_label_yaml import add_label_yaml
 from gdsfactory.labels.ehva import DFT, Dft, add_label_ehva

--- a/gdsfactory/labels/add_label_yaml.py
+++ b/gdsfactory/labels/add_label_yaml.py
@@ -1,4 +1,6 @@
 """Add label YAML."""
+from __future__ import annotations
+
 from typing import List, Optional
 
 import flatdict

--- a/gdsfactory/labels/ehva.py
+++ b/gdsfactory/labels/ehva.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Tuple
 
 import flatdict

--- a/gdsfactory/labels/merge_test_metadata.py
+++ b/gdsfactory/labels/merge_test_metadata.py
@@ -1,4 +1,6 @@
 """Merge mask metadata with test labels to return test_metadata."""
+from __future__ import annotations
+
 import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/gdsfactory/labels/siepic.py
+++ b/gdsfactory/labels/siepic.py
@@ -1,5 +1,7 @@
 """SiEPIC labels one grating coupler from the fiber array using a GDS label."""
 
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/labels/write_labels.py
+++ b/gdsfactory/labels/write_labels.py
@@ -1,5 +1,7 @@
 """Find GDS labels and write them to a CSV file."""
 
+from __future__ import annotations
+
 import csv
 import pathlib
 from pathlib import Path

--- a/gdsfactory/layers.py
+++ b/gdsfactory/layers.py
@@ -10,6 +10,8 @@ load_lyp, name_to_description, name_to_short_name based on phidl.utilities
 preview_layerset based on phidl.geometry
 
 """
+from __future__ import annotations
+
 import pathlib
 from functools import partial
 from pathlib import Path

--- a/gdsfactory/name.py
+++ b/gdsfactory/name.py
@@ -1,4 +1,6 @@
 """Define names, clean values for names."""
+from __future__ import annotations
+
 import hashlib
 from typing import Any
 

--- a/gdsfactory/pack.py
+++ b/gdsfactory/pack.py
@@ -4,6 +4,8 @@ based on phidl.geometry.
 
 """
 
+from __future__ import annotations
+
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -5,6 +5,8 @@ The CrossSection defines the layer numbers, widths and offsetts
 Based on phidl.path
 """
 
+from __future__ import annotations
+
 import hashlib
 import warnings
 from collections.abc import Iterable

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -1,5 +1,7 @@
 """PDK stores layers, cross_sections, cell functions ..."""
 
+from __future__ import annotations
+
 import logging
 import pathlib
 import warnings
@@ -78,7 +80,7 @@ class Pdk(BaseModel):
     cross_sections: Dict[str, CrossSectionFactory] = Field(default_factory=dict)
     cells: Dict[str, ComponentFactory] = Field(default_factory=dict)
     containers: Dict[str, ComponentFactory] = containers_default
-    base_pdk: Optional["Pdk"] = None
+    base_pdk: Optional[Pdk] = None
     default_decorator: Optional[Callable[[Component], None]] = None
     layers: Dict[str, Layer] = Field(default_factory=dict)
     layer_stack: Optional[LayerStack] = None

--- a/gdsfactory/pixelate.py
+++ b/gdsfactory/pixelate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools as it
 from typing import Optional
 

--- a/gdsfactory/quickplotter.py
+++ b/gdsfactory/quickplotter.py
@@ -3,6 +3,8 @@
 based on phidl.quickplotter.
 """
 
+from __future__ import annotations
+
 import sys
 from typing import Optional
 

--- a/gdsfactory/read/__init__.py
+++ b/gdsfactory/read/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.read.from_dphox import from_dphox
 from gdsfactory.read.from_gdspaths import from_gdsdir, from_gdspaths
 from gdsfactory.read.from_np import from_np

--- a/gdsfactory/read/from_dphox.py
+++ b/gdsfactory/read/from_dphox.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from gdsfactory.component import Component, ComponentReference
 
 
-def from_dphox(device: "dp.Device", foundry: "dp.foundry.Foundry") -> Component:
+def from_dphox(device: dp.Device, foundry: dp.foundry.Foundry) -> Component:
     """Returns Gdsfactory Component from a dphox Device.
 
     Note that you need to install dphox `pip install dphox`

--- a/gdsfactory/read/from_gdspaths.py
+++ b/gdsfactory/read/from_gdspaths.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from typing import Tuple
 

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -1,4 +1,6 @@
 """Read component from a numpy.ndarray."""
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/read/from_phidl.py
+++ b/gdsfactory/read/from_phidl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 from functools import lru_cache

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -46,6 +46,8 @@ routes:
             radius: 10
 
 """
+from __future__ import annotations
+
 import importlib
 import io
 import pathlib

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Optional, Union
 

--- a/gdsfactory/read/labels.py
+++ b/gdsfactory/read/labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional
 
 import numpy as np

--- a/gdsfactory/routing/__init__.py
+++ b/gdsfactory/routing/__init__.py
@@ -1,5 +1,7 @@
 """Functions to create routes between components."""
 
+from __future__ import annotations
+
 from gdsfactory.routing import sort_ports, utils
 from gdsfactory.routing.add_electrical_pads_shortest import add_electrical_pads_shortest
 from gdsfactory.routing.add_electrical_pads_top import add_electrical_pads_top

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight

--- a/gdsfactory/routing/add_electrical_pads_top.py
+++ b/gdsfactory/routing/add_electrical_pads_top.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.pad import pad_array as pad_array_function

--- a/gdsfactory/routing/add_electrical_pads_top_dc.py
+++ b/gdsfactory/routing/add_electrical_pads_top_dc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 import gdsfactory as gf

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from typing import Callable, Optional, Tuple
 

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Optional
 
 import gdsfactory as gf

--- a/gdsfactory/routing/factories.py
+++ b/gdsfactory/routing/factories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.routing.get_bundle import (
     get_bundle,
     get_bundle_electrical,

--- a/gdsfactory/routing/fanout.py
+++ b/gdsfactory/routing/fanout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/routing/fanout2x2.py
+++ b/gdsfactory/routing/fanout2x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Optional
 
 import gdsfactory as gf
@@ -16,7 +18,7 @@ def fanout2x2(
     npoints: int = 101,
     select_ports: Callable = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns component with Sbend fanout routes.
 

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -9,6 +9,8 @@ get_bundle calls different function depending on the port orientation.
  - get_bundle_uindirect: ports with indirect U-turns
 
 """
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable, List, Optional, Union
 

--- a/gdsfactory/routing/get_bundle_corner.py
+++ b/gdsfactory/routing/get_bundle_corner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List
 
 import numpy as np

--- a/gdsfactory/routing/get_bundle_from_steps.py
+++ b/gdsfactory/routing/get_bundle_from_steps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -33,7 +35,7 @@ def get_bundle_from_steps(
     path_length_match_loops: int = None,
     path_length_match_extra_length: float = 0.0,
     path_length_match_modify_segment_i: int = -2,
-    **kwargs
+    **kwargs,
 ) -> List[Route]:
     """Returns a list of routes formed by the given waypoints steps.
 

--- a/gdsfactory/routing/get_bundle_from_waypoints.py
+++ b/gdsfactory/routing/get_bundle_from_waypoints.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np

--- a/gdsfactory/routing/get_bundle_path_length_match.py
+++ b/gdsfactory/routing/get_bundle_path_length_match.py
@@ -1,4 +1,6 @@
 """Routes bundles of ports (river routing)."""
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Union
 
 from gdsfactory.components.bend_euler import bend_euler
@@ -36,7 +38,7 @@ def get_bundle_path_length_match(
     route_filter: Callable = get_route_from_waypoints,
     sort_ports: bool = True,
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = strip,
-    **kwargs
+    **kwargs,
 ) -> List[Route]:
     """Returns list of routes that are path length matched.
 

--- a/gdsfactory/routing/get_bundle_sbend.py
+++ b/gdsfactory/routing/get_bundle_sbend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from gdsfactory.components.bend_s import bend_s

--- a/gdsfactory/routing/get_bundle_u.py
+++ b/gdsfactory/routing/get_bundle_u.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np

--- a/gdsfactory/routing/get_input_labels.py
+++ b/gdsfactory/routing/get_input_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from gdsfactory.add_labels import get_input_label, get_input_label_text

--- a/gdsfactory/routing/get_route.py
+++ b/gdsfactory/routing/get_route.py
@@ -32,6 +32,8 @@ To generate a straight route:
 - length: a float with the length of the route
 
 """
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable, Optional, Union
 

--- a/gdsfactory/routing/get_route_astar.py
+++ b/gdsfactory/routing/get_route_astar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from warnings import warn
 

--- a/gdsfactory/routing/get_route_from_steps.py
+++ b/gdsfactory/routing/get_route_from_steps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -21,7 +23,7 @@ def get_route_from_steps(
     bend: ComponentSpec = "bend_euler",
     taper: Optional[ComponentSpec] = "taper",
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
-    **kwargs
+    **kwargs,
 ) -> Route:
     """Returns a route formed by the given waypoints steps.
 

--- a/gdsfactory/routing/get_route_sbend.py
+++ b/gdsfactory/routing/get_route_sbend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.components.bend_s import bend_s
 from gdsfactory.port import Port
 from gdsfactory.types import Route

--- a/gdsfactory/routing/get_routes_bend180.py
+++ b/gdsfactory/routing/get_routes_bend180.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Union
 
 import gdsfactory as gf

--- a/gdsfactory/routing/get_routes_straight.py
+++ b/gdsfactory/routing/get_routes_straight.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Union
 
 import gdsfactory as gf

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import uuid
 import warnings
 from typing import Callable, Dict, List, Optional, Tuple, Union

--- a/gdsfactory/routing/path_length_matching.py
+++ b/gdsfactory/routing/path_length_matching.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Union
 
 import numpy as np

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple, Union
 
 import gdsfactory as gf

--- a/gdsfactory/routing/route_fiber_single.py
+++ b/gdsfactory/routing/route_fiber_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple, Union
 
 import gdstk

--- a/gdsfactory/routing/route_ports_to_side.py
+++ b/gdsfactory/routing/route_ports_to_side.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -1,4 +1,6 @@
 """Route for electrical based on phidl.routing.route_quad."""
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -1,4 +1,6 @@
 """based on phidl.routing."""
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import numpy as np
@@ -273,7 +275,7 @@ def route_sharp(
     layer: Optional[LayerSpec] = None,
     cross_section: Optional[CrossSectionSpec] = None,
     port_names: Tuple[str, str] = ("o1", "o2"),
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Returns Component route between ports.
 

--- a/gdsfactory/routing/route_south.py
+++ b/gdsfactory/routing/route_south.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, List, Optional, Tuple
 
 import numpy as np

--- a/gdsfactory/routing/sort_ports.py
+++ b/gdsfactory/routing/sort_ports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Tuple
 
 from gdsfactory.port import Port
@@ -66,7 +68,6 @@ def sort_ports(ports1: List[Port], ports2: List[Port]) -> Tuple[List[Port], List
 if __name__ == "__main__":
     import gdsfactory as gf
     from gdsfactory.cell import cell
-    from gdsfactory.port import Port
 
     @cell
     def demo_connect_corner(N=6, config="A"):

--- a/gdsfactory/routing/utils.py
+++ b/gdsfactory/routing/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Union
 
 from numpy import float64

--- a/gdsfactory/samples/01_component_pcell.py
+++ b/gdsfactory/samples/01_component_pcell.py
@@ -8,6 +8,8 @@ happening
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.types import LayerSpec
 

--- a/gdsfactory/samples/01_component_pcell_with_pins.py
+++ b/gdsfactory/samples/01_component_pcell_with_pins.py
@@ -1,5 +1,7 @@
 """You can add pins in a pin layer to clearly see the component ports."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.types import LayerSpec
 

--- a/gdsfactory/samples/02_component_autoname.py
+++ b/gdsfactory/samples/02_component_autoname.py
@@ -5,6 +5,8 @@ parameters
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/samples/03_move.py
+++ b/gdsfactory/samples/03_move.py
@@ -6,6 +6,8 @@ There are several actions we can take to move and rotate the geometry.
 These actions include movement, rotation, and reflection.
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/04_connect.py
+++ b/gdsfactory/samples/04_connect.py
@@ -12,6 +12,8 @@ or with a negative number if you want to separate the ports.
 """
 
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/05_remove_layers.py
+++ b/gdsfactory/samples/05_remove_layers.py
@@ -1,6 +1,8 @@
 """You can remove a list of layers from a component."""
 
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/samples/06_remapping_layers.py
+++ b/gdsfactory/samples/06_remapping_layers.py
@@ -1,4 +1,6 @@
 """You can remap layers."""
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/samples/07_flattening_device.py
+++ b/gdsfactory/samples/07_flattening_device.py
@@ -11,6 +11,8 @@ Also, if you specify the `single_layer` argument it will move all of the
 polygons to that single layer.
 
 """
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/samples/11_component_layout.py
+++ b/gdsfactory/samples/11_component_layout.py
@@ -10,6 +10,8 @@ Lets build straight crossing out of a vertical and horizontal arm
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory import LAYER
 from gdsfactory.component import Component

--- a/gdsfactory/samples/12_component_refs.py
+++ b/gdsfactory/samples/12_component_refs.py
@@ -6,6 +6,8 @@
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import Layer

--- a/gdsfactory/samples/13_component_netlist.py
+++ b/gdsfactory/samples/13_component_netlist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/samples/14_component_connectivity.py
+++ b/gdsfactory/samples/14_component_connectivity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import ComponentSpec, CrossSectionSpec
@@ -13,7 +15,7 @@ def ring_single_sample(
     straight: ComponentSpec = "straight",
     bend: ComponentSpec = "bend_euler",
     cross_section: CrossSectionSpec = "strip",
-    **kwargs
+    **kwargs,
 ) -> Component:
     """Single bus ring made of a ring coupler.
 
@@ -52,7 +54,7 @@ def ring_single_sample(
         radius=radius,
         length_x=length_x,
         cross_section=cross_section,
-        **kwargs
+        **kwargs,
     )
     straight_side = gf.get_component(
         straight, length=length_y, cross_section=cross_section, **kwargs

--- a/gdsfactory/samples/15_component_sequence1.py
+++ b/gdsfactory/samples/15_component_sequence1.py
@@ -8,6 +8,8 @@ The actual chain of components is supplied by a string or a list
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components import bend_circular

--- a/gdsfactory/samples/16_component_sequence2.py
+++ b/gdsfactory/samples/16_component_sequence2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.component_sequence import component_sequence

--- a/gdsfactory/samples/17_ports.py
+++ b/gdsfactory/samples/17_ports.py
@@ -8,6 +8,8 @@
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import LayerSpec

--- a/gdsfactory/samples/18_port_markers.py
+++ b/gdsfactory/samples/18_port_markers.py
@@ -1,4 +1,6 @@
 """You can define a function to add pins."""
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_pins import add_pins_triangle
 from gdsfactory.component import Component

--- a/gdsfactory/samples/19_references.py
+++ b/gdsfactory/samples/19_references.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 yaml = """

--- a/gdsfactory/samples/20_components.py
+++ b/gdsfactory/samples/20_components.py
@@ -1,6 +1,8 @@
 """# Components. You can adapt some component functions from the `gdsfactory.components` module. Each function there returns a Component object. Here are two equivalent functions."""
 
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/samples/21_add_fiber_array.py
+++ b/gdsfactory/samples/21_add_fiber_array.py
@@ -1,5 +1,7 @@
 """You can route all component optical ports to a fiber array."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.samples.big_device import big_device

--- a/gdsfactory/samples/22_add_fiber_single.py
+++ b/gdsfactory/samples/22_add_fiber_single.py
@@ -1,5 +1,7 @@
 """You can also connect a component with single fiber INPUT and OUTPUTS (no fiber array)."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.samples.big_device import big_device

--- a/gdsfactory/samples/22_add_pads.py
+++ b/gdsfactory/samples/22_add_pads.py
@@ -1,5 +1,7 @@
 """You can also use the fiber array routing functions for connecting to pads."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.samples.big_device import big_device
 

--- a/gdsfactory/samples/23_reticle.py
+++ b/gdsfactory/samples/23_reticle.py
@@ -1,5 +1,7 @@
 """Sample of a reticle top level Component."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.types import Component
 

--- a/gdsfactory/samples/23_reticle_passives.py
+++ b/gdsfactory/samples/23_reticle_passives.py
@@ -1,5 +1,7 @@
 """Write a sample reticle together with GDS file."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.labels import add_label_yaml
 from gdsfactory.read.labels import add_port_markers

--- a/gdsfactory/samples/24_doe.py
+++ b/gdsfactory/samples/24_doe.py
@@ -4,6 +4,8 @@ by Jan-David Fischbach
 email: jan-david.fischbach@blacksemicon.de
 date: 26.06.22
 """
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/24_doe_2.py
+++ b/gdsfactory/samples/24_doe_2.py
@@ -5,6 +5,8 @@ In this case add_fiber_array does not add labels.
 You can use gf.add_labels.add_labels_to_ports.
 
 """
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/24_doe_3.py
+++ b/gdsfactory/samples/24_doe_3.py
@@ -5,6 +5,8 @@ In this case add_fiber_array does not add labels.
 You can use gf.add_labels.add_labels_to_ports.
 
 """
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/25_slot_cross_section.py
+++ b/gdsfactory/samples/25_slot_cross_section.py
@@ -1,5 +1,7 @@
 """Small demonstration of the slot cross_section utilizing add_center_section=False."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/30_lidar.py
+++ b/gdsfactory/samples/30_lidar.py
@@ -6,6 +6,8 @@ Exercise2. Make a Pcell.
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/30_lidar_pcell.py
+++ b/gdsfactory/samples/30_lidar_pcell.py
@@ -6,6 +6,8 @@ Exercise2. Make a Pcell.
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/samples/30_lidar_with_pads.py
+++ b/gdsfactory/samples/30_lidar_with_pads.py
@@ -6,6 +6,8 @@ Exercise2. Make a Pcell.
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/big_device.py
+++ b/gdsfactory/samples/big_device.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/samples/demo/drc_errors.py
+++ b/gdsfactory/samples/demo/drc_errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.types import Float2, Layer

--- a/gdsfactory/samples/demo/drc_write.py
+++ b/gdsfactory/samples/demo/drc_write.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gdsfactory as gf

--- a/gdsfactory/samples/demo/layers.py
+++ b/gdsfactory/samples/demo/layers.py
@@ -1,4 +1,6 @@
 """Technology settings."""
+from __future__ import annotations
+
 import pathlib
 from typing import Tuple, Union
 

--- a/gdsfactory/samples/demo/layers_xsection.py
+++ b/gdsfactory/samples/demo/layers_xsection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/samples/demo/lvs.py
+++ b/gdsfactory/samples/demo/lvs.py
@@ -1,5 +1,7 @@
 """LVS demo."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/samples/demo/pcell.py
+++ b/gdsfactory/samples/demo/pcell.py
@@ -1,5 +1,7 @@
 """Pcell demo."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/samples/pdk/fab_c.py
+++ b/gdsfactory/samples/pdk/fab_c.py
@@ -1,5 +1,7 @@
 """FabC example."""
 
+from __future__ import annotations
+
 import pathlib
 from typing import Callable
 

--- a/gdsfactory/samples/pdk/fab_d/__init__.py
+++ b/gdsfactory/samples/pdk/fab_d/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .phase_shifters import (
     LAYER,
     ps_heater_doped,

--- a/gdsfactory/samples/pdk/fab_d/phase_shifters.py
+++ b/gdsfactory/samples/pdk/fab_d/phase_shifters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pydantic
 
 import gdsfactory as gf

--- a/gdsfactory/samples/pdk/test_fab_c.py
+++ b/gdsfactory/samples/pdk/test_fab_c.py
@@ -6,6 +6,7 @@ For your PDK i recommend that you store the store the reference GDS files on
 the same repo as you store the code. See code below
 
 ```
+from __future__ import annotations
 import pathlib
 
 dirpath = pathlib.Path(__file__).absolute().with_suffix(".gds")

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.types import ComponentModel, Dict, List, Optional
 
 

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -1,4 +1,6 @@
 """Serialize component settings into YAML or strings."""
+from __future__ import annotations
+
 import functools
 import hashlib
 import inspect

--- a/gdsfactory/show.py
+++ b/gdsfactory/show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from typing import Union
 

--- a/gdsfactory/simulation/__init__.py
+++ b/gdsfactory/simulation/__init__.py
@@ -1,5 +1,7 @@
 """gdsfactory interface to simulations."""
 
+from __future__ import annotations
+
 from gdsfactory.simulation import plot
 from gdsfactory.simulation.get_effective_indices import get_effective_indices
 from gdsfactory.simulation.get_sparameters_path import (

--- a/gdsfactory/simulation/add_simulation_markers.py
+++ b/gdsfactory/simulation/add_simulation_markers.py
@@ -1,4 +1,6 @@
 """Returns component with simulation markers."""
+from __future__ import annotations
+
 import warnings
 
 import numpy as np

--- a/gdsfactory/simulation/convert_sparameters.py
+++ b/gdsfactory/simulation/convert_sparameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import re
 

--- a/gdsfactory/simulation/devsim/__init__.py
+++ b/gdsfactory/simulation/devsim/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import devsim as tcad
 
 from gdsfactory.config import logger

--- a/gdsfactory/simulation/devsim/get_simulation.py
+++ b/gdsfactory/simulation/devsim/get_simulation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from itertools import combinations
 from typing import Dict, Optional, Tuple
 
@@ -203,7 +205,7 @@ def create_2Duz_simulation(
 if __name__ == "__main__":
 
     import gdsfactory as gf
-    from gdsfactory.tech import LayerStack, get_layer_stack_generic
+    from gdsfactory.tech import get_layer_stack_generic
 
     # We choose a representative subdomain of the component
     waveguide = gf.Component()

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -9,6 +9,8 @@ From Chrostowski, L., & Hochberg, M. (2015). Silicon Photonics Design: From Devi
 """
 
 
+from __future__ import annotations
+
 from typing import Optional
 
 import devsim

--- a/gdsfactory/simulation/devsim/get_solver.py
+++ b/gdsfactory/simulation/devsim/get_solver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -174,7 +176,7 @@ class DDComponent(BaseModel):
 if __name__ == "__main__":
 
     import gdsfactory as gf
-    from gdsfactory.tech import LayerStack, get_layer_stack_generic
+    from gdsfactory.tech import get_layer_stack_generic
 
     # We choose a representative subdomain of the component
     waveguide = gf.Component()

--- a/gdsfactory/simulation/disable_print.py
+++ b/gdsfactory/simulation/disable_print.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/gdsfactory/simulation/get_effective_indices.py
+++ b/gdsfactory/simulation/get_effective_indices.py
@@ -1,5 +1,7 @@
 """Calculate effective index for a 1D mode."""
 
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/gdsfactory/simulation/get_sparameters_path.py
+++ b/gdsfactory/simulation/get_sparameters_path.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import pathlib
 from copy import deepcopy

--- a/gdsfactory/simulation/gmeep/__init__.py
+++ b/gdsfactory/simulation/gmeep/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import meep as mp
 
 from gdsfactory.config import logger

--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Dict, Optional, Union
 

--- a/gdsfactory/simulation/gmeep/get_meep_geometry.py
+++ b/gdsfactory/simulation/gmeep/get_meep_geometry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Union
 
 import meep as mp

--- a/gdsfactory/simulation/gmeep/get_port_eigenmode.py
+++ b/gdsfactory/simulation/gmeep/get_port_eigenmode.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import meep as mp
 import numpy as np

--- a/gdsfactory/simulation/gmeep/get_simulation.py
+++ b/gdsfactory/simulation/gmeep/get_simulation.py
@@ -1,4 +1,6 @@
 """Returns simulation from component."""
+from __future__ import annotations
+
 import inspect
 import warnings
 from typing import Any, Dict, Optional, Union

--- a/gdsfactory/simulation/gmeep/get_simulation_grating_farfield.py
+++ b/gdsfactory/simulation/gmeep/get_simulation_grating_farfield.py
@@ -7,6 +7,8 @@
 - add tests
 
 """
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 
 import meep as mp

--- a/gdsfactory/simulation/gmeep/get_simulation_grating_fiber.py
+++ b/gdsfactory/simulation/gmeep/get_simulation_grating_fiber.py
@@ -9,6 +9,8 @@ MFD:
 
 """
 
+from __future__ import annotations
+
 import hashlib
 from typing import Any, Dict, Optional
 

--- a/gdsfactory/simulation/gmeep/meep_adjoint_optimization.py
+++ b/gdsfactory/simulation/gmeep/meep_adjoint_optimization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from types import LambdaType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 

--- a/gdsfactory/simulation/gmeep/test_eigenmode.py
+++ b/gdsfactory/simulation/gmeep/test_eigenmode.py
@@ -1,6 +1,8 @@
 """Compares the modes of a gdsfactory + MEEP waveguide cross-section vs a
 direct MPB calculation."""
 
+from __future__ import annotations
+
 import h5py
 import matplotlib.pyplot as plt
 import numpy as np

--- a/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
@@ -1,5 +1,7 @@
 """test meep sparameters."""
 
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/gmeep/write_sparameters_grating.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_grating.py
@@ -6,6 +6,8 @@ MFD:
 - 9.2 for Oband
 
 """
+from __future__ import annotations
+
 import hashlib
 import pathlib
 import shlex

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -1,5 +1,7 @@
 """Compute and write Sparameters using Meep."""
 
+from __future__ import annotations
+
 import inspect
 import multiprocessing
 import pathlib

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
@@ -1,5 +1,7 @@
 """Compute and write Sparameters using Meep in an MPI pool."""
 
+from __future__ import annotations
+
 import multiprocessing
 import pathlib
 import shutil

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -1,5 +1,7 @@
 """Compute and write Sparameters using Meep in MPI."""
 
+from __future__ import annotations
+
 import multiprocessing
 import pathlib
 import pickle

--- a/gdsfactory/simulation/gmsh/__init__.py
+++ b/gdsfactory/simulation/gmsh/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.simulation.gmsh.mesh import mesh_from_polygons
 from gdsfactory.simulation.gmsh.meshtracker import MeshTracker
 from gdsfactory.simulation.gmsh.parse_gds import (

--- a/gdsfactory/simulation/gmsh/mesh.py
+++ b/gdsfactory/simulation/gmsh/mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 from itertools import combinations
 from typing import Dict, Optional

--- a/gdsfactory/simulation/gmsh/meshtracker.py
+++ b/gdsfactory/simulation/gmsh/meshtracker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 
 import shapely

--- a/gdsfactory/simulation/gmsh/parse_gds.py
+++ b/gdsfactory/simulation/gmsh/parse_gds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shapely
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
 from shapely.ops import linemerge, split

--- a/gdsfactory/simulation/gmsh/parse_layerstack.py
+++ b/gdsfactory/simulation/gmsh/parse_layerstack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.tech import LayerStack

--- a/gdsfactory/simulation/gmsh/scratch/mesh3D.py
+++ b/gdsfactory/simulation/gmsh/scratch/mesh3D.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Optional, Tuple
 
 import pygmsh

--- a/gdsfactory/simulation/gmsh/tests/test_meshing.py
+++ b/gdsfactory/simulation/gmsh/tests/test_meshing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.simulation.gmsh.uz_xsection_mesh import uz_xsection_mesh
 from gdsfactory.simulation.gmsh.xy_xsection_mesh import xy_xsection_mesh

--- a/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 from typing import Dict, Optional, Tuple
 

--- a/gdsfactory/simulation/gtidy3d/__init__.py
+++ b/gdsfactory/simulation/gtidy3d/__init__.py
@@ -5,6 +5,8 @@ solver](https://simulation.cloud/)
 
 """
 
+from __future__ import annotations
+
 import tidy3d as td
 
 from gdsfactory.config import logger

--- a/gdsfactory/simulation/gtidy3d/get_results.py
+++ b/gdsfactory/simulation/gtidy3d/get_results.py
@@ -1,5 +1,7 @@
 """Tidy3D."""
 
+from __future__ import annotations
+
 import concurrent.futures
 import hashlib
 

--- a/gdsfactory/simulation/gtidy3d/get_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation.py
@@ -1,4 +1,6 @@
 """Returns tidy3d simulation from gdsfactory Component."""
+from __future__ import annotations
+
 import warnings
 from typing import Dict, Optional
 

--- a/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
@@ -1,4 +1,6 @@
 """Returns tidy3d simulation from gdsfactory Component."""
+from __future__ import annotations
+
 import warnings
 from typing import Dict, Optional
 

--- a/gdsfactory/simulation/gtidy3d/materials.py
+++ b/gdsfactory/simulation/gtidy3d/materials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Dict, Union
 

--- a/gdsfactory/simulation/gtidy3d/modes.py
+++ b/gdsfactory/simulation/gtidy3d/modes.py
@@ -9,6 +9,8 @@ tidy3d can:
 
 """
 
+from __future__ import annotations
+
 import itertools as it
 import pathlib
 import subprocess
@@ -654,7 +656,7 @@ class Waveguide(BaseModel):
         return ", \n".join([f"{k} = {getattr(self, k)!r}" for k in self.settings])
 
     def get_overlap(
-        self, wg: "Waveguide", mode_index1: int = 0, mode_index2: int = 0
+        self, wg: Waveguide, mode_index1: int = 0, mode_index2: int = 0
     ) -> float:
         """Returns mode overlap integral.
 

--- a/gdsfactory/simulation/gtidy3d/tests/test_modes.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_modes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory.simulation.gtidy3d as gt

--- a/gdsfactory/simulation/gtidy3d/tests/test_results.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_results.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 import gdsfactory.simulation.gtidy3d as gt
 from gdsfactory.config import PATH

--- a/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_simulation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 from jsondiff import diff

--- a/gdsfactory/simulation/gtidy3d/tests/test_write_sparameters.py
+++ b/gdsfactory/simulation/gtidy3d/tests/test_write_sparameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/gtidy3d/utils.py
+++ b/gdsfactory/simulation/gtidy3d/utils.py
@@ -1,5 +1,7 @@
 """gdsfactory tidy3d plugin utils."""
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Optional
 

--- a/gdsfactory/simulation/gtidy3d/write_sparameters.py
+++ b/gdsfactory/simulation/gtidy3d/write_sparameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 import numpy as np

--- a/gdsfactory/simulation/gtidy3d/write_sparameters_grating_coupler.py
+++ b/gdsfactory/simulation/gtidy3d/write_sparameters_grating_coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from typing import Any, Dict, Optional
 

--- a/gdsfactory/simulation/lumerical/__init__.py
+++ b/gdsfactory/simulation/lumerical/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.simulation.lumerical.interconnect import run_wavelength_sweep
 from gdsfactory.simulation.lumerical.read import read_sparameters_lumerical
 from gdsfactory.simulation.lumerical.write_sparameters_lumerical import (

--- a/gdsfactory/simulation/lumerical/interconnect.py
+++ b/gdsfactory/simulation/lumerical/interconnect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import pathlib
 from collections import OrderedDict

--- a/gdsfactory/simulation/lumerical/read.py
+++ b/gdsfactory/simulation/lumerical/read.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import List, Optional, Tuple

--- a/gdsfactory/simulation/lumerical/test_read_sparameters.py
+++ b/gdsfactory/simulation/lumerical/test_read_sparameters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory import components
 from gdsfactory.simulation.lumerical.read import read_sparameters_lumerical

--- a/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
@@ -1,4 +1,6 @@
 """Write Sparameters with Lumerical FDTD."""
+from __future__ import annotations
+
 import shutil
 import time
 from typing import Dict, Optional

--- a/gdsfactory/simulation/lumerical/write_sparameters_lumerical_components.py
+++ b/gdsfactory/simulation/lumerical/write_sparameters_lumerical_components.py
@@ -1,4 +1,6 @@
 """Write Sparameters with for different components."""
+from __future__ import annotations
+
 from typing import Optional
 
 from tqdm.auto import tqdm

--- a/gdsfactory/simulation/modes/__init__.py
+++ b/gdsfactory/simulation/modes/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.simulation.modes import coupler, waveguide
 from gdsfactory.simulation.modes.find_coupling_vs_gap import (
     find_coupling_vs_gap,

--- a/gdsfactory/simulation/modes/coupler.py
+++ b/gdsfactory/simulation/modes/coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/modes/find_coupling_vs_gap.py
+++ b/gdsfactory/simulation/modes/find_coupling_vs_gap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import matplotlib.pyplot as plt
@@ -65,7 +67,7 @@ def find_coupling_vs_gap(
     parity=mp.NO_PARITY,
     filepath: Optional[PathType] = None,
     overwrite: bool = False,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Returns coupling vs gap pandas DataFrame.
 

--- a/gdsfactory/simulation/modes/find_mode_dispersion.py
+++ b/gdsfactory/simulation/modes/find_mode_dispersion.py
@@ -1,5 +1,7 @@
 """Sweep neff over wavelength and returns group index."""
 
+from __future__ import annotations
+
 from functools import partial
 
 from gdsfactory.simulation.gmeep.get_material import get_index

--- a/gdsfactory/simulation/modes/find_modes.py
+++ b/gdsfactory/simulation/modes/find_modes.py
@@ -10,6 +10,8 @@ output as um/lambda, e.g. 1.5um would correspond to the frequency
 1/1.5 = 0.6667.
 
 """
+from __future__ import annotations
+
 import pickle
 from functools import partial
 from typing import Dict

--- a/gdsfactory/simulation/modes/find_modes_cross_section.py
+++ b/gdsfactory/simulation/modes/find_modes_cross_section.py
@@ -10,6 +10,8 @@ output as um/lambda, e.g. 1.5um would correspond to the frequency
 1/1.5 = 0.6667.
 
 """
+from __future__ import annotations
+
 import pickle
 from typing import Dict
 

--- a/gdsfactory/simulation/modes/find_neff_ng_dw_dh.py
+++ b/gdsfactory/simulation/modes/find_neff_ng_dw_dh.py
@@ -6,6 +6,8 @@ https://www.photonics.intec.ugent.be/contact/people.asp?ID=332
 
 """
 
+from __future__ import annotations
+
 import pathlib
 
 import matplotlib.pyplot as plt
@@ -35,7 +37,7 @@ def find_neff_ng_dw_dh(
     mode_number: int = 1,
     core: str = "Si",
     clad: str = "SiO2",
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Computes group and effective index for different widths and heights.
 
@@ -82,7 +84,7 @@ def find_neff_ng_dw_dh(
                 wg_thickness=thickness + dhi,
                 wavelength=wavelength,
                 mode_number=mode_number,
-                **kwargs
+                **kwargs,
             )
             neffs.append(m.neff)
             ngs.append(m.ng)
@@ -97,7 +99,7 @@ def plot_neff_ng_dw_dh(
     thickness: float = thickness0,
     wavelength: float = 1.55,
     mode_number: int = 1,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Plot neff and group index versus width (dw) and height (dh) variations.
 

--- a/gdsfactory/simulation/modes/find_neff_vs_width.py
+++ b/gdsfactory/simulation/modes/find_neff_vs_width.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import matplotlib.pyplot as plt
@@ -21,7 +23,7 @@ def find_neff_vs_width(
     parity=mp.NO_PARITY,
     filepath: Optional[PathType] = None,
     overwrite: bool = False,
-    **kwargs
+    **kwargs,
 ) -> pd.DataFrame:
     """Sweep waveguide width and compute effective index.
 
@@ -56,7 +58,7 @@ def find_neff_vs_width(
             parity=parity,
             nmodes=nmodes,
             wg_width=wg_width,
-            **kwargs
+            **kwargs,
         )
         for mode_number in range(1, nmodes + 1):
             mode = modes[mode_number]

--- a/gdsfactory/simulation/modes/get_mode_solver_coupler.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 from typing import Optional, Tuple, Union

--- a/gdsfactory/simulation/modes/get_mode_solver_cross_section.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_cross_section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 from typing import Dict, Optional, Union

--- a/gdsfactory/simulation/modes/get_mode_solver_rib.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_rib.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 from typing import Optional

--- a/gdsfactory/simulation/modes/neff_convergence_test.py
+++ b/gdsfactory/simulation/modes/neff_convergence_test.py
@@ -6,6 +6,8 @@ Output the results of `find_modes_waveguide` and the smallest
 hyperparameters that allowed convergence.
 
 """
+from __future__ import annotations
+
 from typing import Dict, Tuple
 
 import meep as mp

--- a/gdsfactory/simulation/modes/overlap.py
+++ b/gdsfactory/simulation/modes/overlap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory.simulation.modes as gm

--- a/gdsfactory/simulation/modes/tests/test_dw_dh.py
+++ b/gdsfactory/simulation/modes/tests/test_dw_dh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.simulation.modes.find_neff_ng_dw_dh import find_neff_ng_dw_dh
 
 

--- a/gdsfactory/simulation/modes/tests/test_find_modes.py
+++ b/gdsfactory/simulation/modes/tests/test_find_modes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.simulation.modes.find_modes import find_modes_waveguide

--- a/gdsfactory/simulation/modes/tests/test_find_modes_dispersion.py
+++ b/gdsfactory/simulation/modes/tests/test_find_modes_dispersion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from gdsfactory.simulation.modes.find_mode_dispersion import find_mode_dispersion

--- a/gdsfactory/simulation/modes/tests/test_neff_vs_width.py
+++ b/gdsfactory/simulation/modes/tests/test_neff_vs_width.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory.simulation.modes as gm
 
 

--- a/gdsfactory/simulation/modes/types.py
+++ b/gdsfactory/simulation/modes/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Dict, List, Optional, Union
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/simulation/modes/waveguide.py
+++ b/gdsfactory/simulation/modes/waveguide.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/photonic_circuit_models/coupler.py
+++ b/gdsfactory/simulation/photonic_circuit_models/coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/gdsfactory/simulation/photonic_circuit_models/mzi.py
+++ b/gdsfactory/simulation/photonic_circuit_models/mzi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/gdsfactory/simulation/photonic_circuit_models/ring.py
+++ b/gdsfactory/simulation/photonic_circuit_models/ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/gdsfactory/simulation/plot.py
+++ b/gdsfactory/simulation/plot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Dict, Optional, Tuple
 

--- a/gdsfactory/simulation/plot_csv.py
+++ b/gdsfactory/simulation/plot_csv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/simulation/sax/__init__.py
+++ b/gdsfactory/simulation/sax/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.simulation.sax import models, read
 from gdsfactory.simulation.sax.plot_model import plot_model
 

--- a/gdsfactory/simulation/sax/models.py
+++ b/gdsfactory/simulation/sax/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import jax.numpy as jnp
 from sax.typing_ import SDict
 from sax.utils import reciprocal

--- a/gdsfactory/simulation/sax/plot_model.py
+++ b/gdsfactory/simulation/sax/plot_model.py
@@ -1,5 +1,7 @@
 """Useful plot functions."""
 
+from __future__ import annotations
+
 from typing import Tuple
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/simulation/sax/read.py
+++ b/gdsfactory/simulation/sax/read.py
@@ -1,4 +1,6 @@
 """read Sparameters from CSV file and returns sax model."""
+from __future__ import annotations
+
 import pathlib
 from typing import Union
 

--- a/gdsfactory/simulation/sax/tests/test_mzi.py
+++ b/gdsfactory/simulation/sax/tests/test_mzi.py
@@ -1,4 +1,6 @@
 """Demo of non-hierarchical circuit simulations."""
+from __future__ import annotations
+
 import jax.numpy as jnp
 import sax
 

--- a/gdsfactory/simulation/sax/tests/test_mzi_lattice.py
+++ b/gdsfactory/simulation/sax/tests/test_mzi_lattice.py
@@ -1,4 +1,6 @@
 """Test hierarchical circuit simulations."""
+from __future__ import annotations
+
 from typing import List
 
 import jax.numpy as jnp

--- a/gdsfactory/simulation/simphony/__init__.py
+++ b/gdsfactory/simulation/simphony/__init__.py
@@ -1,4 +1,5 @@
 """gdsfactory simphony circuit simulation plugin."""
+from __future__ import annotations
 
 try:
     from simphony.tools import freq2wl, wl2freq

--- a/gdsfactory/simulation/simphony/add_gc.py
+++ b/gdsfactory/simulation/simphony/add_gc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries import siepic
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/simphony/circuit.py
+++ b/gdsfactory/simulation/simphony/circuit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 from simphony import Model

--- a/gdsfactory/simulation/simphony/components/__init__.py
+++ b/gdsfactory/simulation/simphony/components/__init__.py
@@ -1,4 +1,6 @@
 """components for gdsfactory simphony circuit simulation plugin."""
+from __future__ import annotations
+
 from .bend_circular import bend_circular
 from .bend_euler import bend_euler
 from .coupler import coupler

--- a/gdsfactory/simulation/simphony/components/bend_circular.py
+++ b/gdsfactory/simulation/simphony/components/bend_circular.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from simphony.libraries.sipann import Waveguide
 

--- a/gdsfactory/simulation/simphony/components/bend_euler.py
+++ b/gdsfactory/simulation/simphony/components/bend_euler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from simphony.libraries.sipann import Waveguide
 

--- a/gdsfactory/simulation/simphony/components/coupler.py
+++ b/gdsfactory/simulation/simphony/components/coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries.sipann import Standard
 
 

--- a/gdsfactory/simulation/simphony/components/coupler_fdtd.py
+++ b/gdsfactory/simulation/simphony/components/coupler_fdtd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.simulation.simphony.model_from_gdsfactory import (
     GDSFactorySimphonyWrapper,

--- a/gdsfactory/simulation/simphony/components/coupler_ring.py
+++ b/gdsfactory/simulation/simphony/components/coupler_ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries import sipann
 
 
@@ -8,7 +10,7 @@ def coupler_ring(
     gap: float = 0.22,
     length_x: float = 4.0,
     sw_angle: float = 90.0,
-    **kwargs
+    **kwargs,
 ):
     r"""Return model for for half a ring coupler.
 

--- a/gdsfactory/simulation/simphony/components/coupler_ring_fdtd.py
+++ b/gdsfactory/simulation/simphony/components/coupler_ring_fdtd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony import Model
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/simphony/components/gc.py
+++ b/gdsfactory/simulation/simphony/components/gc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.config import sparameters_path
 from gdsfactory.simulation.simphony.model_from_sparameters import SimphonyFromFile
 

--- a/gdsfactory/simulation/simphony/components/mmi1x2.py
+++ b/gdsfactory/simulation/simphony/components/mmi1x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.simulation.simphony.model_from_gdsfactory import (
     GDSFactorySimphonyWrapper,

--- a/gdsfactory/simulation/simphony/components/mmi2x2.py
+++ b/gdsfactory/simulation/simphony/components/mmi2x2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.simulation.simphony.model_from_gdsfactory import (
     GDSFactorySimphonyWrapper,

--- a/gdsfactory/simulation/simphony/components/mzi.py
+++ b/gdsfactory/simulation/simphony/components/mzi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Optional
 
 from gdsfactory.simulation.simphony.components.mmi1x2 import mmi1x2

--- a/gdsfactory/simulation/simphony/components/mzi_siepic.py
+++ b/gdsfactory/simulation/simphony/components/mzi_siepic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries import siepic
 
 from gdsfactory.simulation.simphony.components.mmi1x2 import mmi1x2

--- a/gdsfactory/simulation/simphony/components/mzi_thermal.py
+++ b/gdsfactory/simulation/simphony/components/mzi_thermal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/gdsfactory/simulation/simphony/components/ring_double.py
+++ b/gdsfactory/simulation/simphony/components/ring_double.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.models import Subcircuit
 
 from gdsfactory.simulation.simphony.components.coupler_ring import coupler_ring

--- a/gdsfactory/simulation/simphony/components/ring_double_siepic.py
+++ b/gdsfactory/simulation/simphony/components/ring_double_siepic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries import siepic
 
 

--- a/gdsfactory/simulation/simphony/components/ring_single.py
+++ b/gdsfactory/simulation/simphony/components/ring_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries.sipann import Racetrack
 from simphony.models import Subcircuit
 

--- a/gdsfactory/simulation/simphony/components/ring_single_siepic.py
+++ b/gdsfactory/simulation/simphony/components/ring_single_siepic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from simphony.libraries import siepic
 

--- a/gdsfactory/simulation/simphony/components/straight.py
+++ b/gdsfactory/simulation/simphony/components/straight.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.libraries.siepic import Waveguide
 
 from gdsfactory.config import logger

--- a/gdsfactory/simulation/simphony/get_transmission.py
+++ b/gdsfactory/simulation/simphony/get_transmission.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from simphony.models import Subcircuit
 from simphony.simulators import SweepSimulator
 

--- a/gdsfactory/simulation/simphony/model_from_gdsfactory.py
+++ b/gdsfactory/simulation/simphony/model_from_gdsfactory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, List, Tuple
 
 import numpy as np
@@ -20,7 +22,7 @@ class GDSFactorySimphonyWrapper(Model):
         *,
         component: Component,
         dirpath=gf.PATH.sparameters,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Take a GDSFactory component and convert it into a Simphony Model object.
 
@@ -45,7 +47,7 @@ class GDSFactorySimphonyWrapper(Model):
 
         super().__init__(name, freq_range=freq_range, pins=pins)
 
-    def s_parameters(self, freqs: "np.array") -> "np.ndarray":
+    def s_parameters(self, freqs: np.array) -> np.ndarray:
         return interpolate(freqs, self.f, self.s)
 
     def _model_from_gdsfactory(

--- a/gdsfactory/simulation/simphony/model_from_sparameters.py
+++ b/gdsfactory/simulation/simphony/model_from_sparameters.py
@@ -1,6 +1,8 @@
 """[[-0.09051371-0.20581339j  0.00704022+0.1328474j \
     0.03733851+0.4879802j ]."""
 
+from __future__ import annotations
+
 from pathlib import PosixPath
 from typing import Optional, Tuple, Union
 
@@ -99,7 +101,7 @@ class SimphonyFromFile(Model):
 
         return self
 
-    def s_parameters(self, freqs: "np.array") -> "np.ndarray":
+    def s_parameters(self, freqs: np.array) -> np.ndarray:
         return interpolate(freqs, self.f, self.s)
 
 

--- a/gdsfactory/simulation/simphony/plot_circuit.py
+++ b/gdsfactory/simulation/simphony/plot_circuit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/simulation/simphony/plot_circuit_montecarlo.py
+++ b/gdsfactory/simulation/simphony/plot_circuit_montecarlo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import numpy as np
 from simphony.models import Subcircuit

--- a/gdsfactory/simulation/simphony/plot_model.py
+++ b/gdsfactory/simulation/simphony/plot_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/simulation/simphony/tests/test_circuit.py
+++ b/gdsfactory/simulation/simphony/tests/test_circuit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/simulation/simphony/tests/test_components.py
+++ b/gdsfactory/simulation/simphony/tests/test_components.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/gdsfactory/simulation/simphony/types.py
+++ b/gdsfactory/simulation/simphony/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 from simphony import Model

--- a/gdsfactory/simulation/sipann/__init__.py
+++ b/gdsfactory/simulation/sipann/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     import SiPANN as _SIPANN
 except ImportError:

--- a/gdsfactory/simulation/sipann/bend_circular.py
+++ b/gdsfactory/simulation/sipann/bend_circular.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from SiPANN.scee import Waveguide
 

--- a/gdsfactory/simulation/sipann/bend_euler.py
+++ b/gdsfactory/simulation/sipann/bend_euler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from SiPANN.scee import Waveguide
 

--- a/gdsfactory/simulation/sipann/coupler.py
+++ b/gdsfactory/simulation/sipann/coupler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from SiPANN.scee import Standard
 
 

--- a/gdsfactory/simulation/sipann/coupler_ring.py
+++ b/gdsfactory/simulation/sipann/coupler_ring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from SiPANN.scee import HalfRacetrack
 
 
@@ -8,7 +10,7 @@ def coupler_ring(
     gap: float = 0.22,
     length_x: float = 4.0,
     sw_angle: float = 90.0,
-    **kwargs
+    **kwargs,
 ):
     r"""Return model for for half a ring coupler.
 

--- a/gdsfactory/simulation/sipann/straight.py
+++ b/gdsfactory/simulation/sipann/straight.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from SiPANN.scee import Waveguide
 
 

--- a/gdsfactory/simulation/thermal/__init__.py
+++ b/gdsfactory/simulation/thermal/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .heater import solve_thermal
 
 __all__ = ("solve_thermal",)

--- a/gdsfactory/simulation/thermal/heater.py
+++ b/gdsfactory/simulation/thermal/heater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, Iterator, Tuple
 
 import matplotlib.pyplot as plt

--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -1,4 +1,6 @@
 """snaps values and coordinates to the GDS grid in nm."""
+from __future__ import annotations
+
 from typing import Optional, Tuple, Union
 
 import numpy as np

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -1,4 +1,6 @@
 """Technology settings."""
+from __future__ import annotations
+
 import pathlib
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 

--- a/gdsfactory/tests/gds/alphabet.py
+++ b/gdsfactory/tests/gds/alphabet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#()+,-./:;<=>?@[{|}~_"

--- a/gdsfactory/tests/gds/diff.py
+++ b/gdsfactory/tests/gds/diff.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.gdsdiff.gdsdiff import gdsdiff
 

--- a/gdsfactory/tests/gds/mmi1x2_L10.py
+++ b/gdsfactory/tests/gds/mmi1x2_L10.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 if __name__ == "__main__":

--- a/gdsfactory/tests/test_add_fiber_array.py
+++ b/gdsfactory/tests/test_add_fiber_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_add_loopback.py
+++ b/gdsfactory/tests/test_add_loopback.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_loopback import add_loopback
 from gdsfactory.component import Component

--- a/gdsfactory/tests/test_add_pins.py
+++ b/gdsfactory/tests/test_add_pins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_add_ports.py
+++ b/gdsfactory/tests/test_add_ports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_pins import add_pins, add_pins_siepic
 from gdsfactory.add_ports import (

--- a/gdsfactory/tests/test_add_settings_label.py
+++ b/gdsfactory/tests/test_add_settings_label.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_cell.py
+++ b/gdsfactory/tests/test_cell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 

--- a/gdsfactory/tests/test_cli.py
+++ b/gdsfactory/tests/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from click.testing import CliRunner
 
 from gdsfactory import __version__

--- a/gdsfactory/tests/test_component_from_yaml.py
+++ b/gdsfactory/tests/test_component_from_yaml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import jsondiff
 import numpy as np
 import pytest

--- a/gdsfactory/tests/test_component_from_yaml2.py
+++ b/gdsfactory/tests/test_component_from_yaml2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_component_from_yaml_bezier.py
+++ b/gdsfactory/tests/test_component_from_yaml_bezier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_component_from_yaml_decorator.py
+++ b/gdsfactory/tests/test_component_from_yaml_decorator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 padding_example0 = """

--- a/gdsfactory/tests/test_component_from_yaml_fail.py
+++ b/gdsfactory/tests/test_component_from_yaml_fail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 yaml_fail = """

--- a/gdsfactory/tests/test_component_from_yaml_ports.py
+++ b/gdsfactory/tests/test_component_from_yaml_ports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_component_from_yaml_uid.py
+++ b/gdsfactory/tests/test_component_from_yaml_uid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 mirror_port = """

--- a/gdsfactory/tests/test_component_sequence.py
+++ b/gdsfactory/tests/test_component_sequence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_components.py
+++ b/gdsfactory/tests/test_components.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_composed_functions.py
+++ b/gdsfactory/tests/test_composed_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import toolz
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_containers.py
+++ b/gdsfactory/tests/test_containers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_copy.py
+++ b/gdsfactory/tests/test_copy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_cross_section.py
+++ b/gdsfactory/tests/test_cross_section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_duplicate_cells.py
+++ b/gdsfactory/tests/test_duplicate_cells.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_flatten.py
+++ b/gdsfactory/tests/test_flatten.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_geometry.py
+++ b/gdsfactory/tests/test_geometry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 r1 = (8, 8)

--- a/gdsfactory/tests/test_get_bundle.py
+++ b/gdsfactory/tests/test_get_bundle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_get_bundle_electrical.py
+++ b/gdsfactory/tests/test_get_bundle_electrical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_electrical_multilayer.py
+++ b/gdsfactory/tests/test_get_bundle_electrical_multilayer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_from_waypoints.py
+++ b/gdsfactory/tests/test_get_bundle_from_waypoints.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_get_bundle_no_grouping.py
+++ b/gdsfactory/tests/test_get_bundle_no_grouping.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_optical.py
+++ b/gdsfactory/tests/test_get_bundle_optical.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_sbend_routing.py
+++ b/gdsfactory/tests/test_get_bundle_sbend_routing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_sort_ports.py
+++ b/gdsfactory/tests/test_get_bundle_sort_ports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_u_direct_different_x.py
+++ b/gdsfactory/tests/test_get_bundle_u_direct_different_x.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_udirect.py
+++ b/gdsfactory/tests/test_get_bundle_udirect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_bundle_west_to_north.py
+++ b/gdsfactory/tests/test_get_bundle_west_to_north.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_netlist.py
+++ b/gdsfactory/tests/test_get_netlist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_route.py
+++ b/gdsfactory/tests/test_get_route.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_route_astar.py
+++ b/gdsfactory/tests/test_get_route_astar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cell import cell
 from gdsfactory.component import Component

--- a/gdsfactory/tests/test_get_route_auto_widen.py
+++ b/gdsfactory/tests/test_get_route_auto_widen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.cross_section import Section
 from gdsfactory.difftest import difftest

--- a/gdsfactory/tests/test_get_route_error.py
+++ b/gdsfactory/tests/test_get_route_error.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_get_route_error2.py
+++ b/gdsfactory/tests/test_get_route_error2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_get_route_error_bundle.py
+++ b/gdsfactory/tests/test_get_route_error_bundle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_hash.py
+++ b/gdsfactory/tests/test_hash.py
@@ -5,6 +5,8 @@ Tests are failing for python3.7
 """
 
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import hash_file
 

--- a/gdsfactory/tests/test_import_from_phidl.py
+++ b/gdsfactory/tests/test_import_from_phidl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_import_gds.py
+++ b/gdsfactory/tests/test_import_gds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.read.import_gds import import_gds
 

--- a/gdsfactory/tests/test_import_gds2.py
+++ b/gdsfactory/tests/test_import_gds2.py
@@ -1,5 +1,7 @@
 # from pprint import pprint
 
+from __future__ import annotations
+
 import jsondiff
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_import_gds_avoid_duplicated_cells.py
+++ b/gdsfactory/tests/test_import_gds_avoid_duplicated_cells.py
@@ -1,5 +1,7 @@
 """avoid duplicated cell names when importing GDS files."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory import geometry
 

--- a/gdsfactory/tests/test_import_gds_cell.py
+++ b/gdsfactory/tests/test_import_gds_cell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_import_gds_cell2.py
+++ b/gdsfactory/tests/test_import_gds_cell2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_import_gds_markers.py
+++ b/gdsfactory/tests/test_import_gds_markers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.read.import_gds import import_gds
 

--- a/gdsfactory/tests/test_import_gds_settings.py
+++ b/gdsfactory/tests/test_import_gds_settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Union
 
 from gdsfactory.components import cells

--- a/gdsfactory/tests/test_import_gds_with_hierarchy.py
+++ b/gdsfactory/tests/test_import_gds_with_hierarchy.py
@@ -1,5 +1,7 @@
 # from pprint import pprint
 
+from __future__ import annotations
+
 import jsondiff
 from pytest_regressions.data_regression import DataRegressionFixture
 

--- a/gdsfactory/tests/test_info.py
+++ b/gdsfactory/tests/test_info.py
@@ -12,6 +12,8 @@ Calculated/derived properties are stored in info
 
 """
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_klayout_tech.py
+++ b/gdsfactory/tests/test_klayout_tech.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from gdsfactory.config import PATH

--- a/gdsfactory/tests/test_label_custom.py
+++ b/gdsfactory/tests/test_label_custom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_label_fiber_array.py
+++ b/gdsfactory/tests/test_label_fiber_array.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_label_fiber_single.py
+++ b/gdsfactory/tests/test_label_fiber_single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_label_in_component_move.py
+++ b/gdsfactory/tests/test_label_in_component_move.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_label_move.py
+++ b/gdsfactory/tests/test_label_move.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_labels.py
+++ b/gdsfactory/tests/test_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.add_labels import (
     get_input_label,

--- a/gdsfactory/tests/test_library_exists.py
+++ b/gdsfactory/tests/test_library_exists.py
@@ -1,5 +1,7 @@
 """ensures gdslibrary exists."""
 
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_manhattan.py
+++ b/gdsfactory/tests/test_manhattan.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/gdsfactory/tests/test_manhattan_sbend.py
+++ b/gdsfactory/tests/test_manhattan_sbend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/gdsfactory/tests/test_metadata_export.py
+++ b/gdsfactory/tests/test_metadata_export.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import toolz
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_metadata_export_pdk.py
+++ b/gdsfactory/tests/test_metadata_export_pdk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_metadata_mask.py
+++ b/gdsfactory/tests/test_metadata_mask.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import toolz
 from omegaconf import OmegaConf
 

--- a/gdsfactory/tests/test_min_exclusion.py
+++ b/gdsfactory/tests/test_min_exclusion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/tests/test_min_inclusion.py
+++ b/gdsfactory/tests/test_min_inclusion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/gdsfactory/tests/test_min_space.py
+++ b/gdsfactory/tests/test_min_space.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.geometry import check_space
 

--- a/gdsfactory/tests/test_min_width.py
+++ b/gdsfactory/tests/test_min_width.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_mutability.py
+++ b/gdsfactory/tests/test_mutability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_name.py
+++ b/gdsfactory/tests/test_name.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_name_with_decorator.py
+++ b/gdsfactory/tests/test_name_with_decorator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_named_references.py
+++ b/gdsfactory/tests/test_named_references.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_netlist_labels.py
+++ b/gdsfactory/tests/test_netlist_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 yaml = """

--- a/gdsfactory/tests/test_netlist_read.py
+++ b/gdsfactory/tests/test_netlist_read.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import PATH

--- a/gdsfactory/tests/test_netlist_with_routes.py
+++ b/gdsfactory/tests/test_netlist_with_routes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_netlist_write.py
+++ b/gdsfactory/tests/test_netlist_write.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 

--- a/gdsfactory/tests/test_netlists.py
+++ b/gdsfactory/tests/test_netlists.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import jsondiff
 import pytest
 from omegaconf import OmegaConf

--- a/gdsfactory/tests/test_no_ports.py
+++ b/gdsfactory/tests/test_no_ports.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory import CrossSection
 from gdsfactory import path as pa

--- a/gdsfactory/tests/test_offset.py
+++ b/gdsfactory/tests/test_offset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.difftest import difftest
 from gdsfactory.geometry.offset import offset

--- a/gdsfactory/tests/test_partial_cross_section.py
+++ b/gdsfactory/tests/test_partial_cross_section.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_partial_function.py
+++ b/gdsfactory/tests/test_partial_function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_path_length_matching.py
+++ b/gdsfactory/tests/test_path_length_matching.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_path_zero_length.py
+++ b/gdsfactory/tests/test_path_zero_length.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_paths.py
+++ b/gdsfactory/tests/test_paths.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import jsondiff
 import numpy as np
 import pytest

--- a/gdsfactory/tests/test_paths_extrude.py
+++ b/gdsfactory/tests/test_paths_extrude.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 from gdsfactory.tech import LAYER
 

--- a/gdsfactory/tests/test_paths_transition.py
+++ b/gdsfactory/tests/test_paths_transition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_paths_transition2.py
+++ b/gdsfactory/tests/test_paths_transition2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_port_by_orientation.py
+++ b/gdsfactory/tests/test_port_by_orientation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_port_from_csv.py
+++ b/gdsfactory/tests/test_port_from_csv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.port import csv2port
 
 

--- a/gdsfactory/tests/test_ports_select.py
+++ b/gdsfactory/tests/test_ports_select.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_ports_select2.py
+++ b/gdsfactory/tests/test_ports_select2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_rotate.py
+++ b/gdsfactory/tests/test_rotate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_route_ports_to_side.py
+++ b/gdsfactory/tests/test_route_ports_to_side.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gdsfactory.difftest import difftest
 from gdsfactory.routing.route_ports_to_side import _sample_route_sides
 

--- a/gdsfactory/tests/test_route_south.py
+++ b/gdsfactory/tests/test_route_south.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_schema.py
+++ b/gdsfactory/tests/test_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import jsonschema

--- a/gdsfactory/tests/test_serialize.py
+++ b/gdsfactory/tests/test_serialize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdstk
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_shear_face_path.py
+++ b/gdsfactory/tests/test_shear_face_path.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import shapely.geometry as sg

--- a/gdsfactory/tests/test_show.py
+++ b/gdsfactory/tests/test_show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gdsfactory as gf

--- a/gdsfactory/tests/test_snap.py
+++ b/gdsfactory/tests/test_snap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gdsfactory as gf
 
 

--- a/gdsfactory/tests/test_validator.py
+++ b/gdsfactory/tests/test_validator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pydantic
 import pytest
 

--- a/gdsfactory/types.py
+++ b/gdsfactory/types.py
@@ -27,6 +27,8 @@ Specs:
 - LayerSpec: (3, 0), 3 (assumes 0 as datatype) or string.
 
 """
+from __future__ import annotations
+
 import json
 import pathlib
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -1,5 +1,7 @@
 """FileWatcher based on watchdog. Looks for changes in files with .pic.yml extension."""
 
+from __future__ import annotations
+
 import logging
 import pathlib
 import sys

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -1,5 +1,7 @@
 """Generate the code from a GDS file based PDK."""
 
+from __future__ import annotations
+
 import datetime
 import pathlib
 from pathlib import Path


### PR DESCRIPTION
Hi @joamatab ,

This PR adds `from __future__ import annotations` to all files and makes the docs cleaner by rendering the type aliases rather than the expanded types. For example,

Before:
![image](https://user-images.githubusercontent.com/3070522/204503260-2dd0348e-17d5-4e24-94c4-4b8111d54b10.png)

After:
![image](https://user-images.githubusercontent.com/3070522/204503415-00475b49-4698-4d4b-91d8-df1c0ea701db.png)

Some minor modifications also needed to happen in a few places which use introspection to determine return annotation types.