### PR TITLE
Fix rename ports by orientation

### DIFF
--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -754,7 +754,7 @@ def rename_ports_by_orientation(
         # Make sure we can backtrack the parent component from the port
         p.parent = component
 
-        if p.orientation:
+        if p.orientation is not None:
             angle = p.orientation % 360
             if angle <= 45 or angle >= 315:
                 direction_ports["E"].append(p)


### PR DESCRIPTION
This patch ensures that a port orientation of 0 degrees sets the port direction label to "E" instead of "S" since  p.orientation == 0 currently evaluates to False. 