### PR TITLE
664b

### DIFF
--- a/docs/notebooks/041_routing_electrical.py
+++ b/docs/notebooks/041_routing_electrical.py
@@ -225,3 +225,22 @@ cc
 c = gf.components.straight_heater_metal(length=100.0)
 cc = gf.routing.add_pads_top(component=c, port_names=("e1",))
 cc
+
+# %%
+n = west = north = south = east = 10
+spacing = 20
+c = gf.components.nxn(
+    xsize=n * spacing,
+    ysize=n * spacing,
+    west=west,
+    east=east,
+    north=north,
+    south=south,
+    port_type="electrical",
+    wg_width=10,
+)
+c
+
+# %%
+cc = gf.routing.add_pads_top(component=c)
+cc

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -801,7 +801,7 @@ class Component(_GeometryHelper):
         orientation: Optional[float] = None,
         port: Optional[Port] = None,
         layer: LayerSpec = None,
-        port_type: str = "optical",
+        port_type: Optional[str] = None,
         cross_section: Optional[CrossSection] = None,
     ) -> Port:
         """Add port to component.
@@ -818,7 +818,7 @@ class Component(_GeometryHelper):
             orientation: in deg.
             port: optional port.
             layer: port layer.
-            port_type: optical, electrical, vertical_dc, vertical_te, vertical_tm.
+            port_type: optical, electrical, vertical_dc, vertical_te, vertical_tm. Defaults to optical.
             cross_section: port cross_section.
         """
         from gdsfactory.pdk import get_layer
@@ -831,6 +831,14 @@ class Component(_GeometryHelper):
             p = port.copy()
             if name is not None:
                 p.name = name
+            if width is not None:
+                p.width = width
+            if orientation is not None:
+                p.orientation = orientation
+            if port_type is not None:
+                p.port_type = port_type
+            if layer is not None:
+                p.layer = layer
             p.parent = self
 
         elif isinstance(name, Port):
@@ -848,7 +856,7 @@ class Component(_GeometryHelper):
                 orientation=orientation,
                 parent=self,
                 layer=layer,
-                port_type=port_type,
+                port_type=port_type or "optical",
                 cross_section=cross_section,
             )
         if name is not None:
@@ -864,6 +872,7 @@ class Component(_GeometryHelper):
         ports: Union[List[Port], Dict[str, Port]],
         prefix: str = "",
         suffix: str = "",
+        **kwargs,
     ) -> None:
         """Add a list or dict of ports.
 
@@ -872,11 +881,12 @@ class Component(_GeometryHelper):
         Args:
             ports: list or dict of ports.
             prefix: to prepend to each port name.
+            suffix: to append to each port name.
         """
         ports = ports if isinstance(ports, list) else ports.values()
         for port in list(ports):
             name = f"{prefix}{port.name}{suffix}"
-            self.add_port(name=name, port=port)
+            self.add_port(name=name, port=port, **kwargs)
 
     def snap_ports_to_grid(self, nm: int = 1) -> None:
         for port in self.ports.values():

