### PR TITLE
Sweep Fabrication

### DIFF
--- a/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
+++ b/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
@@ -5,21 +5,200 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Variability analysis as a subset of model building\n",
+    "# Variability analysis\n",
     "\n",
-    "The same machinery that is used to iterate over component parameters to build models can be used to study the effect of variability on device performance.\n",
+    "The same machinery that is used to iterate over component parameters to build models can be used to study the effect of variability on device performance. \n",
     "\n",
     "## Lithographic parameters\n",
     "\n",
-    "`LithoParameter` parameters have a parametrizable `transformation` attribute that can be used to modify the Component geometry prior to simulation in more complex way than simply changing its calling arguments.\n",
+    "Not all variability can be captured by simply changing the Component or LayerStack input parameters. \n",
     "\n",
+    "`LithoParameter` parameters have a parametrizable `transformation` attribute that can be used to modify the Component geometry prior to simulation in more complex ways than simply changing its calling arguments. The parameter has methods that return a temporary component given an initial component and a transformation type.\n",
+    "\n",
+    "Currently, 4 types of transformation have been coded. Let's create a funky polygon to look at them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "c = gf.Component(\"myComponent\")\n",
+    "poly1a = c.add_polygon(\n",
+    "    [\n",
+    "        [2.8,3],\n",
+    "        [5,3],\n",
+    "        [5,0.8]\n",
+    "    ],\n",
+    "    layer=\"WG\",\n",
+    ")\n",
+    "poly1b = c.add_polygon(\n",
+    "    [\n",
+    "        [2, 0],\n",
+    "        [2, 2],\n",
+    "        [4, 2],\n",
+    "        [4, 0],\n",
+    "    ],\n",
+    "    layer=\"WG\",\n",
+    ")\n",
+    "poly1c = c.add_polygon(\n",
+    "    [\n",
+    "        [0, 0.5],\n",
+    "        [0, 1.5],\n",
+    "        [3, 1.5],\n",
+    "        [3, 0.5],\n",
+    "    ],\n",
+    "    layer=\"WG\",\n",
+    ")\n",
+    "poly2 = c.add_polygon(\n",
+    "    [\n",
+    "        [0, 0],\n",
+    "        [5, 0],\n",
+    "        [5, 3],\n",
+    "        [0, 3],\n",
+    "    ],\n",
+    "    layer=\"SLAB90\",\n",
+    ")\n",
+    "poly3 = c.add_polygon(\n",
+    "    [\n",
+    "        [2.5, -2],\n",
+    "        [3.5, -2],\n",
+    "        [3.5, -0.1],\n",
+    "        [2.5, -0.1],\n",
+    "    ],\n",
+    "    layer=\"WG\",\n",
+    ")\n",
+    "c.add_port(name=\"o1\", center=(0,1), width=1, orientation=0, layer=1)\n",
+    "c.add_port(name=\"o2\", center=(3,-2), width=1, orientation=90, layer=1)\n",
+    "c.plot() # we want to see the ports too"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dilation and erosion\n",
+    "\n",
+    "A `LithoParameter` of `type = \"layer_dilation_erosion\"` parametrizes a layerwise growing (positive value) or shrinking (negative value) of the geometry. Note that the ports are properly resized if they are on the transformed layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.simulation.sax.parameter import LithoParameter\n",
+    "\n",
+    "param = LithoParameter(layername=\"core\")\n",
+    "eroded_c = param.layer_dilation_erosion(c, 0.2)\n",
+    "eroded_c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"core\")\n",
+    "eroded_c = param.layer_dilation_erosion(c, -0.3)\n",
+    "eroded_c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"slab90\")\n",
+    "eroded_c = param.layer_dilation_erosion(c, 0.2)\n",
+    "eroded_c.plot()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Offsets\n",
+    "\n",
+    "Lithography can sometimes laterally offset layers w.r.t. to one another. This is captured by layerwise `type = \"layer_x_offset\"` and  `type = \"layer_x_offset\"`. Note that ports are also translated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"core\")\n",
+    "offset_c = param.layer_x_offset(c, 0.5)\n",
+    "offset_c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"core\")\n",
+    "offset_c = param.layer_y_offset(c, -0.5)\n",
+    "offset_c.plot()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Corner rounding\n",
+    "\n",
+    "The erosion and dilation above is done with \"worst case\" sharp corners. An erosion --> dilation --> erosion sequence, accessible with `type = \"layer_round_corners\"` can be done to parametrize corner rounding. For ports, here parts of the geometry overlapping with ports are patched to prevent the ports from being off the layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"core\")\n",
+    "smooth_c = param.layer_round_corners(c, 0.1)\n",
+    "smooth_c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param = LithoParameter(layername=\"core\")\n",
+    "smooth_c = param.layer_round_corners(c, 0.4)\n",
+    "smooth_c.plot()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Corner analysis\n",
     "\n",
     "For convenience, the model builder can also iterate over only the `min`, `max`, and `nominal` values of all trainable_parameters by using the `types=corners` instead of the default `types=arange` argument of `Model.get_model_input_output(type=\"corners\")`.\n",
     "\n",
     "## Directional coupler example\n",
     "\n",
-    "Consider a directional coupler component which is modeled through a generic `MeepFDTDModel`. The only difference between this and the `FemwellWaveguideModel` from last notebook is how the simulation is defined: everything else involving iteration over parameters, multiprocessing, and model fitting, is identical. This makes model building easily extensible to new simulators."
+    "Consider a directional coupler component which is modeled through a generic `MeepFDTDModel`. The only difference between this and the `FemwellWaveguideModel` from last notebook is how the simulation is defined: everything else involving iteration over parameters, multiprocessing, and model fitting, is identical. This makes model building easily extensible to new simulators.\n",
+    "\n",
+    "Here, we are only interested in variability analysis of the geometry, and so we create a trainable coupler with fixed length and gap:"
    ]
   },
   {
@@ -50,13 +229,12 @@
     "# trainable component function, choosing which parameters to fix and which to consider for the model\n",
     "def trainable_coupler(parameters):\n",
     "    return gf.components.coupler_full(\n",
-    "        coupling_length=parameters[\"coupling_length\"],\n",
-    "        gap=parameters[\"gap\"],\n",
+    "        coupling_length=10,\n",
+    "        gap=0.3,\n",
     "        dw=0.0,\n",
     "    )\n",
     "\n",
-    "parameters = {\"gap\": 0.4, \"coupling_length\": 10}\n",
-    "c = trainable_coupler(parameters)\n",
+    "c = trainable_coupler({})\n",
     "c.plot()"
    ]
   },
