### PR TITLE
Generic mesh refinement, refactoring

### DIFF
--- a/gdsfactory/simulation/devsim/__init__.py
+++ b/gdsfactory/simulation/devsim/__init__.py
@@ -10,8 +10,16 @@ from gdsfactory.simulation.devsim.get_simulation_xsection import (
     dn_carriers,
     k_to_alpha,
 )
+from gdsfactory.simulation.devsim.get_solver import DDComponent
 
 logger.info(f"DEVSIM {tcad.__version__!r} installed at {tcad.__path__!r}")
 
-__all__ = ["dn_carriers", "dalpha_carriers", "alpha_to_k", "k_to_alpha", "PINWaveguide"]
+__all__ = [
+    "dn_carriers",
+    "dalpha_carriers",
+    "alpha_to_k",
+    "k_to_alpha",
+    "PINWaveguide",
+    "DDComponent",
+]
 __version__ = "0.0.1"

--- a/gdsfactory/simulation/devsim/doping.py
+++ b/gdsfactory/simulation/devsim/doping.py
@@ -1,0 +1,100 @@
+from typing import Callable
+
+import numpy as np
+from pydantic import BaseModel
+
+import gdsfactory as gf
+from gdsfactory.tech import Layer
+
+
+class DopingLayerLevel(BaseModel):
+    """Level for doping layer.
+
+    Parameters:
+        layer: (GDSII Layer number, GDSII datatype).
+        type: str: "Acceptor" or "Donor".
+        z_profile: callable evaluating doping versus depth.
+        xy_profile: callable modulating z_profile at the edge of the layer.
+
+    """
+
+    layer: Layer
+    type: str
+    z_profile: Callable
+    # xy_profile: Optional[Callable] = None # not implemented yet
+
+    class Config:
+        """pydantic config."""
+
+        frozen = True
+        extra = "forbid"
+
+
+cm3_to_um3 = 1e-12
+
+
+def get_doping_info_generic(
+    n_conc: float = 1e17,  # * cm3_to_um3,
+    p_conc: float = 1e17,  # * cm3_to_um3,
+    npp_conc: float = 1e18,  # * cm3_to_um3,
+    ppp_conc: float = 1e18,  # * cm3_to_um3,
+):
+
+    layermap = gf.tech.LayerMap()
+
+    doping_info = {
+        "N": DopingLayerLevel(
+            layer=layermap.N,
+            type="Donor",
+            z_profile=step(n_conc),
+        ),
+        "P": DopingLayerLevel(
+            layer=layermap.P,
+            type="Acceptor",
+            z_profile=step(p_conc),
+        ),
+        "NPP": DopingLayerLevel(
+            layer=layermap.NPP,
+            type="Donor",
+            z_profile=step(npp_conc),
+        ),
+        "PPP": DopingLayerLevel(
+            layer=layermap.PPP,
+            type="Acceptor",
+            z_profile=step(ppp_conc),
+        ),
+    }
+
+    return doping_info
+
+
+# def get_doping_xyz():
+#     """Returns acceptor  vs x,y,z from DopingLayerLevel and a component."""
+
+# def get_doping_density():
+#     """Returns acceptor  vs x,y,z from DopingLayerLevel and a component."""
+
+
+# def get_net_doping(component: Component, doping_info: Dict):
+#     """Returns net doping from DopingLayerLevel and a component."""
+
+#     for name, dopinglevel in doping_info.items():
+#         print("ok")
+
+
+def step(c, zmin=-np.inf, zmax=np.inf):
+    """Step function doping of value c, between zmin and zmax."""
+    return lambda y: c
+
+
+# def step(c, zmin=-np.inf, zmax=np.inf):
+#     """Step function doping of value c, between zmin and zmax."""
+#     return lambda x, y, z: np.heaviside(c - zmin) - np.heaviside(c - zmax)
+
+# def gaussian(n0, range, straggle):
+#     """Gaussian function doping of value c."""
+#     return n0*np.exp(-(z - range)**2/(2*straggle**2))
+
+# def pearsonIV(n0, range, straggle):
+#     """Gaussian function doping of value c."""
+#     return n0*np.exp(-(z - range)**2/(2*straggle**2))

--- a/gdsfactory/simulation/devsim/get_solver.py
+++ b/gdsfactory/simulation/devsim/get_solver.py
@@ -4,23 +4,28 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 from devsim import (
+    delete_device,
+    delete_mesh,
     get_contact_list,
+    get_edge_model_values,
     get_interface_list,
+    get_node_model_values,
     get_region_list,
     set_node_values,
     set_parameter,
     solve,
+    write_devices,
 )
 from devsim.python_packages import model_create, simple_physics
 from pydantic import BaseModel, Extra
 
 from gdsfactory import Component
-from gdsfactory.simulation.devsim import create_2Duz_simulation
 from gdsfactory.simulation.devsim.doping import get_doping_info_generic
+from gdsfactory.simulation.devsim.get_simulation import create_2Duz_simulation
 from gdsfactory.tech import LayerStack
 
 
-def SetUniversalParameters(device, region):
+def set_universal_parameters(device, region):
     universal = {
         "q": 1.6e-19,  # , 'coul'),
         "k": 1.3806503e-23,  # , 'J/K'),
@@ -38,6 +43,7 @@ class DDComponent(BaseModel):
     full_layerstack: LayerStack
     physical_layerstack: LayerStack
     resolutions: Optional[Dict[str, Dict]] = {}
+    mesh_scaling_factor: float = (1.0,)
     background_tag: Optional[str] = None
     temp_file_name = "temp.msh2"
     devsim_mesh_name = "temp"
@@ -45,26 +51,16 @@ class DDComponent(BaseModel):
     devsim_simulation_filename = "devsim.dat"
     atol: float = 1e8
     rtol: float = 1e-8
-    max_iter: int = 60
+    max_iter: int = 100
 
     class Config:
         """Enable adding new."""
 
         extra = Extra.allow
 
-    def set_parameters(self, device, regions) -> None:
-
-        for material, region_names in regions.items():
-            for region_name in region_names:
-                SetUniversalParameters(device, region_name)
-                if material == "si":
-                    simple_physics.SetSiliconParameters(device, region_name, T=300)
-                elif material == "sio2":
-                    continue
-                    # physics.SetOxideParameters(device, region_name)
-                elif material == "Aluminum":
-                    # Change to aluminum eventually
-                    simple_physics.SetSiliconParameters(device, region_name, T=300)
+    def set_parameters(self, region, device) -> None:
+        """Set parameters for 300 K."""
+        simple_physics.SetSiliconParameters(device, region, 300)
 
     def initial_solution(self, device, region, circuit_contacts=None) -> None:
         # Create Potential, Potential@n0, Potential@n1
@@ -80,12 +76,13 @@ class DDComponent(BaseModel):
                     device, region, i, True
                 )
             else:
