### PR TITLE
Fix port in grating simulation to avoid substrate overlap (#1329)

### DIFF
--- a/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation_grating_coupler.py
@@ -382,12 +382,14 @@ def get_simulation_grating_coupler(
     size_x = 0 if size_x < 0.001 else size_x
     size_y = 0 if size_y < 0.001 else size_y
     size_y = size_y if is_3d else td.inf
-    size_z = wg_thickness + 2 * zmargin
+    size_z = wg_thickness + zmargin + box_thickness
     waveguide_port_size = [size_x, size_y, size_z]
     xy_shifted = move_polar_rad_copy(
         np.array(port.center), angle=angle * np.pi / 180, length=port_waveguide_offset
     )
-    waveguide_port_center = xy_shifted.tolist() + [0]  # (x, y, z=0)
+    waveguide_port_center = xy_shifted.tolist() + [
+        (wg_thickness + zmargin - box_thickness) / 2
+    ]  # (x, y, z)
 
     waveguide_monitor = td.ModeMonitor(
         center=waveguide_port_center,


### PR DESCRIPTION
This PR is intended to fix the port size in the simulation of grating couplers through Tidy3D by removing their overlap with the substrate, which impairs the mode calculation.

As a result the waveguide is off-center; the distances to the upper and lower parot boundaries are `zmargin` and `box_thickness`, respectively. That should still work correctly if those values are adequate for the mode in question.