### PR TITLE
add angle argument to coupler90bend

### DIFF
--- a/gdsfactory/components/coupler90bend.py
+++ b/gdsfactory/components/coupler90bend.py
@@ -10,6 +10,7 @@ from gdsfactory.types import ComponentSpec, CrossSectionSpec
 def coupler90bend(
     radius: float = 10.0,
     gap: float = 0.2,
+    angle: float = 90.0,
     bend: ComponentSpec = bend_euler,
     cross_section_inner: CrossSectionSpec = "strip",
     cross_section_outer: CrossSectionSpec = "strip",
@@ -19,6 +20,7 @@ def coupler90bend(
     Args:
         radius: um.
         gap: um.
+        angle: of the bends, from beginning to end. Depending on the bend chosen, gap may not be preserved.
         bend: for bend.
         cross_section_inner: spec inner bend.
         cross_section_outer: spec outer bend.
@@ -43,10 +45,10 @@ def coupler90bend(
     spacing = gap + width
 
     bend90_inner = gf.get_component(
-        bend, radius=radius, cross_section=cross_section_inner
+        bend, radius=radius, cross_section=cross_section_inner, angle=angle
     )
     bend90_outer = gf.get_component(
-        bend, radius=radius + spacing, cross_section=cross_section_outer
+        bend, radius=radius + spacing, cross_section=cross_section_outer, angle=angle
     )
     bend_inner_ref = c << bend90_inner
     bend_outer_ref = c << bend90_outer

--- a/gdsfactory/components/coupler90bend.py
+++ b/gdsfactory/components/coupler90bend.py
@@ -10,7 +10,8 @@ from gdsfactory.types import ComponentSpec, CrossSectionSpec
 def coupler90bend(
     radius: float = 10.0,
     gap: float = 0.2,
-    angle: float = 90.0,
+    angle_inner: float = 90.0,
+    angle_outer: float = 90.0,
     bend: ComponentSpec = bend_euler,
     cross_section_inner: CrossSectionSpec = "strip",
     cross_section_outer: CrossSectionSpec = "strip",
@@ -20,7 +21,8 @@ def coupler90bend(
     Args:
         radius: um.
         gap: um.
-        angle: of the bends, from beginning to end. Depending on the bend chosen, gap may not be preserved.
+        angle_inner: of the inner bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
+        angle_outer: of the outer bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
         bend: for bend.
         cross_section_inner: spec inner bend.
         cross_section_outer: spec outer bend.
@@ -45,10 +47,13 @@ def coupler90bend(
     spacing = gap + width
 
     bend90_inner = gf.get_component(
-        bend, radius=radius, cross_section=cross_section_inner, angle=angle
+        bend, radius=radius, cross_section=cross_section_inner, angle=angle_inner
     )
     bend90_outer = gf.get_component(
-        bend, radius=radius + spacing, cross_section=cross_section_outer, angle=angle
+        bend,
+        radius=radius + spacing,
+        cross_section=cross_section_outer,
+        angle=angle_outer,
     )
     bend_inner_ref = c << bend90_inner
     bend_outer_ref = c << bend90_outer
@@ -68,5 +73,8 @@ def coupler90bend(
 
 
 if __name__ == "__main__":
-    c = coupler90bend(radius=3)
+
+    from bend_circular import bend_circular
+
+    c = coupler90bend(radius=3, bend=bend_circular, angle_inner=90, angle_outer=45)
     c.show(show_ports=True)


### PR DESCRIPTION
While this means ports aren't always at 90 degrees, this could be useful inside another component when absorbed

Default behaviour preserved with angle=90 (default):
`    c = coupler90bend(radius=3, bend=bend_euler, angle=90)
`
![image](https://user-images.githubusercontent.com/46427609/209037944-e57b3cf9-e803-4421-a6c6-2cf0452bcec4.png)

Otherwise seems to work fine when giving other values:
`    c = coupler90bend(radius=3, bend=bend_euler, angle=45)
`
![image](https://user-images.githubusercontent.com/46427609/209038006-5cffc6bc-e583-46e7-86c3-d77708bb79a0.png)

There's more errors in gap at higher angles for `bend_euler`
`    c = coupler90bend(radius=3, bend=bend_euler, angle=120)
`
![image](https://user-images.githubusercontent.com/46427609/209038133-eecbb340-ec88-4750-a2a6-654475f8004d.png)
But  `bend_circular` is always fine
`    from bend_circular import bend_circular
    c = coupler90bend(radius=3, bend=bend_circular, angle=160)
    c.show(show_ports=True)`
![image](https://user-images.githubusercontent.com/46427609/209038306-a5f5a19b-80f4-49c6-b900-8fd999f0e0f4.png)