+                # it is more correct for the bias to be 0, and it looks like there is side effects
                 set_parameter(
                     device=device, name=simple_physics.GetContactBiasName(i), value=0.0
                 )
                 simple_physics.CreateSiliconPotentialOnlyContact(device, region, i)
 
-    def drift_difussion_initial_solution(self, device, region):
+    def drift_diffusion_initial_solution(self, device, region, circuit_contacts=None):
         # drift diffusion solution variables
         model_create.CreateSolution(device, region, "Electrons")
         model_create.CreateSolution(device, region, "Holes")
@@ -104,11 +101,16 @@ class DDComponent(BaseModel):
         # Set up equations
         simple_physics.CreateSiliconDriftDiffusion(device, region)
         for i in get_contact_list(device=device):
-            simple_physics.CreateSiliconDriftDiffusionAtContact(device, region, i)
+            if circuit_contacts and i in circuit_contacts:
+                simple_physics.CreateSiliconDriftDiffusionAtContact(
+                    device, region, i, True
+                )
+            else:
+                simple_physics.CreateSiliconDriftDiffusionAtContact(device, region, i)
 
-    def ddsolver(self) -> None:
+    def ddsolver(self, global_meshsize_array=None) -> None:
         """Initialize mesh and solver."""
-        device, self.regions, self.interfaces = create_2Duz_simulation(
+        self.device, self.regions, self.interfaces = create_2Duz_simulation(
             component=self.component,
             xsection_bounds=self.xsection_bounds,
             full_layerstack=self.full_layerstack,
@@ -116,36 +118,27 @@ class DDComponent(BaseModel):
             doping_info=self.doping_info,
             contact_info=self.contact_info,
             resolutions=self.resolutions,
+            mesh_scaling_factor=self.mesh_scaling_factor,
             background_tag=self.background_tag,
+            global_meshsize_array=global_meshsize_array,
         )
-        self.device = device
-        self.set_parameters(device=device, regions=self.regions)
-
-        i = 0
-        for region in self.regions["si"]:
-            if i == 0:
-                model_create.CreateSolution(device, region, "Potential")
-                simple_physics.CreateSiliconPotentialOnly(device, region)
-                i += 1
-            else:
-                self.initial_solution(device=device, region=region)
-        for region in ["anode", "cathode"]:
-            self.initial_solution(device=device, region=region)
-
-        # model_create.CreateSolution(device, "left_clad", "Potential")
-        # CreateOxidePotentialOnly(device, "left_clad")
-        # self.initial_solution(device=device, region="left_clad")
-
-        # model_create.CreateSolution(device, "right_clad", "Potential")
-        # CreateOxidePotentialOnly(device, "right_clad")
-        # self.initial_solution(device=device, region="right_clad")
+        device = self.device
 
         for region in get_region_list(device=device):
-            self.drift_difussion_initial_solution(device=device, region=region)
+            self.set_parameters(device=device, region=region)
+
+        for region in get_region_list(device=device):
+            self.initial_solution(device=device, region=region)
+
+        for region in get_region_list(device=device):
+            self.drift_diffusion_initial_solution(device=device, region=region)
+
         for interface in get_interface_list(device=device):
             simple_physics.CreateSiliconSiliconInterface(
                 device=device, interface=interface
             )
+
+        self.save_device("debug.dat")
 
         solve(
             type="dc",
@@ -154,14 +147,15 @@ class DDComponent(BaseModel):
             maximum_iterations=self.max_iter,
         )
 
-    def ramp_voltage(self, Vfinal: float, Vstep: float, Vinit: float = 0.0) -> None:
+    def ramp_voltage(
+        self, Vfinal: float, Vstep: float, Vinit: float = 0.0, contact_name="cathode"
+    ) -> None:
         """Ramps the solution from Vi to Vf."""
-        device = "MyDevice"
         V = Vinit
         while np.abs(V) <= np.abs(Vfinal):
             set_parameter(
-                device=device,
-                name=simple_physics.GetContactBiasName("cathode"),
+                device=self.device,
+                name=simple_physics.GetContactBiasName(contact_name),
                 value=V,
             )
             solve(
@@ -171,6 +165,28 @@ class DDComponent(BaseModel):
                 maximum_iterations=self.max_iter,
             )
             V += Vstep
+
+    def get_node_field(self, region_name, field_name="Electrons"):
+        return get_node_model_values(
+            device=self.device, region=region_name, name=field_name
+        )
+
+    def get_edge_field(self, region_name, field_name="EdgeLength"):
+        return get_edge_model_values(
+            device=self.device, region=region_name, name=field_name
+        )
+
+    def get_regions(self):
+        return get_region_list(device=self.device)
+
+    def save_device(self, filepath) -> None:
+        """Save Device to a tecplot filepath that you can open with Paraview."""
+        write_devices(file=filepath, type="tecplot")
+
+    def delete_device(self) -> None:
+        """Delete this devsim device and mesh."""
+        delete_mesh(mesh=self.devsim_mesh_name)
+        delete_device(device=self.devsim_mesh_name)
 
 
 if __name__ == "__main__":
@@ -222,23 +238,26 @@ if __name__ == "__main__":
             via_contact_locations, PPP_location, operation="AND", layer=cathode_layer
         )
     )
