### PR TITLE
use _ipython_display_ for side-effect display methods

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1245,11 +1245,9 @@ class Component(_GeometryHelper):
         polygons = self._cell.get_polygons(depth=None)
         return {(polygon.layer, polygon.datatype) for polygon in polygons}
 
-    def _repr_html_(self) -> None:
+    def _ipython_display_(self) -> None:
         """Show geometry in KLayout and in matplotlib for Jupyter Notebooks."""
-
         self.show(show_ports=True)  # show in klayout
-        self.__repr__()
         self.plot_klayout()
 
     def plot_klayout(self) -> None:

--- a/gdsfactory/simulation/gtidy3d/modes.py
+++ b/gdsfactory/simulation/gtidy3d/modes.py
@@ -681,10 +681,9 @@ class Waveguide(BaseModel):
         plot(self.Xx, self.Yx, nx, mode=np.abs(Ey_) ** 2, title=f"Ey::{neff_:.3f}")
         plt.show()
 
-    def _repr_html_(self) -> str:
+    def _ipython_display_(self) -> None:
         """Show index in matplotlib for Jupyter Notebooks."""
         self.plot_index()
-        return self.__repr__()
 
     def __repr__(self) -> str:
         """Show waveguide name."""


### PR DESCRIPTION
`_repr_html_` should not produce output via side effects. Instead, it should _return_ HTML as text, which these methods do not do (also, matplotlib figures are generally PNG output, not HTML).

Since these hooks use plotting methods to publish output, the method which expects that behavior is `_ipython_display_()`, so I elected to use the proper hook name to match IPython's expected behavior.

The alternative would be to implement these methods as `_repr_png_` and capture and serialize matplotlib figures to PNG. But because of the calls to `plt.show()`, that might be hard to change without breaking things or introducing duplicate output, so I went with the smallest fix.

Related to https://github.com/Textualize/rich/issues/2803 which produces duplicate output because of these side effects.