### PR TITLE
Cache fem modes

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -4,6 +4,7 @@ To create a component you need to extrude the path with a cross-section.
 """
 from __future__ import annotations
 
+import hashlib
 import inspect
 import sys
 from collections.abc import Iterable
@@ -120,6 +121,11 @@ class CrossSection(BaseModel):
             "add_pins": {"exclude": True},
             "add_bbox": {"exclude": True},
         }
+
+    @property
+    def name(self) -> str:
+        h = hashlib.md5(str(self).encode()).hexdigest()[:8]
+        return f"xs_{h}"
 
     def copy(self, width: Optional[float] = None):
         xs = super().copy()

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -16,7 +16,6 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from gdsfactory.add_pins import add_bbox_siepic, add_pins_siepic_optical_2nm
-from gdsfactory.serialization import clean_dict
 from gdsfactory.tech import Section
 
 Layer = Tuple[int, int]
@@ -187,48 +186,6 @@ class CrossSection(BaseModel):
             for layer, points in zip(x.bbox_layers, padding):
                 c.add_polygon(points, layer=layer)
         return c
-
-    def to_dict(
-        self,
-    ) -> Dict[str, Any]:
-        """Returns Dict representation of a cross section.
-
-        Args:
-            ignore_components_prefix: for components to ignore when exporting.
-            ignore_functions_prefix: for functions to ignore when exporting.
-            with_cells: write cells recursively.
-            with_ports: write port information dict.
-        """
-        return clean_dict(
-            {
-                "name": self.name,
-                "layer": self.layer,
-                "width": self.width,
-                "offset": self.offset,
-                "radius": self.radius,
-                "width_wide": self.width_wide,
-                "auto_widen": self.auto_widen,
-                "auto_widen_minimum_length": self.auto_widen_minimum_length,
-                "taper_length": self.taper_length,
-                "bbox_layers": self.bbox_layers,
-                "bbox_offsets": self.bbox_offsets,
-                "cladding_layers": self.cladding_layers,
-                "cladding_offsets": self.cladding_offsets,
-                "sections": self.sections,
-                "port_names": self.port_names,
-                "port_types": self.port_types,
-                "min_length": self.min_length,
-                "start_straight_length": self.start_straight_length,
-                "end_straight_length": self.end_straight_length,
-                "snap_to_grid": self.snap_to_grid,
-                "decorator": self.decorator,
-                "add_pins": self.add_pins,
-                "add_bbox": self.add_bbox,
-                "info": self.info,
-                "add_center_section": self.add_center_section,
-                "mirror": self.mirror,
-            }
-        )
 
 
 class Transition(CrossSection):
@@ -1489,5 +1446,3 @@ if __name__ == "__main__":
     p = gf.path.straight()
     c = p.extrude(xs)
     c.show()
-
-    print(xs.to_dict())

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -308,6 +308,7 @@ def cross_section(
     add_bbox: Optional[Callable] = None,
     add_center_section: bool = True,
     mirror: bool = False,
+    name: Optional[str] = None,
 ) -> CrossSection:
     """Return CrossSection.
 
