### PR TITLE
Femwell cache size

### DIFF
--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -14,6 +14,12 @@ from gdsfactory.technology import LayerStack
 from gdsfactory.types import CrossSectionSpec, PathType
 
 
+def load_mesh_basis(mesh_filename: PathType):
+    mesh = Mesh.load(mesh_filename)
+    basis = Basis(mesh, ElementTriN2() * ElementTriP2())
+    return mesh, basis
+
+
 def compute_cross_section_modes(
     cross_section: CrossSectionSpec,
     layerstack: LayerStack,
@@ -96,8 +102,7 @@ def compute_cross_section_modes(
     )
 
     # Assign materials to mesh elements
-    mesh = Mesh.load(mesh_filename)
-    basis = Basis(mesh, ElementTriN2() * ElementTriP2())
+    mesh, basis = load_mesh_basis(mesh_filename)
     basis0 = basis.with_element(ElementTriP0())
     epsilon = basis0.zeros(dtype=complex)
     for layername, layer in layerstack.layers.items():

--- a/gdsfactory/simulation/get_modes_path.py
+++ b/gdsfactory/simulation/get_modes_path.py
@@ -63,7 +63,7 @@ def _get_modes_data(**kwargs) -> np.ndarray:
     return np.load(filepath)
 
 
-get_modes_path_femwell = partial(_get_modes_path, tool="femwell", extension="pickle")
+get_modes_path_femwell = partial(_get_modes_path, tool="femwell")
 
 
 def test_get_modes_path(test: bool = True) -> None:


### PR DESCRIPTION
Mode data for femwell is now 1.5M by saving mesh instead of basis functions, and saving neffs and basis coefficients under npz. 

Addresses #1152 

![image](https://user-images.githubusercontent.com/46427609/212778859-ef909a06-23a3-4272-ad33-420c7754078f.png)

Option to only cache neff and not modes + mesh could reduce this further