@@ -85,7 +263,7 @@
     "}\n",
     "\n",
     "sim_settings = dict(\n",
-    "    resolution=10,\n",
+    "    resolution=30,\n",
     "    xmargin=1.0,\n",
     "    ymargin=1.0,\n",
     "    is_3d=False,\n",
@@ -104,11 +282,8 @@
     "        \"sim_settings\": sim_settings,\n",
     "    },\n",
     "    trainable_parameters={\n",
-    "        \"coupling_length\": NamedParameter(\n",
-    "            min_value=10, max_value=10, nominal_value=10, step=10\n",
-    "        ),\n",
-    "        \"gap\": NamedParameter(\n",
-    "            min_value=0.2, max_value=0.2, nominal_value=0.2, step=0.3\n",
+    "        \"dilation_magnitude\": LithoParameter(\n",
+    "            type=\"layer_dilation_erosion\", layername=\"core\", min_value=-0.05, max_value=0.05, nominal_value=0.0, step=0.05\n",
     "        ),\n",
     "    },\n",
     "    non_trainable_parameters={\n",
@@ -126,15 +301,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_vectors, output_vectors = coupler_model.get_model_input_output(type=\"arange\")"
+    "input_vectors, output_vectors = coupler_model.get_model_input_output(type=\"corners\")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "We can analyze the output vectors as a function of input vectors to study variability (TODO). Since such a change of morphology can also be approximated with a change in gap and waveguide width of the original component, we can compare the results to a model of the component with these as swept NamedParameters (TODO)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since such a change of morphology can also be approximated with a change in gap and waveguide width of the original component, we can compare the results to a model of the component with these as swept NamedParameters (todo)."
+   ]
   }
  ],
  "metadata": {

--- a/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
+++ b/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_vectors, output_vectors = coupler_model.get_model_input_output(type=\"corners\")"
+    "# input_vectors, output_vectors = coupler_model.get_model_input_output(type=\"corners\")"
    ]
   },
   {
@@ -310,14 +310,6 @@
    "metadata": {},
    "source": [
     "We can analyze the output vectors as a function of input vectors to study variability (TODO). Since such a change of morphology can also be approximated with a change in gap and waveguide width of the original component, we can compare the results to a model of the component with these as swept NamedParameters (TODO)."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Since such a change of morphology can also be approximated with a change in gap and waveguide width of the original component, we can compare the results to a model of the component with these as swept NamedParameters (todo)."
    ]
   }
  ],

