### PR TITLE
Flat netlist

### DIFF
--- a/docs/notebooks/11_get_netlist.ipynb
+++ b/docs/notebooks/11_get_netlist.ipynb
@@ -389,11 +389,133 @@
    "source": [
     "n_recursive.keys()"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## get_netlist_flat\n",
+    "\n",
+    "The recursive netlist can be flattened:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_netlist = c.get_netlist_flat()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The flat netlist contains the same keys as a regular netlist, and can be used similarly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_netlist.keys()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, its instances are flattened and uniquely renamed according to hierarchy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_netlist[\"instances\"].keys()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Placement information is accumulated, and connections and ports are mapped, respectively, to the ports of the unique instances or the component top level ports. This can be plotted:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.plot_netlist_flat(with_labels=False)  # labels get cluttered"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## allow_multiple_connections\n",
+    "\n",
+    "The default `get_netlist` function (also used by default by `get_netlist_recurse` and `get_netlist_flat`) can identify more than two ports sharing the same connection through the `allow_multiple` flag.\n",
+    "\n",
+    "For instance, consider a resistor network with one shared node:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vdiv = gf.Component(\"voltageDivider\")\n",
+    "r1 = vdiv << gf.components.resistance_sheet()\n",
+    "r2 = vdiv << gf.components.resistance_sheet()\n",
+    "r3 = vdiv << gf.get_component(gf.components.resistance_sheet).rotate()\n",
+    "r4 = vdiv << gf.get_component(gf.components.resistance_sheet).rotate()\n",
+    "\n",
+    "r1.connect(\"pad2\", r2.ports[\"pad1\"])\n",
+    "r3.connect(\"pad1\", r2.ports[\"pad1\"], preserve_orientation=True)\n",
+    "r4.connect(\"pad2\", r2.ports[\"pad1\"], preserve_orientation=True)\n",
+    "\n",
+    "vdiv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    vdiv.get_netlist_flat()\n",
+    "except Exception as exc:\n",
+    "    print(exc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vdiv.get_netlist_flat(allow_multiple=True)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "gdsfactory_srim",
    "language": "python",
    "name": "python3"
   },
@@ -407,7 +529,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0812c0e95dbda637e29019a0b7cdaea2a8eb8ed2ab9b7320ca5d44200ec34a9a"
+   }
   }
  },
  "nbformat": 4,

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -422,18 +422,21 @@ class Component(_GeometryHelper):
         ports_ccw = self.get_ports_list(clockwise=False, **kwargs)
         return snap_to_grid(ports_ccw[0].y - ports_cw[0].y)
 
-    def plot_netlist(self, with_labels: bool = True, font_weight: str = "normal"):
+    def plot_netlist(
+        self, with_labels: bool = True, font_weight: str = "normal", **kwargs
+    ):
         """Plots a netlist graph with networkx.
 
         Args:
             with_labels: add label to each node.
             font_weight: normal, bold.
+            **kwargs: keyword arguments for the get_netlist function
         """
         import matplotlib.pyplot as plt
         import networkx as nx
 
         plt.figure()
-        netlist = self.get_netlist()
+        netlist = self.get_netlist(**kwargs)
         connections = netlist["connections"]
         placements = netlist["placements"]
         G = nx.Graph()
@@ -443,7 +446,43 @@ class Component(_GeometryHelper):
                 for k, v in connections.items()
             ]
         )
+        pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
+        labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
+        nx.draw(
+            G,
+            with_labels=with_labels,
+            font_weight=font_weight,
+            labels=labels,
+            pos=pos,
+        )
+        return G
 
