### PR TITLE
Fem mode solver

### DIFF
--- a/docs/notebooks/plugins/fem/01_mode_solving.ipynb
+++ b/docs/notebooks/plugins/fem/01_mode_solving.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Finite-element mode solver\n",
+    "\n",
+    "PDEs can be solved on meshed components.\n",
+    "\n",
+    "For instance, a finite-element mode solver can easily be called on a component cross-section. Unlike the other mode solvers, this actually uses the component geometry instead of a hardcoded geometry.\n",
+    "\n",
+    "Below, we directly compute the modes of a Gdsfactory cross-section (internally, a \"uz\" mesh is defined perpendicular to a straight component with the provided cross-section). We also downsample layers from the LayerStack, and both the cross-section and LayerStack can be modified prior to simulation to change the geometry. The refractive indices are interpolated from the dict `gdsfactory.pdk._ACTIVE_PDK`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "from gdsfactory.simulation.fem.mode_solver import compute_cross_section_modes\n",
+    "from gdsfactory.tech import LayerStack, get_layer_stack_generic\n",
+    "from gdsfactory.cross_section import rib\n",
+    "\n",
+    "filtered_layerstack = LayerStack(\n",
+    "    layers={\n",
+    "        k: get_layer_stack_generic().layers[k]\n",
+    "        for k in (\n",
+    "            \"core\",\n",
+    "            \"clad\",\n",
+    "            \"slab90\",\n",
+    "            \"box\",\n",
+    "        )\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "filtered_layerstack.layers[\"core\"].thickness = 0.2 # Perturb the layerstack before simulating\n",
+    "\n",
+    "resolutions = {}\n",
+    "resolutions[\"core\"] = {\"resolution\": 0.02, \"distance\": 2}\n",
+    "resolutions[\"clad\"] = {\"resolution\": 0.2, \"distance\": 1}\n",
+    "resolutions[\"box\"] = {\"resolution\": 0.2, \"distance\": 1}\n",
+    "resolutions[\"slab90\"] = {\"resolution\": 0.05, \"distance\": 1}\n",
+    "\n",
+    "lams, basis, xs = compute_cross_section_modes(cross_section=rib(width=0.6), \n",
+    "                            layerstack=filtered_layerstack,\n",
+    "                            wl = 1.55,\n",
+    "                            num_modes = 4, \n",
+    "                            resolutions=resolutions,\n",
+    "                        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The solver returns the effective indices (lams), FEM basis functions (basis) and eigenvectors (xs):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lams, basis, xs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These can be used as inputs to other [femwell mode solver functions](https://github.com/HelgeGehring/femwell/blob/main/femwell/mode_solver.py) to inspect or analyze the modes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "from femwell import mode_solver\n",
+    "import numpy as np\n",
+    "\n",
+    "fig = mode_solver.plot_mode(basis, np.real(xs[0]), plot_vectors=False, colorbar=True, title='E', direction='y')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "te_frac = mode_solver.calculate_te_frac(basis, xs[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "te_frac"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.8 ('gf1_tooling')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "9681f22f6b021b51767cd12f2ee94a3aa82f62cc2b3c7aa4d0f31bfe25e768dd"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/plugins_mesh.md
+++ b/docs/plugins_mesh.md
@@ -11,5 +11,6 @@
    notebooks/plugins/meshing/02_2D_xy_mesh.ipynb
    notebooks/plugins/meshing/03_2D_uz_mesh.ipynb
    notebooks/plugins/meshing/04_refinement.ipynb
+   notebooks/plugins/fem/01_mode_solving.ipynb
 
 ```

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -1,0 +1,121 @@
+import numpy as np
+from femwell import mode_solver
+from skfem import Basis, ElementTriN2, ElementTriP0, ElementTriP2, Mesh
+
+import gdsfactory as gf
+from gdsfactory.pdk import _ACTIVE_PDK
+from gdsfactory.tech import LayerStack, get_layer_stack_generic
+from gdsfactory.types import CrossSectionSpec
+
+
+def compute_cross_section_modes(
+    cross_section: CrossSectionSpec,
+    layerstack: LayerStack,
+    wl: float = 1.55,
+    num_modes: int = 4,
+    order: int = 1,
+    radius: float = np.inf,
+    filename: str = "mesh.msh",
+    **kwargs,
+):
+    """Calculate effective index of a straight cross-section.
+
+    Arguments:
+        cross_section: gdsfactory cross-section
+        layerstack: gdsfactory layerstack
+        wl: wavelength (um)
+        num_modes: number of modes to return
+        order: order of the mesh elements
+        radius: bend radius of the cross-section
+        filename (str, path): where to save the .msh file
+        Keyword Args: Arguments for gdsfactory.simulation.gmsh.uz_xsection_mesh.uz_xsection_mesh():
+            resolutions (Dict): Pairs {"layername": {"resolution": float, "distance": "float}} to roughly control mesh refinement within and away from entity, respectively
+            mesh_scaling_factor (float): factor multiply mesh geometry by
+            default_resolution_min (float): gmsh minimal edge length
+            default_resolution_max (float): gmsh maximal edge length
+            background_tag (str): name of the background layer to add (default: no background added)
+            background_padding (Tuple): [xleft, ydown, xright, yup] distances to add to the components and to fill with background_tag
+            global_meshsize_array: np array [x,y,z,lc] to parametrize the mesh
+            global_meshsize_interpolant_func: interpolating function for global_meshsize_array
+            extra_shapes_dict: Optional[OrderedDict] = OrderedDict of {key: geo} with key a label and geo a shapely (Multi)Polygon or (Multi)LineString of extra shapes to override component
+            merge_by_material: boolean, if True will merge polygons from layers with the same layer.material. Physical keys will be material in this case.
+    """
+    # Get meshable component from cross-section
+    c = gf.components.straight(length=10, cross_section=cross_section)
+    c.show()
+    bounds = c.bbox
+    dx = np.diff(bounds[:, 0])
+
+    # Mesh
+    mesh = c.to_gmsh(
+        type="uz",
+        xsection_bounds=[[dx / 2, bounds[0, 1]], [dx / 2, bounds[1, 1]]],
+        layer_stack=layerstack,
+        filename=filename,
+        **kwargs,
+    )
+
+    # Assign materials to mesh elements
+    mesh = Mesh.load("mesh.msh")
+    basis = Basis(mesh, ElementTriN2() * ElementTriP2())
+    basis0 = basis.with_element(ElementTriP0())
+    epsilon = basis0.zeros(dtype=complex)
+    for layername, layer in layerstack.layers.items():
+        if layername in mesh.subdomains.keys():
+            epsilon[basis0.get_dofs(elements=layername)] = (
+                _ACTIVE_PDK.materials_index[layer.material](wl) ** 2
+            )
+        if "background_tag" in kwargs.keys():
+            epsilon[basis0.get_dofs(elements=kwargs["background_tag"])] = (
+                _ACTIVE_PDK.materials_index[kwargs["background_tag"]](wl) ** 2
+            )
+
+    # Mode solve
+    lams, basis, xs = mode_solver.compute_modes(
+        basis0,
+        epsilon,
+        wavelength=wl,
+        mu_r=1,
+        num_modes=num_modes,
+        order=order,
+        radius=radius,
+    )
+
+    return lams, basis, xs
+
+    def plot_cross_section_modes():
+        return True
+
+
+if __name__ == "__main__":
+
+    filtered_layerstack = LayerStack(
+        layers={
+            k: get_layer_stack_generic().layers[k]
+            for k in (
+                "core",
+                "clad",
+                "slab90",
+                "box",
+            )
+        }
+    )
+
+    filtered_layerstack["core"].thickness = 0.2
+
+    resolutions = {}
+    resolutions["core"] = {"resolution": 0.02, "distance": 2}
+    resolutions["clad"] = {"resolution": 0.2, "distance": 1}
+    resolutions["box"] = {"resolution": 0.2, "distance": 1}
+    resolutions["slab90"] = {"resolution": 0.05, "distance": 1}
+
+    compute_cross_section_modes(
+        cross_section="rib",
+        layerstack=filtered_layerstack,
+        wl=1.55,
+        num_modes=4,
+        order=1,
+        radius=np.inf,
+        filename="mesh.msh",
+        resolutions=resolutions,
+    )

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         }
     )
 
-    filtered_layerstack["core"].thickness = 0.2
+    filtered_layerstack.layers["core"].thickness = 0.2
 
     resolutions = {}
     resolutions["core"] = {"resolution": 0.02, "distance": 2}

--- a/gdsfactory/simulation/fem/test_mode_solver.py
+++ b/gdsfactory/simulation/fem/test_mode_solver.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from gdsfactory.simulation.fem.mode_solver import compute_cross_section_modes
+from gdsfactory.tech import LayerStack, get_layer_stack_generic
+
+
+def test_compute_cross_section_mode():
+
+    filtered_layerstack = LayerStack(
+        layers={
+            k: get_layer_stack_generic().layers[k]
+            for k in (
+                "core",
+                "clad",
+                "slab90",
+                "box",
+            )
+        }
+    )
+
+    filtered_layerstack.layers["core"].thickness = 0.2
+
+    resolutions = {}
+    resolutions["core"] = {"resolution": 0.02, "distance": 2}
+    resolutions["clad"] = {"resolution": 0.2, "distance": 1}
+    resolutions["box"] = {"resolution": 0.2, "distance": 1}
+    resolutions["slab90"] = {"resolution": 0.05, "distance": 1}
+
+    lams, basis, xs = compute_cross_section_modes(
+        cross_section="rib",
+        layerstack=filtered_layerstack,
+        wl=1.55,
+        num_modes=4,
+        order=1,
+        radius=np.inf,
+        filename="mesh.msh",
+        resolutions=resolutions,
+    )
+
+    assert len(lams) == 4
+
+
+if __name__ == "__main__":
+
+    test_compute_cross_section_mode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ gmsh = [
     "pygmsh",
     "pyvista",
     "trimesh",
-    "shapely"
+    "shapely",
+    "femwell",
     ]
 sipann = ["SIPANN==2.0.0"]
 tidy3d = ["tidy3d-beta==1.8.0"]


### PR DESCRIPTION
Unlike other mode solvers, directly uses the gdsfactory cross-section (no need to hardcode geometry), which can be arbitrarily complicated thanks to z_to_bias parameter

Also used in model extraction (my next PR)

Requires femwell (updated requirements), I have bundled it with "gmsh"

@HelgeGehring 