--- a/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
+++ b/docs/notebooks/plugins/sax/03_variability_analysis.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Variability analysis as a subset of model building\n",
+    "\n",
+    "The same machinery that is used to iterate over component parameters to build models can be used to study the effect of variability on device performance.\n",
+    "\n",
+    "## Lithographic parameters\n",
+    "\n",
+    "`LithoParameter` parameters have a parametrizable `transformation` attribute that can be used to modify the Component geometry prior to simulation in more complex way than simply changing its calling arguments.\n",
+    "\n",
+    "## Corner analysis\n",
+    "\n",
+    "For convenience, the model builder can also iterate over only the `min`, `max`, and `nominal` values of all trainable_parameters by using the `types=corners` instead of the default `types=arange` argument of `Model.get_model_input_output(type=\"corners\")`.\n",
+    "\n",
+    "## Directional coupler example\n",
+    "\n",
+    "Consider a directional coupler component which is modeled through a generic `MeepFDTDModel`. The only difference between this and the `FemwellWaveguideModel` from last notebook is how the simulation is defined: everything else involving iteration over parameters, multiprocessing, and model fitting, is identical. This makes model building easily extensible to new simulators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from gdsfactory.simulation.sax.parameter import NamedParameter\n",
+    "from gdsfactory.technology import LayerStack\n",
+    "from gdsfactory.pdk import _ACTIVE_PDK, get_layer_stack\n",
+    "\n",
+    "\n",
+    "# gdsfactory layerstack\n",
+    "filtered_layerstack = LayerStack(\n",
+    "    layers={\n",
+    "        k: get_layer_stack().layers[k]\n",
+    "        for k in (\n",
+    "            \"slab90\",\n",
+    "            \"core\",\n",
+    "            \"box\",\n",
+    "            \"clad\",\n",
+    "        )\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "# trainable component function, choosing which parameters to fix and which to consider for the model\n",
+    "def trainable_coupler(parameters):\n",
+    "    return gf.components.coupler_full(\n",
+    "        coupling_length=parameters[\"coupling_length\"],\n",
+    "        gap=parameters[\"gap\"],\n",
+    "        dw=0.0,\n",
+    "    )\n",
+    "\n",
+    "parameters = {\"gap\": 0.4, \"coupling_length\": 10}\n",
+    "c = trainable_coupler(parameters)\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When defining the model, we add the LithoParameter `erosion_magnitude`. For all models, a `TransformParameter` which if set, will offset the provided component prior to simulation, emulating erosion (when <1), nominal behaviour (when 1) and dilation (when >1). This morphological transformation is currently global; more advanced spatially-correlated filters are an obvious next step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.simulation.sax.meep_FDTD_model import MeepFDTDModel\n",
+    "\n",
+    "# Simulation settings\n",
+    "port_symmetries_coupler = {\n",
+    "    \"o1@0,o1@0\": [\"o2@0,o2@0\", \"o3@0,o3@0\", \"o4@0,o4@0\"],\n",
+    "    \"o2@0,o1@0\": [\"o1@0,o2@0\", \"o3@0,o4@0\", \"o4@0,o3@0\"],\n",
+    "    \"o3@0,o1@0\": [\"o1@0,o3@0\", \"o2@0,o4@0\", \"o4@0,o2@0\"],\n",
+    "    \"o4@0,o1@0\": [\"o1@0,o4@0\", \"o2@0,o3@0\", \"o3@0,o2@0\"],\n",
+    "}\n",
+    "\n",
+    "sim_settings = dict(\n",
+    "    resolution=10,\n",
+    "    xmargin=1.0,\n",
+    "    ymargin=1.0,\n",
+    "    is_3d=False,\n",
+    "    port_source_names=[\"o1\"],\n",
+    "    port_symmetries=port_symmetries_coupler,\n",
+    "    run=True,\n",
+    "    overwrite=False,\n",
+    "    layer_stack=filtered_layerstack,\n",
+    "    z=0.1,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "coupler_model = MeepFDTDModel(trainable_component=trainable_coupler,\n",
+    "    layerstack=filtered_layerstack,\n",
+    "    simulation_settings={\n",
+    "        \"sim_settings\": sim_settings,\n",
+    "    },\n",
+    "    trainable_parameters={\n",
+    "        \"coupling_length\": NamedParameter(\n",
+    "            min_value=10, max_value=10, nominal_value=10, step=10\n",
+    "        ),\n",
+    "        \"gap\": NamedParameter(\n",
+    "            min_value=0.2, max_value=0.2, nominal_value=0.2, step=0.3\n",
+    "        ),\n",
+    "    },\n",
+    "    non_trainable_parameters={\n",
+    "        \"wavelength\": NamedParameter(\n",
+    "            min_value=1.54, max_value=1.56, nominal_value=1.55, step=0.01\n",
+    "        ),\n",
+    "    },\n",
+    "    num_modes=1,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_vectors, output_vectors = coupler_model.get_model_input_output(type=\"arange\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gdsfactory",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "19d269ed95feaaac3f5a2d92915e9fd960bd420d94635eb150e438afb1801d52"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -196,7 +196,7 @@ def compute_component_slice_modes(
         num_modes=num_modes,
         order=order,
         radius=radius,
-        solver="slepc",
+        # solver="slepc",
     )
 
     if with_cache:

--- a/gdsfactory/simulation/fem/mode_solver.py
+++ b/gdsfactory/simulation/fem/mode_solver.py
@@ -196,7 +196,7 @@ def compute_component_slice_modes(
         num_modes=num_modes,
         order=order,
         radius=radius,
-        # solver="slepc",
+        solver="slepc",
     )
 
     if with_cache:

--- a/gdsfactory/simulation/sax/build_model.py
+++ b/gdsfactory/simulation/sax/build_model.py
@@ -140,7 +140,7 @@ class Model:
         """
         for key, value in litho_param_dict.items():
             lithoParameter_obj = self.trainable_parameters[key]
-            current_component = lithoParameter_obj.transformation(
+            current_component = lithoParameter_obj.get_transformation(
                 current_component, value
             )
         return current_component

--- a/gdsfactory/simulation/sax/build_model.py
+++ b/gdsfactory/simulation/sax/build_model.py
@@ -7,7 +7,11 @@ from tqdm.contrib.itertools import product
 
 from gdsfactory.simulation.sax.interpolators import nd_nd_interpolation
 from gdsfactory.simulation.sax.mlp import mlp_regression
-from gdsfactory.simulation.sax.parameter import LayerStackThickness, NamedParameter
+from gdsfactory.simulation.sax.parameter import (
+    LayerStackThickness,
+    NamedParameter,
+    LithoParameter,
+)
 from gdsfactory.technology import LayerStack
 from gdsfactory.typings import PortSymmetries
 
@@ -93,7 +97,7 @@ class Model:
         }
 
     def parse_input_dict(self, input_dict):
-        """Separates between LayerStackThickness inputs and NamedParameter inputs.
+        """Separates between LayerStackThickness, NamedParameter, and LithoParameter inputs.
 
         Args:
             input_dict: key needs to match the keys in self.trainable_parameters
@@ -101,15 +105,18 @@ class Model:
         """
         param_dict = {}
         layerstack_param_dict = {}
+        litho_param_dict = {}
         for key, value in input_dict.items():
             if type(self.trainable_parameters[key]) is NamedParameter:
                 param_dict[key] = value
             elif type(self.trainable_parameters[key]) is LayerStackThickness:
                 layerstack_param_dict[key] = value
-        return param_dict, layerstack_param_dict
+            elif type(self.trainable_parameters[key]) is LithoParameter:
+                litho_param_dict[key] = value
+        return param_dict, layerstack_param_dict, litho_param_dict
 
     def perturb_layerstack(self, layerstack_param_dict):
-        """Returns a temporary LayerStack with a new thickness value for the (currently) LayerStackThickness objects in layerstack_param_dict.
+        """Returns a temporary LayerStack with a new thickness value for the (current) LayerStackThickness objects in layerstack_param_dict.
 
         Args:
             layerstack_param_dict: key needs to match a key in self.trainable_parameters having for value a LayerStackThickness object
@@ -122,6 +129,21 @@ class Model:
                 LayerStackThickness_obj.layername
             ].thickness = thickness
         return perturbed_layerstack
