### PR TITLE
Fix meep neff fdtd

### DIFF
--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -40,6 +40,10 @@ def get_material(
     materials = [material.lower() for material in MATERIALS]
     name = name.lower()
 
+    # HOTFIX: Make sure that overrides are applied before any other assignments can occur
+    if not isinstance(material_name_to_meep[name], str):
+        return mp.Medium(epsilon=material_name_to_meep[name] ** 2)
+
     if dispersive:
         if name in material_name_to_meep.keys():
             name_or_index = material_name_to_meep[name]
@@ -51,9 +55,6 @@ def get_material(
     else:
         material_index = get_material_index(name, wavelength)
         return mp.Medium(epsilon=material_index**2)
-
-    if not isinstance(name_or_index, str):
-        return mp.Medium(epsilon=name_or_index**2)
 
     name = name_or_index.lower()
     if name not in materials:

--- a/gdsfactory/simulation/gmeep/test_materials.py
+++ b/gdsfactory/simulation/gmeep/test_materials.py
@@ -1,0 +1,34 @@
+import gdsfactory as gf
+from gdsfactory.simulation.gmeep.write_sparameters_meep import write_sparameters_meep
+
+
+def test_materials_override() -> None:
+    """Checks that materials are properly overridden if index is provided."""
+
+    c = gf.components.straight(length=2)
+
+    # Default (materials strings)
+    sp1 = write_sparameters_meep(
+        c,
+        run=False,
+        animate=False,
+        is_3d=False,
+        overwrite=True,
+    )
+
+    # Override
+    sp2 = write_sparameters_meep(
+        c,
+        run=False,
+        animate=False,
+        material_name_to_meep=dict(si=2.0),
+        is_3d=False,
+        overwrite=True,
+    )
+
+    assert sp1.geometry[0].material.epsilon(freq=1)[0][0] != 4.0
+    assert sp2.geometry[0].material.epsilon(freq=1)[0][0] == 4.0
+
+
+if __name__ == "__main__":
+    test_materials_override()


### PR DESCRIPTION
Fix a bug where materials_to_dict values were overriden by default PDK values in MEEP simulator. It was causing the 2.5D FDTD to be completely off

Added test to monitor this in the future

@HelgeGehring @joamatab 