### PR TITLE
width_to_z and gmsh requirements

### DIFF
--- a/gdsfactory/simulation/gmsh/process_component.py
+++ b/gdsfactory/simulation/gmsh/process_component.py
@@ -21,7 +21,17 @@ def bufferize(layerstack: LayerStack):
                 buffer_magnitude = layer.thickness * np.tan(
                     np.radians(layer.sidewall_angle)
                 )
-                layer.z_to_bias = ([0, 1], [0, -1 * buffer_magnitude])
+                if layer.width_to_z:
+                    layer.z_to_bias = (
+                        [0, layer.width_to_z, 1],
+                        [
+                            1 * buffer_magnitude * layer.width_to_z,
+                            0,
+                            -1 * buffer_magnitude * (1 - layer.width_to_z),
+                        ],
+                    )
+                else:
+                    layer.z_to_bias = ([0, 1], [0, -1 * buffer_magnitude])
 
     return layerstack
 

--- a/gdsfactory/tech.py
+++ b/gdsfactory/tech.py
@@ -109,6 +109,7 @@ class LayerLevel(BaseModel):
         zmin: height position where material starts in um.
         material: material name.
         sidewall_angle: in degrees with respect to normal.
+        width_to_z: if sidewall_angle, relative z-position (0 --> zmin, 1 --> zmin + thickness) where structural width equals GDS lauer width.
         z_to_bias: parametrizes shrinking/expansion of the design GDS layer
             when extruding from zmin (0) to zmin + thickness (1).
             Defaults no buffering [[0, 1], [0, 0]].
@@ -132,7 +133,8 @@ class LayerLevel(BaseModel):
     thickness_tolerance: Optional[float] = None
     zmin: float
     material: Optional[str] = None
-    sidewall_angle: float = 0
+    sidewall_angle: float = 0.0
+    width_to_z: float = 0.0
     z_to_bias: Optional[Tuple[List[float], List[float]]] = None
     info: Dict[str, Any] = {}
 
@@ -262,7 +264,8 @@ def get_layer_stack_generic(
                 zmin=0.0,
                 material="si",
                 info={"mesh_order": 1},
-                sidewall_angle=0,
+                sidewall_angle=10,
+                width_to_z=0.5,
             ),
             clad=LayerLevel(
                 # layer=LAYER.WGCLAD,
@@ -317,6 +320,7 @@ def get_layer_stack_generic(
                 material="Aluminum",
                 info={"mesh_order": 1},
                 sidewall_angle=-10,
+                width_to_z=0,
             ),
             metal1=LayerLevel(
                 layer=LAYER.M1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ gmsh = [
     "pygmsh",
     "pyvista",
     "trimesh",
+    "shapely<=1.8.4"
     ]
 sipann = ["SIPANN==2.0.0"]
 tidy3d = ["tidy3d-beta==1.7.1"]


### PR DESCRIPTION
If sidewall, can specific at which height gds layer width equals structural width