+
+    def perturb_geometry(self, current_component, litho_param_dict):
+        """Returns a temporary Component on which all the morphological operations contained in the current litho_param_dict have been applied.
+
+        Args:
+            current_component: the current component, with params_dict already applied
+            litho_param_dict: key needs to match a key in self.trainable_parameters having for value a LithoParameter object
+                                    value is the input to the LithoParameter transformation attribute
+        """
+        for key, value in litho_param_dict.items():
+            lithoParameter_obj = self.trainable_parameters[key]
+            current_component = lithoParameter_obj.transformation(
+                current_component, value
+            )
+        return current_component
 
     def define_output_vector_labels(self):
         """Uses number of component ports, number of modes solved for, and port_symmetries to define smallest output vector."""

--- a/gdsfactory/simulation/sax/femwell_waveguide_model.py
+++ b/gdsfactory/simulation/sax/femwell_waveguide_model.py
@@ -21,7 +21,9 @@ class FemwellWaveguideModel(Model):
 
     def outputs_from_inputs(self, input_dict):
         """For the mode solver, results vectors is neffs."""
-        param_dict, layerstack_param_dict = self.parse_input_dict(input_dict)
+        param_dict, layerstack_param_dict, litho_param_dict = self.parse_input_dict(
+            input_dict
+        )
         input_crosssection = self.component(param_dict).info["cross_section"]
         input_layerstack = self.perturb_layerstack(layerstack_param_dict)
 