--- a/gdsfactory/components/pad.py
+++ b/gdsfactory/components/pad.py
@@ -53,7 +53,9 @@ def pad(
     c = Component()
     layer = gf.get_layer(layer)
     rect = compass(
-        size=size, layer=layer, port_inclusion=port_inclusion, port_type="electrical"
+        size=size,
+        layer=layer,
+        port_inclusion=port_inclusion,  # port_type="electrical"
     )
     c_ref = c.add_ref(rect)
     c.add_ports(c_ref.ports)

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -727,9 +727,10 @@ def _rename_ports_clockwise_top_right(
 def rename_ports_by_orientation(
     component: Component,
     layers_excluded: LayerSpec = None,
-    select_ports: Optional[Callable[..., List[Port]]] = None,
+    select_ports: Callable = select_ports,
     function=_rename_ports_facing_side,
     prefix: str = "o",
+    **kwargs,
 ) -> Component:
     """Returns Component with port names based on port orientation (E, N, W, S).
 
@@ -739,6 +740,7 @@ def rename_ports_by_orientation(
         select_ports: function to select_ports.
         function: to rename ports.
         prefix: to add on each port name.
+        kwargs: select_ports settings.
 
     .. code::
 
@@ -755,7 +757,7 @@ def rename_ports_by_orientation(
     direction_ports: PortsMap = {x: [] for x in ["E", "N", "W", "S"]}
 
     ports = component.ports
-    ports = select_ports(ports) if select_ports else ports
+    ports = select_ports(ports, **kwargs)
 
     ports_on_layer = [p for p in ports.values() if p.layer not in layers_excluded]
 
@@ -786,8 +788,10 @@ def auto_rename_ports(
     function=_rename_ports_clockwise,
     select_ports_optical: Optional[Callable] = select_ports_optical,
     select_ports_electrical: Optional[Callable] = select_ports_electrical,
+    prefix: str = "",
     prefix_optical: str = "o",
     prefix_electrical: str = "e",
+    port_type: Optional[str] = None,
     **kwargs,
 ) -> Component:
     """Adds prefix for optical and electrical.
@@ -799,22 +803,41 @@ def auto_rename_ports(
         select_ports_electrical: to select electrical ports.
         prefix_optical: prefix of optical ports.
         prefix_electrical: prefix of electrical ports.
+        port_type: select ports with port type (optical, electrical, vertical_te).
+
+    Keyword Args:
+        prefix: select ports with port name prefix.
+        suffix: select ports with port name suffix.
+        orientation: select ports with orientation in degrees.
+        width: select ports with port width.
+        layers_excluded: List of layers to exclude.
+        clockwise: if True, sort ports clockwise, False: counter-clockwise.
 
     """
-    rename_ports_by_orientation(
-        component=component,
-        select_ports=select_ports_optical,
-        prefix=prefix_optical,
-        function=function,
-        **kwargs,
-    )
-    rename_ports_by_orientation(
-        component=component,
-        select_ports=select_ports_electrical,
-        prefix=prefix_electrical,
-        function=function,
-        **kwargs,
-    )
+    if port_type is None:
+        rename_ports_by_orientation(
+            component=component,
+            select_ports=select_ports_optical,
+            prefix=prefix_optical,
+            function=function,
+            **kwargs,
+        )
+        rename_ports_by_orientation(
+            component=component,
+            select_ports=select_ports_electrical,
+            prefix=prefix_electrical,
+            function=function,
+            **kwargs,
+        )
+    else:
+        rename_ports_by_orientation(
+            component=component,
+            select_ports=select_ports,
+            prefix=prefix,
+            function=function,
+            port_type=port_type,
+            **kwargs,
+        )
     return component
 
 

--- a/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_.yml
+++ b/tests/test_component_from_yaml/test_netlists_sample_different_link_factory_.yml
@@ -524,59 +524,6 @@ placements:
     y: 600.0
 ports: {}
 warnings:
-  electrical:
-    unconnected_ports:
-    - message: 16 unconnected electrical ports!
-      ports:
-      - bl,e1
-      - bl,e2
-      - bl,e3
-      - bl,e4
-      - tl,e1
-      - tl,e2
-      - tl,e3
-      - tl,e4
-      - br,e1
-      - br,e2
-      - br,e3
-      - br,e4
-      - tr,e1
-      - tr,e2
-      - tr,e3
-      - tr,e4
-      values:
-      - - -50.0
-        - 0.0
-      - - 0.0
-        - 50.0
-      - - 50.0
-        - 0.0
-      - - 0.0
-        - -50.0
-      - - -50.0
-        - 200.0
-      - - 0.0
-        - 250.0
-      - - 50.0
-        - 200.0
-      - - 0.0
-        - 150.0
-      - - 850.0
-        - 400.0
-      - - 900.0
-        - 450.0
-      - - 950.0
-        - 400.0
-      - - 900.0
-        - 350.0
-      - - 850.0
-        - 600.0
-      - - 900.0
-        - 650.0
-      - - 950.0
-        - 600.0
-      - - 900.0
-        - 550.0
   optical:
     unconnected_ports:
     - message: 4 unconnected optical ports!


### PR DESCRIPTION
- `gf.add_ports()` can overwrite new port settings. This is useful for changing port types when promoting ports to a higher hiearchical level.
- `Component.auto_rename_ports` can rename specific port types with specific port_prefix