### PR TITLE
fixing position of rotated "no orientation" ports

### DIFF
--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -484,14 +484,7 @@ class ComponentReference(_GeometryHelper):
     ) -> Tuple[ndarray, float]:
         """Apply GDS-type transformation to a port (x_ref)."""
         new_point = np.array(point)
-        new_orientation = orientation
-
-        if orientation is None:
-            if origin is not None:
-                new_point = new_point + np.array(origin)
-            if x_reflection:
-                new_point[1] = -new_point[1]
-            return new_point, new_orientation
+        new_orientation = orientation or 0
 
         if x_reflection:
             new_point[1] = -new_point[1]
@@ -501,7 +494,11 @@ class ComponentReference(_GeometryHelper):
             new_orientation += rotation
         if origin is not None:
             new_point = new_point + np.array(origin)
-        new_orientation = mod(new_orientation, 360)
+
+        if orientation is None:
+            new_orientation = orientation
+        else:
+            new_orientation = mod(new_orientation, 360)
 
         return new_point, new_orientation
 

--- a/gdsfactory/tests/test_rotate.py
+++ b/gdsfactory/tests/test_rotate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy.testing as npt
+
 import gdsfactory as gf
 
 
@@ -12,6 +14,32 @@ def test_rotate() -> None:
 
     assert c1.uid == c2.uid
     assert c1r.uid == c2r.uid
+
+
+def test_rotate_port() -> None:
+    port_center_original = (10, 0)
+    port_center_expected = (0, 10)
+    rotation = 90
+    port_orientation_expected = rotation
+    c1 = gf.Component()
+    p1 = c1.add_port(
+        "o1", center=port_center_original, width=5, layer="WG", orientation=0
+    )
+    p2 = p1.copy()
+    p2.orientation = None
+    c1.add_port("e1", port=p2)
+    c = gf.Component()
+    c1_ref = c << c1
+    c1_ref.rotate(rotation)
+    port_center_actual = c1_ref["o1"].center
+    port_orientation_actual = c1_ref["o1"].orientation
+    npt.assert_almost_equal(port_center_actual, port_center_expected)
+    assert port_orientation_actual == port_orientation_expected
+
+    port_center_actual_no_orientation = c1_ref["e1"].center
+    port_orientation_actual_no_orientation = c1_ref["e1"].orientation
+    npt.assert_almost_equal(port_center_actual_no_orientation, port_center_expected)
+    assert port_orientation_actual_no_orientation is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @joamatab , we found a pretty serious bug today.

When references are rotated, ports with no orientation are not correctly transformed. This PR fixes that bug and adds a simple test for this case.