### PR TITLE
Fix stl export

### DIFF
--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -26,6 +26,7 @@ def to_stl(
 
     """
     import shapely
+    import trimesh
     from trimesh.creation import extrude_polygon
     from gdsfactory.pdk import get_layer_views, get_layer_stack
 
@@ -54,6 +55,7 @@ def to_stl(
                 / f"{filepath.stem}_{layer[0]}_{layer[1]}{filepath.suffix}"
             )
             print(f"Write {filepath_layer.absolute()!r}")
+            meshes = []
             for polygon in polygons:
                 p = shapely.geometry.Polygon(polygon)
                 mesh = extrude_polygon(p, height=height)
@@ -62,7 +64,9 @@ def to_stl(
                     *layer_views.get_from_tuple(layer).fill_color.as_rgb_tuple(),
                     0.5,
                 )
-                mesh.export(filepath_layer)
+                meshes.append(mesh)
+            layer_mesh = trimesh.util.concatenate(meshes)
+            layer_mesh.export(filepath_layer)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -15,6 +15,7 @@ def to_stl(
     layer_stack: Optional[LayerStack] = None,
     exclude_layers: Optional[Tuple[Layer, ...]] = None,
     hull_invalid_polygons: bool = True,
+    scale: Optional[float] = None,
 ) -> None:
     """Exports a Component into STL.
 
@@ -25,6 +26,7 @@ def to_stl(
         layer_stack: contains thickness and zmin for each layer.
         exclude_layers: layers to exclude.
         hull_invalid_polygons: If True, replaces invalid polygons (determined by shapely.Polygon.is_valid) with its convex hull.
+        scale: Optional factor by which to scale meshes before writing.
 
     """
     import shapely
@@ -71,7 +73,12 @@ def to_stl(
                     0.5,
                 )
                 meshes.append(mesh)
+
             layer_mesh = trimesh.util.concatenate(meshes)
+
+            if scale:
+                layer_mesh.apply_scale(scale)
+
             layer_mesh.export(filepath_layer)
 
 

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -14,6 +14,7 @@ def to_stl(
     layer_views: Optional[LayerViews] = None,
     layer_stack: Optional[LayerStack] = None,
     exclude_layers: Optional[Tuple[Layer, ...]] = None,
+    hull_invalid_polygons: bool = True,
 ) -> None:
     """Exports a Component into STL.
 
@@ -23,6 +24,7 @@ def to_stl(
         layer_views: layer colors from Klayout Layer Properties file.
         layer_stack: contains thickness and zmin for each layer.
         exclude_layers: layers to exclude.
+        hull_invalid_polygons: If True, replaces invalid polygons (determined by shapely.Polygon.is_valid) with its convex hull.
 
     """
     import shapely
@@ -58,6 +60,10 @@ def to_stl(
             meshes = []
             for polygon in polygons:
                 p = shapely.geometry.Polygon(polygon)
+
+                if hull_invalid_polygons and not p.is_valid:
+                    p = p.convex_hull
+
                 mesh = extrude_polygon(p, height=height)
                 mesh.apply_translation((0, 0, zmin))
                 mesh.visual.face_colors = (

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -32,9 +32,8 @@ def to_stl(
     import shapely
     import trimesh
     from trimesh.creation import extrude_polygon
-    from gdsfactory.pdk import get_layer_views, get_layer_stack
+    from gdsfactory.pdk import get_layer_stack
 
-    layer_views = layer_views or get_layer_views()
     layer_stack = layer_stack or get_layer_stack()
 
     layer_to_thickness = layer_stack.get_layer_to_thickness()
@@ -68,10 +67,6 @@ def to_stl(
 
                 mesh = extrude_polygon(p, height=height)
                 mesh.apply_translation((0, 0, zmin))
-                mesh.visual.face_colors = (
-                    *layer_views.get_from_tuple(layer).fill_color.as_rgb_tuple(),
-                    0.5,
-                )
                 meshes.append(mesh)
 
             layer_mesh = trimesh.util.concatenate(meshes)


### PR DESCRIPTION
`gdsfactory/export/to_stl`: 
- Fix issue where only one mesh was being written per layer
- Add scaling factor for output mesh
- Add option to write the convex hull of invalid polygons rather than failing entirely
- Remove call to set face color of mesh since STL doesn't support this anyway