### PR TITLE
Advertise pre-built Docker image in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![docs](https://github.com/gdsfactory/gdsfactory/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/gdsfactory/)
 [![PyPI](https://img.shields.io/pypi/v/gdsfactory)](https://pypi.org/project/gdsfactory/)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/gdsfactory.svg)](https://anaconda.org/conda-forge/gdsfactory)
+[![Dockerhub](https://img.shields.io/docker/pulls/joamatab/gdsfactory)](https://hub.docker.com/r/joamatab/gdsfactory)
 [![PyPI Python](https://img.shields.io/pypi/pyversions/gdsfactory.svg)](https://pypi.python.org/pypi/gdsfactory)
 [![issues](https://img.shields.io/github/issues/gdsfactory/gdsfactory)](https://github.com/gdsfactory/gdsfactory/issues)
 [![forks](https://img.shields.io/github/forks/gdsfactory/gdsfactory.svg)](https://github.com/gdsfactory/gdsfactory/network/members)

--- a/docs/notebooks/_2_install.ipynb
+++ b/docs/notebooks/_2_install.ipynb
@@ -55,7 +55,16 @@
     "- `pip install gdsfactory[gmsh]` for mesh plugins.\n",
     "- `pip install gdsfactory[devsim]` for TCAD simulations.\n",
     "- `pip install gdsfactory[meow]` for EME (Eigen Mode Expansion) simulations.\n",
-    "- `mamba install pymeep=*=mpi_mpich_* -y` for open source FDTD MEEP simulations. Notice that it works for MacOS and Linux, so for windows you need to use the [WSL (windows subsystem for linux)](https://learn.microsoft.com/en-us/windows/wsl/install)."
+    "- `mamba install pymeep=*=mpi_mpich_* -y` for open source FDTD MEEP simulations. Notice that it works for MacOS and Linux, so for Windows you need to use the [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install).\n",
+    "\n",
+    "\n",
+    "## Docker container\n",
+    "\n",
+    "Alternatively, one may use the pre-built Docker image from [hub.docker.com/r/joamatab/gdsfactory](https://hub.docker.com/r/joamatab/gdsfactory) or build it yourself with\n",
+    "```bash\n",
+    "docker build -t joamatab/gdsfactory .\n",
+    "```\n",
+    "For example, VS Code supports development inside a container, see [Developing inside a Container](https://code.visualstudio.com/docs/devcontainers/containers) for details.\n"
    ]
   },
   {


### PR DESCRIPTION
I suggest adding a link to Dockerhub in the README in the form of a badge and mentioning it in the docs. If the location or formatting should be different, this branch can be edited.

Closes #1131