+    def plot_netlist_flat(
+        self, with_labels: bool = True, font_weight: str = "normal", **kwargs
+    ):
+        """Plots a netlist graph with networkx.
+
+        Args:
+            flat: if true, will plot the flat netlist
+            with_labels: add label to each node.
+            font_weight: normal, bold.
+            **kwargs: keyword arguments for the get_netlist function
+        """
+        import matplotlib.pyplot as plt
+        import networkx as nx
+
+        plt.figure()
+        netlist = self.get_netlist_flat(**kwargs)
+        connections = netlist["connections"]
+        placements = netlist["placements"]
+        connections_list = []
+        for k, v_list in connections.items():
+            for v in v_list:
+                connections_list.append(
+                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                )
+        G = nx.Graph()
+        G.add_edges_from(connections_list)
         pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
         labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
         nx.draw(
@@ -483,6 +522,8 @@ class Component(_GeometryHelper):
             tolerance: tolerance in nm to consider two ports connected.
             exclude_port_types: optional list of port types to exclude from netlisting.
             get_instance_name: function to get instance name.
+            allow_multiple: False to raise an error if more than two ports share the same connection.
+                if True, will return key: [value] pairs with [value] a list of all connected instances.
 
         Returns:
             Netlist dict (instances, connections, placements, ports)
@@ -508,6 +549,8 @@ class Component(_GeometryHelper):
             tolerance: tolerance in nm to consider two ports connected.
             exclude_port_types: optional list of port types to exclude from netlisting.
             get_instance_name: function to get instance name.
+            allow_multiple: False to raise an error if more than two ports share the same connection.
+                if True, will return key: [value] pairs with [value] a list of all connected instances.
 
         Returns:
             Dictionary of netlists, keyed by the name of each component.
@@ -515,6 +558,28 @@ class Component(_GeometryHelper):
         from gdsfactory.get_netlist import get_netlist_recursive
 
         return get_netlist_recursive(component=self, **kwargs)
+
+    def get_netlist_flat(self, **kwargs) -> Dict[str, DictConfig]:
+        """Returns a netlist where all subinstances are exposed and independently named.
+
+        Keyword Args:
+            component: to extract netlist.
+            component_suffix: suffix to append to each component name.
+                useful if to save and reload a back-annotated netlist.
+            get_netlist_func: function to extract individual netlists.
+            full_settings: True returns all, false changed settings.
+            tolerance: tolerance in nm to consider two ports connected.
+            exclude_port_types: optional list of port types to exclude from netlisting.
+            get_instance_name: function to get instance name.
+            allow_multiple: False to raise an error if more than two ports share the same connection.
+                if True, will return key: [value] pairs with [value] a list of all connected instances.
+
+        Returns:
+            Dictionary of netlists, keyed by the name of each component.
+        """
+        from gdsfactory.get_netlist_flat import get_netlist_flat
+
+        return get_netlist_flat(component=self, **kwargs)
 
     def assert_ports_on_grid(self, nm: int = 1) -> None:
         """Asserts that all ports are on grid."""

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -705,6 +705,7 @@ class ComponentReference(_GeometryHelper):
         port: Union[str, Port],
         destination: Port,
         overlap: float = 0.0,
+        preserve_orientation: bool = False,
     ) -> ComponentReference:
         """Return ComponentReference where port connects to a destination.
 
@@ -712,6 +713,7 @@ class ComponentReference(_GeometryHelper):
             port: origin (port, or port name) to connect.
             destination: destination port.
             overlap: how deep does the port go inside.
+            preserve_orientation: if True, will not rotate the reference to align the port orientations; reference will keep its orientation pre-connection.
 
         Returns:
             ComponentReference: with correct rotation to connect to destination.
@@ -727,7 +729,11 @@ class ComponentReference(_GeometryHelper):
                 f"port = {port!r} not in {self.parent.name!r} ports {ports}"
             )
 
-        if destination.orientation is not None and p.orientation is not None:
+        if (
+            destination.orientation is not None
+            and p.orientation is not None
+            and preserve_orientation is not True
+        ):
             angle = 180 + destination.orientation - p.orientation
             angle = angle % 360
             self.rotate(angle=angle, center=p.center)

--- a/gdsfactory/components/resistance_sheet.py
+++ b/gdsfactory/components/resistance_sheet.py
@@ -46,9 +46,11 @@ def resistance_sheet(
     r0 = c << compass(
         size=(length + layer_offsets[0], width + layer_offsets[0]), layer=layers[0]
     )
+    c.absorb(r0)
 
     for layer, offset in zip(layers[1:], layer_offsets[1:]):
-        c << compass(size=(length + 2 * offset, width + 2 * offset), layer=layer)
+        r = c << compass(size=(length + 2 * offset, width + 2 * offset), layer=layer)
+        c.absorb(r)
 
     pad1.connect("e3", r0.ports["e1"])
     pad2.connect("e1", r0.ports["e3"])
@@ -71,6 +73,8 @@ def resistance_sheet(
         width=width,
         orientation=port_orientation2,
     )
+    c.absorb(pad1)
+    c.absorb(pad2)
     return c
 
 

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -143,7 +143,7 @@ def get_netlist(
         exclude_port_types: optional list of port types to exclude from netlisting.
         get_instance_name: function to get instance name.
         allow_multiple: False to raise an error if more than two ports share the same connection.
-            if True, will return sequential pairwise connections.
+            if True, will return key: [value] pairs with [value] a list of all connected instances.
 
     Returns:
         instances: Dict of instance name and settings.

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -111,6 +111,7 @@ def get_netlist(
     tolerance: int = 5,
     exclude_port_types: Optional[Union[List[str], Tuple[str]]] = ("placement",),
     get_instance_name: Callable[..., str] = get_instance_name_from_alias,
+    allow_multiple: bool = False,
 ) -> Dict[str, Any]:
     """From Component returns instances, connections and placements dict.
 
