### PR TITLE
layer priority operation

### DIFF
--- a/gdsfactory/geometry/__init__.py
+++ b/gdsfactory/geometry/__init__.py
@@ -11,6 +11,7 @@ from gdsfactory.geometry.check_inclusion import check_inclusion
 from gdsfactory.geometry.check_space import check_space
 from gdsfactory.geometry.check_width import check_width
 from gdsfactory.geometry.invert import invert
+from gdsfactory.geometry.layer_priority import layer_priority
 from gdsfactory.geometry.offset import offset
 from gdsfactory.geometry.outline import outline
 from gdsfactory.geometry.trim import trim
@@ -32,4 +33,5 @@ __all__ = (
     "xor_diff",
     "functions",
     "trim",
+    "layer_priority",
 )

--- a/gdsfactory/geometry/layer_priority.py
+++ b/gdsfactory/geometry/layer_priority.py
@@ -1,0 +1,119 @@
+import gdsfactory as gf
+from gdsfactory.typings import LayerSpec, ComponentSpec
+import numpy as np
+
+
+def layer_priority(
+    component: ComponentSpec,
+    layer_high_order: LayerSpec,
+    layer_low_order: LayerSpec,
+    remove_high_order: bool = False,
+    **kwargs,
+):
+    """Returns a new component where a specified layer is removed from another.
+
+    Arguments:
+        layer_high_order: layer used to etch
+        layer_low_order: layer etched into
+        remove_high_order: whether to also remove the high order layer polygons. Useful if the higher order layer is purely logical.
+        kwargs: leyword arguments for boolean difference operation
+    """
+    c = gf.Component()
+
+    # Obtain component subsets
+    layers_to_remove = (
+        [gf.get_layer(layer_low_order), gf.get_layer(layer_high_order)]
+        if remove_high_order
+        else [gf.get_layer(layer_low_order)]
+    )
+    component_minus_layers = component.extract(
+        [
+            gf.get_layer(layer)
+            for layer in component.get_layers()
+            if gf.get_layer(layer) not in layers_to_remove
+        ]
+    )
+    component_high_order = component.extract([layer_high_order])
+    component_low_order = component.extract([layer_low_order])
+
+    # Remove high priority from low priority
+    component_high_order_removed_from_low_order = gf.geometry.boolean(
+        A=component_low_order,
+        B=component_high_order,
+        operation="A-B",
+        layer=layer_low_order,
+        **kwargs,
+    )
+
+    # Place all the other layers
+    c << component_minus_layers
+    c << component_high_order_removed_from_low_order
+
+    c.add_ports(ports=component.ports)
+
+    return c
+
+
+def test_layer_priority() -> None:
+    funky_cross_section = gf.cross_section.cross_section(
+        width=0.5,
+        layer="WG",
+        sections=[
+            gf.cross_section.Section(width=2, layer="N"),
+            gf.cross_section.Section(width=2, layer="SLAB150"),
+        ],
+    )
+
+    c = gf.components.coupler(cross_section=funky_cross_section)
+
+    c_WG_before = c.extract([gf.get_layer("WG")])
+    c_SLAB150_before = c.extract([gf.get_layer("SLAB150")])
+    c_N_before = c.extract([gf.get_layer("N")])
+
+    c_processed = layer_priority(
+        component=c,
+        layer_high_order="WG",
+        layer_low_order="SLAB150",
+        remove_high_order=False,
+    )
+
+    c_WG_after = c_processed.extract([gf.get_layer("WG")])
+    c_SLAB150_after = c_processed.extract([gf.get_layer("SLAB150")])
+    c_N_after = c_processed.extract([gf.get_layer("N")])
+
+    assert np.isclose(c_WG_before.area(), c_WG_after.area(), atol=1e-3)
+    assert np.isclose(c_N_before.area(), c_N_after.area(), atol=1e-3)
+    assert c_SLAB150_before.area() > c_SLAB150_after.area()
+
+    c_processed = layer_priority(
+        component=c,
+        layer_high_order="WG",
+        layer_low_order="SLAB150",
+        remove_high_order=True,
+    )
+    c_WG_after = c_processed.extract([gf.get_layer("WG")])
+
+    assert c_WG_after.area() == 0
+
+
+if __name__ == "__main__":
+    funky_cross_section = gf.cross_section.cross_section(
+        width=0.5,
+        layer="WG",
+        sections=[
+            gf.cross_section.Section(width=2, layer="N"),
+            gf.cross_section.Section(width=2, layer="SLAB150"),
+        ],
+    )
+
+    c = gf.components.coupler(cross_section=funky_cross_section)
+
+    c_processed = layer_priority(
+        component=c,
+        layer_high_order="WG",
+        layer_low_order="SLAB150",
+        remove_high_order=False,
+    )
+    c_processed.show(show_ports=True)
+
+    # test_layer_priority()


### PR DESCRIPTION
@mdecea 

sometimes you bring two large cross sections together and they overlap

the simplest fix is to do some booleans (sorry Joaquin!) to reprioritize the layers where they touch

Example:

```
    funky_cross_section = gf.cross_section.cross_section(
        width=0.5,
        layer="WG",
        sections=[
            gf.cross_section.Section(width=2, layer="N"),
            gf.cross_section.Section(width=2, layer="SLAB150"),
        ],
    )

    c = gf.components.coupler(cross_section=funky_cross_section)
```

Original all layers:
![image](https://user-images.githubusercontent.com/46427609/224508018-56ed4da4-b068-4ad1-8d83-adc2af98c8a1.png)

The SLAB from the neighbour overlaps with the WG of the other:

![image](https://user-images.githubusercontent.com/46427609/224508125-c19246ee-c3fc-4b7e-84ff-4f76940eb9f7.png)


Process the component, saying which layer needs to be cut out of which:

```
    c_processed = layer_priority(
        component=c,
        layer_high_order="WG",
        layer_low_order="SLAB150",
        remove_high_order=False,
    )
    c_processed.show(show_ports=True)
```

![image](https://user-images.githubusercontent.com/46427609/224508056-417c7a1a-d009-43d9-bcfd-bbfeb8ce883a.png)

WG (high order layer)

![image](https://user-images.githubusercontent.com/46427609/224508112-8ca3c069-b86d-4388-b9c4-016e8d2eb70b.png)


SLAB (low order layer)

![image](https://user-images.githubusercontent.com/46427609/224508079-0bf72b51-3338-4b81-9e75-fa06a7b79aff.png)

It leaves the rest of the layers alone (here, N):

![image](https://user-images.githubusercontent.com/46427609/224508103-6f2cf6d8-3e02-4cc6-bd76-629c83cc780a.png)




