### PR TITLE
Fix boundary condition in 2D grating simulation and mode plotting

### DIFF
--- a/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
@@ -468,25 +468,27 @@ def get_simulation_grating_coupler(
 
         if is_3d:
             fig, axs = plt.subplots(num_modes, 2, figsize=(12, 12))
-        else:
-            fig, axs = plt.subplots(num_modes, 3, figsize=(12, 12))
-
-        for mode_ind in range(num_modes):
-            if is_3d:
+            for mode_ind in range(num_modes):
                 modes.Ey.isel(mode_index=mode_ind).abs.plot(
                     x="y", y="z", cmap="magma", ax=axs[mode_ind, 0]
                 )
                 modes.Ez.isel(mode_index=mode_ind).abs.plot(
                     x="y", y="z", cmap="magma", ax=axs[mode_ind, 1]
                 )
-            else:
-                modes.Ex.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 0])
-                modes.Ey.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 1])
-                modes.Ez.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 2])
+        else:
+            fig, axs = plt.subplots(num_modes, 3, figsize=(12, 12))
+            for mode_ind in range(num_modes):
+                ax1 = axs[mode_ind, 0]
+                ax2 = axs[mode_ind, 1]
+                ax3 = axs[mode_ind, 2]
 
-                axs[mode_ind, 0].set_title(f"|Ex|: mode_index={mode_ind}")
-                axs[mode_ind, 1].set_title(f"|Ey|: mode_index={mode_ind}")
-                axs[mode_ind, 2].set_title(f"|Ez|: mode_index={mode_ind}")
+                modes.Ex.isel(mode_index=mode_ind).abs.plot(ax=ax1)
+                modes.Ey.isel(mode_index=mode_ind).abs.plot(ax=ax2)
+                modes.Ez.isel(mode_index=mode_ind).abs.plot(ax=ax3)
+
+                ax1.set_title(f"|Ex|: mode_index={mode_ind}")
+                ax2.set_title(f"|Ey|: mode_index={mode_ind}")
+                ax3.set_title(f"|Ez|: mode_index={mode_ind}")
 
         if is_3d:
             axs[mode_ind, 0].set_aspect("equal")

--- a/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
@@ -218,7 +218,12 @@ def get_simulation_grating_coupler(
     layer_to_zmin = layer_stack.get_layer_to_zmin()
     # layer_to_sidewall_angle = layer_stack.get_layer_to_sidewall_angle()
 
-    boundary_spec = boundary_spec or td.BoundarySpec.all_sides(boundary=td.PML())
+    boundary_spec = boundary_spec or (
+        td.BoundarySpec.all_sides(boundary=td.PML()) if is_3d else
+        td.BoundarySpec(
+            x=td.Boundary.pml(), y=td.Boundary.periodic(), z=td.Boundary.pml(),
+        )
+    )
     grid_spec = grid_spec or td.GridSpec.auto(wavelength=wavelength)
 
     assert isinstance(
@@ -450,14 +455,15 @@ def get_simulation_grating_coupler(
 
     if plot_modes:
         src_plane = td.Box(center=waveguide_port_center, size=waveguide_port_size)
-        ms = td.plugins.ModeSolver(simulation=sim, plane=src_plane, freq=freq0)
-
         mode_spec = td.ModeSpec(num_modes=num_modes)
-        modes = ms.solve(mode_spec=mode_spec)
+        ms = td.plugins.ModeSolver(
+                simulation=sim, plane=src_plane, freqs=[freq0], mode_spec=mode_spec,
+        )
+        modes = ms.solve()
 
         print(
             "Effective index of computed modes: ",
-            ", ".join([f"{mode.n_eff:1.4f}" for mode in modes]),
+            ", ".join([f"{n_eff:1.4f}" for n_eff in modes.n_eff.isel(f=0).values]),
         )
 
         if is_3d:
@@ -467,16 +473,16 @@ def get_simulation_grating_coupler(
 
         for mode_ind in range(num_modes):
             if is_3d:
-                abs(modes[mode_ind].field_data.Ey).plot(
+                modes.Ey.isel(mode_index=mode_ind).abs.plot(
                     x="y", y="z", cmap="magma", ax=axs[mode_ind, 0]
                 )
-                abs(modes[mode_ind].field_data.Ez).plot(
+                modes.Ez.isel(mode_index=mode_ind).abs.plot(
                     x="y", y="z", cmap="magma", ax=axs[mode_ind, 1]
                 )
             else:
-                abs(modes[mode_ind].field_data.Ex).plot(ax=axs[mode_ind, 0])
-                abs(modes[mode_ind].field_data.Ey).plot(ax=axs[mode_ind, 1])
-                abs(modes[mode_ind].field_data.Ez).plot(ax=axs[mode_ind, 2])
+                modes.Ex.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 0])
+                modes.Ey.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 1])
+                modes.Ez.isel(mode_index=mode_ind).abs.plot(ax=axs[mode_ind, 2])
 
                 axs[mode_ind, 0].set_title(f"|Ex|: mode_index={mode_ind}")
                 axs[mode_ind, 1].set_title(f"|Ey|: mode_index={mode_ind}")


### PR DESCRIPTION
For 2D simulations, the boundary condition in the direction orthogonal to the simulation plane must be set to periodic, for the filed normalization to work.

Additionally, some fixes for plotting modes are included.

Issue described in https://github.com/flexcompute/tidy3d/issues/627