### PR TITLE
Fix non-manhattan routes doc formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Contributors (in chronological order):
 - Joaquin Matres (Google): write some documentation pages, help porting from gdspy to gdstk.
 - Damien Bonneau (PsiQuantum): cell decorator, Component routing functions, Klayout placer.
 - Pete Shadbolt (PsiQuantum): Klayout auto-placer, Klayout GDS interface (klive).
-- Troy Tamas (Rockley): get_route_from_steps, netlist driven flow (from_yaml).
+- Troy Tamas (Rockley): yaml-based pics, routers (from steps and all-angle)
 - Floris Laporte (Rockley): netlist extraction and circuit simulation interface with SAX.
 - Alec Hammond (Meta Reality Labs Research): Meep and MPB interface.
 - Simon Bilodeau (Princeton): Meep FDTD write Sparameters, TCAD device simulator.
@@ -225,6 +225,7 @@ Contributors (in chronological order):
 - Raphaël Dubé-Demers (EHVA, EXFO): measurement database.
 - Bohan Zhang (Boston University): grating coupler improvements.
 - Niko Savola (IQM): optimization, notebook and code improvements.
+- Sky Chilstedt (Rockley): improvements to API and docs
 
 Open source heroes:
 

--- a/docs/notebooks/042_non-manhattan-router.ipynb
+++ b/docs/notebooks/042_non-manhattan-router.ipynb
@@ -128,6 +128,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -137,6 +138,7 @@
     "</div>\n",
     "\n",
     "The non-manhattan (all-angle) router allows you to route between ports and in directions which are not aligned with the x and y axes, which is the constraint of most other gdsfactory routers. Unlike phidl's `smooth()` however, the all-angle router \n",
+    "\n",
     "- has a `steps` based syntax, fully compatible with the yaml-based circuit flow\n",
     "- builds paths from available PDK components, such that routes can be simulated naturally by S-matrix-based circuit modeling tools, like SAX\n",
     "- allows for advanced logic in selecting appropriate bends, cross-sections, and automatic tapers, based on context\n",
@@ -179,11 +181,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Bends and connectors\n",
     "Let's first consider the \"simple\" case, as shown above, where the vectors of the two ports to route between intersect at a point. The logic for how to build the route is as follows:\n",
+    "\n",
     "1. Find the intersection point of the two port vectors.\n",
     "2. Place the bend at the intersection point of the two vectors by its \"handle\". The bend's handle is the point of intersetion of it's inverted port vectors (i.e. if the ports were pointed inwards rather than outwards). For any arbitrary bend, this guarantees that the ports of the bend will be in the straight line of sight of the ports which they should connect to, inset by some amount.\n",
     "3. Call the route or segment's specified connector function to generate a straight section between the bend's ports and their adjacent ports.\n",
@@ -191,6 +195,7 @@
     "Now, this is where it gets fun. Since we've calculated our bend first and worked backwards, we know how much room we have for the straight connector, and we can take that into consideration when creating it.\n",
     "\n",
     "The three connectors available by default are\n",
+    "\n",
     "- `low_loss`: auto-tapers to the lowest-loss cross-section possible to fit in the given segment\n",
     "- `auto_taper`: auto-tapers to the cross-section specified, based on the active pdk's specified `layer_transitions`\n",
     "- `simple`: simply routes with a straight in the cross-section specified (no auto-tapering)\n",
@@ -352,7 +357,7 @@
     "    <a href=\"#\" class=\"close\" data-dismiss=\"alert\" aria-label=\"close\">&times;</a>\n",
     "    <strong>Klayout tip:</strong> If you don't already have <code>angle</code> displayed on your ruler in klayout, you can enable it by by going to <code>File -> Setup</code>, then from <code>Rulers And Annotations / Templates</code>, update the <code>Label Format</code> for your ruler to display both distance and angle.\n",
     "\n",
-    "<code>Label Format: $D, angle=$(180/M_PI*atan2(Y,X)) deg</code>\n",
+    "<code>Label Format: &dollar;D, angle=&dollar;(180/M_PI*atan2(Y,X)) deg</code>\n",
     " </div>\n",
     "\n",
     "Then, translate the steps you took with the ruler into a set of steps directives."
@@ -423,7 +428,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-input"
+     "remove-cell"
     ]
    },
    "outputs": [],


### PR DESCRIPTION
Hi @joamatab , I noticed that some sections of the docs for all-angle routing got formatted funny. In particular
- both ordered and bullet lists did not get formatted properly
- html hint boxes had some funny formatting

I think I fixed both of these. Please confirm. 

Also, I think [this ](https://jupyterbook.org/en/stable/reference/cheatsheet.html#admonitions) may be a nicer way to do the hint boxes... They came out rendered funny for me when working in the actual notebook though, so I kept as html for now.

I also made some small updates to the acks