### PR TITLE
Add methods to return ports as a DataFrame

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -662,6 +662,40 @@ class Component(_GeometryHelper):
         """
         return list(select_ports(self.ports, **kwargs).values())
 
+    def get_ports_pandas(self):
+        import pandas as pd
+
+        col_spec = [
+            "name",
+            "width",
+            "center",
+            "orientation",
+            "layer",
+            "port_type",
+            "shear_angle",
+        ]
+
+        return pd.DataFrame(
+            [port.to_dict() for port in self.get_ports_list()], columns=col_spec
+        )
+
+    def get_ports_polars(self):
+        import polars as pl
+
+        col_spec = {
+            "name": pl.Utf8,
+            "width": pl.Float64,
+            "center": pl.List(pl.Float64),
+            "orientation": pl.Float64,
+            "layer": pl.List(pl.UInt16),
+            "port_type": pl.Utf8,
+            "shear_angle": pl.Float64,
+        }
+
+        return pl.DataFrame(
+            [port.to_dict() for port in self.get_ports_list()], schema=col_spec
+        )
+
     def ref(
         self,
         position: Coordinate = (0, 0),

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -136,9 +136,8 @@ class Port:
             else self.orientation,
             "layer": self.layer,
             "port_type": self.port_type,
+            "shear_angle": self.shear_angle,
         }
-        if self.shear_angle:
-            d["shear_angle"] = self.shear_angle
         return clean_value_json(d)
 
     def to_yaml(self) -> str:
@@ -978,15 +977,15 @@ __all__ = [
 if __name__ == "__main__":
     import gdsfactory as gf
 
-    c = gf.Component()
-    cross_section = gf.cross_section.strip
-    c.add_port(
-        "o1",
-        center=(0, 0),
-        orientation=0,
-        port_type="optical",
-        cross_section=cross_section,
-    )
+    # c = gf.Component()
+    # cross_section = gf.cross_section.strip()
+    # c.add_port(
+    #     "o1",
+    #     center=(0, 0),
+    #     orientation=0,
+    #     port_type="optical",
+    #     cross_section=cross_section,
+    # )
 
     # c = gf.components.straight_heater_metal()
     # c.auto_rename_ports()
@@ -999,3 +998,10 @@ if __name__ == "__main__":
     # print(p0)
     # print(type(p0.to_dict()["center"][0]))
     # p = Port("o1", orientation=0, center=(9, 0), layer=(1, 0), cross_section=)
+
+    c = gf.components.component_lattice()
+
+    df = c.get_ports_pandas()
+    print(df)
+
+    c.show()


### PR DESCRIPTION
Adding methods to return a DataFrame of component ports. This way we don't need to implement every possible filter in `select_ports` and can instead use libraries designed for filtering DataFrames (pandas & polars).