@@ -342,6 +343,7 @@ def cross_section(
         add_center_section: whether a section with `width` and `layer`
               is added during extrude.
         mirror: if True, reflects the offsets.
+        name: cross section name for serialization
 
 
     .. plot::
@@ -380,6 +382,7 @@ def cross_section(
         add_pins=add_pins,
         add_center_section=add_center_section,
         mirror=mirror,
+        name=name,
     )
 
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from gdsfactory.add_pins import add_bbox_siepic, add_pins_siepic_optical_2nm
+from gdsfactory.serialization import clean_dict
 from gdsfactory.tech import Section
 
 Layer = Tuple[int, int]
@@ -186,6 +187,48 @@ class CrossSection(BaseModel):
             for layer, points in zip(x.bbox_layers, padding):
                 c.add_polygon(points, layer=layer)
         return c
+
+    def to_dict(
+        self,
+    ) -> Dict[str, Any]:
+        """Returns Dict representation of a cross section.
+
+        Args:
+            ignore_components_prefix: for components to ignore when exporting.
+            ignore_functions_prefix: for functions to ignore when exporting.
+            with_cells: write cells recursively.
+            with_ports: write port information dict.
+        """
+        return clean_dict(
+            {
+                "name": self.name,
+                "layer": self.layer,
+                "width": self.width,
+                "offset": self.offset,
+                "radius": self.radius,
+                "width_wide": self.width_wide,
+                "auto_widen": self.auto_widen,
+                "auto_widen_minimum_length": self.auto_widen_minimum_length,
+                "taper_length": self.taper_length,
+                "bbox_layers": self.bbox_layers,
+                "bbox_offsets": self.bbox_offsets,
+                "cladding_layers": self.cladding_layers,
+                "cladding_offsets": self.cladding_offsets,
+                "sections": self.sections,
+                "port_names": self.port_names,
+                "port_types": self.port_types,
+                "min_length": self.min_length,
+                "start_straight_length": self.start_straight_length,
+                "end_straight_length": self.end_straight_length,
+                "snap_to_grid": self.snap_to_grid,
+                "decorator": self.decorator,
+                "add_pins": self.add_pins,
+                "add_bbox": self.add_bbox,
+                "info": self.info,
+                "add_center_section": self.add_center_section,
+                "mirror": self.mirror,
+            }
+        )
 
 
 class Transition(CrossSection):
@@ -1443,3 +1486,5 @@ if __name__ == "__main__":
     p = gf.path.straight()
     c = p.extrude(xs)
     c.show()
+
+    print(xs.to_dict())

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -15,7 +15,7 @@ def compute_cross_section_modes(
     num_modes: int = 4,
     order: int = 1,
     radius: float = np.inf,
-    filename: str = "mesh.msh",
+    mesh_filename: str = "mesh.msh",
     **kwargs,
 ):
     """Calculate effective index of a straight cross-section.
@@ -27,7 +27,7 @@ def compute_cross_section_modes(
         num_modes: number of modes to return.
         order: order of the mesh elements.
         radius: bend radius of the cross-section.
-        filename (str, path): where to save the .msh file.
+        mesh_filename (str, path): where to save the .msh file.
 
     Keyword Args:
         resolutions (Dict): Pairs {"layername": {"resolution": float, "distance": "float}}
@@ -53,12 +53,12 @@ def compute_cross_section_modes(
         type="uz",
         xsection_bounds=[[dx / 2, bounds[0, 1]], [dx / 2, bounds[1, 1]]],
         layer_stack=layerstack,
-        filename=filename,
+        filename=mesh_filename,
         **kwargs,
     )
 
     # Assign materials to mesh elements
-    mesh = Mesh.load("mesh.msh")
+    mesh = Mesh.load(mesh_filename)
     basis = Basis(mesh, ElementTriN2() * ElementTriP2())
     basis0 = basis.with_element(ElementTriP0())
     epsilon = basis0.zeros(dtype=complex)

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -68,7 +68,7 @@ def compute_cross_section_modes(
 
     sim_settings = sim_settings.copy()
     sim_settings["layerstack"] = layerstack.to_dict()
-    sim_settings["cross_section"] = gf.get_cross_section(cross_section).to_dict()
+    sim_settings["cross_section"] = dict(gf.get_cross_section(cross_section))
     filepath = pathlib.Path(filepath)
     filepath_sim_settings = filepath.with_suffix(".yml")
 

--- a/gdsfactory/simulation/fem/test_mode_solver.py
+++ b/gdsfactory/simulation/fem/test_mode_solver.py
@@ -35,6 +35,7 @@ def test_compute_cross_section_mode():
         radius=np.inf,
         filename="mesh.msh",
         resolutions=resolutions,
+        overwrite=True,
     )
 
     assert len(lams) == 4

--- a/gdsfactory/simulation/get_modes_path.py
+++ b/gdsfactory/simulation/get_modes_path.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import hashlib
+import pathlib
+from copy import deepcopy
+from functools import partial
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+import gdsfactory as gf
+from gdsfactory.name import clean_value
+from gdsfactory.pdk import get_modes_path
+from gdsfactory.tech import LAYER_STACK
+from gdsfactory.types import CrossSectionSpec
+
+
+def get_kwargs_hash(**kwargs) -> str:
+    """Returns kwargs parameters hash."""
+    kwargs_list = [f"{key}={clean_value(kwargs[key])}" for key in sorted(kwargs.keys())]
+    kwargs_string = "_".join(kwargs_list)
+    return hashlib.md5(kwargs_string.encode()).hexdigest()[:8]
+
+
+def _get_modes_path(
+    cross_section: CrossSectionSpec,
+    dirpath: Optional[Path] = None,
+    **kwargs,
+) -> Path:
+    """Return modes npz filepath hashing simulation settings for \
+            a consistent unique name.
+
+    Args:
+        cross_section: cross_section or cross_section factory.
+        dirpath: directory to store sparameters in CSV.
+            Defaults to active Pdk.sparameters_path.
+        kwargs: simulation settings.
+
+    """
+    dirpath = dirpath or get_modes_path()
+    cross_section = gf.get_cross_section(cross_section)
+
+    dirpath = pathlib.Path(dirpath)
+    dirpath = (
+        dirpath / cross_section.function_name
+        if hasattr(cross_section, "function_name")
+        else dirpath
+    )
+    dirpath.mkdir(exist_ok=True, parents=True)
+    return dirpath / f"{cross_section.name}_{get_kwargs_hash(**kwargs)}.npz"
+
+
+def _get_modes_data(**kwargs) -> np.ndarray:
+    """Returns modes data in a pandas DataFrame.
+
+    Keyword Args:
+        cross_section: cross_section or cross_section factory.
+        dirpath: directory path to store sparameters.
+        kwargs: simulation settings.
+
+    """
+    filepath = _get_modes_path(**kwargs)
+    return np.load(filepath)
+
+
+get_modes_path_femwell = partial(_get_modes_path, tool="femwell")
+
+
+def test_get_modes_path(test: bool = True) -> None:
+    import gdsfactory as gf
+
+    nm = 1e-3
+    layer_stack2 = deepcopy(LAYER_STACK)
+    layer_stack2.layers["core"].thickness = 230 * nm
+
+    cross_section = gf.cross_section.strip(name="strip")
+
+    p1 = get_modes_path_femwell(cross_section=cross_section)
+    p2 = get_modes_path_femwell(cross_section=cross_section, layer_stack=layer_stack2)
+    p3 = get_modes_path_femwell(
+        cross_section=cross_section, material_name_to_lumerical=dict(si=3.6)
+    )
+
+    if test:
+        name1 = "strip_782ce72c"
+        name2 = "strip_a01df6f8"
+        name3 = "strip_e88b3d6d"
+
+        assert p1.stem == name1, p1.stem
+        assert p2.stem == name2, p2.stem
+        assert p3.stem == name3, p3.stem
+    else:
+        print(f"name1 = {p1.stem!r}")
+        print(f"name2 = {p2.stem!r}")
+        print(f"name3 = {p3.stem!r}")
+
+
+if __name__ == "__main__":
+
+    # cross_section = gf.cross_section.strip(name="strip")
+    # p = get_modes_path_femwell(cross_section)
+    # print(p)
+
+    # modes = np.load(p)
+    # modesd = dict(modes)
+    # print(modesd)
+
+    # test_get_modes_path(test=False)
+    test_get_modes_path(test=True)


### PR DESCRIPTION
Caching of FEM modes. 

Since this is the first mode solver that does not use a hardcoded geometry and directly acts on cross-sections, we serialize the cross-section + layerstack similar to what is done for component S-parameters.

@joamatab can we generate names for cross-sections, maybe using a decorator like Components? Right now I'm setting the name attribute when defining the cross-section, would be nice to have nice defaults

Also I need to pickle load the sk-fem basis function objects, since they cannot be reduced to an array. Maybe there's a better way?