### PR TITLE
Add autosummary to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_autosummary/
 
 # PyBuilder
 target/


### PR DESCRIPTION
I tried building the docs locally and the `docs/_autosummary` was visible in my untracked git files. I think it makes sense to gitignore it, as the build folder is ignored as well.