### PR TITLE
Remove Suggested fix section from feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,3 @@ Adding the code in `fixme/` folder is also a great option for others to reproduc
 
 **Describe the solution you'd like**
 What would you like to happen?
-
-**Suggested fix**
-How could we fix the bug?


### PR DESCRIPTION
This PR simply removes the _Suggested fix_ section from the feature issue template, as it doesn't really belong there.

Closes #1129 