### PR TITLE
update tidy3d

### DIFF
--- a/docs/notebooks/09_pdk_import.ipynb
+++ b/docs/notebooks/09_pdk_import.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "gf.clear_cache()\n",
     "\n",
-    "c = gf.import_gds(gdspath)\n",
+    "c = gf.import_gds(gdspath, read_metadata=True)\n",
     "c"
    ]
   },
@@ -126,7 +126,7 @@
    "source": [
     "import gdsfactory as gf\n",
     "\n",
-    "c2 = gf.import_gds(gdspath, name=\"mzi_sample\")\n",
+    "c2 = gf.import_gds(gdspath, name=\"mzi_sample\", read_metadata=True)\n",
     "c2"
    ]
   },

--- a/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
+++ b/docs/notebooks/plugins/meep/001_meep_sparameters.ipynb
@@ -1253,7 +1253,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/test_write_sparameters_meep.py
@@ -69,6 +69,7 @@ def test_sparameters_straight_mpi() -> None:
         c, ymargin=0, overwrite=True, **simulation_settings
     )
     sp = np.load(filepath)
+    sp = dict(sp)
 
     # Check reasonable reflection/transmission
     assert np.allclose(np.abs(sp["o1@0,o2@0"]), 1, atol=1e-02), np.abs(sp["o1@0,o2@0"])
@@ -96,6 +97,7 @@ def test_sparameters_straight_batch() -> None:
 
     filepath = filepaths[0]
     sp = np.load(filepath)
+    sp = dict(sp)
 
     # Check reasonable reflection/transmission
     assert np.allclose(np.abs(sp["o1@0,o2@0"]), 1, atol=1e-02), np.abs(sp["o1@0,o2@0"])
@@ -131,7 +133,7 @@ def test_sparameters_lazy_parallelism() -> None:
     filepath_serial = gm.write_sparameters_meep_mpi(
         c, ymargin=0, overwrite=True, lazy_parallelism=False, **simulation_settings
     )
-    sp_serial = np.load(filepath_serial)
+    sp_serial = dict(np.load(filepath_serial))
 
     # Check matching reflection/transmission
     assert np.allclose(sp_parallel["o1@0,o1@0"], sp_serial["o1@0,o1@0"], atol=1e-2)
@@ -141,11 +143,22 @@ def test_sparameters_lazy_parallelism() -> None:
 
 
 if __name__ == "__main__":
-    test_sparameters_straight()
+    # test_sparameters_straight()
     # test_sparameters_straight_mpi(None)
     # test_sparameters_crossing_symmetric(False)
     # test_sparameterslazy_parallelism()
     # test_sparameters_straight_symmetric()
     # test_sparameters_straight_batch()
-    # test_sparameters_straight_mpi()
+    test_sparameters_straight_mpi()
     # test_sparameters_crossing_symmetric()
+
+    # c = gf.components.straight(length=2)
+    # p = 3
+    # c = gf.add_padding_container(c, default=0, top=p, bottom=p)
+    # filepath = gm.write_sparameters_meep_mpi(
+    #     c, ymargin=0, overwrite=True, **simulation_settings
+    # )
+    # sp = dict(np.load(filepath))
+
+    # # Check reasonable reflection/transmission
+    # assert np.allclose(np.abs(sp["o1@0,o2@0"]), 1, atol=1e-02), np.abs(sp["o1@0,o2@0"])

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -180,7 +180,7 @@ def write_sparameters_meep_mpi(
         "from gdsfactory.simulation.gmeep import write_sparameters_meep\n\n",
         "from gdsfactory.read import import_gds\n",
         'if __name__ == "__main__":\n\n',
-        f'\tcomponent = import_gds("{component_file}")\n',
+        f'\tcomponent = import_gds("{component_file}", read_metadata=True)\n',
         f"\twith open(\"{parameters_file}\", 'rb') as inp:\n",
         "\t\tparameters_dict = pickle.load(inp)\n\n" "\twrite_sparameters_meep(\n",
         "\t\tcomponent = component,\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,12 @@ gmsh = [
     "shapely",
     ]
 sipann = ["SIPANN==2.0.0", "simphony==0.6.1"]
-tidy3d = ["tidy3d-beta==1.8.0"]
+tidy3d = ["tidy3d-beta==1.8.1"]
 devsim = [
     "devsim",
     "mkl",
     "pyvista",
-    "tidy3d-beta==1.8.0",
+    "tidy3d-beta==1.8.1",
     ]
 meow = [
     "meow-sim",


### PR DESCRIPTION
- update tidy3d from 1.8.0 to 1.8.1
- fix write_sparameters_meep_mpi, after default `read_metadata=False` in import_gds