### PR TITLE
name argument added to cross_section function

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -309,6 +309,7 @@ def cross_section(
     add_bbox: Optional[Callable] = None,
     add_center_section: bool = True,
     mirror: bool = False,
+    name: Optional[str] = None
 ) -> CrossSection:
     """Return CrossSection.
 
@@ -343,6 +344,7 @@ def cross_section(
         add_center_section: whether a section with `width` and `layer`
               is added during extrude.
         mirror: if True, reflects the offsets.
+        name: cross_section name.
 
 
     .. plot::
@@ -381,6 +383,7 @@ def cross_section(
         add_pins=add_pins,
         add_center_section=add_center_section,
         mirror=mirror,
+        name=name
     )
 
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -309,7 +309,7 @@ def cross_section(
     add_bbox: Optional[Callable] = None,
     add_center_section: bool = True,
     mirror: bool = False,
-    name: Optional[str] = None
+    name: Optional[str] = None,
 ) -> CrossSection:
     """Return CrossSection.
 
@@ -383,7 +383,7 @@ def cross_section(
         add_pins=add_pins,
         add_center_section=add_center_section,
         mirror=mirror,
-        name=name
+        name=name,
     )
 
 


### PR DESCRIPTION
This PR fixes the issue where the cross_section function never passes the 'name' argument to the CrossSection class.