### PR TITLE
Update S-parameter plotting

### DIFF
--- a/gdsfactory/simulation/plot.py
+++ b/gdsfactory/simulation/plot.py
@@ -165,7 +165,7 @@ def plot_loss2x2(
 def plot_backreflection(
     sp: Dict[str, np.ndarray], ports: Sequence[str], ax: Optional[plt.Axes] = None
 ) -> None:
-    """Plots backreflection in dB.
+    """Plots backreflection in dB for coupler.
 
     Args:
         sp: sparameters dict np.ndarray.
@@ -188,7 +188,7 @@ def plot_backreflection(
         ax.plot(x, 10 * np.log10(sum(power.values())), "k--", label="Total")
     ax.set_xlim((x[0], x[-1]))
     ax.set_xlabel("wavelength (nm)")
-    ax.set_ylabel("excess loss (dB)")
+    ax.set_ylabel("reflection (dB)")
     plt.legend()
 
 

--- a/gdsfactory/simulation/plot.py
+++ b/gdsfactory/simulation/plot.py
@@ -10,6 +10,12 @@ import numpy as np
 import gdsfactory as gf
 
 
+def _check_ports(sp: Dict[str, np.ndarray], ports: Sequence[str]):
+    for port in ports:
+        if port not in sp:
+            raise ValueError(f"Did not find port {port} in {list(sp.keys())}")
+
+
 def plot_sparameters(
     sp: Dict[str, np.ndarray],
     logscale: bool = True,
@@ -167,8 +173,7 @@ def plot_backreflection(
         ax: matplotlib axis object to draw into.
 
     """
-    if not all([p in sp for p in ports]):
-        raise ValueError(f"Did not find all ports {ports} in {list(sp.keys())}")
+    _check_ports(sp, ports)
 
     power = {port: np.abs(sp[port]) ** 2 for port in ports}
     x = sp["wavelengths"] * 1e3


### PR DESCRIPTION
This PR contains plotting updates for the S-parameter plotting utilities in `gdsfactory.simulation.plot`.

Added:

- `plot_reflection` for plotting the reflection in multiport devices.

Changed:

- Updated loss, imbalance, and reflection plots to support devices with arbitrary port specifications and added aliases for 1x2 and 2x2 configurations.
- Make above plotting functions accept `matplotlib.Axes` objects so that we can draw into existing figures.

Fixed:

- Imbalance plot did not actually show the power imbalance in percent as the label suggested but instead showed the ratio of the raw S-parameters. Changed it so that the imbalance is now instead given in dB according to `10 log10(1 - (port1_power - port2_power))`.