--- a/gdsfactory/simulation/sax/meep_FDTD_model.py
+++ b/gdsfactory/simulation/sax/meep_FDTD_model.py
@@ -23,8 +23,12 @@ class MeepFDTDModel(Model):
 
     def outputs_from_inputs(self, input_dict):
         """Setup and run a simulation with one set of inputs."""
-        param_dict, layerstack_param_dict = self.parse_input_dict(input_dict)
-        input_component = self.component(param_dict)
+        param_dict, layerstack_param_dict, litho_param_dict = self.parse_input_dict(
+            input_dict
+        )
+        input_component = self.perturb_geometry(
+            self.component(param_dict), litho_param_dict
+        )
         # input_layerstack = self.perturb_layerstack(layerstack_param_dict)
 
         wavelengths = self.non_trainable_parameters["wavelength"]
@@ -54,7 +58,7 @@ class MeepFDTDModel(Model):
 
 if __name__ == "__main__":
     import gdsfactory as gf
-    from gdsfactory.simulation.sax.parameter import NamedParameter
+    from gdsfactory.simulation.sax.parameter import NamedParameter, LithoParameter
     from gdsfactory.technology import LayerStack
 
     c = gf.components.coupler_full(
@@ -109,10 +113,17 @@ if __name__ == "__main__":
         },
         trainable_parameters={
             "coupling_length": NamedParameter(
-                min_value=0.1, max_value=10.1, nominal_value=5, step=10
+                min_value=5, max_value=5, nominal_value=5, step=10
             ),
             "gap": NamedParameter(
-                min_value=0.2, max_value=0.5, nominal_value=0.2, step=0.3
+                min_value=0.2, max_value=0.2, nominal_value=0.2, step=0.3
+            ),
+            "erosion_dilation": LithoParameter(
+                min_value=-0.2,
+                max_value=0.2,
+                nominal_value=0.0,
+                step=0.2,
+                layername="core",
             ),
         },
         non_trainable_parameters={
@@ -123,7 +134,7 @@ if __name__ == "__main__":
         num_modes=1,
     )
 
