### PR TITLE
Add layer selector widget to notebook view

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1266,7 +1266,7 @@ class Component(_GeometryHelper):
             layer_views = get_layer_views()
             layer_views.to_lyp(filepath=lyp_path)
             layout = LayoutViewer(gdspath, lyp_path)
-            display(layout.image)
+            display(layout.widget)
         except ImportError:
             print(
                 "You can install `pip install gdsfactory[full]` for better visualization"

--- a/gdsfactory/utils/color_utils.py
+++ b/gdsfactory/utils/color_utils.py
@@ -1,4 +1,10 @@
-def ensure_six_digit_hex_color(color: str) -> str:
+def ensure_six_digit_hex_color(color: str | int) -> str:
+    if isinstance(color, int):
+        color = f"#{color:06x}"
+
+    color = color.replace("0x", "#")
+
+    # Convert shortened format to 6-digit (#0fc -> #00ffcc)
     if color[0] == "#" and len(color) == 4:
         color = "#" + "".join([2 * str(c) for c in color[1:]])
     return color


### PR DESCRIPTION
Adds a new widget to the LayerViewer for toggling layer visibility. Still much more to do to make it nice, but this is the first step.
TODO:
- Hierarchical toggling works (try toggling "Doping"), but the hierarchy is not visible in the widget.
- Layer toggle button size is hard-coded rather than leveraging css styling properly
- Will support tabbed layer files with a little bit more work

@joamatab 
@tvt173 
