### PR TITLE
mirroring cross-section at class level

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -100,12 +100,13 @@ class CrossSection(BaseModel):
         """Extend BaseModel init to process mirroring."""
         super().__init__(**data)
 
-        if data["mirror"]:
-            data["offset"] *= -1
-            for section in data["sections"]:
-                section.offset *= -1
-            for offset in data["cladding_offsets"]:
-                offset *= -1
+        if "mirror" in data.keys():
+            if data["mirror"]:
+                data["offset"] *= -1
+                for section in data["sections"]:
+                    section.offset *= -1
+                for offset in data["cladding_offsets"]:
+                    offset *= -1
 
     class Config:
         """Configuration."""


### PR DESCRIPTION
Repeat #1048 but for all cross-sections instead of just pn as discussed in #1049, by overriding CrossSection constructor. Default is False to preserve legacy behaviour, but the tests fail now (KeyError everywhere).

Continued discussion in #1049 for followup

EDIT: I fixed all KeyErrors with a check, now all tests pass after rebuilding the regressions