-    contact_info = {}
-    contact_info["anode"] = {
-        "gds_layer": anode_layer,
-        "physical_layerlevel_to_replace": "via_contact",
-        "physical_layerlevel_to_contact": "slab90",
-    }
-    contact_info["cathode"] = {
-        "gds_layer": cathode_layer,
-        "physical_layerlevel_to_replace": "via_contact",
-        "physical_layerlevel_to_contact": "slab90",
+    contact_info = {
+        "anode": {
+            "gds_layer": anode_layer,
+            "physical_layerlevel_to_replace": "via_contact",
+            "physical_layerlevel_to_contact": "slab90",
+        },
+        "cathode": {
+            "gds_layer": cathode_layer,
+            "physical_layerlevel_to_replace": "via_contact",
+            "physical_layerlevel_to_contact": "slab90",
+        },
     }
 
     waveguide.show()
 
-    resolutions = {}
-    resolutions["core"] = {"resolution": 0.01, "distance": 2}
-    resolutions["slab90"] = {"resolution": 0.03, "distance": 1}
+    # Initial meshing
+    resolutions = {
+        "core": {"resolution": 0.02, "distance": 1},
+        "slab90": {"resolution": 0.05, "distance": 1},
+    }
 
     c = DDComponent(
         component=waveguide,
@@ -248,7 +267,191 @@ if __name__ == "__main__":
         doping_info=get_doping_info_generic(),
         contact_info=contact_info,
         resolutions=resolutions,
+        mesh_scaling_factor=1e-4,
         background_tag=None,
     )
+
     c.ddsolver()
-    c.save_device("test.dat")
+    c.save_device("test1.dat")
+
+    # c.ramp_voltage(-0.3, -0.1, contact_name="cathode")
+    # c.save_device("test2.dat")
+
+    # Tabulate old lcs
+    xs = {}
+    ys = {}
+    lcs = {}
+    potentials = {}
+    electrons = {}
+    holes = {}
+    for regionname in c.get_regions():
+        xs[regionname] = np.array(c.get_node_field(regionname, "x"))
+        ys[regionname] = np.array(c.get_node_field(regionname, "y"))
+        lcs[regionname] = np.sqrt(np.array(c.get_node_field(regionname, "NodeVolume")))
+        potentials[regionname] = np.array(c.get_node_field(regionname, "Potential"))
+        electrons[regionname] = np.array(c.get_node_field(regionname, "Electrons"))
+        holes[regionname] = np.array(c.get_node_field(regionname, "Holes"))
+
+    N = sum(len(x) for x in xs.values())
+    # old_lcs = np.zeros([N, 4])
+    um_to_cm = 1e-4
+    xs = np.hstack([np.array(x) for x in xs.values()]) / um_to_cm
+    ys = np.hstack([np.array(y) for y in ys.values()]) / um_to_cm
+    lcs = np.hstack([np.array(lc) for lc in lcs.values()]) / um_to_cm
+    potentials = np.hstack([np.array(x) for x in potentials.values()])
+    electrons = np.hstack([np.array(x) for x in electrons.values()])
+    holes = np.hstack([np.array(x) for x in holes.values()])
+
+    # Get gradient of electron and potential fields
+    from scipy.interpolate import SmoothBivariateSpline
+
+    potential_g = SmoothBivariateSpline(x=xs, y=ys, z=potentials).partial_derivative(
+        dx=1, dy=1
+    )
+    electrons_g = SmoothBivariateSpline(x=xs, y=ys, z=electrons).partial_derivative(
+        dx=1, dy=1
+    )
+    holes_g = SmoothBivariateSpline(x=xs, y=ys, z=holes).partial_derivative(dx=1, dy=1)
+
+    # Use gradient to reduce characteristic length in fast-varying regions
+    import matplotlib.pyplot as plt
+
+    # plt.plot(grid_z2(xs, ys, grid=False))
+
+    plt.scatter(xs, lcs)
+    plt.show()
+    fig = plt.figure()
+    ax = plt.gca()
+    ax.scatter(
+        xs,
+        np.abs(potential_g(xs, ys, grid=False))
+        / np.max(np.abs(potential_g(xs, ys, grid=False))),
+    )
+    ax.set_yscale("log")
+    plt.show()
+    ax = plt.gca()
+    ax.scatter(
+        xs,
+        np.abs(electrons_g(xs, ys, grid=False))
+        / np.max(np.abs(electrons_g(xs, ys, grid=False))),
+    )
+    ax.scatter(
+        xs,
+        np.abs(holes_g(xs, ys, grid=False))
+        / np.max(np.abs(holes_g(xs, ys, grid=False))),
+    )
+    ax.set_yscale("log")
+    plt.show()
+
+    def rescale(lcs, field, xs, ys, step=0.5):
+        """Rescale lcs depending on field."""
+        # inds = np.where(xs > xlims[0] and xs < xlims[1] and ys > ylims[0] and ys < ylims[1])
+        norm = np.abs(field(xs, ys, grid=False)) / np.max(
+            np.abs(field(xs, ys, grid=False))
+        )
+        return lcs * (1 - step * norm)
+
+    # um_to_cm = 1e-4
+    meshing_field = np.zeros([N, 4])
+    meshing_field[:, 0] = xs
+    meshing_field[:, 1] = ys
+    meshing_field[:, 2] = np.zeros(N)
+    meshing_field[:, 3] = (
+        (
+            rescale(lcs, electrons_g, xs, ys, step=0.02)
+            + rescale(lcs, holes_g, xs, ys, step=0.02)
+        )
+        / 2
+        * rescale(lcs, potential_g, xs, ys, step=0.02)
+    )
+
+    print(np.shape(meshing_field))
+    print(meshing_field[:, 0])
+    print(meshing_field[:, 1])
+    print(meshing_field[:, 2])
+    print(meshing_field[:, 3])
+
+    plt.scatter(meshing_field[:, 0], lcs)
+    plt.scatter(meshing_field[:, 0], meshing_field[:, 3])
+    plt.show()
+
+    # c.delete_device()
+    # c = DDComponent(
+    #     component=waveguide,
+    #     xsection_bounds=[(4, -4), (4, 4)],
+    #     full_layerstack=get_layer_stack_generic(),
+    #     physical_layerstack=physical_layerstack,
+    #     doping_info=get_doping_info_generic(),
+    #     contact_info=contact_info,
+    #     resolutions=resolutions,
+    #     mesh_scaling_factor=1e-4,
+    #     background_tag=None,
+    # )
+
+    # c.ddsolver(global_meshsize_array=meshing_field)
+    # c.save_device("test_remeshed.dat")
+
+    # Get gradients to remesh on
+    # import pyvista as pv
+    # reader = pv.get_reader('test1.dat')
+    # mesh = reader.read()
+
+    # x_g = []
+    # y_g = []
+
+    # potential_g = []
+    # electrons_g = []
+    # for block in mesh:
+    #     potential_g.append(block.compute_derivative(scalars="Potential")["gradient"])
+    #     electrons_g.append(block.compute_derivative(scalars="Electrons")["gradient"])
+    # potential_g = np.vstack(potential_g)
+    # electrons_g = np.vstack(electrons_g)
+    # # potential_g = np.insert(np.vstack(potential_g), 2, values=0, axis=1)
+    # # electrons_g = np.insert(np.vstack(electrons_g), 2, values=0, axis=1)
+
+    # # If gradients are large at a given node, reduce its characteristic length
+    # import matplotlib.pyplot as plt
+    # plt.plot(electrons)
+    # plt.show()
+    # print(np.max(np.abs(potential_g[:,2])))
+    # print(np.max(np.abs(electrons_g[:,2])))
+
+    # c.delete_device()
+    # c.ddsolver(global_meshsize_array=mesh_g)
+    # c.save_device("test2.dat")
+
+    # c.ramp_voltage(-2, -0.5, contact_name="cathode")
+    # c.save_device("test2.dat")
+
+    # xs = {}
+    # ys = {}
+    # efields = {}
+    # edensities = {}
+    # for regionname in c.regions["si"]:
+    #     xs[regionname] = np.array(c.get_node_field(regionname, "x"))
+    #     ys[regionname] = np.array(c.get_node_field(regionname, "y"))
+    #     edensities[regionname] = np.array(np.log10(c.get_node_field(regionname, "Electrons")))
+    # for regionname in c.regions["si"]:
+    #     efields[regionname] = np.array(c.get_edge_field(regionname, "ElectricField")) # derivative of potential
+
+    # c.save_device("test0.dat")
+    # c.delete_device()
+
+    # # Second, refined meshing
+    # lc_min = 0.001
+    # lc_max = 0.2
+    # N = sum(len(x) for x in xs.values())
+    # print(N)
+    # mesh_g = (lc_max + lc_min)/2*np.ones([N,4])
+    # mesh_g[:,0] = np.hstack([np.array(x) for x in xs.values()])
+    # mesh_g[:,1] = np.hstack([np.array(y) for y in ys.values()])
+    # mesh_g[:,2] = np.zeros(N)
+
+    # def rescale(arr):
+    #     arr /= np.max(np.abs(arr)) # now 0 to 1
+    #     arr = np.abs(arr) # now 0 to 1
+    #     arr = np.reciprocal(arr) # map from 1 to infty
+    #     return np.reciprocal(arr/np.max(np.abs(arr),axis=0), )
+
+    # mesh_g[:,3] = np.reciprocal(np.abs(np.hstack([np.array(efield) for efield in efields.values()])))
+    # print(mesh_g)

--- a/gdsfactory/simulation/gmsh/__init__.py
+++ b/gdsfactory/simulation/gmsh/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from gdsfactory.simulation.gmsh.mesh import mesh_from_polygons
 from gdsfactory.simulation.gmsh.meshtracker import MeshTracker
 from gdsfactory.simulation.gmsh.parse_gds import (
-    break_line,
     cleanup_component,
     fuse_polygons,
     round_coordinates,
@@ -38,7 +37,6 @@ __all__ = [
     "round_coordinates",
     "to_polygons",
     "tile_shapes",
-    "break_line",
     "get_layers_at_z",
     "order_layerstack",
     "list_unique_layerstack_z",

--- a/gdsfactory/simulation/gmsh/break_geometry.py
+++ b/gdsfactory/simulation/gmsh/break_geometry.py
@@ -1,0 +1,134 @@
+from collections import OrderedDict
+
+from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
+from shapely.ops import linemerge, split
+
+from gdsfactory.simulation.gmsh.parse_gds import tile_shapes
+
+
+def break_line(line, other_line):
+    intersections = line.intersection(other_line)
+    if not intersections.is_empty:
+        for intersection in (
+            intersections.geoms if hasattr(intersections, "geoms") else [intersections]
+        ):
+            if intersection.type != "Point":
+                new_coords_start, new_coords_end = intersection.boundary.geoms
+                line = linemerge(split(line, new_coords_start))
+                line = linemerge(split(line, new_coords_end))
+    return line
+
+
+def break_geometry(shapes_dict: OrderedDict):
+    """Break up lines and polygon edges so that plane is tiled with no partially overlapping line segments.
+
+    Args:
+        shapes_dict: arbitrary dict of shapely polygons and lines, with ordering setting mesh priority
+
+    Returns:
+        polygons_broken_dict: dict of shapely polygons, with smallest number of individual vertices
+        lines_broken_dict: dict of shapely lines, with smallest number of individual vertices
+    """
+    # Break up shapes in order so that plane is tiled with non-overlapping layers
+    shapes_tiled_dict = tile_shapes(shapes_dict)
+
+    polygons_broken_dict = OrderedDict()
+    lines_broken_dict = OrderedDict()
+    for _first_index, (first_name, _init_first_shapes) in enumerate(
+        shapes_dict.items()
+    ):
+        first_shapes = shapes_tiled_dict[first_name]
+        broken_shapes = []
+        for first_shape in (
+            first_shapes.geoms if hasattr(first_shapes, "geoms") else [first_shapes]
+        ):
+            # First line exterior
+            first_exterior_line = (
+                LineString(first_shape.exterior)
+                if first_shape.type == "Polygon"
+                else first_shape
+            )
+            for second_name, second_shapes in shapes_dict.items():
+                # Do not compare to itself
+                if second_name != first_name:
+                    second_shapes = shapes_tiled_dict[second_name]
+                    for second_shape in (
+                        second_shapes.geoms
+                        if hasattr(second_shapes, "geoms")
+                        else [second_shapes]
+                    ):
+                        # Second line exterior
+                        second_exterior_line = (
+                            LineString(second_shape.exterior)
+                            if second_shape.type == "Polygon"
+                            else second_shape
+                        )
+                        first_exterior_line = break_line(
+                            first_exterior_line, second_exterior_line
+                        )
+                        # Second line interiors
+                        for second_interior_line in (
+                            second_shape.interiors
+                            if second_shape.type == "Polygon"
+                            else []
+                        ):
+                            second_interior_line = LineString(second_interior_line)
+                            first_exterior_line = break_line(
+                                first_exterior_line, second_interior_line
+                            )
+            # First line interiors
+            if first_shape.type in ["Polygon", "MultiPolygon"]:
+                first_shape_interiors = []
+                for first_interior_line in first_shape.interiors:
+                    first_interior_line = LineString(first_interior_line)
+                    for second_name, second_shapes in shapes_dict.items():
+                        if second_name != first_name:
+                            second_shapes = shapes_tiled_dict[second_name]
+                            for second_shape in (
+                                second_shapes.geoms
+                                if hasattr(second_shapes, "geoms")
+                                else [second_shapes]
+                            ):
+                                # Exterior
+                                second_exterior_line = (
+                                    LineString(second_shape.exterior)
+                                    if second_shape.type == "Polygon"
+                                    else second_shape
+                                )
+                                first_interior_line = break_line(
+                                    first_interior_line, second_exterior_line
+                                )
+                                # Interiors
+                                for second_interior_line in (
+                                    second_shape.interiors
+                                    if second_shape.type == "Polygon"
+                                    else []
+                                ):
+                                    second_interior_line = LineString(
+                                        second_interior_line
+                                    )
+                                    first_interior_line = break_line(
+                                        first_interior_line, second_interior_line
+                                    )
+                    first_shape_interiors.append(first_interior_line)
+            if first_shape.type in ["Polygon", "MultiPolygon"]:
+                broken_shapes.append(
+                    Polygon(first_exterior_line, holes=first_shape_interiors)
+                )
+            else:
+                broken_shapes.append(LineString(first_exterior_line))
+        if broken_shapes:
+            if first_shape.type in ["Polygon", "MultiPolygon"]:
+                polygons_broken_dict[first_name] = (
+                    MultiPolygon(broken_shapes)
+                    if len(broken_shapes) > 1
+                    else broken_shapes[0]
+                )
+            else:
+                lines_broken_dict[first_name] = (
+                    MultiLineString(broken_shapes)
+                    if len(broken_shapes) > 1
+                    else broken_shapes[0]
+                )
+
+    return polygons_broken_dict, lines_broken_dict

--- a/gdsfactory/simulation/gmsh/mesh.py
+++ b/gdsfactory/simulation/gmsh/mesh.py
@@ -1,216 +1,183 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from itertools import combinations
+from itertools import combinations, product
 from typing import Dict, Optional
 
 import gmsh
+import numpy as np
 import pygmsh
-from shapely.geometry import LineString, MultiLineString, MultiPolygon, Point, Polygon
+from scipy.interpolate import NearestNDInterpolator
+from shapely.geometry import LineString, Point, Polygon
 
+from gdsfactory.simulation.gmsh.break_geometry import break_geometry
 from gdsfactory.simulation.gmsh.meshtracker import MeshTracker
-from gdsfactory.simulation.gmsh.parse_gds import break_line, tile_shapes
+from gdsfactory.simulation.gmsh.refine import (
+    global_callback_refinement,
+    surface_interface_refinement,
+)
+
+
+def define_entities(model, shapes_dict: OrderedDict):
+    """Adds the polygons and lines from a "shapes_dict" as physical entities in the pygmsh model "model".
+
+    Args:
+        model: pygmsh model to define the entities into.
+        shapes_dict: OrderedDict containing shapes to mesh as values, and keys as physical tags.
+
+    Returns:
+        model: updated pygmsh model.
+        meshtracker: meshtracker object containing the mapping between labels, shapely objects, and gmsh objects.
+    """
+    # Break up lines and polygon edges so that plane is tiled with no partially overlapping line segments
+    polygons_broken_dict, lines_broken_dict = break_geometry(shapes_dict)
+    # Instantiate shapely to gmsh map
+    meshtracker = MeshTracker(model=model, atol=1e-3)
+    # Add lines, reusing line segments
+    model, meshtracker = add_lines(model, meshtracker, lines_broken_dict)
+    # Add surfaces, reusing lines
+    model, meshtracker = add_surfaces(model, meshtracker, polygons_broken_dict)
+    # Add interfaces
+    model, meshtracker = tag_interfaces(model, meshtracker, polygons_broken_dict)
+    # Synchronize
+    model.synchronize()
+
+    return model, meshtracker
+
+
+def add_lines(model, meshtracker, lines_broken_dict):
+    """Add lines, reusing segments via meshtracker.
+
+    Args:
+        model: pygmsh model
+        meshtracker: meshtracker object
+        lines_broken_dict: dict
+
+    Returns:
+        model: updated pygmsh model
+        meshtracker: updated meshtracker object
+    """
+    for line_name, line in lines_broken_dict.items():
+        meshtracker.add_get_xy_line(line, line_name)
+
+    return model, meshtracker
+
+
+def add_surfaces(model, meshtracker, polygons_broken_dict):
+    """Add surfaces of polygons_broken_dict to model, reusing lines via meshtracker.
+
+    Args:
+        model: pygmsh model
+        meshtracker: meshtracker object
+        polygons_broken_dict: dict of
+
+    Returns:
+        model: updated pygmsh model
+        meshtracker: updated meshtracker object
+    """
+    for polygon_name, polygons in polygons_broken_dict.items():
+        gmsh_surfaces = []
+        for polygon in polygons if hasattr(polygons, "geoms") else [polygons]:
+            gmsh_surface = meshtracker.add_xy_surface(polygon, f"{polygon_name}")
+            gmsh_surfaces.append(gmsh_surface)
+        meshtracker.model.add_physical(gmsh_surfaces, f"{polygon_name}")
+
+    return model, meshtracker
+
+
+def tag_interfaces(model, meshtracker, polygons_broken_dict):
+    """Tag all interfacial lines between polygons as logged in meshtracker.
+
+    Args:
+        model: pygmsh model
+        meshtracker: meshtracker object
+        polygons_broken_dict: dict of
+
+    Returns:
+        model: updated pygmsh model
+        meshtracker: updated meshtracker object
+    """
+    for surface1, surface2 in combinations(polygons_broken_dict.keys(), 2):
+        if interfaces := [
+            line
+            for index, line in enumerate(meshtracker.gmsh_xy_segments)
+            if (
+                meshtracker.xy_segments_main_labels[index] == surface1
+                and meshtracker.xy_segments_secondary_labels[index] == surface2
+            )
+            or (
+                meshtracker.xy_segments_main_labels[index] == surface2
+                and meshtracker.xy_segments_secondary_labels[index] == surface1
+            )
+        ]:
+            model.add_physical(interfaces, f"{surface1}___{surface2}")
+
+    return model, meshtracker
 
 
 def mesh_from_polygons(
     shapes_dict: OrderedDict,
     resolutions: Optional[Dict[str, float]] = None,
+    mesh_scaling_factor: float = 1.0,
     default_resolution_min: float = 0.01,
     default_resolution_max: float = 0.5,
     filename: Optional[str] = None,
+    global_meshsize_array: Optional[np.array] = None,
+    global_meshsize_interpolant_func: Optional[callable] = NearestNDInterpolator,
+    verbosity: Optional[bool] = False,
 ):
-    """Return a 2D mesh from an ordered dict of shapely polygons."""
-    with pygmsh.occ.geometry.Geometry() as geometry:
+    """Return a 2D mesh from an ordered dict of shapely polygons.
 
-        gmsh.initialize()
+    Args:
+        shapes_dict: OrderedDict containing shapes to mesh.
+        resolutions: Dict with same keys as shapes_dict. containing another dict with resolution settings:
+            resolution: density of the mesh
+            distance: "dropoff" distance of this resolution away from the surface
+        default_resolution_min: gmsh default smallest characteristic length
+        default_resolution_max: gmsh default largest characteristic length
+        filename: to save the mesh
+        global_meshsize_array: array [x,y,z,lc] defining local mesh sizes. Not used if None
+        global_meshsize_interpolant: interpolation function for array [x,y,z,lc]. Default scipy.interpolate.NearestNDInterpolator
+        verbosity: boolean, gmsh sdout as it meshes
+    """
+    global_meshsize_callback_bool = global_meshsize_array is not None
+
+    with pygmsh.occ.geometry.Geometry() as geometry:
 
         geometry.characteristic_length_min = default_resolution_min
         geometry.characteristic_length_max = default_resolution_max
 
         model = geometry.__enter__()
 
-        # Break up shapes in order so that plane is tiled with non-overlapping layers
-        shapes_tiled_dict = tile_shapes(shapes_dict)
+        # Define geometry
+        (
+            model,
+            meshtracker,
+        ) = define_entities(model, shapes_dict)
 
-        # Break up lines and polygon edges so that plane is tiled with no partially overlapping line segments
-        polygons_broken_dict = OrderedDict()
-        lines_broken_dict = OrderedDict()
-        for _first_index, (first_name, _init_first_shapes) in enumerate(
-            shapes_dict.items()
-        ):
-            first_shapes = shapes_tiled_dict[first_name]
-            broken_shapes = []
-            for first_shape in (
-                first_shapes.geoms if hasattr(first_shapes, "geoms") else [first_shapes]
-            ):
-                # First line exterior
-                first_exterior_line = (
-                    LineString(first_shape.exterior)
-                    if first_shape.type == "Polygon"
-                    else first_shape
-                )
-                for _second_index, (second_name, second_shapes) in enumerate(
-                    shapes_dict.items()
-                ):
-                    # Do not compare to itself
-                    if second_name == first_name:
-                        continue
-                    else:
-                        second_shapes = shapes_tiled_dict[second_name]
-                        for second_shape in (
-                            second_shapes.geoms
-                            if hasattr(second_shapes, "geoms")
-                            else [second_shapes]
-                        ):
-                            # Second line exterior
-                            second_exterior_line = (
-                                LineString(second_shape.exterior)
-                                if second_shape.type == "Polygon"
-                                else second_shape
-                            )
-                            first_exterior_line = break_line(
-                                first_exterior_line, second_exterior_line
-                            )
-                            # Second line interiors
-                            for second_interior_line in (
-                                second_shape.interiors
-                                if second_shape.type == "Polygon"
-                                else []
-                            ):
-                                second_interior_line = LineString(second_interior_line)
-                                first_exterior_line = break_line(
-                                    first_exterior_line, second_interior_line
-                                )
-                # First line interiors
-                if first_shape.type == "Polygon" or first_shape.type == "MultiPolygon":
-                    first_shape_interiors = []
-                    for first_interior_line in first_shape.interiors:
-                        first_interior_line = LineString(first_interior_line)
-                        for _second_index, (second_name, second_shapes) in enumerate(
-                            shapes_dict.items()
-                        ):
-                            if second_name == first_name:
-                                continue
-                            else:
-                                second_shapes = shapes_tiled_dict[second_name]
-                                for second_shape in (
-                                    second_shapes.geoms
-                                    if hasattr(second_shapes, "geoms")
-                                    else [second_shapes]
-                                ):
-                                    # Exterior
-                                    second_exterior_line = (
-                                        LineString(second_shape.exterior)
-                                        if second_shape.type == "Polygon"
-                                        else second_shape
-                                    )
-                                    first_interior_line = break_line(
-                                        first_interior_line, second_exterior_line
-                                    )
-                                    # Interiors
-                                    for second_interior_line in (
-                                        second_shape.interiors
-                                        if second_shape.type == "Polygon"
-                                        else []
-                                    ):
-                                        second_interior_line = LineString(
-                                            second_interior_line
-                                        )
-                                        first_interior_line = break_line(
-                                            first_interior_line, second_interior_line
-                                        )
-                        first_shape_interiors.append(first_interior_line)
-                if first_shape.type == "Polygon" or first_shape.type == "MultiPolygon":
-                    broken_shapes.append(
-                        Polygon(first_exterior_line, holes=first_shape_interiors)
-                    )
-                else:
-                    broken_shapes.append(LineString(first_exterior_line))
-            if broken_shapes:
-                if first_shape.type == "Polygon" or first_shape.type == "MultiPolygon":
-                    polygons_broken_dict[first_name] = (
-                        MultiPolygon(broken_shapes)
-                        if len(broken_shapes) > 1
-                        else broken_shapes[0]
-                    )
-                else:
-                    lines_broken_dict[first_name] = (
-                        MultiLineString(broken_shapes)
-                        if len(broken_shapes) > 1
-                        else broken_shapes[0]
-                    )
+        # Synchronize
+        model.synchronize()
 
-        # Add lines, reusing line segments
-        meshtracker = MeshTracker(model=model, atol=1e-3)
-        for line_name, line in lines_broken_dict.items():
-            meshtracker.add_get_xy_line(line, line_name)
-
-        # Add surfaces, reusing lines to simplify at early stage
-        for polygon_name, polygons in polygons_broken_dict.items():
-            gmsh_surfaces = []
-            for polygon in polygons if hasattr(polygons, "geoms") else [polygons]:
-                gmsh_surface = meshtracker.add_xy_surface(polygon, f"{polygon_name}")
-                gmsh_surfaces.append(gmsh_surface)
-            meshtracker.model.add_physical(gmsh_surfaces, f"{polygon_name}")
-
-        # Refinement in surfaces
-        n = 0
-        refinement_fields = []
-        for label, resolution in resolutions.items():
-            # Inside surface
-            mesh_resolution = resolution["resolution"]
-            gmsh.model.mesh.field.add("MathEval", n)
-            gmsh.model.mesh.field.setString(n, "F", f"{mesh_resolution}")
-            gmsh.model.mesh.field.add("Restrict", n + 1)
-            gmsh.model.mesh.field.setNumber(n + 1, "InField", n)
-            gmsh.model.mesh.field.setNumbers(
-                n + 1,
-                "SurfacesList",
-                meshtracker.get_gmsh_xy_surfaces_from_label(label),
+        # Refinement
+        if not global_meshsize_callback_bool and resolutions:
+            surface_interface_refinement(
+                model,
+                meshtracker,
+                resolutions,
+                default_resolution_min,
+                default_resolution_max,
             )
-            # Around surface
-            mesh_distance = resolution["distance"]
-            gmsh.model.mesh.field.add("Distance", n + 2)
-            gmsh.model.mesh.field.setNumbers(
-                n + 2, "CurvesList", meshtracker.get_gmsh_xy_lines_from_label(label)
+
+        elif global_meshsize_callback_bool:
+            global_callback_refinement(
+                model,
+                global_meshsize_array,
+                global_meshsize_interpolant_func,
             )
-            gmsh.model.mesh.field.setNumber(n + 2, "Sampling", 100)
-            gmsh.model.mesh.field.add("Threshold", n + 3)
-            gmsh.model.mesh.field.setNumber(n + 3, "InField", n + 2)
-            gmsh.model.mesh.field.setNumber(n + 3, "SizeMin", mesh_resolution)
-            gmsh.model.mesh.field.setNumber(n + 3, "SizeMax", default_resolution_max)
-            gmsh.model.mesh.field.setNumber(n + 3, "DistMin", 0)
-            gmsh.model.mesh.field.setNumber(n + 3, "DistMax", mesh_distance)
-            # Save and increment
-            refinement_fields.append(n + 1)
-            refinement_fields.append(n + 3)
-            n += 4
 
-        # Use the smallest element size overall
-        gmsh.model.mesh.field.add("Min", n)
-        gmsh.model.mesh.field.setNumbers(n, "FieldsList", refinement_fields)
-        gmsh.model.mesh.field.setAsBackgroundMesh(n)
-
-        gmsh.model.mesh.MeshSizeFromPoints = 0
-        gmsh.model.mesh.MeshSizeFromCurvature = 0
-        gmsh.model.mesh.MeshSizeExtendFromBoundary = 0
-
-        # Tag all interfacial lines
-        for surface1, surface2 in combinations(polygons_broken_dict.keys(), 2):
-            interfaces = []
-            for index, line in enumerate(meshtracker.gmsh_xy_segments):
-                if (
-                    meshtracker.xy_segments_main_labels[index] == surface1
-                    and meshtracker.xy_segments_secondary_labels[index] == surface2
-                ) or (
-                    meshtracker.xy_segments_main_labels[index] == surface2
-                    and meshtracker.xy_segments_secondary_labels[index] == surface1
-                ):
-                    interfaces.append(line)
-            if interfaces:
-                model.add_physical(interfaces, f"{surface1}___{surface2}")
-
-        mesh = geometry.generate_mesh(dim=2, verbose=True)
+        # Perform meshing
+        gmsh.option.setNumber("Mesh.ScalingFactor", mesh_scaling_factor)
+        mesh = geometry.generate_mesh(dim=2, verbose=verbosity)
 
         if filename:
             gmsh.write(f"{filename}")
@@ -292,13 +259,39 @@ if __name__ == "__main__":
     # The edge of a polygon and another polygon (or entire simulation domain) will form a line object that can be refined independently
     resolutions = {}
     resolutions["core"] = {"resolution": 0.05, "distance": 0}
-    resolutions["core_clad"] = {"resolution": 0.01, "distance": 0.5}
-    resolutions["clad_box"] = {"resolution": 0.01, "distance": 0.5}
+    resolutions["core___clad"] = {"resolution": 0.01, "distance": 0.5}
+    resolutions["clad___box"] = {"resolution": 0.01, "distance": 0.5}
     resolutions["bottom_edge"] = {"resolution": 0.05, "distance": 0.5}
     resolutions["left_edge"] = {"resolution": 0.05, "distance": 0.5}
     # resolutions["clad"] = {"resolution": 0.1, "dist_min": 0.01, "dist_max": 0.3}
 
-    mesh = mesh_from_polygons(shapes, resolutions, filename="mesh.msh")
+    xs = np.linspace(-wsim / 2, wsim / 2, 500)
+    ys = np.linspace(-hcore / 2 - hbox, -hcore / 2 + hclad, 500)
+    global_meshsize_array = []
+
+    ls0 = 0.02
+    ls1 = 0.05
+    ls2 = 0.005
+
+    r = 0.5
+    for x, y in product(xs, ys):
+        if np.abs(x) ** 2 + np.abs(y) ** 2 <= r**2:
+            global_meshsize_array.append([x, y, 0, ls2])
+        elif y > 0:
+            global_meshsize_array.append([x, y, 0, ls1])
+        else:
+            global_meshsize_array.append([x, y, 0, ls0])
+
+    global_meshsize_array = np.array(global_meshsize_array)
+
+    mesh = mesh_from_polygons(
+        shapes,
+        resolutions,
+        mesh_scaling_factor=0.1,
+        filename="mesh.msh",
+        global_meshsize_array=global_meshsize_array,
+        verbosity=True,
+    )
 
     # gmsh.write("mesh.msh")
     # gmsh.clear()

--- a/gdsfactory/simulation/gmsh/meshtracker.py
+++ b/gdsfactory/simulation/gmsh/meshtracker.py
@@ -97,7 +97,6 @@ class MeshTracker:
 
         Args:
             shapely_xy_point (shapely.geometry.Point): x, y coordinates
-            resolution (float): gmsh resolution at that point
         """
         index = self.get_point_index(shapely_xy_point)
         if index is not None:

--- a/gdsfactory/simulation/gmsh/parse_gds.py
+++ b/gdsfactory/simulation/gmsh/parse_gds.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import shapely
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
-from shapely.ops import linemerge, split
 
 
 def round_coordinates(geom, ndigits=3):
@@ -22,7 +21,7 @@ def round_coordinates(geom, ndigits=3):
 
 def fuse_polygons(component, layername, layer, round_tol=2, simplify_tol=1e-2):
     """Take all polygons from a layer, and returns a single (Multi)Polygon shapely object."""
-    layer_component = component.extract(layer["layer"])
+    layer_component = component.extract(layer)
     shapely_polygons = [
         round_coordinates(shapely.geometry.Polygon(polygon), round_tol)
         for polygon in layer_component.get_polygons()
@@ -40,7 +39,7 @@ def cleanup_component(component, layerstack, round_tol=2, simplify_tol=1e-2):
         layername: fuse_polygons(
             component,
             layername,
-            layer,
+            layer["layer"],
             round_tol=round_tol,
             simplify_tol=simplify_tol,
         )
@@ -93,16 +92,3 @@ def tile_shapes(shapes_dict):
             shapes_tiled_dict[lower_name] = MultiLineString(tiled_lower_shapes)
 
     return shapes_tiled_dict
-
-
-def break_line(line, other_line):
-    intersections = line.intersection(other_line)
-    if not intersections.is_empty:
-        for intersection in (
-            intersections.geoms if hasattr(intersections, "geoms") else [intersections]
-        ):
-            if intersection.type != "Point":
-                new_coords_start, new_coords_end = intersection.boundary.geoms
-                line = linemerge(split(line, new_coords_start))
-                line = linemerge(split(line, new_coords_end))
-    return line

--- a/gdsfactory/simulation/gmsh/refine.py
+++ b/gdsfactory/simulation/gmsh/refine.py
@@ -1,0 +1,94 @@
+import gmsh
+
+
+def global_callback_refinement(
+    model,
+    global_meshsize_array,
+    global_meshsize_interpolant_func,
+):
+    """Refine gmsh/pygmsh model according to a global callback dict.
+
+    Args:
+        model
+        global_meshsize_array
+        global_meshsize_interpolant_func
+    Returns:
+        model
+    """
+    global_meshsize_interpolant = global_meshsize_interpolant_func(
+        global_meshsize_array[:, 0:3], global_meshsize_array[:, 3]
+    )
+
+    def meshSizeCallback(dim, tag, x, y, z, lc):
+        return min(lc, global_meshsize_interpolant(x, y, z))
+
+    gmsh.model.mesh.setSizeCallback(meshSizeCallback)
+
+    # Turn off default meshing options
+    gmsh.model.mesh.MeshSizeFromPoints = 0
+    gmsh.model.mesh.MeshSizeFromCurvature = 0
+    gmsh.model.mesh.MeshSizeExtendFromBoundary = 0
+
+    return model
+
+
+def surface_interface_refinement(
+    model,
+    meshtracker,
+    resolutions,
+    default_resolution_min,
+    default_resolution_max,
+):
+    """Refine gmsh/pygmsh model according to a resolutions dict.
+
+    Args:
+        model
+        meshtracker
+        resolutions
+        default_resolution_min
+        default_resolution_max
+    Returns:
+        model
+        meshtracker
+    """
+    n = 0
+    refinement_fields = []
+    for label, resolution in resolutions.items():
+        # Inside surface
+        mesh_resolution = resolution["resolution"]
+        gmsh.model.mesh.field.add("MathEval", n)
+        gmsh.model.mesh.field.setString(n, "F", f"{mesh_resolution}")
+        gmsh.model.mesh.field.add("Restrict", n + 1)
+        gmsh.model.mesh.field.setNumber(n + 1, "InField", n)
+        gmsh.model.mesh.field.setNumbers(
+            n + 1,
+            "SurfacesList",
+            meshtracker.get_gmsh_xy_surfaces_from_label(label),
+        )
+        # Around surface
+        mesh_distance = resolution["distance"]
+        gmsh.model.mesh.field.add("Distance", n + 2)
+        gmsh.model.mesh.field.setNumbers(
+            n + 2, "CurvesList", meshtracker.get_gmsh_xy_lines_from_label(label)
+        )
+        gmsh.model.mesh.field.setNumber(n + 2, "Sampling", 100)
+        gmsh.model.mesh.field.add("Threshold", n + 3)
+        gmsh.model.mesh.field.setNumber(n + 3, "InField", n + 2)
+        gmsh.model.mesh.field.setNumber(n + 3, "SizeMin", mesh_resolution)
+        gmsh.model.mesh.field.setNumber(n + 3, "SizeMax", default_resolution_max)
+        gmsh.model.mesh.field.setNumber(n + 3, "DistMin", 0)
+        gmsh.model.mesh.field.setNumber(n + 3, "DistMax", mesh_distance)
+        refinement_fields.extend((n + 1, n + 3))
+        n += 4
+
+    # Use the smallest element size overall
+    gmsh.model.mesh.field.add("Min", n)
+    gmsh.model.mesh.field.setNumbers(n, "FieldsList", refinement_fields)
+    gmsh.model.mesh.field.setAsBackgroundMesh(n)
+
+    # Turn off default meshing options
+    gmsh.model.mesh.MeshSizeFromPoints = 0
+    gmsh.model.mesh.MeshSizeFromCurvature = 0
+    gmsh.model.mesh.MeshSizeExtendFromBoundary = 0
+
+    return model, meshtracker

--- a/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
+from scipy.interpolate import NearestNDInterpolator
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 
 import gdsfactory as gf
@@ -116,11 +117,14 @@ def uz_xsection_mesh(
     xsection_bounds: Tuple[Tuple[float, float], Tuple[float, float]],
     layerstack: LayerStack,
     resolutions: Optional[Dict],
+    mesh_scaling_factor: float = 1.0,
     default_resolution_min: float = 0.01,
     default_resolution_max: float = 0.5,
     background_tag: Optional[str] = None,
     background_padding: Tuple[float, float, float, float] = (2.0, 2.0, 2.0, 2.0),
     filename: Optional[str] = None,
+    global_meshsize_array: Optional[np.array] = None,
+    global_meshsize_interpolant_func: Optional[callable] = NearestNDInterpolator,
 ):
     # Fuse and cleanup polygons of same layer in case user overlapped them
     layer_polygons_dict = cleanup_component(component, layerstack)
@@ -168,9 +172,12 @@ def uz_xsection_mesh(
     return mesh_from_polygons(
         shapes,
         resolutions=resolutions,
+        mesh_scaling_factor=mesh_scaling_factor,
         filename=filename,
         default_resolution_min=default_resolution_min,
         default_resolution_max=default_resolution_max,
+        global_meshsize_array=global_meshsize_array,
+        global_meshsize_interpolant_func=global_meshsize_interpolant_func,
     )
 
 


### PR DESCRIPTION
* Mesh code refactoring (break into smaller functions)
* Extending devsim plugin to accept mesh callbacks
* Mesh callback to define position-dependent characteristic length: allows meshing based on arbitrary criteria, e.g.

```
     # Define geometry as usual...

    # Create some x and y values
    xs = np.linspace(-wsim / 2, wsim / 2, 1000)
    ys = np.linspace(-hcore / 2 - hbox, -hcore / 2 + hclad, 1000)
    background_field = []

    # Assign mesh sizes to the x, y values (z also needs to be defines, set to 0)
    # I want a circle with mesh size ls2 with radius 0.5
    # Then size ls1 for positive y
    # and finally size ls0 for negative y
    ls0 = 0.02
    ls1 = 0.05
    ls2 = 0.005

    r = 0.5
    for x, y in product(xs, ys):
        if np.abs(x) ** 2 + np.abs(y) ** 2 <= r**2:
            background_field.append([x, y, 0, ls2])
        elif y > 0:
            background_field.append([x, y, 0, ls1])
        else:
            background_field.append([x, y, 0, ls0])

    # The callback needs a smooth function, so I interpolate these x,y values:
    from scipy.interpolate import NearestNDInterpolator
    background_field = np.array(background_field)
    background_field = NearestNDInterpolator(background_field[:,0:3], background_field[:,3])

    # Call meshing function...
```

on some shapes will refine in the shape of a circle in the middle, and different resolution above and below y=0:

![image](https://user-images.githubusercontent.com/46427609/204925679-c152ca50-692b-42fb-b858-ecb4fd7a6630.png)