-    input_vectors, output_vectors = coupler_model.get_model_input_output(type="corners")
+    input_vectors, output_vectors = coupler_model.get_model_input_output(type="arange")
     # interpolator = coupler_model.set_nd_nd_interp()
 
     # import jax.numpy as jnp

--- a/gdsfactory/simulation/sax/parameter.py
+++ b/gdsfactory/simulation/sax/parameter.py
@@ -4,6 +4,10 @@ import numpy as np
 
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.technology import LayerStack
+import gdsfactory as gf
+import shapely
+from shapely.affinity import translate
+from shapely.ops import unary_union
 
 
 class Parameter:
@@ -17,10 +21,10 @@ class Parameter:
         """Generic parameter class for training Component models.
 
         Arguments:
-            min_value: minimum value of the parameter. Default to layer thickness minus tolerance.
-            max_value: maximum value of the parameter. Default to layer thickness plus tolerance.
-            nominal_value: nominal value of the parameter. Default to layer thickness.
-            step: size of the step going from min_value to max_value when generating data. Default to 3 steps between min and max.
+            min_value: minimum value of the parameter.
+            max_value: maximum value of the parameter.
+            nominal_value: nominal value of the parameter.
+            step: size of the step going from min_value to max_value when generating data.
         """
 
     def sample(self, rand_val: float = None):
@@ -60,6 +64,10 @@ class LayerStackThickness(Parameter):
         Arguments:
             layerstack: LayerStack
             layername: Name of the layer in the layerstack
