### PR TITLE
Transition does not inherit from CrossSection

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,12 +46,14 @@ Classes and functions for construction and manipulation of geometric objects.
 
    CrossSection
    Transition
+   xsection
    cross_section
    strip
    strip_auto_widen
    heater_metal
    pin
    pn
+   pn_with_trenches
    strip_heater_metal_undercut
    strip_heater_metal
    strip_heater_doped

--- a/gdsfactory/components/taper_cross_section.py
+++ b/gdsfactory/components/taper_cross_section.py
@@ -29,7 +29,6 @@ def taper_cross_section(
         kwargs: cross_section settings for section2.
 
 
-
     .. code::
 
                            _____________________

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -752,11 +752,11 @@ def extrude(
     c = Component()
 
     x = get_cross_section(cross_section)
-    snap_to_grid_nm = int(1e3 * (x.snap_to_grid or get_grid_size()))
     sections = x.sections or []
     sections = list(sections)
 
-    if x.layer and x.width and x.add_center_section:
+    if isinstance(x, CrossSection):
+        snap_to_grid_nm = int(1e3 * (x.snap_to_grid or get_grid_size()))
         sections += [
             Section(
                 width=x.width,
@@ -767,17 +767,17 @@ def extrude(
             )
         ]
 
-    if x.cladding_layers and x.cladding_offsets:
-        for layer, cladding_offset in zip(x.cladding_layers, x.cladding_offsets):
-            width = x.width(1) if callable(x.width) else x.width
-            width = max(width) if isinstance(width, Iterable) else width
-            sections += [
-                Section(
-                    width=width + 2 * cladding_offset,
-                    offset=x.offset,
-                    layer=get_layer(layer),
-                )
-            ]
+        if x.cladding_layers and x.cladding_offsets:
+            for layer, cladding_offset in zip(x.cladding_layers, x.cladding_offsets):
+                width = x.width(1) if callable(x.width) else x.width
+                width = max(width) if isinstance(width, Iterable) else width
+                sections += [
+                    Section(
+                        width=width + 2 * cladding_offset,
+                        offset=x.offset,
+                        layer=get_layer(layer),
+                    )
+                ]
 
     for section in sections:
         width = section.width
@@ -942,13 +942,13 @@ def extrude(
 
     c.info["length"] = float(np.round(p.length(), 3))
 
-    if x.add_bbox:
-        c = x.add_bbox(c)
-    if x.add_pins:
-        c = x.add_pins(c)
-
-    if x.decorator:
-        c = x.decorator(c) or c
+    if isinstance(x, CrossSection):
+        if x.add_bbox:
+            c = x.add_bbox(c)
+        if x.add_pins:
+            c = x.add_pins(c)
+        if x.decorator:
+            c = x.decorator(c) or c
     return c
 
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -25,6 +25,7 @@ from gdsfactory.typings import (
     ComponentFactory,
     ComponentSpec,
     CrossSection,
+    Transition,
     CrossSectionFactory,
     CrossSectionSpec,
     Dict,
@@ -438,9 +439,11 @@ class Pdk(BaseModel):
 
     def get_cross_section(
         self, cross_section: CrossSectionSpec, **kwargs
-    ) -> CrossSection:
+    ) -> Union[CrossSection, Transition]:
         """Returns cross_section from a cross_section spec."""
         if isinstance(cross_section, CrossSection):
+            return cross_section.copy(**kwargs)
+        elif isinstance(cross_section, Transition):
             return cross_section.copy(**kwargs)
         elif callable(cross_section):
             return cross_section(**kwargs)
@@ -476,7 +479,7 @@ class Pdk(BaseModel):
         else:
             raise ValueError(
                 "get_cross_section expects a CrossSectionSpec (CrossSection, "
-                f"CrossSectionFactory, string or dict), got {type(cross_section)}"
+                f"CrossSectionFactory, Transition, string or dict), got {type(cross_section)}"
             )
 
     def get_layer(self, layer: LayerSpec) -> Layer:

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -42,7 +42,7 @@ from typing_extensions import Literal
 
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.component_layout import Label
-from gdsfactory.cross_section import CrossSection, Section
+from gdsfactory.cross_section import CrossSection, Section, Transition
 from gdsfactory.port import Port
 from gdsfactory.technology import LayerLevel, LayerStack
 
@@ -166,6 +166,7 @@ Coordinate = Tuple[float, float]
 Coordinates = Tuple[Coordinate, ...]
 ComponentOrPath = Union[Component, PathType]
 CrossSectionFactory = Callable[..., CrossSection]
+TransitionFactory = Callable[..., Transition]
 CrossSectionOrFactory = Union[CrossSection, Callable[..., CrossSection]]
 PortSymmetries = Dict[str, List[str]]
 PortsDict = Dict[str, Port]
@@ -182,7 +183,12 @@ CellSpec = Union[
 
 ComponentSpecDict = Dict[str, ComponentSpec]
 CrossSectionSpec = Union[
-    str, CrossSectionFactory, CrossSection, Dict[str, Any]
+    str,
+    CrossSectionFactory,
+    CrossSection,
+    Transition,
+    TransitionFactory,
+    Dict[str, Any],
 ]  # cross_section function, function name or dict
 
 MultiCrossSectionAngleSpec = List[Tuple[CrossSectionSpec, Tuple[int, ...]]]


### PR DESCRIPTION
- Transition does not inherit from CrossSection
- add gf.cross_section.pn_with_trenches
- allow CrossSection.layer = None, and remove `add_center_section` parameter to CrossSection. Now you can use Layer=None for that.

@tvt173 
@thomasdorch 

related to #1365 