### PR TITLE
Fix flatten refs recursive

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -2439,6 +2439,7 @@ def test_import_gds_settings():
 
 def test_flatten_invalid_refs_recursive():
     import gdsfactory as gf
+    from gdsfactory.difftest import run_xor
 
     @gf.cell
     def flat():
@@ -2460,12 +2461,12 @@ def test_flatten_invalid_refs_recursive():
     c_orig = hierarchy()
     c_new = flatten_invalid_refs_recursive(c_orig)
     assert c_new is not c_orig
-    assert c_new != c_orig
-    assert c_orig.references[0].parent.name != c_new.references[0].parent.name
-    assert (
-        c_orig.references[1].parent.references[0].parent.name
-        != c_new.references[1].parent.references[0].parent.name
-    )
+    invalid_refs_filename = "invalid_refs.gds"
+    invalid_refs_fixed_filename = "invalid_refs_fixed.gds"
+    # gds files should still be same to 1nm tolerance
+    c_orig.write_gds(invalid_refs_filename)
+    c_new.write_gds(invalid_refs_fixed_filename)
+    run_xor(invalid_refs_filename, invalid_refs_fixed_filename)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -174,7 +174,7 @@ class ComponentReference(_GeometryHelper):
                 columns=columns, rows=rows, v1=v1, v2=v2
             )
 
-        self.ref_cell = component
+        self._ref_cell = component
         self._owner = None
         self._name = name
 
@@ -208,8 +208,12 @@ class ComponentReference(_GeometryHelper):
         return self._reference.repetition.spacing
 
     @property
+    def ref_cell(self):
+        return self._ref_cell
+
+    @property
     def parent(self):
-        return self.ref_cell
+        return self._ref_cell
 
     @property
     def origin(self):
@@ -243,9 +247,17 @@ class ComponentReference(_GeometryHelper):
     def x_reflection(self, value):
         self._reference.x_reflection = value
 
+    def _set_ref_cell(self, value):
+        self._ref_cell = value
+        self._reference.cell = value._cell
+
+    @ref_cell.setter
+    def ref_cell(self, value):
+        self._set_ref_cell(value)
+
     @parent.setter
     def parent(self, value):
-        self.ref_cell = value
+        self._set_ref_cell(value)
 
     def get_polygons(
         self,


### PR DESCRIPTION
I noticed a bug in the new `flatten_invalid_refs_recursive` function which caused some refs to drop. While debugging, I realized there is also a bug in the setter of ComponentReference.`parent` and also `ref_cell`, that the actual gdstk cell does not update when you set it to something new. This MR fixes both of those issues.