### PR TITLE
Set KLayout technology to active PDK if available

### DIFF
--- a/gdsfactory/generic_tech/klayout/pymacros/klive.lym
+++ b/gdsfactory/generic_tech/klayout/pymacros/klive.lym
@@ -64,6 +64,7 @@ class MyServer(pya.QTcpServer):
 
             # Interpret the data
             gds_path = data["gds"]
+            technology = data["technology"]
 
             # Store the current view
             window = pya.Application.instance().main_window()
@@ -91,6 +92,24 @@ class MyServer(pya.QTcpServer):
             view.max_hier()
             if previous_view and data["keep_position"]==True:
                 view.zoom_box(previous_view)
+
+            if technology:
+                # Parse loaded technologies (only listed by index)
+                menu = window.menu()
+                technologies = menu.items("@toolbar.technology_selector")
+                tech_actions = [menu.action(f"@toolbar.technology_selector.technology_{i}") for i in range(len(technologies))]
+                tech_names = [action.title for action in tech_actions]
+
+                if technology in tech_names:
+                    tech_actions[tech_names.index(technology)].trigger()
+
+                    cell_view = view.active_cellview()
+                    cell_view.technology = technology
+
+                    print("Using {}".format(technology))
+                    connection.write("Using {}".format(technology))
+                else:
+                    print("Could not find technology {} in list of technologies: {}".format(technology, tech_names))
 
             # Report progress
             print("Loaded {}".format(gds_path))

--- a/gdsfactory/klive.py
+++ b/gdsfactory/klive.py
@@ -12,17 +12,21 @@ import json
 import os
 import socket
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 
 
 def show(
-    gds_filename: Union[Path, str], keep_position: bool = True, port: int = 8082
+    gds_filename: Union[Path, str],
+    keep_position: bool = True,
+    technology: Optional[str] = None,
+    port: int = 8082,
 ) -> None:
     """Show GDS in klayout.
 
     Args:
         gds_filename: to show.
         keep_position: keep position and active layers.
+        technology: Name of the KLayout technology to use.
         port: klayout server port.
 
     """
@@ -31,6 +35,7 @@ def show(
     data = {
         "gds": os.path.abspath(gds_filename),
         "keep_position": keep_position,
+        "technology": technology,
     }
     data_string = json.dumps(data)
     try:
@@ -49,5 +54,6 @@ if __name__ == "__main__":
     import gdsfactory as gf
 
     c = gf.components.straight()
-    gdspath = c.write_gds()
-    show(gdspath)
+    # gdspath = c.write_gds()
+    # show(gdspath)
+    c.show()

--- a/gdsfactory/show.py
+++ b/gdsfactory/show.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Union
+from typing import Union, Optional
 
 from gdsfactory import klive
 from gdsfactory.component import Component
 
 
-def show(component: Union[Component, str, pathlib.Path], **kwargs) -> None:
+def show(
+    component: Union[Component, str, pathlib.Path],
+    technology: Optional[str] = None,
+    **kwargs,
+) -> None:
     """Write GDS and show Component in KLayout.
 
     Args:
         component: Component or GDS path.
+        technology: Name of KLayout technology to load when displaying component.
 
     Keyword Args:
         gdspath: GDS file path to write to.
@@ -21,11 +26,16 @@ def show(component: Union[Component, str, pathlib.Path], **kwargs) -> None:
         timestamp: Defaults to 2019-10-25. If None uses current time.
 
     """
+    if technology is None:
+        from gdsfactory.pdk import get_active_pdk
+
+        technology = get_active_pdk().name
+
     if isinstance(component, pathlib.Path):
         component = str(component)
-        return klive.show(component)
+        return klive.show(component, technology=technology)
     elif isinstance(component, str):
-        return klive.show(component)
+        return klive.show(component, technology=technology)
     elif component is None:
         raise ValueError(
             "Component is None, make sure that your function returns the component"
@@ -33,7 +43,7 @@ def show(component: Union[Component, str, pathlib.Path], **kwargs) -> None:
 
     elif hasattr(component, "write_gds"):
         gdspath = component.write_gds(logging=False, **kwargs)
-        klive.show(gdspath)
+        klive.show(gdspath, technology=technology)
     else:
         raise ValueError(
             f"Component is {type(component)!r}, make sure pass a Component or a path"


### PR DESCRIPTION
With this PR, we can specify the name of a technology for KLayout to use when calling `show()`. If none is specified, it will automatically try to load the technology with the same name as the active PDK.

Inspired by #1244 