### PR TITLE
add cross_section to mmi1x2_with_sbend

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## 6.41.0
+
+- Improve decorator docs [PR](https://github.com/gdsfactory/gdsfactory/pull/1287)
+- Neural net interpolation & MEEP corner iterator [PR](https://github.com/gdsfactory/gdsfactory/pull/1285)
+- add `mmi1x2_with_sbend` and `mmi2x2_with_sbend` [PR](https://github.com/gdsfactory/gdsfactory/pull/1283) and [PR](https://github.com/gdsfactory/gdsfactory/pull/1286)
+
 ## 6.40.0 [PR](https://github.com/gdsfactory/gdsfactory/pull/1281)
 
 - fix devsim plugin

--- a/gdsfactory/components/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmi2x2_with_sbend.py
@@ -1,19 +1,25 @@
 import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import ComponentSpec
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from gdsfactory.components.bend_s import bend_s
 
 
 @gf.cell
 def mmi2x2_with_sbend(
-    with_sbend: bool = False,
+    with_sbend: bool = True,
     s_bend: ComponentSpec = bend_s,
+    cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Returns mmi2x2 for Cband.
 
-    A C_band 2x2MMI in 220nm thick silicon from
+    A C_band 2x2MMI in 220nm thick silicon
     https://opg.optica.org/oe/fulltext.cfm?uri=oe-25-23-28957&id=376719
+
+    Args:
+        with_sbend: add sbend.
+        s_bend: S-bend spec.
+        cross_section: spec.
     """
 
     def mmi_widths(t):
@@ -25,30 +31,34 @@ def mmi2x2_with_sbend(
     c = gf.Component()
 
     P = gf.path.straight(length=2 * 2.4 + 2 * 1.6, npoints=5)
-    X = gf.CrossSection(width=mmi_widths, offset=0, layer="WG")
-    c << gf.path.extrude(P, cross_section=X)
+
+    xs = gf.get_cross_section(cross_section)
+    xs.width = mmi_widths
+    c << gf.path.extrude(P, cross_section=xs)
 
     # Add input and output tapers
     top_input_block = c << gf.components.taper(
-        length=1, width1=0.5, width2=0.7, layer="WG"
+        length=1, width1=0.5, width2=0.7, cross_section=cross_section
     ).move((-1, 0.45))
     bottom_input_block = c << gf.components.taper(
-        length=1, width1=0.5, width2=0.7, layer="WG"
+        length=1, width1=0.5, width2=0.7, cross_section=cross_section
     ).move((-1, -0.45))
 
     top_output_block = c << gf.components.taper(
-        length=1, width1=0.7, width2=0.5, layer="WG"
+        length=1, width1=0.7, width2=0.5, cross_section=cross_section
     ).move((8, 0.45))
     bottom_output_block = c << gf.components.taper(
-        length=1, width1=0.7, width2=0.5, layer="WG"
+        length=1, width1=0.7, width2=0.5, cross_section=cross_section
     ).move((8, -0.45))
 
     if with_sbend:
-        top_input_sbend_ref = c << s_bend()
+        sbend = gf.get_component(s_bend, cross_section=cross_section)
+
+        top_input_sbend_ref = c << sbend
         top_input_sbend_ref.mirror([0, 1])
-        bottom_input_sbend_ref = c << s_bend()
-        top_output_sbend_ref = c << s_bend()
-        bottom_output_sbend_ref = c << s_bend()
+        bottom_input_sbend_ref = c << sbend
+        top_output_sbend_ref = c << sbend
+        bottom_output_sbend_ref = c << sbend
         bottom_output_sbend_ref.mirror([0, 1])
 
         top_input_sbend_ref.connect("o1", destination=top_input_block.ports["o1"])
@@ -72,6 +82,9 @@ def mmi2x2_with_sbend(
 
 
 if __name__ == "__main__":
-    # c = mmi2x2_with_sbend(with_sbend=True)
-    c = mmi2x2_with_sbend(with_sbend=False)
+    c = mmi2x2_with_sbend(
+        with_sbend=True,
+        cross_section=dict(cross_section="strip", settings=dict(layer=(2, 0))),
+    )
+    # c = mmi2x2_with_sbend(with_sbend=False)
     c.show(show_ports=True)

--- a/tests/test_components/test_settings_mmi1x2_with_sbend_.yml
+++ b/tests/test_components/test_settings_mmi1x2_with_sbend_.yml
@@ -3,13 +3,15 @@ settings:
   changed: {}
   child: null
   default:
+    cross_section: strip
     s_bend:
       function: bend_s
-    with_sbend: false
+    with_sbend: true
   full:
+    cross_section: strip
     s_bend:
       function: bend_s
-    with_sbend: false
+    with_sbend: true
   function_name: mmi1x2_with_sbend
   info: {}
   info_version: 2

--- a/tests/test_components/test_settings_mmi2x2_with_sbend_.yml
+++ b/tests/test_components/test_settings_mmi2x2_with_sbend_.yml
@@ -3,13 +3,15 @@ settings:
   changed: {}
   child: null
   default:
+    cross_section: strip
     s_bend:
       function: bend_s
-    with_sbend: false
+    with_sbend: true
   full:
+    cross_section: strip
     s_bend:
       function: bend_s
-    with_sbend: false
+    with_sbend: true
   function_name: mmi2x2_with_sbend
   info: {}
   info_version: 2


### PR DESCRIPTION
- pass cross_section to new components so we can easily adapt them to different foundry processes


@alexsludds 