### PR TITLE
Expose compiled docs in `test_docs` as artifact

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -133,3 +133,9 @@ jobs:
           echo ${{ secrets.TIDY3D_AUTH }} > $HOME/.tidy3d/auth.json
           cd docs
           make html
+      - name: Upload docs as artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: docs
+          path: docs/build/html/


### PR DESCRIPTION
This PR adds exposing the compiled docs in `test_docs` as an artifact.
The default artifact expiration policy for the repo should be adjusted to something reasonable, or a value in days be added here.

The docs seem to take over 100 MB of space so maybe 1 week or less would be good. What do you think @joamatab ?
The policy may be added with the `retention-days: 7` input.

Closes #1071