@@ -141,6 +142,8 @@ def get_netlist(
         tolerance: tolerance in nm to consider two ports connected.
         exclude_port_types: optional list of port types to exclude from netlisting.
         get_instance_name: function to get instance name.
+        allow_multiple: False to raise an error if more than two ports share the same connection.
+            if True, will return sequential pairwise connections.
 
     Returns:
         instances: Dict of instance name and settings.
@@ -253,7 +256,11 @@ def get_netlist(
         if exclude_port_types and port_type in exclude_port_types:
             continue
         connections_t, warnings_t = extract_connections(
-            port_names, name2port, port_type, tolerance=tolerance
+            port_names,
+            name2port,
+            port_type,
+            tolerance=tolerance,
+            allow_multiple=allow_multiple,
         )
         if warnings_t:
             warnings[port_type] = warnings_t
@@ -290,6 +297,7 @@ def extract_connections(
     port_type: str,
     tolerance: int = 5,
     validators: Optional[Dict[str, Callable]] = None,
+    allow_multiple: bool = False,
 ):
     if validators is None:
         validators = DEFAULT_CONNECTION_VALIDATORS
@@ -301,6 +309,7 @@ def extract_connections(
         port_type,
         tolerance=tolerance,
         connection_validator=validator,
+        allow_multiple=allow_multiple,
     )
 
 
@@ -311,6 +320,7 @@ def _extract_connections_two_sweep(
     connection_validator: Callable,
     tolerance: int,
     raise_error_for_warnings: Optional[List[str]] = None,
+    allow_multiple: bool = False,
 ):
     warnings = defaultdict(list)
     if raise_error_for_warnings is None:
@@ -351,9 +361,21 @@ def _extract_connections_two_sweep(
                 connection_validator(port1, port2, ports_at_xy, warnings)
                 connections.append(ports_at_xy)
 
-            else:
+            elif not allow_multiple:
                 warnings["multiple_connections"].append(ports_at_xy)
                 raise ValueError(f"Found multiple connections at {xy}:{ports_at_xy}")
+
+            else:
+                num_ports = len(ports_at_xy)
+                for portindex1, portindex2 in zip(
+                    range(-1, num_ports - 1), range(0, num_ports)
+                ):
+                    port1 = ports[ports_at_xy[portindex1]]
+                    port2 = ports[ports_at_xy[portindex2]]
+                    connection_validator(port1, port2, ports_at_xy, warnings)
+                    connections.append(
+                        [ports_at_xy[portindex1], ports_at_xy[portindex2]]
+                    )
 
     if unconnected_port_names:
         unconnected_non_top_level = [

--- a/gdsfactory/get_netlist_flat.py
+++ b/gdsfactory/get_netlist_flat.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+from collections.abc import Iterable
+from typing import Any, Dict, List
+from gdsfactory.component import Component
+
+from gdsfactory.get_netlist import get_netlist_recursive
+
+
+def get_netlist_flat(
+    component: Component,
+    **kwargs,
+) -> Dict[str, Any]:
+    """Parses a recursive netlist for a component as if it was a single netlist of its lowest-level instances.
+
+    Procedure:
+        - Recursively parse the recursive dict to generate a unique list of all instances **even if they are reused**
+          Each entry is formatted as [(netlist, instance),...], and defines a unique flat_name = {top}{hierarchy_delimiter}{instance}{hierarchy_delimiter}{instance}{hierarchy_delimiter}...
+        - Populate the flat netlist dict with similar entries as regular gdsfactory netlists:
+            - instances: component, info, and settings from the original netlist, but keyed with flat_name
+            - placements: For instance corresponding to each flat_name, accumulate placements across the hierarchy
+            - ports and connections: each unique port of each flat_name instance is uniquely named as flat_name,port_name
+                                     for each flat_name,port_name, starting at lowest hierarchy level:
+                                        - list connections at that level (finding the proper other flat_name,port_name if non-leaf level)
+                                        - if possible, maps the port to a port of that instance's netlist, and repeat at a higher level
+                                        - if the top level is reached, assign that flat_name,port_name to a top-level component port instead
+                    the returned ports dict has top level component portname: flat_name,port_name mappings
+                    the returned connections dict is sorted and flattened into a minimal (flat_name,port_name)_1: [(flat_name,port_name)] key: value pairs
+                        If allow_multiple flag in get_netlist is True, the values will be lists (to support multiple connections)
+            - name: top_level_component name
+
+    Args:
+        component: to extract flat netlist.
+
+    Keyword Args: (for get_netlist_recursive)
+        component_suffix: suffix to append to each component name.
+            useful if to save and reload a back-annotated netlist.
+        get_netlist_func: function to extract individual netlists.
+        full_settings: True returns all, false changed settings.
+        tolerance: tolerance in nm to consider two ports connected.
+        exclude_port_types: optional list of port types to exclude from netlisting.
+        get_instance_name: function to get instance name.
+
+    Returns:
+        instances: Dict of instance name and settings.
+        connections: Dict of Instance1Name,portName: Instance2Name,portName.
+        placements: Dict of instance names and placements (x, y, rotation).
+        port: Dict portName: ComponentName,port.
+        name: name of component.
+        warnings: warning messages (disconnected pins).
+    """
+    recursive_netlist = get_netlist_recursive(component, **kwargs)
+    top_level_name = component.name
+    hierarchical_instances = _flatten_hierarchy(top_level_name, recursive_netlist)
+    connections = {}
+    ports = {}
+    placements = {}
+    instances = {}
+    for hierarchical_instance in hierarchical_instances:
+        c, p = _map_connections_ports(
+            hierarchical_instance, top_level_name, recursive_netlist
+        )
+        for key, value in c.items():
+            if len(value) != 0:
+                connections[key] = value
+        for key, value in p.items():
+            if len(value) != 0:
+                ports[key] = value
+        placements.update(
+            _accumulate_placements(hierarchical_instance, recursive_netlist)
+        )
+        instances.update(_get_instance_info(hierarchical_instance, recursive_netlist))
+
+    return {
+        "connections": connections,
+        "placements": placements,
+        "instances": instances,
+        "ports": ports,
+        "name": recursive_netlist[top_level_name]["name"],
+    }
+
+
+def _flat_name(
+    hierarchy,
+    hierarchy_delimiter: str = "~",
+):
+    """Returns a unique name for the instance from its hierarchy."""
+    name = ""
+    for _, instance in hierarchy[:-1]:
+        name += instance
+        name += hierarchy_delimiter
+    name += hierarchy[-1][1]
+    return name
+
+
+def _get_instance_info(hierarchy, recursive_netlist):
+    """Returns instance info from its instance data."""
+    return {
+        _flat_name(hierarchy): recursive_netlist[hierarchy[-2][0]]["instances"][
+            hierarchy[-1][1]
+        ]
+    }
+
+
+def _get_leaf(
+    instance_port,
+    netlist,
+    flat_name,
+    all_netlists,
+    hierarchy_delimiter: str = "~",
+):
+    """Given a instance,port and its netlist, maps ports down to the lowest hierarchy level."""
+    instance, port = instance_port.split(",")
+    netlist = all_netlists[netlist]["instances"][instance]["component"]
+    found_lower_level = netlist in all_netlists.keys()
+    if found_lower_level:
+        instance_port = all_netlists[netlist]["ports"][port]
+        flat_name = f"{flat_name}{hierarchy_delimiter}{instance}"
+        found_lower_level, flat_name = _get_leaf(
+            instance_port, netlist, flat_name, all_netlists
+        )
+    else:
+        found_lower_level = False
+        flat_name = f"{flat_name}{hierarchy_delimiter}{instance_port}"
+    return found_lower_level, flat_name
+
+
+def _lateral_map(
+    local_leaf_port: str,
+    all_netlists: Dict[str, Any],
+    higher_component: str,
+    level: int,
+    hierarchy,
+    hierarchy_delimiter: str = "~",
+):
+    """Returns connected ports at this hierarchical level."""
+    lateral_equivalencies = []
+    for port1, port2 in all_netlists[higher_component]["connections"].items():
+        flat_name_prefix = _flat_name(hierarchy[: len(hierarchy) - level - 1])
+        if local_leaf_port == port1 and local_leaf_port != port2:
+            lateral_equivalencies.append(
+                _get_leaf(port2, higher_component, flat_name_prefix, all_netlists)[1]
+            )
+        elif local_leaf_port == port2 and local_leaf_port != port1:
+            lateral_equivalencies.append(
+                _get_leaf(port1, higher_component, flat_name_prefix, all_netlists)[1]
+            )
+    return lateral_equivalencies
+
+
+def _map_connections_ports(
+    hierarchy,
+    top_name,
+    all_netlists,
+    hierarchy_delimiter: str = "~",
+):
+    """Returns all nodes of interest across the flat recursive netlist."""
+    connections = {}
+    ports = {}
+
+    # Starting point is ports of the leaf instance
+    leaf_instance = hierarchy[-1][1]
+    leaf_instance_ports = list(gf.get_component(hierarchy[-1][0]).ports.keys())
+
+    for leaf_portname in leaf_instance_ports:
+        current_connections = []
+        current_ports = []
+        local_leaf_port = f"{leaf_instance},{leaf_portname}"
+        for level, ((higher_component, higher_instance),) in enumerate(
+            hierarchy[:-1][::-1]
+        ):
+            # Identify connected node (with flattened names)
+            current_connections.extend(
+                _lateral_map(
+                    local_leaf_port,
+                    all_netlists,
+                    higher_component,
+                    level,
+                    hierarchy,
+                    hierarchy_delimiter,
+                )
+            )
+            # Traverse up to higher level
+            found_higher_level = False
+            for portname, port in all_netlists[higher_component]["ports"].items():
+                if local_leaf_port == port:
+                    local_leaf_port = f"{higher_instance},{portname}"
+                    found_higher_level = True
+                    # If there is a port at top level, map to that as well
+                    if higher_instance == top_name:
+                        current_ports.append(local_leaf_port)
+            if not found_higher_level:
+                break
+        flat_leaf_port = f"{_flat_name(hierarchy)},{leaf_portname}"
+        connections[flat_leaf_port] = current_connections
+        ports[flat_leaf_port] = current_ports
+
+    return connections, ports
+
+
+def _accumulate_placements(
+    hierarchy,
+    all_netlists,
+):
+    """Iterate through hierarchy tuples, accumulating placement information."""
+    placements = {key: 0 for key in ["x", "y", "mirror", "rotation"]}
+    for (higher_component, _higher_instance), (_lower_component, lower_instance) in zip(
+        hierarchy[:-1], hierarchy[1:]
+    ):
+        for key in ["x", "y", "mirror", "rotation"]:
+            placements[key] += all_netlists[higher_component]["placements"][
+                lower_instance
+            ][key]
+
+    return {_flat_name(hierarchy): placements}
+
+
+def _flatten_str_list(xs):
+    """Flatten nested list of strings to list of strings."""
+    for x in xs:
+        if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+            yield from _flatten_str_list(x)
+        else:
+            yield x
+
+
+def _flatten_hierarchy(
+    netlist_name: str,
+    all_netlists: List[Dict[str, any]],
+    hierarchy_delimiter: str = "~",
+    component_instance_delimiter: str = ";",
+):
+    """Converts _flatten_netlist output str's to list of hierarchical (component, instance) tuples."""
+
+    instance_dict = _flatten_hierarchy_recurse(
+        netlist_name=netlist_name,
+        all_netlists=all_netlists,
+        hierarchy_delimiter=hierarchy_delimiter,
+        component_instance_delimiter=component_instance_delimiter,
+    )
+
+    hierarchies_lists = []
+    for hierarchy in _flatten_str_list(list(instance_dict.keys())):
+        hierarchy_list = []
+        levels = hierarchy.split(hierarchy_delimiter)
+        for level in levels:
+            components, instance = level.split(component_instance_delimiter)
+            hierarchy_list.append((components, instance))
+        hierarchies_lists.append(hierarchy_list)
+
+    return hierarchies_lists
+
+
+def _flatten_hierarchy_recurse(
+    netlist_name: str,
+    all_netlists: List[Dict[str, any]],
+    hierarchy: str = None,
+    hierarchy_delimiter: str = "~",
+    component_instance_delimiter: str = ";",
+) -> Dict[str, Any]:
+    """Flattens the provided recursive netlist by recursively updating a list.
+
+    Args:
+        netlist_name: netlist entry to flatten
+        all_netlists: list of all possible netlists (output of get_netlist_recursive)
+        hierarchy: str to append to netlist_name
+        hierarchy_delimiter: str to separate hierarchy levels in flattened keys
+        component_instance_delimiter: str to separate instance name from component name for netlist reconstruction
+
+    Returns:
+        str of ...{hierarchy_delimiter}{component}{component_instance_delimiter}{instance}{hierarchy_delimiter} used to flatten the netlist
+    """
+    instance_dict = {}
+    if hierarchy is None:
+        top_component = all_netlists[netlist_name]["name"]
+        hierarchy = f"{top_component}{component_instance_delimiter}{netlist_name}"
+    for instance_name, instance in all_netlists[netlist_name]["instances"].items():
+        component_name = instance["component"]
+        hierarchy_str = f"{hierarchy}{hierarchy_delimiter}{component_name}{component_instance_delimiter}{instance_name}"
+        if component_name not in all_netlists.keys():
+            instance_dict[hierarchy_str] = True  # Done for this leaf
+        else:
+            instance_dict |= _flatten_hierarchy_recurse(
+                component_name,
+                all_netlists,
+                hierarchy_str,
+            )
+
+    return instance_dict
+
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    """
+    Testing electrical netlist w/ identical component references
+    """
+    # Define compound component
+    series_resistors = gf.Component("seriesResistors")
+    rseries1 = series_resistors << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+    rseries2 = series_resistors << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+    rseries1.connect("pad2", rseries2.ports["pad1"])
+    series_resistors.add_port("pad1", port=rseries1.ports["pad1"])
+    series_resistors.add_port("pad2", port=rseries2.ports["pad2"])
+
+    # Increase hierarchy levels more
+    double_series_resistors = gf.Component("double_seriesResistors")
+    rseries1 = double_series_resistors << gf.get_component(series_resistors)
+    rseries2 = double_series_resistors << gf.get_component(series_resistors)
+    rseries1.connect("pad2", rseries2.ports["pad1"])
+    double_series_resistors.add_port("pad1", port=rseries1.ports["pad1"])
+    double_series_resistors.add_port("pad2", port=rseries2.ports["pad2"])
+
+    # Define top-level component
+    vdiv = gf.Component("voltageDivider")
+    r1 = vdiv << double_series_resistors
+    r2 = vdiv << series_resistors
+    r3 = (
+        vdiv
+        << gf.get_component(
+            gf.components.resistance_sheet, width=20, ohms_per_square=20
+        ).rotate()
+    )
+    r4 = vdiv << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+
+    r1.connect("pad2", r2.ports["pad1"])
+    r3.connect("pad1", r2.ports["pad1"], preserve_orientation=True)
+    r4.connect("pad1", r3.ports["pad2"], preserve_orientation=True)
+
+    vdiv.add_port("gnd1", port=r2.ports["pad2"])
+    vdiv.add_port("gnd2", port=r4.ports["pad2"])
+    vdiv.add_port("vsig", port=r1.ports["pad1"])
+    vdiv.show(show_ports=True)
+
+    recursive_netlist = get_netlist_recursive(vdiv, allow_multiple=True)
+    import pprint
+
+    print("RECURSIVE NETLIST")
+    print("")
+    pprint.pprint(recursive_netlist)
+    print("")
+    print("OPERATION")
+    print("")
+
+    flat_netlist = get_netlist_flat(vdiv, allow_multiple=True)
+    print("")
+    print("FLAT NETLIST")
+    print("")
+    pprint.pprint(flat_netlist)

--- a/gdsfactory/get_netlist_flat.py
+++ b/gdsfactory/get_netlist_flat.py
@@ -279,10 +279,12 @@ def _flatten_hierarchy_recurse(
         if component_name not in all_netlists.keys():
             instance_dict[hierarchy_str] = True  # Done for this leaf
         else:
-            instance_dict |= _flatten_hierarchy_recurse(
-                component_name,
-                all_netlists,
-                hierarchy_str,
+            instance_dict.update(
+                _flatten_hierarchy_recurse(
+                    component_name,
+                    all_netlists,
+                    hierarchy_str,
+                )
             )
 
     return instance_dict

--- a/gdsfactory/tests/test_netlists_flat.py
+++ b/gdsfactory/tests/test_netlists_flat.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+
+
+def test_flat_netlist_photonic():
+    coupler_lengths = [10, 20, 30, 40]
+    coupler_gaps = [0.1, 0.2, 0.4, 0.5]
+    delta_lengths = [10, 100, 200]
+
+    c = gf.components.mzi_lattice(
+        coupler_lengths=coupler_lengths,
+        coupler_gaps=coupler_gaps,
+        delta_lengths=delta_lengths,
+    )
+    gf.get_netlist_flat.get_netlist_flat(c)
+    assert True
+
+
+def test_flatten_netlist_identical_references():
+    """
+    Testing electrical netlist w/ identical component references
+    """
+    # Define compound component
+    series_resistors = gf.Component("seriesResistors")
+    rseries1 = series_resistors << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+    rseries2 = series_resistors << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+    rseries1.connect("pad2", rseries2.ports["pad1"])
+    series_resistors.add_port("pad1", port=rseries1.ports["pad1"])
+    series_resistors.add_port("pad2", port=rseries2.ports["pad2"])
+
+    # Increase hierarchy levels more
+    double_series_resistors = gf.Component("double_seriesResistors")
+    rseries1 = double_series_resistors << gf.get_component(series_resistors)
+    rseries2 = double_series_resistors << gf.get_component(series_resistors)
+    rseries1.connect("pad2", rseries2.ports["pad1"])
+    double_series_resistors.add_port("pad1", port=rseries1.ports["pad1"])
+    double_series_resistors.add_port("pad2", port=rseries2.ports["pad2"])
+
+    # Define top-level component
+    vdiv = gf.Component("voltageDivider")
+    r1 = vdiv << double_series_resistors
+    r2 = vdiv << series_resistors
+    r3 = (
+        vdiv
+        << gf.get_component(
+            gf.components.resistance_sheet, width=20, ohms_per_square=20
+        ).rotate()
+    )
+    r4 = vdiv << gf.get_component(
+        gf.components.resistance_sheet, width=20, ohms_per_square=20
+    )
+
+    r1.connect("pad2", r2.ports["pad1"])
+    r3.connect("pad1", r2.ports["pad1"], preserve_orientation=True)
+    r4.connect("pad1", r3.ports["pad2"], preserve_orientation=True)
+
+    vdiv.add_port("gnd1", port=r2.ports["pad2"])
+    vdiv.add_port("gnd2", port=r4.ports["pad2"])
+    vdiv.add_port("vsig", port=r1.ports["pad1"])
+    vdiv.show(show_ports=True)
+
+    assert (
+        len(
+            gf.get_netlist_flat.get_netlist_flat(vdiv, allow_multiple=True)["instances"]
+        )
+        == 8
+    )
+
+
+if __name__ == "__main__":
+
+    test_flatten_netlist_identical_references()
+    test_flat_netlist_photonic()

--- a/gdsfactory/tests/test_netlists_flat.py
+++ b/gdsfactory/tests/test_netlists_flat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory.get_netlist_flat import get_netlist_flat
 
 
 def test_flat_netlist_photonic():
@@ -64,12 +65,7 @@ def test_flatten_netlist_identical_references():
     vdiv.add_port("vsig", port=r1.ports["pad1"])
     vdiv.show(show_ports=True)
 
-    assert (
-        len(
-            gf.get_netlist_flat.get_netlist_flat(vdiv, allow_multiple=True)["instances"]
-        )
-        == 8
-    )
+    assert len(get_netlist_flat(vdiv, allow_multiple=True)["instances"]) == 8
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Parse recursive netlists to generate flat netlists with unique nodes (w/ simple test)
- Flag to allow multiple connections at a netlist node
- Update the relevant doc notebook
- Absorb references in resistance_sheet (example case)

Example:

```
coupler_lengths = [10, 20, 30, 40]
coupler_gaps = [0.1, 0.2, 0.4, 0.5]
delta_lengths = [10, 100, 200]

c = gf.components.mzi_lattice(
    coupler_lengths=coupler_lengths,
    coupler_gaps=coupler_gaps,
    delta_lengths=delta_lengths,
)
```

Before (only one level of references):

`c.plot_netlist()`

![image](https://user-images.githubusercontent.com/46427609/214447404-d682ddbe-b972-4226-b4ba-c8297b9f5ab2.png)

`get_netlist_recursive` outputs a dict of dicts, and the individual dicts can be plotted as above, but not together.


After (logical flattening):

`c.plot_netlist_flat(with_labels=False) # labels get cluttered`

![image](https://user-images.githubusercontent.com/46427609/214447390-0f2962da-2364-4d3a-84e9-e6836115cb46.png)


This is an important step toward Spice netlisting #681 #1054 