### PR TITLE
install uses copy instead of symlink

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,7 +7,7 @@ tag = True
 
 [bumpversion:file:pyproject.toml]
 
-[bumpversion:file:docs/contribution.md]
+[bumpversion:file:docs/notebooks/08_pdk.py]
 
 [bumpversion:file:gdsfactory/__init__.py]
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,9 +34,6 @@ jobs:
         run: |
           sudo apt install libglu1-mesa
           make gdslib plugins-debian full
-          make notebooks
-          rm docs/notebooks/*.py
-          rm docs/notebooks/**/*.py
           make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -135,7 +135,4 @@ jobs:
         run: |
           mkdir -p $HOME/.tidy3d
           echo ${{ secrets.TIDY3D_AUTH }} > $HOME/.tidy3d/auth.json
-          make notebooks
-          rm docs/notebooks/*.py
-          rm docs/notebooks/**/*.py
           make docs

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Or you can install only the ones you need.
   * Eigenmode Expansion (EME)
     - [MEOW](https://gdsfactory.github.io/gdsfactory/notebooks/eme/01_meow.html)
 * [Electromagnetic Wave Solvers using Finite Difference Time Domain (FDTD)](https://gdsfactory.github.io/gdsfactory/plugins_fdtd.html)
-  - [tid3d](https://gdsfactory.github.io/gdsfactory/notebooks/tidy3d/00_tidy3d.html)
+  - [tidy3d](https://gdsfactory.github.io/gdsfactory/notebooks/tidy3d/00_tidy3d.html)
   - [MEEP](https://gdsfactory.github.io/gdsfactory/notebooks/meep/001_meep_sparameters.html)
   - [Ansys Lumerical FDTD](https://gdsfactory.github.io/gdsfactory/notebooks/lumerical/1_fdtd_sparameters.html)
 * [S-Parameter Circuit Solvers](https://gdsfactory.github.io/gdsfactory/plugins_circuits.html)

--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ It provides you a common syntax for design (KLayout, gdstk, Ansys Lumerical, tid
 
 ![tool interfaces](https://i.imgur.com/9fNLRvJ.png)
 
-Multiple Silicon Photonics foundries have gdsfactory PDKs available. Talk to your foundry to access their gdsfactory PDK.
+Multiple Photonic foundries have gdsfactory PDKs available. Talk to your foundry to access their gdsfactory PDK.
 
 You can also access:
 
+- instructions on [how to build your own PDK](https://gdsfactory.github.io/gdsfactory/notebooks/08_pdk.html)
+- instructions on [how to import a PDK from a library of fixed GDS cells](https://gdsfactory.github.io/gdsfactory/notebooks/09_pdk_import.html)
 - open source PDKs available on GitHub
   - [UBCPDK](https://gdsfactory.github.io/ubc/README.html)
   - [skywater130](https://gdsfactory.github.io/skywater130/README.html)
-- instructions on [how to build your own PDK](https://gdsfactory.github.io/gdsfactory/notebooks/08_pdk.html)
-- instructions on [how to import a PDK from a library of fixed GDS cells](https://gdsfactory.github.io/gdsfactory/notebooks/09_pdk_import.html)
 
 ## Installation
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ logo: logo.png
 execute:
   # execute_notebooks: cache
   timeout: 60
-  allow_errors: true
+  allow_errors: false
   # timeout: -1
   execute_notebooks: force
   # execute_notebooks: "off"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -74,3 +74,7 @@ sphinx:
     nb_execution_show_tb: True
     html_js_files:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
+    nb_custom_formats:
+        .py:
+            - jupytext.reads
+            - fmt: py

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -24,6 +24,7 @@ chapters:
       - file: notebooks/04_components_
       - file: notebooks/04_components_hierarchy
       - file: notebooks/08_pdk
+      - file: notebooks/08_pdk_examples
       - file: notebooks/09_pdk_import
       - file: notebooks/07_mask
       - file: notebooks/04_routing

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -56,24 +56,6 @@ You can run tests with `pytest`. This will run 3 types of tests:
     - you can check out any changes in your library with `gf gds diff ref_layouts/bbox.gds run_layouts/bbox.gds`
     - it will also store all differences in `diff_layouts` and you can combine and show them in KLayout with `make diff`
 
-## Testing your own PDK cells
-
-As you create your cell functions you should write tests for them. See for example the tests in the [ubc PDK](https://github.com/gdsfactory/ubc)
-
-Pytest-regressions automatically creates the CSV and YAML files for you, as well `gdsfactory.gdsdiff` will store the reference GDS in ref_layouts and check for geometry differences using XOR.
-
-gdsfactory is **not** backwards compatible, which means that the package will keep improving and evolving.
-
-1. To make your work stable you should install a specific version and [pin the version](https://martin-thoma.com/python-requirements/) in your `requirements.txt` or `pyproject.toml` as `gdsfactory==6.48.3` replacing `6.48.3` by whatever version you end up using.
-2. Before you upgrade gdsfactory to a newer version make sure your tests pass to make sure that things behave as expected
-
-
-## Compare gds files
-
-You can use the command line `gf gds diff gds1.gds gds2.gds` to overlay `gds1.gds` and `gds2.gds` files and show them in KLayout.
-
-For example, if you changed the mmi1x2 and made it 5um longer by mistake, you could `gf gds diff ref_layouts/mmi1x2.gds run_layouts/mmi1x2.gds` and see the GDS differences in Klayout.
-
 
 ## Acks
 

--- a/docs/notebooks/08_pdk.py
+++ b/docs/notebooks/08_pdk.py
@@ -4,15 +4,16 @@
 #     custom_cell_magics: kql
 #     text_representation:
 #       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.14.4
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
 
+# %% [markdown]
 # # PDK
 #
 # gdsfactory includes a generic PDK, that you can use as an inspiration to create your own.
@@ -39,6 +40,7 @@
 # - `get_component` returns a Component from the registered cells or containers.
 # - `get_cross_section` returns a CrossSection from the registered cross_sections.
 
+# %% [markdown]
 # ## layers
 #
 # GDS layers are a tuple of two integer number `gdslayer/gdspurpose`
@@ -51,7 +53,7 @@
 #
 # Lets generate the layers definition code from a KLayout `lyp` file.
 
-# + tags=[]
+# %% tags=[]
 import pathlib
 from typing import Callable, Tuple
 
@@ -85,7 +87,7 @@ PDK.activate()
 print(lyp_to_dataclass(PATH.klayout_lyp))
 
 
-# + tags=[]
+# %% tags=[]
 class LayerMap(BaseModel):
     WG: Layer = (1, 0)
     DEVREC: Layer = (68, 0)
@@ -134,8 +136,8 @@ class LayerMap(BaseModel):
 
 
 LAYER = LayerMap()
-# -
 
+# %% [markdown]
 # There are some default layers in some generic components and cross_sections, that it may be convenient adding.
 #
 # | Layer          | Purpose                                                      |
@@ -164,18 +166,19 @@ LAYER = LayerMap()
 #
 # ```
 
+# %% [markdown]
 # ## cross_sections
 #
 # You can create a `CrossSection` from scratch or you can customize the cross_section functions in `gf.cross_section`
 
-# + tags=[]
+# %% tags=[]
 strip2 = gf.partial(gf.cross_section.strip, layer=(2, 0))
 
-# + tags=[]
+# %% tags=[]
 c = gf.components.straight(cross_section=strip2)
 c
 
-# + tags=[]
+# %% tags=[]
 pin = gf.partial(
     gf.cross_section.strip,
     sections=(
@@ -186,19 +189,19 @@ pin = gf.partial(
 c = gf.components.straight(cross_section=pin)
 c
 
-# + tags=[]
+# %% tags=[]
 strip_wide = gf.partial(gf.cross_section.strip, width=3)
 
 
-# + tags=[]
+# %% tags=[]
 strip = gf.partial(
     gf.cross_section.strip, auto_widen=True
 )  # auto_widen tapers to wider waveguides for lower loss in long straight sections.
 
-# + tags=[]
+# %% tags=[]
 cross_sections = dict(strip_wide=strip_wide, pin=pin, strip=strip)
-# -
 
+# %% [markdown]
 # ## cells
 #
 # Cells are functions that return Components. They are parametrized and accept also cells as parameters, so you can build many levels of complexity. Cells are also known as PCells or parametric cells.
@@ -208,13 +211,13 @@ cross_sections = dict(strip_wide=strip_wide, pin=pin, strip=strip)
 #
 # For example, you can make some wide MMIs for a particular technology. Lets say the best MMI width you found it to be 9um.
 
-# + tags=[]
+# %% tags=[]
 mmi1x2 = gf.partial(gf.components.mmi1x2, width_mmi=9)
 mmi2x2 = gf.partial(gf.components.mmi2x2, width_mmi=9)
 
 cells = dict(mmi1x2=mmi1x2, mmi2x2=mmi2x2)
-# -
 
+# %% [markdown]
 # ## PDK
 #
 # You can register Layers, ComponentFactories (Parametric cells) and CrossSectionFactories (cross_sections) into a PDK. Then you can access them by a string after you activate the pdk `PDK.activate()`.
@@ -223,7 +226,7 @@ cells = dict(mmi1x2=mmi1x2, mmi2x2=mmi2x2)
 #
 # You can access layers from the active Pdk using the layer name or a tuple/list of two numbers.
 
-# + tags=[]
+# %% tags=[]
 from gdsfactory.generic_tech import get_generic_pdk
 
 generic_pdk = get_generic_pdk()
@@ -239,42 +242,42 @@ pdk1 = gf.Pdk(
 )
 pdk1.activate()
 
-# + tags=[]
+# %% tags=[]
 pdk1.get_layer("WG")
 
-# + tags=[]
+# %% tags=[]
 pdk1.get_layer([1, 0])
-# -
 
+# %% [markdown]
 # ### CrossSectionSpec
 #
 # You can access cross_sections from the pdk from the cross_section name, or using a dict to customize the CrossSection
 
-# + tags=[]
+# %% tags=[]
 pdk1.get_cross_section("pin")
 
-# + tags=[]
+# %% tags=[]
 cross_section_spec_string = "pin"
 gf.components.straight(cross_section=cross_section_spec_string)
 
-# + tags=[]
+# %% tags=[]
 cross_section_spec_dict = dict(cross_section="pin", settings=dict(width=2))
 print(pdk1.get_cross_section(cross_section_spec_dict))
 wg_pin = gf.components.straight(cross_section=cross_section_spec_dict)
 wg_pin
-# -
 
+# %% [markdown]
 # ### ComponentSpec
 #
 # You can get Component from the active pdk using the cell name (string) or a dict.
 
-# + tags=[]
+# %% tags=[]
 pdk1.get_component("mmi1x2")
 
-# + tags=[]
+# %% tags=[]
 pdk1.get_component(dict(component="mmi1x2", settings=dict(length_mmi=10)))
-# -
 
+# %% [markdown]
 # Now you can define PDKs for different Fabs
 #
 # ### FabA
@@ -283,7 +286,7 @@ pdk1.get_component(dict(component="mmi1x2", settings=dict(length_mmi=10)))
 #
 # The waveguide traces are 2um wide.
 
-# + tags=[]
+# %% tags=[]
 nm = 1e-3
 
 
@@ -369,11 +372,11 @@ c = gf.components.mzi()
 c_gc = gf.routing.add_fiber_array(component=c, grating_coupler=gc, with_loopback=False)
 c_gc.plot()
 
-# + tags=[]
+# %% tags=[]
 c = c_gc.to_3d()
 c.show(show_ports=True)
-# -
 
+# %% [markdown]
 # ### FabB
 #
 # FabB has photonic waveguides that require rectangular cladding layers to avoid dopants
@@ -381,7 +384,7 @@ c.show(show_ports=True)
 # Lets say that the waveguides are defined in layer (2, 0) and are 0.3um wide, 1um thick
 #
 
-# + tags=[]
+# %% tags=[]
 nm = 1e-3
 
 
@@ -502,17 +505,17 @@ wg_gc = gf.routing.add_fiber_array(
 )
 wg_gc.plot()
 
-# + tags=[]
+# %% tags=[]
 c = wg_gc.to_3d()
 c.show(show_ports=True)
-# -
 
+# %% [markdown]
 # ### FabC
 #
 # Lets assume that fab C has similar technology to the generic PDK in gdsfactory and that you just want to remap some layers, and adjust the widths.
 #
 
-# + tags=[]
+# %% tags=[]
 nm = 1e-3
 
 
@@ -713,10 +716,10 @@ pdk = gf.Pdk(
 pdk.activate()
 
 
-# + tags=[]
+# %% tags=[]
 LAYER_VIEWS.layer_map.values()
 
-# + tags=[]
+# %% tags=[]
 mzi = mzi_nc()
 mzi_gc = gf.routing.add_fiber_single(
     component=mzi,
@@ -728,24 +731,32 @@ mzi_gc = gf.routing.add_fiber_single(
 )
 mzi_gc.plot()
 
-# + tags=[]
+# %% tags=[]
 c = mzi_gc.to_3d()
 c.show(show_ports=True)
 
-# + tags=[]
+# %% tags=[]
 ls = get_layer_stack_fab_c()
-# -
 
-# ## PDK Testing
+# %% [markdown]
+# ## Testing PDK cells
 #
 # To make sure all your PDK PCells produce the components that you want, it's important to test your PDK cells.
 #
 # As you write your own cell functions you want to make sure you do not break or produced unwanted regressions later on. You should write tests for this.
 #
-# Make sure you create a `test_components.py` file for pytest to test your PDK.
+# Make sure you create a `test_components.py` file for pytest to test your PDK. See for example the tests in the [ubc PDK](https://github.com/gdsfactory/ubc)
+#
+# Pytest-regressions automatically creates the CSV and YAML files for you, as well `gdsfactory.gdsdiff` will store the reference GDS in ref_layouts and check for geometry differences using XOR.
+#
+# gdsfactory is **not** backwards compatible, which means that the package will keep improving and evolving.
+#
+# 1. To make your work stable you should install a specific version and [pin the version](https://martin-thoma.com/python-requirements/) in your `requirements.txt` or `pyproject.toml` as `gdsfactory==6.48.3` replacing `6.48.3` by whatever version you end up using.
+# 2. Before you upgrade gdsfactory to a newer version make sure your tests pass to make sure that things behave as expected
+#
 #
 
-# + tags=[]
+# %% tags=[]
 """This code tests all your cells in the PDK
 
 it will test 3 things:
@@ -791,13 +802,19 @@ def test_assert_ports_on_grid(component_name: str):
     component.assert_ports_on_grid()
 
 
-# -
+# %% [markdown]
+# ## Compare gds files
+#
+# You can use the command line `gf gds diff gds1.gds gds2.gds` to overlay `gds1.gds` and `gds2.gds` files and show them in KLayout.
+#
+# For example, if you changed the mmi1x2 and made it 5um longer by mistake, you could `gf gds diff ref_layouts/mmi1x2.gds run_layouts/mmi1x2.gds` and see the GDS differences in Klayout.
 
+# %% [markdown]
 # ## PDK decorator
 #
 # You can also define a PDK decorator (function) that runs over every PDK PCell.
 
-# +
+# %%
 from gdsfactory.add_pins import add_pins_siepic
 
 
@@ -847,7 +864,7 @@ c1 = gf.components.straight(length=5)
 print(has_valid_transformations(c1))
 c1.layers
 
-# +
+# %%
 pdk = gf.Pdk(
     name="fab_c",
     cells=cells,
@@ -863,20 +880,21 @@ pdk.activate()
 c1 = gf.components.straight(length=5)
 print(has_valid_transformations(c1))
 c1.layers
-# -
 
+# %% [markdown]
 # if you zoom in you will see a device recognition layer and pins.
 #
 # ![devrec](https://i.imgur.com/U9IPOei.png)
 #
 
+# %% [markdown]
 # ## Version control components
 #
 # For version control your component library you can use GIT
 #
 # For tracking changes you can add `Component` changelog in the PCell docstring.
 
-# +
+# %%
 from gdsfactory.generic_tech import get_generic_pdk
 
 PDK = get_generic_pdk()
@@ -916,13 +934,13 @@ def litho_ruler(
 
 c = litho_ruler(cache=False)
 c.plot()
-# -
 
+# %% [markdown]
 # Lets assume that later on you change the code inside the PCell and want to keep a changelog.
 # You can use the docstring Notes to document any significant changes in the component.
 
 
-# +
+# %%
 @gf.cell
 def litho_ruler(
     height: float = 2,

--- a/docs/notebooks/08_pdk_examples.py
+++ b/docs/notebooks/08_pdk_examples.py
@@ -25,7 +25,34 @@
 #
 # The waveguide traces are 2um wide.
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
+
+import pathlib
+from typing import Callable, Tuple
+
+import pytest
+from pydantic import BaseModel
+from pytest_regressions.data_regression import DataRegressionFixture
+
+from gdsfactory.add_pins import add_pin_rectangle_inside
+from gdsfactory.component import Component
+from gdsfactory.config import PATH
+from gdsfactory.cross_section import cross_section
+from gdsfactory.decorators import flatten_invalid_refs, has_valid_transformations
+from gdsfactory.difftest import difftest
+from gdsfactory.generic_tech import get_generic_pdk
+from gdsfactory.technology import (
+    LayerLevel,
+    LayerStack,
+    LayerView,
+    LayerViews,
+    lyp_to_dataclass,
+)
+from gdsfactory.typings import Layer, LayerSpec
+
+import gdsfactory as gf
+
+gf.config.rich_output()
 nm = 1e-3
 
 
@@ -111,7 +138,7 @@ c = gf.components.mzi()
 c_gc = gf.routing.add_fiber_array(component=c, grating_coupler=gc, with_loopback=False)
 c_gc.plot()
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 c = c_gc.to_3d()
 c.show(show_ports=True)
 
@@ -123,7 +150,7 @@ c.show(show_ports=True)
 # Lets say that the waveguides are defined in layer (2, 0) and are 0.3um wide, 1um thick
 #
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 nm = 1e-3
 
 
@@ -144,7 +171,8 @@ class LayerMap(BaseModel):
 LAYER = LayerMap()
 
 
-# The LayerViews class supports grouping LayerViews within each other. These groups are maintained when exporting a LayerViews object to a KLayout layer properties (.lyp) file.
+# The LayerViews class supports grouping LayerViews within each other.
+# These groups are maintained when exporting a LayerViews object to a KLayout layer properties (.lyp) file.
 class FabBLayerViews(LayerViews):
     WG = LayerView(color="red")
     SLAB150 = LayerView(color="blue")
@@ -244,7 +272,7 @@ wg_gc = gf.routing.add_fiber_array(
 )
 wg_gc.plot()
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 c = wg_gc.to_3d()
 c.show(show_ports=True)
 
@@ -254,7 +282,7 @@ c.show(show_ports=True)
 # Lets assume that fab C has similar technology to the generic PDK in gdsfactory and that you just want to remap some layers, and adjust the widths.
 #
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 nm = 1e-3
 
 
@@ -455,10 +483,10 @@ pdk = gf.Pdk(
 pdk.activate()
 
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 LAYER_VIEWS.layer_map.values()
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 mzi = mzi_nc()
 mzi_gc = gf.routing.add_fiber_single(
     component=mzi,
@@ -470,9 +498,9 @@ mzi_gc = gf.routing.add_fiber_single(
 )
 mzi_gc.plot()
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 c = mzi_gc.to_3d()
 c.show(show_ports=True)
 
-# %% tags=[] vscode={"languageId": "python"}
+# %% tags=[]
 ls = get_layer_stack_fab_c()

--- a/docs/notebooks/08_pdk_examples.py
+++ b/docs/notebooks/08_pdk_examples.py
@@ -1,0 +1,478 @@
+# ---
+# jupyter:
+#   jupytext:
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # PDK examples
+
+# %% [markdown]
+# Now you can define PDKs for different Fabs
+#
+# ### FabA
+#
+# FabA only has one waveguide layer available that is defined in GDS layer (30, 0)
+#
+# The waveguide traces are 2um wide.
+
+# %% tags=[] vscode={"languageId": "python"}
+nm = 1e-3
+
+
+class LayerMap(BaseModel):
+    WG: Layer = (34, 0)
+    SLAB150: Layer = (2, 0)
+    DEVREC: Layer = (68, 0)
+    PORT: Layer = (1, 10)
+    PORTE: Layer = (1, 11)
+    TE: Layer = (203, 0)
+    TM: Layer = (204, 0)
+    TEXT: Layer = (66, 0)
+
+
+LAYER = LayerMap()
+
+
+class FabALayerViews(LayerViews):
+    WG = LayerView(color="gold")
+    SLAB150 = LayerView(color="red")
+    TE = LayerView(color="green")
+
+
+LAYER_VIEWS = FabALayerViews(layer_map=LAYER.dict())
+
+
+def get_layer_stack_faba(
+    thickness_wg: float = 500 * nm, thickness_slab: float = 150 * nm
+) -> LayerStack:
+    """Returns fabA LayerStack"""
+
+    class FabALayerStack(LayerStack):
+        strip = LayerLevel(
+            layer=LAYER.WG,
+            thickness=thickness_wg,
+            zmin=0.0,
+            material="si",
+        )
+        strip2 = LayerLevel(
+            layer=LAYER.SLAB150,
+            thickness=thickness_slab,
+            zmin=0.0,
+            material="si",
+        )
+
+    return FabALayerStack()
+
+
+LAYER_STACK = get_layer_stack_faba()
+
+WIDTH = 2
+
+# Specify a cross_section to use
+strip = gf.partial(gf.cross_section.cross_section, width=WIDTH, layer=LAYER.WG)
+
+mmi1x2 = gf.partial(
+    gf.components.mmi1x2,
+    width=WIDTH,
+    width_taper=WIDTH,
+    width_mmi=3 * WIDTH,
+    cross_section=strip,
+)
+
+generic_pdk = gf.generic_tech.get_generic_pdk()
+
+fab_a = gf.Pdk(
+    name="Fab_A",
+    cells=dict(mmi1x2=mmi1x2),
+    cross_sections=dict(strip=strip),
+    layers=LAYER.dict(),
+    base_pdk=generic_pdk,
+    sparameters_path=gf.config.sparameters_path,
+    layer_views=LAYER_VIEWS,
+    layer_stack=LAYER_STACK,
+)
+fab_a.activate()
+
+gc = gf.partial(
+    gf.components.grating_coupler_elliptical_te, layer=LAYER.WG, cross_section=strip
+)
+
+c = gf.components.mzi()
+c_gc = gf.routing.add_fiber_array(component=c, grating_coupler=gc, with_loopback=False)
+c_gc.plot()
+
+# %% tags=[] vscode={"languageId": "python"}
+c = c_gc.to_3d()
+c.show(show_ports=True)
+
+# %% [markdown]
+# ### FabB
+#
+# FabB has photonic waveguides that require rectangular cladding layers to avoid dopants
+#
+# Lets say that the waveguides are defined in layer (2, 0) and are 0.3um wide, 1um thick
+#
+
+# %% tags=[] vscode={"languageId": "python"}
+nm = 1e-3
+
+
+class LayerMap(BaseModel):
+    WG: Layer = (2, 0)
+    SLAB150: Layer = (3, 0)
+    DEVREC: Layer = (68, 0)
+    PORT: Layer = (1, 10)
+    PORTE: Layer = (1, 11)
+    TE: Layer = (203, 0)
+    TM: Layer = (204, 0)
+    TEXT: Layer = (66, 0)
+    LABEL: Layer = (201, 0)
+    DOPING_BLOCK1: Layer = (61, 0)
+    DOPING_BLOCK2: Layer = (62, 0)
+
+
+LAYER = LayerMap()
+
+
+# The LayerViews class supports grouping LayerViews within each other. These groups are maintained when exporting a LayerViews object to a KLayout layer properties (.lyp) file.
+class FabBLayerViews(LayerViews):
+    WG = LayerView(color="red")
+    SLAB150 = LayerView(color="blue")
+    TE = LayerView(color="green")
+    PORT = LayerView(color="green", alpha=0)
+
+    class DopingBlockGroup(LayerView):
+        DOPING_BLOCK1 = LayerView(color="green", alpha=0)
+        DOPING_BLOCK2 = LayerView(color="green", alpha=0)
+
+    DopingBlocks = DopingBlockGroup()
+
+
+LAYER_VIEWS = FabBLayerViews(layer_map=LAYER)
+
+
+def get_layer_stack_fab_b(
+    thickness_wg: float = 1000 * nm, thickness_slab: float = 150 * nm
+) -> LayerStack:
+    """Returns fabA LayerStack."""
+
+    class FabBLayerStack(LayerStack):
+        strip = LayerLevel(
+            layer=LAYER.WG,
+            thickness=thickness_wg,
+            zmin=0.0,
+            material="si",
+        )
+        strip2 = LayerLevel(
+            layer=LAYER.SLAB150,
+            thickness=thickness_slab,
+            zmin=0.0,
+            material="si",
+        )
+
+    return FabBLayerStack()
+
+
+LAYER_STACK = get_layer_stack_fab_b()
+
+
+WIDTH = 0.3
+BBOX_LAYERS = (LAYER.DOPING_BLOCK1, LAYER.DOPING_BLOCK2)
+BBOX_OFFSETS = (3, 3)
+
+# use cladding_layers and cladding_offsets if the foundry prefers conformal blocking doping layers instead of squared
+# bbox_layers and bbox_offsets makes rectangular waveguides.
+strip = gf.partial(
+    gf.cross_section.cross_section,
+    width=WIDTH,
+    layer=LAYER.WG,
+    # bbox_layers=BBOX_LAYERS,
+    # bbox_offsets=BBOX_OFFSETS,
+    cladding_layers=BBOX_LAYERS,
+    cladding_offsets=BBOX_OFFSETS,
+)
+
+straight = gf.partial(gf.components.straight, cross_section=strip)
+bend_euler = gf.partial(gf.components.bend_euler, cross_section=strip)
+mmi1x2 = gf.partial(
+    gf.components.mmi1x2,
+    cross_section=strip,
+    width=WIDTH,
+    width_taper=WIDTH,
+    width_mmi=4 * WIDTH,
+)
+mzi = gf.partial(gf.components.mzi, cross_section=strip, splitter=mmi1x2)
+gc = gf.partial(
+    gf.components.grating_coupler_elliptical_te, layer=LAYER.WG, cross_section=strip
+)
+
+cells = dict(
+    gc=gc,
+    mzi=mzi,
+    mmi1x2=mmi1x2,
+    bend_euler=bend_euler,
+    straight=straight,
+    taper=gf.components.taper,
+)
+cross_sections = dict(strip=strip)
+
+pdk = gf.Pdk(
+    name="fab_b",
+    cells=cells,
+    cross_sections=cross_sections,
+    layers=LAYER.dict(),
+    sparameters_path=gf.config.sparameters_path,
+    layer_views=LAYER_VIEWS,
+    layer_stack=LAYER_STACK,
+)
+pdk.activate()
+
+
+c = mzi()
+wg_gc = gf.routing.add_fiber_array(
+    component=c, grating_coupler=gc, cross_section=strip, with_loopback=False
+)
+wg_gc.plot()
+
+# %% tags=[] vscode={"languageId": "python"}
+c = wg_gc.to_3d()
+c.show(show_ports=True)
+
+# %% [markdown]
+# ### FabC
+#
+# Lets assume that fab C has similar technology to the generic PDK in gdsfactory and that you just want to remap some layers, and adjust the widths.
+#
+
+# %% tags=[] vscode={"languageId": "python"}
+nm = 1e-3
+
+
+class LayerMap(BaseModel):
+    WG: Layer = (10, 1)
+    WG_CLAD: Layer = (10, 2)
+    WGN: Layer = (34, 0)
+    WGN_CLAD: Layer = (36, 0)
+    SLAB150: Layer = (2, 0)
+    DEVREC: Layer = (68, 0)
+    PORT: Layer = (1, 10)
+    PORTE: Layer = (1, 11)
+    TE: Layer = (203, 0)
+    TM: Layer = (204, 0)
+    TEXT: Layer = (66, 0)
+    LABEL: Layer = (201, 0)
+
+
+LAYER = LayerMap()
+WIDTH_NITRIDE_OBAND = 0.9
+WIDTH_NITRIDE_CBAND = 1.0
+PORT_TYPE_TO_LAYER = dict(optical=(100, 0))
+
+
+# This is something you usually define in KLayout
+class FabCLayerViews(LayerViews):
+    WG = LayerView(color="black")
+    SLAB150 = LayerView(color="blue")
+    WGN = LayerView(color="orange")
+    WGN_CLAD = LayerView(color="blue", alpha=0, visible=False)
+
+    class SimulationGroup(LayerView):
+        TE = LayerView(color="green")
+        PORT = LayerView(color="green", alpha=0)
+
+    Simulation = SimulationGroup()
+
+    class DopingGroup(LayerView):
+        DOPING_BLOCK1 = LayerView(color="green", alpha=0, visible=False)
+        DOPING_BLOCK2 = LayerView(color="green", alpha=0, visible=False)
+
+    Doping = DopingGroup()
+
+
+LAYER_VIEWS = FabCLayerViews(layer_map=LAYER)
+
+
+def get_layer_stack_fab_c(
+    thickness_wg: float = 350.0 * nm, thickness_clad: float = 3.0
+) -> LayerStack:
+    """Returns generic LayerStack"""
+
+    class FabCLayerStack(LayerStack):
+        core = LayerLevel(
+            layer=LAYER.WGN,
+            thickness=thickness_wg,
+            zmin=0,
+        )
+        clad = LayerLevel(
+            layer=LAYER.WGN_CLAD,
+            thickness=thickness_clad,
+            zmin=0,
+        )
+
+    return FabCLayerStack()
+
+
+LAYER_STACK = get_layer_stack_fab_c()
+
+
+def add_pins(
+    component: Component,
+    function: Callable = add_pin_rectangle_inside,
+    pin_length: float = 0.5,
+    port_layer: Layer = LAYER.PORT,
+    **kwargs,
+) -> Component:
+    """Add Pin port markers.
+
+    Args:
+        component: to add ports.
+        function: to add pins.
+        pin_length: in um.
+        port_layer: spec.
+        kwargs: function kwargs.
+    """
+    for p in component.ports.values():
+        function(
+            component=component,
+            port=p,
+            layer=port_layer,
+            layer_label=port_layer,
+            pin_length=pin_length,
+            **kwargs,
+        )
+    return component
+
+
+# cross_section constants
+bbox_layers = [LAYER.WGN_CLAD]
+bbox_offsets = [3]
+
+# Nitride Cband
+xs_nc = gf.partial(
+    cross_section,
+    width=WIDTH_NITRIDE_CBAND,
+    layer=LAYER.WGN,
+    bbox_layers=bbox_layers,
+    bbox_offsets=bbox_offsets,
+    add_pins=add_pins,
+)
+# Nitride Oband
+xs_no = gf.partial(
+    cross_section,
+    width=WIDTH_NITRIDE_OBAND,
+    layer=LAYER.WGN,
+    bbox_layers=bbox_layers,
+    bbox_offsets=bbox_offsets,
+    add_pins=add_pins,
+)
+
+
+cross_sections = dict(xs_nc=xs_nc, xs_no=xs_no, strip=xs_nc)
+
+# LEAF cells have pins
+mmi1x2_nc = gf.partial(
+    gf.components.mmi1x2,
+    width=WIDTH_NITRIDE_CBAND,
+    cross_section=xs_nc,
+)
+mmi1x2_no = gf.partial(
+    gf.components.mmi1x2,
+    width=WIDTH_NITRIDE_OBAND,
+    cross_section=xs_no,
+)
+bend_euler_nc = gf.partial(
+    gf.components.bend_euler,
+    cross_section=xs_nc,
+)
+straight_nc = gf.partial(
+    gf.components.straight,
+    cross_section=xs_nc,
+)
+bend_euler_no = gf.partial(
+    gf.components.bend_euler,
+    cross_section=xs_no,
+)
+straight_no = gf.partial(
+    gf.components.straight,
+    cross_section=xs_no,
+)
+
+gc_nc = gf.partial(
+    gf.components.grating_coupler_elliptical_te,
+    grating_line_width=0.6,
+    layer=LAYER.WGN,
+    cross_section=xs_nc,
+)
+
+# HIERARCHICAL cells are made of leaf cells
+mzi_nc = gf.partial(
+    gf.components.mzi,
+    cross_section=xs_nc,
+    splitter=mmi1x2_nc,
+    straight=straight_nc,
+    bend=bend_euler_nc,
+)
+mzi_no = gf.partial(
+    gf.components.mzi,
+    cross_section=xs_no,
+    splitter=mmi1x2_no,
+    straight=straight_no,
+    bend=bend_euler_no,
+)
+
+
+cells = dict(
+    mmi1x2_nc=mmi1x2_nc,
+    mmi1x2_no=mmi1x2_no,
+    bend_euler_nc=bend_euler_nc,
+    bend_euler_no=bend_euler_no,
+    straight_nc=straight_nc,
+    straight_no=straight_no,
+    gc_nc=gc_nc,
+    mzi_nc=mzi_nc,
+    mzi_no=mzi_no,
+)
+
+pdk = gf.Pdk(
+    name="fab_c",
+    cells=cells,
+    cross_sections=cross_sections,
+    layers=LAYER.dict(),
+    sparameters_path=gf.config.sparameters_path,
+    layer_views=LAYER_VIEWS,
+    layer_stack=LAYER_STACK,
+)
+pdk.activate()
+
+
+# %% tags=[] vscode={"languageId": "python"}
+LAYER_VIEWS.layer_map.values()
+
+# %% tags=[] vscode={"languageId": "python"}
+mzi = mzi_nc()
+mzi_gc = gf.routing.add_fiber_single(
+    component=mzi,
+    grating_coupler=gc_nc,
+    cross_section=xs_nc,
+    optical_routing_type=1,
+    straight=straight_nc,
+    bend=bend_euler_nc,
+)
+mzi_gc.plot()
+
+# %% tags=[] vscode={"languageId": "python"}
+c = mzi_gc.to_3d()
+c.show(show_ports=True)
+
+# %% tags=[] vscode={"languageId": "python"}
+ls = get_layer_stack_fab_c()

--- a/docs/notebooks/09_pdk_import.py
+++ b/docs/notebooks/09_pdk_import.py
@@ -1,17 +1,19 @@
 # ---
 # jupyter:
 #   jupytext:
+#     custom_cell_magics: kql
 #     text_representation:
 #       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.14.4
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
 
+# %% [markdown]
 # # Import PDK
 #
 # ## Import PDK in GDS format
@@ -35,7 +37,7 @@
 # - `Component.write_gds()` saves GDS
 # - `Component.write_gds_metadata()` save GDS + YAML metadata
 
-# +
+# %% vscode={"languageId": "python"}
 from typing import Dict, Tuple
 
 # Lets generate the script that we need to have to each GDS cell into gdsfactory
@@ -51,46 +53,57 @@ PDK.activate()
 
 c = gf.components.mzi()
 c
-# -
 
+# %% [markdown]
 # You can write **GDS** files only
 
+# %% vscode={"languageId": "python"}
 gdspath = c.write_gds("extra/mzi.gds")
 
+# %% [markdown]
 # Or **GDS** with **YAML** metadata information (ports, settings, cells ...)
 
+# %% vscode={"languageId": "python"}
 gdspath = c.write_gds_with_metadata("extra/mzi.gds")
 
+# %% [markdown]
 # This created a `mzi.yml` file that contains:
 # - ports
 # - cells (flat list of cells)
 # - info (function name, module, changed settings, full settings, default settings)
 
+# %% vscode={"languageId": "python"}
 c.metadata.keys()
 
+# %% [markdown]
 # You can read GDS files into gdsfactory thanks to the `import_gds` function
 #
 # `import_gds` reads the same GDS file from disk without losing any information
 
-# +
+# %% vscode={"languageId": "python"}
 gf.clear_cache()
 
 c = gf.import_gds(gdspath, read_metadata=True)
 c
-# -
 
+# %% vscode={"languageId": "python"}
 c2 = gf.import_gds(gdspath, name="mzi_sample", read_metadata=True)
 c2
 
+# %% vscode={"languageId": "python"}
 c2.name
 
+# %% vscode={"languageId": "python"}
 c3 = gf.routing.add_fiber_single(c2)
 c3
 
+# %% vscode={"languageId": "python"}
 gdspath = c3.write_gds_with_metadata("extra/pdk.gds")
 
+# %% vscode={"languageId": "python"}
 gf.labels.write_labels.write_labels_klayout(gdspath, layer_label=gf.LAYER.LABEL)
 
+# %% [markdown]
 # ### add ports from pins
 #
 # Sometimes the GDS does not have YAML metadata, therefore you need to figure out the port locations, widths and orientations.
@@ -106,24 +119,31 @@ gf.labels.write_labels.write_labels_klayout(gdspath, layer_label=gf.LAYER.LABEL)
 #
 # Lets add pins, save a GDS and then import it back.
 
+# %% vscode={"languageId": "python"}
 c = gf.components.straight(
     decorator=gf.add_pins.add_pins
 )  # add pins inside the component
 c
 
+# %% vscode={"languageId": "python"}
 gdspath = c.write_gds("extra/wg.gds")
 
+# %% vscode={"languageId": "python"}
 gf.clear_cache()
 c2 = gf.import_gds(gdspath)
 c2
 
+# %% vscode={"languageId": "python"}
 c2.ports  # import_gds does not automatically add the pins
 
+# %% vscode={"languageId": "python"}
 c3 = gf.import_gds(gdspath, decorator=gf.add_ports.add_ports_from_markers_inside)
 c3
 
+# %% vscode={"languageId": "python"}
 c3.ports
 
+# %% [markdown]
 # Foundries provide PDKs in different formats and commercial tools.
 #
 # The easiest way to import a PDK into gdsfactory is to
@@ -159,9 +179,10 @@ c3.ports
 #
 # Then you can add the information about the GDS files and the Layers inside that package
 
+# %% vscode={"languageId": "python"}
 print(lyp_to_dataclass(PATH.klayout_lyp))
 
-# +
+# %% vscode={"languageId": "python"}
 # lets create a sample PDK (for demo purposes only) using GDSfactory
 # if the PDK is in a commercial tool you can also do this. Make sure you save a single pdk.gds
 
@@ -174,22 +195,27 @@ sample_pdk_cells = gf.grid(
 )
 sample_pdk_cells.write_gds("extra/pdk.gds")
 sample_pdk_cells
-# -
 
+# %% vscode={"languageId": "python"}
 sample_pdk_cells.get_dependencies()
 
+# %% vscode={"languageId": "python"}
 # we write the sample PDK into a single GDS file
 gf.clear_cache()
 gf.write_cells.write_cells(
     gdspath="extra/pdk.gds", dirpath="extra/gds", recursively=True
 )
 
+# %% vscode={"languageId": "python"}
 print(gf.write_cells.get_import_gds_script("extra/gds"))
 
+# %% [markdown]
 # You can also include the code to plot each fix cell in the docstring.
 
+# %% vscode={"languageId": "python"}
 print(gf.write_cells.get_import_gds_script("extra/gds", module="samplepdk.components"))
 
+# %% [markdown]
 # ## Import PDK from other python packages
 #
 # You can Write the cells to GDS and use the
@@ -206,18 +232,7 @@ print(gf.write_cells.get_import_gds_script("extra/gds", module="samplepdk.compon
 # - review your code with your colleagues and other gdsfactory developers to get feedback. This is key to get better at coding gdsfactory.
 # - get rid of any warnings you see.
 
-# ## Foundry PDKs
-#
-# You can build PDKs for different foundries. PDKs contain some foundry IP (layer stack, Design Rules) and are available only under and NDA.
-# For accessing the gdsfactory PDK please contact your foundry for access.
-#
-#
-# Some PDKs are open source and publicly available:
-#
-# - [ubcpdk](https://github.com/gdsfactory/ubc)
-# - [sky130](https://github.com/gdsfactory/skywater130)
-#
-#
+# %% [markdown]
 # ## Build your own PDK
 #
 # You can create a PDK as a python library using a cookiecutter template. For example, you can use this one.

--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -20,17 +20,30 @@ VERSION = "6.48.3"
 LAYER_LABEL = LAYER.LABEL
 
 
+plugins = ["ray", "femwell", "devsim", "tidy3d", "meep", "meow", "lumapi", "sax"]
+
+
 def print_version(ctx: Context, param: Option, value: bool) -> None:
     """Prints the version."""
     if not value or ctx.resilient_parsing:
         return
-    click.echo(VERSION)
+    click.echo(f"gdsfactory {VERSION}")
+    for plugin in plugins:
+        try:
+            import importlib
+
+            m = importlib.import_module(plugin)
+            try:
+                click.echo(f"{plugin} {m.__version__}")
+            except AttributeError:
+                click.echo(f"{plugin} installed")
+        except ImportError:
+            click.echo(f"{plugin} not installed")
+
     ctx.exit()
 
 
 # TOOL
-
-
 @click.group()
 def tool() -> None:
     """Commands working with gdsfactory tool."""
@@ -178,4 +191,5 @@ cli.add_command(watch)
 
 
 if __name__ == "__main__":
-    cli()
+    # cli()
+    print_version()

--- a/gdsfactory/components/spiral_double.py
+++ b/gdsfactory/components/spiral_double.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         separation=2,
         number_of_loops=3,
         npoints=1000,
-        cross_section="nitride",
+        cross_section="rib_with_trenches",
     )
     print(c.ports["o1"].orientation)
     print(c.ports["o2"].orientation)

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -47,7 +47,11 @@ MAX_NAME_LENGTH = 32
 
 logger.remove()
 logger.add(sink=sys.stderr, level="INFO")
-logger.info(f"Load {str(module_path)!r} {__version__}")
+
+
+def print_version():
+    """Print gdsfactory version and install directory."""
+    logger.info(f"gdsfactory {__version__} {str(module_path)!r}")
 
 
 default_config = io.StringIO(

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -505,6 +505,68 @@ def slot(
     )
 
 
+@xsection
+def rib_with_trenches(
+    width: float = 0.5,
+    width_trench: float = 2.0,
+    width_slab: float = 7.0,
+    layer: Optional[LayerSpec] = "WG",
+    layer_trench: LayerSpec = "DEEP_ETCH",
+    **kwargs,
+) -> CrossSection:
+    """Return CrossSection of rib waveguide defined by trenches.
+
+    Args:
+        width: main Section width (um) or function parameterized from 0 to 1.
+            the width at t==0 is the width at the beginning of the Path.
+            the width at t==1 is the width at the end.
+        width_slab: in um.
+        width_trench: in um.
+        layer: ridge layer. None adds only ridge.
+        layer_trench: layer to etch trenches.
+        kwargs: cross_section settings.
+
+
+    .. code::
+
+
+        _____         __________         ________
+             |        |         |        |
+             |________|         |________|
+
+       __________________________________________
+             <------->                           |
+            width_trench
+                                                 |
+       <---------------------------------------->
+
+
+
+    .. plot::
+        :include-source:
+
+        import gdsfactory as gf
+
+        xs = gf.cross_section.rib_with_trenches(width=0.5)
+        p = gf.path.arc(radius=10, angle=45)
+        c = p.extrude(xs)
+        c.plot()
+    """
+    trench_offset = width / 2 + width_trench / 2
+    sections = [Section(width=width_slab, layer=layer)]
+    sections += [
+        Section(width=width_trench, offset=offset, layer=layer_trench)
+        for offset in [+trench_offset, -trench_offset]
+    ]
+
+    return CrossSection(
+        width=width,
+        layer=None,
+        sections=tuple(sections),
+        **kwargs,
+    )
+
+
 metal1 = partial(
     cross_section,
     layer="M1",
@@ -852,7 +914,7 @@ def pn_with_trenches(
     Args:
         width: width of the ridge in um.
         layer: ridge layer. None adds only ridge.
-        layer_trenches: layer to etch trenches.
+        layer_trench: layer to etch trenches.
         gap_low_doping: from waveguide center to low doping. Only used for PIN.
         gap_medium_doping: from waveguide center to medium doping.
             None removes medium doping.
@@ -1631,7 +1693,8 @@ if __name__ == "__main__":
     #     mirror=False,
     # )
     # xs = pn_with_trenches(width=0.3)
-    xs = slot(width=0.3)
+    # xs = slot(width=0.3)
+    xs = rib_with_trenches()
     p = gf.path.straight()
     c = p.extrude(xs)
     c.show(show_ports=True)

--- a/gdsfactory/geometry/offset.py
+++ b/gdsfactory/geometry/offset.py
@@ -88,7 +88,6 @@ if __name__ == "__main__":
     d = 0.8
     # d = 1
     c2 = gf.geometry.offset(c1, distance=+d, layer=layer_slab)
-
     c3 = gf.geometry.offset(c2, distance=-d, layer=layer_slab)
 
     c << c1.extract(layers=("WG",))

--- a/gdsfactory/install.py
+++ b/gdsfactory/install.py
@@ -5,7 +5,6 @@ import configparser
 import os
 import pathlib
 import shutil
-import subprocess
 import sys
 from typing import Optional
 
@@ -33,9 +32,7 @@ def make_link(src, dest, overwrite: bool = True) -> None:
         if sys.platform == "win32":
             # https://stackoverflow.com/questions/32877260/privlege-error-trying-to-create-symlink-using-python-on-windows-10
             print("Trying to create a junction instead of a symlink...")
-            proc = subprocess.check_call(f"mklink /J {dest} {src}", shell=True)
-            if proc != 0:
-                print("Could not create link!")
+            shutil.copy(src, dest)
     print("Symlink made:")
     print(f"From: {src}")
     print(f"To:   {dest}")

--- a/gdsfactory/klive.py
+++ b/gdsfactory/klive.py
@@ -1,10 +1,4 @@
-"""Stream GDS to Klayout.
-
-You can install gdsfactory KLayout integration:
-
-- run `gf tool install`
-- install the Klayout plugin through klayout package manager.
-"""
+"""Stream GDS to Klayout. Requires gdsfactory KLayout integration."""
 
 from __future__ import annotations
 
@@ -28,7 +22,6 @@ def show(
         keep_position: keep position and active layers.
         technology: Name of the KLayout technology to use.
         port: klayout server port.
-
     """
     if not os.path.isfile(gds_filename):
         raise ValueError(f"{gds_filename} does not exist")


### PR DESCRIPTION
- install uses copy instead of symlink if symlink fails
- add `gf.cross_section.rib_with_trenches`
- use python instead of jupyter notebooks to build docs
- logger does not automatically print the version of the tool
- gf --version prints all plugin versions

@thomasdorch 