### PR TITLE
add minimum for width_slab

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -552,6 +552,8 @@ def rib_with_trenches(
         c = p.extrude(xs)
         c.plot()
     """
+    width_slab = max(width_slab, width + 2 * width_trench)
+
     trench_offset = width / 2 + width_trench / 2
     sections = [Section(width=width_slab, layer=layer)]
     sections += [


### PR DESCRIPTION
would be good to ensure the slab is wide enough. also it allows to set `width_slab` to `0` to just make it as wide as necessary for the trenches