### PR TITLE
Add interdigital capacitor

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -147,6 +147,7 @@ from gdsfactory.components.grating_coupler_rectangular_arbitrary_slab import (
 from gdsfactory.components.grating_coupler_tree import grating_coupler_tree
 from gdsfactory.components.greek_cross import greek_cross
 from gdsfactory.components.hline import hline
+from gdsfactory.components.interdigital_capacitor import interdigital_capacitor
 from gdsfactory.components.L import L
 from gdsfactory.components.litho_calipers import litho_calipers
 from gdsfactory.components.litho_ruler import litho_ruler
@@ -423,6 +424,7 @@ __all__ = [
     "grating_tooth_points",
     "greek_cross",
     "hline",
+    "interdigital_capacitor",
     "litho_calipers",
     "litho_ruler",
     "litho_steps",

--- a/gdsfactory/components/interdigital_capacitor.py
+++ b/gdsfactory/components/interdigital_capacitor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from itertools import chain
+from math import ceil, floor
+from typing import Union
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.types import LayerSpec
+
+
+@gf.cell
+def interdigital_capacitor(
+    fingers: int = 4,
+    finger_length: Union[float, int] = 20.0,
+    finger_gap: Union[float, int] = 2.0,
+    thickness: Union[float, int] = 5.0,
+    layer: LayerSpec = "WG",
+) -> Component:
+    """Generates an interdigital capacitor with ports on both ends.
+
+    See for example Zhu et al., `Accurate circuit model of interdigital
+    capacitor and its application to design of new uasi-lumped miniaturized
+    filters with suppression of harmonic resonance`, doi: 10.1109/22.826833.
+
+    Note:
+        ``finger_length=0`` effectively provides a plate capacitor.
+
+    Args:
+        fingers: total fingers of the capacitor
+        finger_length: length of the probing fingers
+        finger_gap: length of gap between the fingers
+        thickness: Thickness of fingers and section before the fingers.
+        layer: spec.
+    """
+    c = Component()
+
+    assert fingers >= 1, "Must have at least 1 finger"
+
+    width = 2 * thickness + finger_length + finger_gap  # total length
+    height = fingers * thickness + (fingers - 1) * finger_gap  # total height
+    points_1 = [
+        (0, 0),
+        (0, height),
+        (thickness + finger_length, height),
+        (thickness + finger_length, height - thickness),
+        (thickness, height - thickness),
+        *chain.from_iterable(
+            (
+                (thickness, height - (2 * i) * (thickness + finger_gap)),
+                (
+                    thickness + finger_length,
+                    height - (2 * i) * (thickness + finger_gap),
+                ),
+                (
+                    thickness + finger_length,
+                    height - (2 * i) * (thickness + finger_gap) - thickness,
+                ),
+                (thickness, height - (2 * i) * (thickness + finger_gap) - thickness),
+            )
+            for i in range(ceil(fingers / 2))
+        ),
+        (thickness, 0),
+        (0, 0),
+    ]
+
+    points_2 = [
+        (width, 0),
+        (width, height),
+        (width - thickness, height),
+        *chain.from_iterable(
+            (
+                (
+                    width - thickness,
+                    height - (1 + 2 * i) * thickness - (1 + 2 * i) * finger_gap,
+                ),
+                (
+                    width - (thickness + finger_length),
+                    height - (1 + 2 * i) * thickness - (1 + 2 * i) * finger_gap,
+                ),
+                (
+                    width - (thickness + finger_length),
+                    height - (2 + 2 * i) * thickness - (1 + 2 * i) * finger_gap,
+                ),
+                (
+                    width - thickness,
+                    height - (2 + 2 * i) * thickness - (1 + 2 * i) * finger_gap,
+                ),
+            )
+            for i in range(floor(fingers / 2))
+        ),
+        (width - thickness, 0),
+        (width, 0),
+    ]
+
+    c.add_polygon(points_1, layer=layer)
+    c.add_polygon(points_2, layer=layer)
+    c.add_port(
+        name="o1",
+        center=(0, height / 2),
+        width=thickness,
+        orientation=180,
+        layer=layer,
+    )
+    c.add_port(
+        name="o2",
+        center=(width, height / 2),
+        width=thickness,
+        orientation=0,
+        layer=layer,
+    )
+    return c
+
+
+if __name__ == "__main__":
+
+    c = interdigital_capacitor()
+    c.show(show_ports=True)


### PR DESCRIPTION
This PR implements an [interdigital capacitor](https://www.keysight.com/us/en/assets/7018-08093/technical-overviews-archived/5989-8912.pdf) component with parametrisation for
* amount of fingers
  * length
  * gap
  * thickness

Also, using `finger_length=0`, one gets a plate capacitor

![image](https://user-images.githubusercontent.com/7860886/212992510-5b5de06c-22e4-4339-a58a-a3206bf8b09d.png)

@joamatab, could you check if there's anything missing in the component definition here?

Part of https://github.com/gdsfactory/gdsfactory/issues/610