### PR TITLE
fix missing conversion from rad (gdstk) to deg

### DIFF
--- a/gdsfactory/labels/write_labels.py
+++ b/gdsfactory/labels/write_labels.py
@@ -5,6 +5,7 @@ import pathlib
 from pathlib import Path
 from typing import Iterator, Tuple
 
+import numpy as np
 from loguru import logger
 
 import gdsfactory as gf
@@ -120,9 +121,10 @@ def write_labels_gdstk(
             and label.text.startswith(prefix)
         ):
             x, y = label.origin
-            labels += [(label.text, x, y, label.rotation)]
+            rot = np.rad2deg(label.rotation)
+            labels += [(label.text, x, y, rot)]
             if debug:
-                print(label.text, x, y, label.rotation)
+                print(label.text, x, y, rot)
 
     with open(filepath, "w", newline="") as f:
         writer = csv.writer(f)


### PR DESCRIPTION
fixes #925
gdstk handles rotation in rad, gdsfactory in deg.
For the future we'll probably want to add test coverage.