+            min_value: minimum value of the parameter. Default to layer thickness minus tolerance.
+            max_value: maximum value of the parameter. Default to layer thickness plus tolerance.
+            nominal_value: nominal value of the parameter. Default to layer thickness.
+            step: size of the step going from min_value to max_value when generating data. Default to 3 steps between min and max.
         """
         super().__init__(**kwargs)
         self.layerstack = layerstack or get_layer_stack()
@@ -82,10 +90,175 @@ class LayerStackThickness(Parameter):
 
 class NamedParameter(Parameter):
     def __init__(self, **kwargs) -> None:
-        """Parameter associated with the Component or simulation (e.g. wavelength)."""
+        """Parameter associated with the Component function signature or simulation (e.g. some physical dimension, wavelength)."""
         super().__init__(**kwargs)
         self.min_value = kwargs.get("min_value")
         self.max_value = kwargs.get("max_value")
         self.nominal_value = kwargs.get("nominal_value")
         self.step = kwargs.get("step")
         return None
+
+
+class LithoParameter(Parameter):
+    def __init__(
+        self,
+        type: str = "layer_dilation_erosion",
+        layerstack: Optional[LayerStack] = None,
+        layername: Optional[str] = "core",
+        **kwargs,
+    ) -> None:
+        """Parameter associated with a morphological transformation of the Component.
+
+        Currently implemented transformations:
+            * Erosion and dilation (type = "layer_dilation_erosion")
+            * Layer translation offset (type = "layer_x_offset" and "layer_y_offset")
+            * Corner rounding (type = "layer_round_corners")
+        """
+        self.min_value = kwargs.get("min_value")
+        self.max_value = kwargs.get("max_value")
+        self.nominal_value = kwargs.get("nominal_value")
+        self.step = kwargs.get("step")
+        layerstack = layerstack or get_layer_stack()
+
+        self.layer = layerstack[layername].layer
+
+        if type == "layer_dilation_erosion":
+            self.transformation = self.layer_dilation_erosion
+        elif type == "layer_x_offset":
+            self.transformation = self.layer_x_offset
+        elif type == "layer_y_offset":
+            self.transformation = self.layer_y_offset
+        elif type == "layer_round_corners":
+            self.transformation = self.layer_round_corners
+
+        return None
+
+    def layer_dilation_erosion(self, component, dilation_value):
+        temp_component = gf.Component()
+        for layer, layer_polygons in component.get_polygons(by_spec=True).items():
+            if layer == self.layer:
+                # Make sure all layer polygons are fused properly
+                shapely_polygons = [
+                    shapely.geometry.Polygon(polygon) for polygon in layer_polygons
+                ]
+                shapely_polygons = unary_union(shapely_polygons)
+                for shapely_polygon in (
+                    shapely_polygons.geoms
+                    if hasattr(shapely_polygons, "geoms")
+                    else [shapely_polygons]
+                ):
+                    buffered_polygon = shapely_polygon.buffer(dilation_value)
+                    temp_component.add_polygon(
+                        buffered_polygon.exterior.coords, layer=layer
+                    )
+            else:
+                for layer_polygon in layer_polygons:
+                    temp_component.add_polygon(layer_polygon, layer=layer)
+        temp_component.add_ports(ports=component.get_ports())
+        return temp_component
+
+    def layer_x_offset(self, component, offset_value):
+        temp_component = gf.Component()
+        for layer, layer_polygons in component.get_polygons(by_spec=True).items():
+            for layer_polygon in layer_polygons:
+                if layer == self.layer:
+                    shapely_polygon = shapely.geometry.Polygon(layer_polygon)
+                    translated_polygon = translate(
+                        shapely_polygon, xoff=offset_value, yoff=0.0
+                    )
+                    temp_component.add_polygon(
+                        translated_polygon.exterior.coords, layer=layer
+                    )
+                else:
+                    temp_component.add_polygon(layer_polygon, layer=layer)
+        temp_component.add_ports(ports=component.get_ports())
+        return temp_component
+
+    def layer_y_offset(self, component, offset_value):
+        temp_component = gf.Component()
+        for layer, layer_polygons in component.get_polygons(by_spec=True).items():
+            for layer_polygon in layer_polygons:
+                if layer == self.layer:
+                    shapely_polygon = shapely.geometry.Polygon(layer_polygon)
+                    translated_polygon = translate(
+                        shapely_polygon, xoff=0.0, yoff=offset_value
+                    )
+                    temp_component.add_polygon(
+                        translated_polygon.exterior.coords, layer=layer
+                    )
+                else:
+                    temp_component.add_polygon(layer_polygon, layer=layer)
+        temp_component.add_ports(ports=component.get_ports())
+        return temp_component
+
+    def layer_round_corners(self, component, round_value):
+        temp_component = gf.Component()
+        for layer, layer_polygons in component.get_polygons(by_spec=True).items():
+            for layer_polygon in layer_polygons:
+                if layer == self.layer:
+                    shapely_polygon = shapely.geometry.Polygon(layer_polygon)
+                    buffered_polygon = (
+                        shapely_polygon.buffer(round_value, join_style=1)
+                        .buffer(-2 * round_value, join_style=1)
+                        .buffer(round_value, join_style=1)
+                    )
+                    temp_component.add_polygon(
+                        buffered_polygon.exterior.coords, layer=layer
+                    )
+                else:
+                    temp_component.add_polygon(layer_polygon, layer=layer)
+        temp_component.add_ports(component.ports)
+        return temp_component
+
+
+if __name__ == "__main__":
+    c = gf.Component("myComponent")
+    poly1 = c.add_polygon(
+        [
+            [4.0, -2.5],
+            [3.0, -2.5],
+            [2.0, -2.5],
+            [1.5, -3.0],
+            [2.0, -3.5],
+            [2.5, -4.0],
+            [2.0, -4.5],
+            [1.0, -4.5],
+            [0.5, -4.0],
+            [0.5, -3.0],
+            [0.5, -2.0],
+            [1.0, -1.5],
+            [1.5, -1.0],
+            [1.5, -0.0],
+        ],
+        layer=1,
+    )
+    poly2 = c.add_polygon(
+        [
+            [0.5, -4.5],
+            [4, -4.5],
+            [4, 0],
+            [0.5, 0],
+        ],
+        layer=2,
+    )
+    c.show()
+
+    # param = LithoParameter(layername="core")
+    # eroded_c = param.layer_dilation_erosion(c, 0.2)
+    # eroded_c.show()
+
+    # param = LithoParameter(layername=(1,0))
+    # eroded_c = param.layer_dilation_erosion(c, -0.2)
+    # eroded_c.show()
+
+    # param = LithoParameter(layername=(1,0))
+    # eroded_c = param.layer_x_offset(c, 0.5)
+    # eroded_c.show()
+
+    # param = LithoParameter(layername=(1,0))
+    # eroded_c = param.layer_y_offset(c, 0.5)
+    # eroded_c.show()
+
+    # param = LithoParameter(layername=(1,0))
+    # eroded_c = param.layer_round_corners(c, 0.2)
+    # eroded_c.show()

--- a/gdsfactory/simulation/sax/tests/test_parameters.py
+++ b/gdsfactory/simulation/sax/tests/test_parameters.py
@@ -1,0 +1,63 @@
+from gdsfactory.simulation.sax.parameter import LithoParameter
+import gdsfactory as gf
+
+
+def test_litho_parameters():
+    c = gf.Component("myComponent")
+    c.add_polygon(
+        [[2.8, 3], [5, 3], [5, 0.8]],
+        layer=1,
+    )
+    c.add_polygon(
+        [
+            [2, 0],
+            [2, 2],
+            [4, 2],
+            [4, 0],
+        ],
+        layer=1,
+    )
+    c.add_polygon(
+        [
+            [0, 0.5],
+            [0, 1.5],
+            [3, 1.5],
+            [3, 0.5],
+        ],
+        layer=1,
+    )
+    c.add_polygon(
+        [
+            [0, 0],
+            [5, 0],
+            [5, 3],
+            [0, 3],
+        ],
+        layer=2,
+    )
+    c.add_polygon(
+        [
+            [2.5, -2],
+            [3.5, -2],
+            [3.5, -0.1],
+            [2.5, -0.1],
+        ],
+        layer=1,
+    )
+    c.add_port(name="o1", center=(0, 1), width=1, orientation=0, layer=1)
+    c.add_port(name="o2", center=(3, -2), width=1, orientation=90, layer=1)
+
+    param = LithoParameter(layername="core")
+    param.layer_dilation_erosion(c, 0.2)
+
+    param = LithoParameter(layername="core")
+    param.layer_dilation_erosion(c, -0.2)
+
+    param = LithoParameter(layername="core")
+    param.layer_x_offset(c, 0.5)
+
+    param = LithoParameter(layername="core")
+    param.layer_y_offset(c, 0.5)
+
+    param = LithoParameter(layername="core")
+    param.layer_round_corners(c, 0.2)


### PR DESCRIPTION
some cleaned up work I had lying around to treat morphological transformations as parameters to the model builder, e.g.

Initial geometry:

![image](https://user-images.githubusercontent.com/46427609/219982368-38c3fa41-49c4-4044-a076-40f6813a814c.png)

Dilation and erosion (ports are shrunk and grown too):

![image](https://user-images.githubusercontent.com/46427609/219982396-b058a4c6-3422-45dc-ab28-da5e215c961c.png)

Offsets between layers (ports are also translated):

![image](https://user-images.githubusercontent.com/46427609/219982410-d09949e1-12be-466c-a108-77416c321cc6.png)

Corner rounding (ports are padded to maintain continuity):

![image](https://user-images.githubusercontent.com/46427609/219982430-f808bbe6-b357-41a8-bb2b-7fdb7209f7c3.png)

This can be swept just like any other Component or LayerStack parameters in the model builder:

![image](https://user-images.githubusercontent.com/46427609/219982526-a0f4edbb-04a1-49aa-8ecb-da9202ed2701.png)


Next step is to include better distributed processing in the generic model builder. I think with Ray we can scale from local, to cluster, to cloud seamlessly, so just need to format the remote decorator properly