### PR TITLE
propagate cross_section arg into taper

### DIFF
--- a/gdsfactory/components/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_coupler_rectangular.py
@@ -87,6 +87,7 @@ def grating_coupler_rectangular(
         width2=width_grating,
         width1=wg_width,
         layer=layer,
+        cross_section=cross_section,
     )
 
     c.add_port(port=taper_ref.ports["o1"], name="o1")


### PR DESCRIPTION
cross_section argument for grating_coupler_rectangular component is not propagated into the taper which defaults to 'strip' and incorrectly sets parameters in the taper function e.g. x.bbox_layers - This PR fixes this.