### PR TITLE
Rework Meep get_materials logic

### DIFF
--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -42,11 +42,13 @@ def get_material(
     if name not in material_name_to_meep and name not in materials:
         raise KeyError(f"material {name!r} not found in available materials")
 
-    if isinstance(material_name_to_meep[name], (int, float)):
-        # if material is only a number, we can return early regardless of dispersion
-        return mp.Medium(index=material_name_to_meep[name])
+    meep_name = material_name_to_meep[name]
 
-    material = getattr(mat, MATERIALS[materials.index(name)])
+    if isinstance(meep_name, (int, float)):
+        # if material is only a number, we can return early regardless of dispersion
+        return mp.Medium(index=meep_name)
+
+    material = getattr(mat, meep_name)
 
     if dispersive:
         return material

--- a/gdsfactory/simulation/gmeep/get_material.py
+++ b/gdsfactory/simulation/gmeep/get_material.py
@@ -93,7 +93,7 @@ def get_index(
 
 def test_index() -> None:
     n = get_index(name="sin")
-    n_reference = 1.9983425877199599
+    n_reference = 1.9962797317138816
     assert np.isclose(n, n_reference), n
 
 

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -332,6 +332,7 @@ def write_sparameters_meep(
             port_margin=port_margin,
             port_monitor_offset=port_monitor_offset,
             port_source_offset=port_source_offset,
+            dispersive=dispersive,
             is_3d=is_3d,
             **settings,
         )


### PR DESCRIPTION
Reworks the logic in `gmeep.get_material` so that overrides in `material_name_to_meep` are properly handled and add missing material overrides when `run=False` in `write_sparameters_meep`.

Started working on this before #1359 was merged, which already includes the main fix, so @simbilod maybe have a quick look if these changes are alright.

I removed the `pdk.get_material_index` because it only pulls from the default `material_name_to_meep` (which are Meep materials anyways). I guess this is subject to change, but currently neither version discerns between Meep materials and pdk-defined ones.

Note that the test is currently failing because the reference value used in `test_index()` comes from tidy3d's `sin` instead of Meep's `Si3N4_NIR`. Meep gives a value of `n = 1.9962797317138816`, and tidy3d gives `1.9983425877199599`. I am unsure what the intended behavior here is. To me it would make sense to use Meep's material (otherwise dispersion is not going to work anyways), but I didn't want to change the test.