### PR TITLE
mesh by material option & 2D physical group for interfaces

### DIFF
--- a/gdsfactory/simulation/gmsh/parse_gds.py
+++ b/gdsfactory/simulation/gmsh/parse_gds.py
@@ -4,7 +4,7 @@ import shapely
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon, box
 
 
-def round_coordinates(geom, ndigits=3):
+def round_coordinates(geom, ndigits=5):
     """Round coordinates to n_digits to eliminate floating point errors."""
 
     def _round_coords(x, y, z=None):
@@ -19,7 +19,7 @@ def round_coordinates(geom, ndigits=3):
     return shapely.ops.transform(_round_coords, geom)
 
 
-def fuse_polygons(component, layername, layer, round_tol=2, simplify_tol=1e-2):
+def fuse_polygons(component, layername, layer, round_tol=5, simplify_tol=1e-5):
     """Take all polygons from a layer, and returns a single (Multi)Polygon shapely object."""
     layer_component = component.extract(layer)
     shapely_polygons = [

--- a/gdsfactory/simulation/gmsh/process_component.py
+++ b/gdsfactory/simulation/gmsh/process_component.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Dict
 
 import numpy as np
+from shapely.geometry import MultiPolygon
+from shapely.ops import unary_union
 
+from gdsfactory.simulation.gmsh.parse_gds import to_polygons
 from gdsfactory.tech import LayerLevel, LayerStack
 
 
@@ -85,3 +88,23 @@ def process_buffers(layer_polygons_dict: Dict, layerstack: LayerStack):
         )
 
     return extended_layer_polygons_dict, LayerStack(layers=extended_layerstack_layers)
+
+
+def merge_by_material_func(layer_polygons_dict: Dict, layerstack: LayerStack):
+    """Merge polygons of layer_polygons_dict whose layerstack keys share the same material in layerstack values.
+
+    Returns new layer_polygons_dict with merged polygons and materials as keys.
+    """
+    merged_layer_polygons_dict = {}
+    for layername, polygons in layer_polygons_dict.items():
+        material = layerstack.layers[layername].material
+        if material in merged_layer_polygons_dict:
+            merged_layer_polygons_dict[material] = unary_union(
+                MultiPolygon(
+                    to_polygons([merged_layer_polygons_dict[material], polygons])
+                )
+            )
+        else:
+            merged_layer_polygons_dict[material] = polygons
+
+    return merged_layer_polygons_dict

--- a/gdsfactory/simulation/gmsh/process_component.py
+++ b/gdsfactory/simulation/gmsh/process_component.py
@@ -108,3 +108,29 @@ def merge_by_material_func(layer_polygons_dict: Dict, layerstack: LayerStack):
             merged_layer_polygons_dict[material] = polygons
 
     return merged_layer_polygons_dict
+
+
+def create_2D_surface_interface(
+    layer_polygons: MultiPolygon,
+    thickness_min: float = 0.0,
+    thickness_max: float = 0.01,
+    simplify: float = 0.005,
+):
+    """Create 2D entity at the interface of two layers/materials.
+
+    Arguments:
+        layer_polygons: shapely polygons.
+        thickness_min: distance to define the interfacial region towards the polygon.
+        thickness_max: distance to define the interfacial region away from the polygon.
+        simplify: simplification factor for over-parametrized geometries
+
+    Returns:
+        shapely interface polygon
+    """
+    interfaces = layer_polygons.boundary
+    interface_surface = layer_polygons.boundary
+    left_hand_side = interfaces.buffer(thickness_max, single_sided=True)
+    right_hand_side = interfaces.buffer(-thickness_min, single_sided=True)
+    interface_surface = left_hand_side.union(right_hand_side)
+
+    return interface_surface.simplify(simplify, preserve_topology=False)

--- a/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/uz_xsection_mesh.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+from shapely.ops import unary_union
 
 import gdsfactory as gf
 from gdsfactory.simulation.gmsh.mesh import mesh_from_polygons
@@ -183,7 +184,7 @@ def uz_xsection_mesh(
     )
 
     # u-z coordinates to gmsh-friendly polygons
-    # Remove terminal layers
+    # Remove terminal layers and merge polygons
     layer_order = order_layerstack(layerstack)  # gds layers
     shapes = OrderedDict() if extra_shapes_dict is None else extra_shapes_dict
     for layername in layer_order:
@@ -192,7 +193,7 @@ def uz_xsection_mesh(
             if gds_name == layername:
                 layer_shapes = list(bounds)
                 current_shapes.append(MultiPolygon(to_polygons(layer_shapes)))
-        shapes[layername] = MultiPolygon(to_polygons(current_shapes))
+        shapes[layername] = unary_union(MultiPolygon(to_polygons(current_shapes)))
 
     # Add background polygon
     if background_tag is not None:

--- a/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
@@ -14,6 +14,7 @@ from gdsfactory.simulation.gmsh.parse_layerstack import (
     get_layers_at_z,
     order_layerstack,
 )
+from gdsfactory.simulation.gmsh.process_component import merge_by_material_func
 from gdsfactory.tech import LayerStack
 from gdsfactory.types import ComponentOrReference
 
@@ -32,6 +33,7 @@ def xy_xsection_mesh(
     global_meshsize_array: Optional[np.array] = None,
     global_meshsize_interpolant_func: Optional[callable] = NearestNDInterpolator,
     extra_shapes_dict: Optional[OrderedDict] = None,
+    merge_by_material: Optional[bool] = False,
 ):
     """Mesh xy cross-section of component at height z.
 
@@ -49,6 +51,7 @@ def xy_xsection_mesh(
         global_meshsize_array: np array [x,y,z,lc] to parametrize the mesh
         global_meshsize_interpolant_func: interpolating function for global_meshsize_array
         extra_shapes_dict: Optional[OrderedDict] = OrderedDict of {key: geo} with key a label and geo a shapely (Multi)Polygon or (Multi)LineString of extra shapes to override component
+        merge_by_material: boolean, if True will merge polygons from layers with the same layer.material. Physical keys will be material in this case.
     """
     # Find layers present at this z-level
     layers = get_layers_at_z(layerstack, z)
@@ -74,6 +77,10 @@ def xy_xsection_mesh(
                 [bounds[2] + background_padding[2], bounds[1] - background_padding[1]],
             ]
         )
+
+    # Merge by material
+    if merge_by_material:
+        shapes = merge_by_material_func(shapes, layerstack)
 
     # Mesh
     return mesh_from_polygons(


### PR DESCRIPTION
Option to have the mesh elements defined by material instead of layer

EDIT: Also option to generate a mesh representing the _surface_ of another surface for e.g. a finite-element version of loss calculation #831 . The new surface is returned with physical tag {old name}Int for now.

Example:

  ```
  geometry = uz_xsection_mesh(
        c,
        [(4, -15), (4, 15)],
        filtered_layerstack,
        resolutions=resolutions,
        # background_tag="Oxide",
        filename="mesh.msh",
        merge_by_material=True,
        interface_surfaces={"si": (0.002, 0.002, 0.0002)},
    )


    resolutions = {}
    resolutions["si"] = {"resolution": 0.02, "distance": 0.1}
    resolutions["siInt"] = {"resolution": 0.0003, "distance": 0.1}
    resolutions["Aluminum"] = {"resolution": 0.1, "distance": 1}
```

![image](https://user-images.githubusercontent.com/46427609/207798386-0734510f-5680-4d10-9362-dc1e181673d6.png)


![image](https://user-images.githubusercontent.com/46427609/207798055-46adc5da-8a4b-41a6-8ae2-7674ab5167d7.png)
