### PR TITLE
Improve STL Export

### DIFF
--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -46,41 +46,43 @@ def to_stl(
     layer_tuples = list(layer_stack.layers.values())
     for layer, polygons in component_with_booleans.get_polygons(by_spec=True).items():
         if (
-            layer not in exclude_layers
-            and layer in layer_to_thickness
-            and layer in layer_to_zmin
-            and layer in component_layers
+            layer in exclude_layers
+            or layer not in layer_to_thickness
+            or layer not in layer_to_zmin
+            or layer not in component_layers
         ):
-            height = layer_to_thickness[layer]
-            zmin = layer_to_zmin[layer]
+            continue
 
-            layer_name = (
-                layer_names[layer_tuples.index(layer)]
-                if use_layer_name
-                else f"{layer[0]}_{layer[1]}"
-            )
+        height = layer_to_thickness[layer]
+        zmin = layer_to_zmin[layer]
 
-            filepath_layer = (
-                filepath.parent / f"{filepath.stem}_{layer_name}{filepath.suffix}"
-            )
-            print(f"Write {filepath_layer.absolute()!r}")
-            meshes = []
-            for polygon in polygons:
-                p = shapely.geometry.Polygon(polygon)
+        layer_name = (
+            layer_names[layer_tuples.index(layer)]
+            if use_layer_name
+            else f"{layer[0]}_{layer[1]}"
+        )
 
-                if hull_invalid_polygons and not p.is_valid:
-                    p = p.convex_hull
+        filepath_layer = (
+            filepath.parent / f"{filepath.stem}_{layer_name}{filepath.suffix}"
+        )
+        print(f"Write {filepath_layer.absolute()!r}")
+        meshes = []
+        for polygon in polygons:
+            p = shapely.geometry.Polygon(polygon)
 
-                mesh = trimesh.creation.extrude_polygon(p, height=height)
-                mesh.apply_translation((0, 0, zmin))
-                meshes.append(mesh)
+            if hull_invalid_polygons and not p.is_valid:
+                p = p.convex_hull
 
-            layer_mesh = trimesh.util.concatenate(meshes)
+            mesh = trimesh.creation.extrude_polygon(p, height=height)
+            mesh.apply_translation((0, 0, zmin))
+            meshes.append(mesh)
 
-            if scale:
-                layer_mesh.apply_scale(scale)
+        layer_mesh = trimesh.util.concatenate(meshes)
 
-            layer_mesh.export(filepath_layer)
+        if scale:
+            layer_mesh.apply_scale(scale)
+
+        layer_mesh.export(filepath_layer)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -26,6 +26,7 @@ def to_stl(
 
     """
     import shapely
+    import trimesh
     from trimesh.creation import extrude_polygon
     from gdsfactory.pdk import get_layer_views, get_layer_stack
 
@@ -54,6 +55,7 @@ def to_stl(
                 / f"{filepath.stem}_{layer[0]}_{layer[1]}{filepath.suffix}"
             )
             print(f"Write {filepath_layer.absolute()!r}")
+            meshes = []
             for polygon in polygons:
                 p = shapely.geometry.Polygon(polygon)
                 mesh = extrude_polygon(p, height=height)
@@ -62,7 +64,9 @@ def to_stl(
                     *layer_views.get_from_tuple(layer).fill_color.as_rgb_tuple(),
                     0.5,
                 )
-                mesh.export(filepath_layer)
+                meshes.append(mesh)
+            layer_mesh = trimesh.util.concatenate(meshes)
+            layer_mesh.export(filepath_layer)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -4,14 +4,13 @@ import pathlib
 from typing import Optional, Tuple
 
 from gdsfactory.component import Component
-from gdsfactory.technology import LayerStack, LayerViews
+from gdsfactory.technology import LayerStack
 from gdsfactory.typings import Layer
 
 
 def to_stl(
     component: Component,
     filepath: str,
-    layer_views: Optional[LayerViews] = None,
     layer_stack: Optional[LayerStack] = None,
     exclude_layers: Optional[Tuple[Layer, ...]] = None,
     hull_invalid_polygons: bool = True,
@@ -22,7 +21,6 @@ def to_stl(
     Args:
         component: to export.
         filepath: to write STL to.
-        layer_views: layer colors from Klayout Layer Properties file.
         layer_stack: contains thickness and zmin for each layer.
         exclude_layers: layers to exclude.
         hull_invalid_polygons: If True, replaces invalid polygons (determined by shapely.Polygon.is_valid) with its convex hull.
@@ -32,9 +30,8 @@ def to_stl(
     import shapely
     import trimesh
     from trimesh.creation import extrude_polygon
-    from gdsfactory.pdk import get_layer_views, get_layer_stack
+    from gdsfactory.pdk import get_layer_stack
 
-    layer_views = layer_views or get_layer_views()
     layer_stack = layer_stack or get_layer_stack()
 
     layer_to_thickness = layer_stack.get_layer_to_thickness()
@@ -68,10 +65,6 @@ def to_stl(
 
                 mesh = extrude_polygon(p, height=height)
                 mesh.apply_translation((0, 0, zmin))
-                mesh.visual.face_colors = (
-                    *layer_views.get_from_tuple(layer).fill_color.as_rgb_tuple(),
-                    0.5,
-                )
                 meshes.append(mesh)
 
             layer_mesh = trimesh.util.concatenate(meshes)

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -15,6 +15,7 @@ def to_stl(
     layer_stack: Optional[LayerStack] = None,
     exclude_layers: Optional[Tuple[Layer, ...]] = None,
     hull_invalid_polygons: bool = True,
+    scale: Optional[float] = None,
 ) -> None:
     """Exports a Component into STL.
 
@@ -25,6 +26,7 @@ def to_stl(
         layer_stack: contains thickness and zmin for each layer.
         exclude_layers: layers to exclude.
         hull_invalid_polygons: If True, replaces invalid polygons (determined by shapely.Polygon.is_valid) with its convex hull.
+        scale: Optional factor by which to scale meshes before writing.
 
     """
     import shapely
@@ -71,7 +73,12 @@ def to_stl(
                     0.5,
                 )
                 meshes.append(mesh)
+
             layer_mesh = trimesh.util.concatenate(meshes)
+
+            if scale:
+                layer_mesh.apply_scale(scale)
+
             layer_mesh.export(filepath_layer)
 
 

--- a/gdsfactory/export/to_stl.py
+++ b/gdsfactory/export/to_stl.py
@@ -14,6 +14,7 @@ def to_stl(
     layer_views: Optional[LayerViews] = None,
     layer_stack: Optional[LayerStack] = None,
     exclude_layers: Optional[Tuple[Layer, ...]] = None,
+    hull_invalid_polygons: bool = True,
 ) -> None:
     """Exports a Component into STL.
 
@@ -23,6 +24,7 @@ def to_stl(
         layer_views: layer colors from Klayout Layer Properties file.
         layer_stack: contains thickness and zmin for each layer.
         exclude_layers: layers to exclude.
+        hull_invalid_polygons: If True, replaces invalid polygons (determined by shapely.Polygon.is_valid) with its convex hull.
 
     """
     import shapely
@@ -58,6 +60,10 @@ def to_stl(
             meshes = []
             for polygon in polygons:
                 p = shapely.geometry.Polygon(polygon)
+
+                if hull_invalid_polygons and not p.is_valid:
+                    p = p.convex_hull
+
                 mesh = extrude_polygon(p, height=height)
                 mesh.apply_translation((0, 0, zmin))
                 mesh.visual.face_colors = (


### PR DESCRIPTION
`gdsfactory/export/to_stl`:

- Fix issue where only one mesh was being written per layer
- Add scaling factor for output mesh
- Add option to write the convex hull of invalid polygons rather than failing entirely
- Remove call to set face color of mesh since STL doesn't support this anyway
- Add option to use LayerLevel names instead of layer tuples for STL filenames