### PR TITLE
add ports info to tests, and add pad_rectangular

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## 6.64.0
+
+- add add_pads_bot and add_pads_top [PR](https://github.com/gdsfactory/gdsfactory/pull/1446)
+- improve Component.add_ports [PR](https://github.com/gdsfactory/gdsfactory/pull/1448)
+- add ports info to tests, and add pad_rectangular [PR](https://github.com/gdsfactory/gdsfactory/pull/1449)
+
 ## [6.63.0](https://github.com/gdsfactory/gdsfactory/pull/1445)
 
 - add `bend_euler_s.info['length']`

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1860,7 +1860,7 @@ class Component(_GeometryHelper):
         ignore_components_prefix: Optional[List[str]] = None,
         ignore_functions_prefix: Optional[List[str]] = None,
         with_cells: bool = False,
-        with_ports: bool = False,
+        with_ports: bool = True,
     ) -> Dict[str, Any]:
         """Returns Dict representation of a component.
 

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -181,6 +181,7 @@ from gdsfactory.components.optimal_step import optimal_step
 from gdsfactory.components.pack_doe import generate_doe, pack_doe, pack_doe_grid
 from gdsfactory.components.pad import (
     pad,
+    pad_rectangular,
     pad_array,
     pad_array0,
     pad_array90,
@@ -486,6 +487,7 @@ __all__ = [
     "pack_doe_grid",
     "pack_doe",
     "pad",
+    "pad_rectangular",
     "pad_array",
     "pad_array0",
     "pad_array180",

--- a/gdsfactory/components/pad.py
+++ b/gdsfactory/components/pad.py
@@ -11,28 +11,8 @@ from gdsfactory.typings import ComponentSpec, LayerSpec, Union, Float2
 
 
 @cell
-def pad_pdk(pad_width: Union[str, Float2] = "pad_width", **kwargs) -> Component:
-    """Returns square pad with ports.
-
-    Pad width defaults to `pad_width` constant.
-
-    Keyword Args:
-        size: x, y size.
-        layer: pad layer.
-        bbox_layers: list of layers.
-        bbox_offsets: Optional offsets for each layer with respect to size.
-            positive grows, negative shrinks the size.
-        port_inclusion: from edge.
-        port_orientation: in degrees.
-    """
-    width = gf.get_constant(pad_width)
-    size = (width, width)
-    return pad(size=size, **kwargs)
-
-
-@cell
 def pad(
-    size: Tuple[float, float] = (100.0, 100.0),
+    size: Union[str, Float2] = (100.0, 100.0),
     layer: LayerSpec = "MTOP",
     bbox_layers: Optional[Tuple[LayerSpec, ...]] = None,
     bbox_offsets: Optional[Tuple[float, ...]] = None,
@@ -52,6 +32,7 @@ def pad(
     """
     c = Component()
     layer = gf.get_layer(layer)
+    size = gf.get_constant(size)
     rect = compass(
         size=size,
         layer=layer,
@@ -87,6 +68,9 @@ def pad(
         width=width,
     )
     return c
+
+
+pad_rectangular = partial(pad, size="pad_size")
 
 
 @cell
@@ -135,7 +119,7 @@ pad_array180 = partial(pad_array, orientation=180, columns=1, rows=3)
 
 
 if __name__ == "__main__":
-    c = pad_pdk()
+    c = pad_rectangular()
     # c = pad()
     # c = pad(layer_to_inclusion={(3, 0): 10})
     # print(c.ports)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -45,7 +45,7 @@ constants = {
     "fiber_input_to_output_spacing": 200.0,
     "metal_spacing": 10.0,
     "pad_spacing": 100.0,
-    "pad_width": 80.0,
+    "pad_size": (80, 80),
 }
 
 nm = 1e-3

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -19,7 +19,7 @@ from gdsfactory.typings import (
 )
 
 from gdsfactory.components.straight_heater_metal import straight_heater_metal
-from gdsfactory.components.pad import pad_pdk
+from gdsfactory.components.pad import pad_rectangular
 
 
 @cell
@@ -33,7 +33,7 @@ def add_pads_bot(
     layer_label: LayerSpec = "TEXT",
     pad_port_name: str = "e1",
     pad_port_labels: Optional[Tuple[str, ...]] = None,
-    pad: ComponentSpec = pad_pdk,
+    pad: ComponentSpec = pad_rectangular,
     bend: ComponentSpec = "wire_corner",
     straight_separation: float = 15.0,
     pad_spacing: Union[str, float] = "pad_spacing",

--- a/gdsfactory/samples/01_component_pcell/test_straight_wide.yml
+++ b/gdsfactory/samples/01_component_pcell/test_straight_wide.yml
@@ -1,4 +1,29 @@
 name: straight_wide
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.5
+    layer:
+    - 2
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 5.0
+    - 0.5
+    layer:
+    - 2
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/gdsfactory/samples/01_component_pcell_with_pins/test_straight_narrow.yml
+++ b/gdsfactory/samples/01_component_pcell_with_pins/test_straight_narrow.yml
@@ -1,4 +1,29 @@
 name: straight_narrow
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.15
+    layer:
+    - 2
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.3
+  o2:
+    center:
+    - 5.0
+    - 0.15
+    layer:
+    - 2
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.3
 settings:
   changed: {}
   child: null

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
@@ -1,4 +1,29 @@
 name: bend_euler_f84cb6d2
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_nc_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_514a8b8c
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  opt_te_1554_15:
+    center:
+    - 16.6
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: opt_te_1554_15
+    orientation: 0
+    port_type: opt_te_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
@@ -1,4 +1,41 @@
 name: mmi1x2_1fb8ba6f
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 15.5
+    - 0.625
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o3:
+    center:
+    - 15.5
+    - -0.625
+    layer:
+    - 34
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
@@ -1,4 +1,41 @@
 name: mmi1x2_77b0da92
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.9
+  o2:
+    center:
+    - 15.5
+    - 0.625
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.9
+  o3:
+    center:
+    - 15.5
+    - -0.625
+    layer:
+    - 34
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.9
 settings:
   changed:
     cross_section:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_nc_.yml
@@ -1,4 +1,29 @@
 name: mzi_e687e91e
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 81.2
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed:
     bend:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mzi_no_.yml
@@ -1,4 +1,29 @@
 name: mzi_f7f1cb39
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.9
+  o2:
+    center:
+    - 81.2
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.9
 settings:
   changed:
     bend:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
@@ -1,4 +1,29 @@
 name: straight_f84cb6d2
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed:
     cross_section:

--- a/tests/test_add_fiber_array/test_settings_test_tapers_.yml
+++ b/tests/test_add_fiber_array/test_settings_test_tapers_.yml
@@ -1,4 +1,53 @@
 name: straight_length20_width_85caa607
+ports:
+  opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-loopback0:
+    center:
+    - -180.5
+    - -28.5
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-loopback0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-loopback1:
+    center:
+    - 200.5
+    - -28.5
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-loopback1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-o1:
+    center:
+    - -53.5
+    - -28.5
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-o2:
+    center:
+    - 73.5
+    - -28.5
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-straight_length20_width2-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_add_fiber_array/test_settings_test_type0_.yml
+++ b/tests/test_add_fiber_array/test_settings_test_type0_.yml
@@ -1,4 +1,77 @@
 name: coupler_gap0p244_length_0ee3ac51
+ports:
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback0:
+    center:
+    - -314.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback1:
+    center:
+    - 320.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o1:
+    center:
+    - -187.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o2:
+    center:
+    - -60.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o3:
+    center:
+    - 66.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o4:
+    center:
+    - 193.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_add_fiber_array/test_settings_test_type1_.yml
+++ b/tests/test_add_fiber_array/test_settings_test_type1_.yml
@@ -1,4 +1,77 @@
 name: coupler_gap0p2_length5p_13b79348
+ports:
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-loopback0:
+    center:
+    - -315.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-loopback0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-loopback1:
+    center:
+    - 320.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-loopback1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o1:
+    center:
+    - -188.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o2:
+    center:
+    - -61.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o3:
+    center:
+    - 66.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o4:
+    center:
+    - 193.0
+    - -55.4
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p2_length5p0-o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_add_fiber_array/test_settings_test_type2_.yml
+++ b/tests/test_add_fiber_array/test_settings_test_type2_.yml
@@ -1,4 +1,77 @@
 name: coupler_gap0p244_length_10b57faa
+ports:
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback0:
+    center:
+    - -314.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback1:
+    center:
+    - 320.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-loopback1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o1:
+    center:
+    - -187.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o2:
+    center:
+    - -60.7
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o3:
+    center:
+    - 66.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o4:
+    center:
+    - 193.3
+    - -55.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-coupler_gap0p244_length5p67-o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_add_pads/test_settings_test_type0_.yml
+++ b/tests/test_add_pads/test_settings_test_type0_.yml
@@ -1,4 +1,65 @@
 name: straight_heater_metal_u_5bdea33f
+ports:
+  e1:
+    center:
+    - -16.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 116.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  elec-pad_pdk-None-e1:
+    center:
+    - -16.0
+    - 46.5
+    layer:
+    - 49
+    - 0
+    name: elec-pad_pdk-None-e1
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 80.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 100.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_add_pads/test_settings_test_type0_.yml
+++ b/tests/test_add_pads/test_settings_test_type0_.yml
@@ -24,18 +24,18 @@ ports:
     port_type: electrical
     shear_angle: null
     width: 11.0
-  elec-pad_pdk-None-e1:
+  elec-pad_sizepad_size-None-e1:
     center:
     - -16.0
     - 46.5
     layer:
     - 49
     - 0
-    name: elec-pad_pdk-None-e1
+    name: elec-pad_sizepad_size-None-e1
     orientation: 270
     port_type: placement
     shear_angle: null
-    width: 80.0
+    width: 80
   o1:
     center:
     - 0.0
@@ -132,7 +132,9 @@ settings:
       get_input_labels_function: null
       layer_label: TEXT
       pad:
-        function: pad_pdk
+        function: pad
+        settings:
+          size: pad_size
       pad_port_labels: null
       pad_port_name: e1
       pad_spacing: pad_spacing
@@ -154,7 +156,9 @@ settings:
       get_input_labels_function: null
       layer_label: TEXT
       pad:
-        function: pad_pdk
+        function: pad
+        settings:
+          size: pad_size
       pad_port_labels: null
       pad_port_name: e1
       pad_spacing: pad_spacing

--- a/tests/test_all_angle_routing/test_settings_aar_basic_01_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_basic_01_.yml
@@ -1,4 +1,29 @@
 name: aar_basic_01
+ports:
+  o1:
+    center:
+    - 109.848
+    - 101.736
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 10
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_bundles_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_bundles_.yml
@@ -1,4 +1,5 @@
 name: aar_bundles
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_gone_wrong_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_gone_wrong_.yml
@@ -1,4 +1,5 @@
 name: aar_gone_wrong
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_implicit_final_angle_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_implicit_final_angle_.yml
@@ -1,4 +1,5 @@
 name: aar_implicit_final_angle
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_slalom_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_slalom_.yml
@@ -1,4 +1,5 @@
 name: aar_slalom
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_start_end_customizations_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_start_end_customizations_.yml
@@ -1,4 +1,5 @@
 name: aar_start_end_customizations
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_step_definitions_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_step_definitions_.yml
@@ -1,4 +1,5 @@
 name: aar_step_definitions
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_aar_tricky_connections_.yml
+++ b/tests/test_all_angle_routing/test_settings_aar_tricky_connections_.yml
@@ -1,4 +1,5 @@
 name: aar_tricky_connections
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_all_angle_routing/test_settings_all_angle_routes_.yml
+++ b/tests/test_all_angle_routing/test_settings_all_angle_routes_.yml
@@ -1,4 +1,5 @@
 name: all_angle_routes
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_component_from_yaml/test_settings_sample_connections_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_connections_.yml
@@ -1,4 +1,5 @@
 name: sample_connections_65d4d507
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_different_link_factory_.yml
@@ -1,4 +1,5 @@
 name: sample_path_length_matc_a159252b
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_docstring_.yml
@@ -1,4 +1,5 @@
 name: sample_docstring_7864c0c5
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_doe_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_doe_.yml
@@ -1,4 +1,5 @@
 name: mask_8d17f522
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_doe_function_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_doe_function_.yml
@@ -1,4 +1,5 @@
 name: mask_compact_48574a98
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_mirror_simple_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_mirror_simple_.yml
@@ -1,4 +1,5 @@
 name: sample_mirror_simple_f31e619a
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_mmis_.yml
@@ -1,4 +1,41 @@
 name: sample_mmis_6fafede2
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 80.0
+    - 99.375
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 80.0
+    - 100.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_rotation_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_rotation_.yml
@@ -1,4 +1,5 @@
 name: sample_rotation_0aef407a
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
+++ b/tests/test_component_from_yaml/test_settings_sample_waypoints_.yml
@@ -1,4 +1,5 @@
 name: sample_waypoints_dac9e992
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
+++ b/tests/test_component_from_yaml/test_settings_yaml_anchor_.yml
@@ -1,4 +1,5 @@
 name: yaml_anchor_14cbc915
+ports: {}
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml2/test_components_0_.yml
+++ b/tests/test_component_from_yaml2/test_components_0_.yml
@@ -1,4 +1,41 @@
 name: mirror_port_76e6504a
+ports:
+  o1:
+    center:
+    - -5.0
+    - 9.375
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -5.0
+    - 10.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 20.0
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml2/test_components_1_.yml
+++ b/tests/test_component_from_yaml2/test_components_1_.yml
@@ -1,4 +1,41 @@
 name: mirror_x_75c3bb5f
+ports:
+  o1:
+    center:
+    - 35.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 35.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 60.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml2/test_components_2_.yml
+++ b/tests/test_component_from_yaml2/test_components_2_.yml
@@ -1,4 +1,41 @@
 name: rotation_8fb1e19c
+ports:
+  o1:
+    center:
+    - 10.625
+    - 45.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 9.375
+    - 45.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml2/test_components_3_.yml
+++ b/tests/test_component_from_yaml2/test_components_3_.yml
@@ -1,4 +1,17 @@
 name: dxdy_95ee1103
+ports:
+  o1:
+    center:
+    - 65.0
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     conf:

--- a/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
+++ b/tests/test_component_from_yaml_ports/test_component_from_yaml_ports.yml
@@ -1,4 +1,41 @@
 name: component_yaml_ports_9329f23c
+ports:
+  o1:
+    center:
+    - -0.5
+    - 0.225
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.45
+  o2:
+    center:
+    - 13.0
+    - 3.675
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.45
+  o3:
+    center:
+    - 13.0
+    - -3.225
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.45
 settings:
   changed:
     conf:

--- a/tests/test_component_sequence/test_component_from_sequence_0_.yml
+++ b/tests/test_component_sequence/test_component_from_sequence_0_.yml
@@ -1,4 +1,29 @@
 name: component_sequence_b024f52e
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 40.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     sequence: ABHBA

--- a/tests/test_component_sequence/test_component_from_sequence_1_.yml
+++ b/tests/test_component_sequence/test_component_from_sequence_1_.yml
@@ -1,4 +1,29 @@
 name: component_sequence_ae8efed6
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 70.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     sequence: '!HH'

--- a/tests/test_component_sequence/test_component_from_sequence_2_.yml
+++ b/tests/test_component_sequence/test_component_from_sequence_2_.yml
@@ -1,4 +1,29 @@
 name: component_sequence_1c90b562
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 40.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     sequence: AB

--- a/tests/test_component_sequence/test_component_from_sequence_3_.yml
+++ b/tests/test_component_sequence/test_component_from_sequence_3_.yml
@@ -1,4 +1,29 @@
 name: component_sequence_d35ca83a
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 70.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     sequence: HH!

--- a/tests/test_component_sequence/test_component_from_sequence_4_.yml
+++ b/tests/test_component_sequence/test_component_from_sequence_4_.yml
@@ -1,4 +1,29 @@
 name: component_sequence_6b7730d5
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 30.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     sequence: H

--- a/tests/test_components/test_settings_C_.yml
+++ b/tests/test_components/test_settings_C_.yml
@@ -1,4 +1,29 @@
 name: C
+ports:
+  o1:
+    center:
+    - 10.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_L_.yml
+++ b/tests/test_components/test_settings_L_.yml
@@ -1,4 +1,29 @@
 name: L
+ports:
+  e1:
+    center:
+    - 0.0
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 1
+  e2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0
+    port_type: electrical
+    shear_angle: null
+    width: 1
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_add_fiducials_.yml
+++ b/tests/test_components/test_settings_add_fiducials_.yml
@@ -1,4 +1,77 @@
 name: pad_array_add_fiducials
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e12:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e12
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e13:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e13
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e14:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e14
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e15:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e15
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e16:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e16
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_add_fiducials_offsets_.yml
+++ b/tests/test_components/test_settings_add_fiducials_offsets_.yml
@@ -1,4 +1,77 @@
 name: pad_array_add_fiducials_offsets
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e12:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e12
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e13:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e13
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e14:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e14
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e15:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e15
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e16:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e16
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_add_frame_.yml
+++ b/tests/test_components/test_settings_add_frame_.yml
@@ -1,4 +1,5 @@
 name: add_frame
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_add_grating_couplers_.yml
+++ b/tests/test_components/test_settings_add_grating_couplers_.yml
@@ -1,4 +1,5 @@
 name: straight_add_grating_couplers
+ports: {}
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_add_grating_couplers_with_loopback_fiber_array_.yml
+++ b/tests/test_components/test_settings_add_grating_couplers_with_loopback_fiber_array_.yml
@@ -1,4 +1,5 @@
 name: spiral_inner_io_add_gra_f2760628
+ports: {}
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/tests/test_components/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -1,4 +1,53 @@
 name: spiral_inner_io_2a92e51_16913f51
+ports:
+  loopback1:
+    center:
+    - 67.473
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: loopback1
+    orientation: 270
+    port_type: loopback
+    shear_angle: null
+    width: 0.5
+  loopback2:
+    center:
+    - 67.473
+    - 210.0
+    layer:
+    - 1
+    - 0
+    name: loopback2
+    orientation: 90
+    port_type: loopback
+    shear_angle: null
+    width: 0.5
+  o1:
+    center:
+    - 0.0
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 210.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_align_wafer_.yml
+++ b/tests/test_components/test_settings_align_wafer_.yml
@@ -1,4 +1,5 @@
 name: align_wafer
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_array_.yml
+++ b/tests/test_components/test_settings_array_.yml
@@ -1,4 +1,149 @@
 name: array
+ports:
+  o1_1_1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_2:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_3:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_4:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_5:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_5
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_6:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_6
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_1:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_2:
+    center:
+    - 160.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_3:
+    center:
+    - 310.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_4:
+    center:
+    - 460.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_5:
+    center:
+    - 610.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_6:
+    center:
+    - 760.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_array_with_fanout_.yml
+++ b/tests/test_components/test_settings_array_with_fanout_.yml
@@ -1,4 +1,41 @@
 name: array_with_fanout
+ports:
+  o1:
+    center:
+    - -45.0
+    - -80.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -45.0
+    - -70.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -45.0
+    - -60.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_array_with_fanout_2d_.yml
+++ b/tests/test_components/test_settings_array_with_fanout_2d_.yml
@@ -1,4 +1,77 @@
 name: array_with_fanout_2d
+ports:
+  o1_1_1:
+    center:
+    - -45.0
+    - -80.0
+    layer:
+    - 1
+    - 0
+    name: o1_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_2_1:
+    center:
+    - -45.0
+    - 70.0
+    layer:
+    - 1
+    - 0
+    name: o1_2_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_1:
+    center:
+    - -45.0
+    - -70.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_2_1:
+    center:
+    - -45.0
+    - 80.0
+    layer:
+    - 1
+    - 0
+    name: o2_2_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_1:
+    center:
+    - -45.0
+    - -60.0
+    layer:
+    - 1
+    - 0
+    name: o3_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_2_1:
+    center:
+    - -45.0
+    - 90.0
+    layer:
+    - 1
+    - 0
+    name: o3_2_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_array_with_via_.yml
+++ b/tests/test_components/test_settings_array_with_via_.yml
@@ -1,4 +1,41 @@
 name: array_with_via
+ports:
+  e0:
+    center:
+    - -65.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e0
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e1:
+    center:
+    - -65.5
+    - 10.0
+    layer:
+    - 45
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - -65.5
+    - 20.0
+    layer:
+    - 45
+    - 0
+    name: e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_array_with_via_2d_.yml
+++ b/tests/test_components/test_settings_array_with_via_2d_.yml
@@ -1,4 +1,77 @@
 name: array_with_via_2d
+ports:
+  e0_1_1:
+    center:
+    - -65.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e0_1_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e0_2_1:
+    center:
+    - -65.5
+    - 150.0
+    layer:
+    - 45
+    - 0
+    name: e0_2_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e1_1_1:
+    center:
+    - -65.5
+    - 10.0
+    layer:
+    - 45
+    - 0
+    name: e1_1_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e1_2_1:
+    center:
+    - -65.5
+    - 160.0
+    layer:
+    - 45
+    - 0
+    name: e1_2_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2_1_1:
+    center:
+    - -65.5
+    - 20.0
+    layer:
+    - 45
+    - 0
+    name: e2_1_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2_2_1:
+    center:
+    - -65.5
+    - 170.0
+    layer:
+    - 45
+    - 0
+    name: e2_2_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_awg_.yml
+++ b/tests/test_components/test_settings_awg_.yml
@@ -1,4 +1,53 @@
 name: awg
+ports:
+  E0:
+    center:
+    - 45.25
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: E0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  E1:
+    center:
+    - 50.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: E1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  E2:
+    center:
+    - 54.75
+    - -0.0
+    layer:
+    - 1
+    - 0
+    name: E2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bbox_.yml
+++ b/tests/test_components/test_settings_bbox_.yml
@@ -1,4 +1,5 @@
 name: bbox
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bend_circular180_.yml
+++ b/tests/test_components/test_settings_bend_circular180_.yml
@@ -1,4 +1,29 @@
 name: bend_circular_angle180
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     angle: 180

--- a/tests/test_components/test_settings_bend_circular_.yml
+++ b/tests/test_components/test_settings_bend_circular_.yml
@@ -1,4 +1,29 @@
 name: bend_circular
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bend_circular_heater_.yml
+++ b/tests/test_components/test_settings_bend_circular_heater_.yml
@@ -1,4 +1,29 @@
 name: bend_circular_heater
+ports:
+  in:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  out:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: out
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bend_euler180_.yml
+++ b/tests/test_components/test_settings_bend_euler180_.yml
@@ -1,4 +1,29 @@
 name: bend_euler_angle180
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     angle: 180

--- a/tests/test_components/test_settings_bend_euler_.yml
+++ b/tests/test_components/test_settings_bend_euler_.yml
@@ -1,4 +1,29 @@
 name: bend_euler
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bend_euler_s_.yml
+++ b/tests/test_components/test_settings_bend_euler_s_.yml
@@ -1,4 +1,29 @@
 name: bend_euler_s
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bend_port_.yml
+++ b/tests/test_components/test_settings_bend_port_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_metal_u_b8c91210
+ports:
+  e1:
+    center:
+    - 336.0
+    - -20.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 336.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_bend_s_.yml
+++ b/tests/test_components/test_settings_bend_s_.yml
@@ -1,4 +1,29 @@
 name: bezier_c3570097_bend_s
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 11.0
+    - 2.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_bend_straight_bend_.yml
+++ b/tests/test_components/test_settings_bend_straight_bend_.yml
@@ -1,4 +1,29 @@
 name: bend_straight_bend
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.0
+    - 30.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_bezier_.yml
+++ b/tests/test_components/test_settings_bezier_.yml
@@ -1,4 +1,29 @@
 name: bezier
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 2.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cavity_.yml
+++ b/tests/test_components/test_settings_cavity_.yml
@@ -1,4 +1,29 @@
 name: dbr_cavity
+ports:
+  o1:
+    center:
+    - -10.0
+    - -1.65
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.1
+    - -1.65
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_cdc_.yml
+++ b/tests/test_components/test_settings_cdc_.yml
@@ -1,4 +1,53 @@
 name: cdc
+ports:
+  o1:
+    center:
+    - -10.0
+    - 5.25
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 2.0
+  o2:
+    center:
+    - -10.0
+    - -6.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.75
+  o3:
+    center:
+    - 40.0
+    - 5.25
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 2.0
+  o4:
+    center:
+    - 40.0
+    - -6.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.75
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cdsem_all_.yml
+++ b/tests/test_components/test_settings_cdsem_all_.yml
@@ -1,4 +1,5 @@
 name: cdsem_all
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_circle_.yml
+++ b/tests/test_components/test_settings_circle_.yml
@@ -1,4 +1,5 @@
 name: circle
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coh_rx_dual_pol_.yml
+++ b/tests/test_components/test_settings_coh_rx_dual_pol_.yml
@@ -1,4 +1,5 @@
 name: coh_rx_dual_pol
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coh_rx_single_pol_.yml
+++ b/tests/test_components/test_settings_coh_rx_single_pol_.yml
@@ -1,4 +1,53 @@
 name: coh_rx_single_pol
+ports:
+  LO_in:
+    center:
+    - -60.0
+    - -1.25
+    layer:
+    - 1
+    - 0
+    name: LO_in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  i_out:
+    center:
+    - 355.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: i_out
+    orientation: 0
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  q_out:
+    center:
+    - 370.0
+    - -15.0
+    layer:
+    - 45
+    - 0
+    name: q_out
+    orientation: 0
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  signal_in:
+    center:
+    - -60.0
+    - 3.75
+    layer:
+    - 1
+    - 0
+    name: signal_in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coh_tx_dual_pol_.yml
+++ b/tests/test_components/test_settings_coh_tx_dual_pol_.yml
@@ -1,4 +1,617 @@
 name: coh_tx_dual_pol
+ports:
+  o1:
+    center:
+    - -115.5
+    - -147.25
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 473.85
+    - -55.75
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 473.85
+    - -238.75
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  pol1_mzm_i_e1:
+    center:
+    - 45.5
+    - 16.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_e2:
+    center:
+    - 45.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_e3:
+    center:
+    - 135.5
+    - 21.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_i_e4:
+    center:
+    - 135.5
+    - 33.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_i_e5:
+    center:
+    - 225.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_e6:
+    center:
+    - 225.5
+    - 16.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_e7:
+    center:
+    - 135.5
+    - 11.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_i_e8:
+    center:
+    - 135.5
+    - 23.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_q_e1:
+    center:
+    - 45.5
+    - -94.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_e2:
+    center:
+    - 45.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_e3:
+    center:
+    - 135.5
+    - -89.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_q_e4:
+    center:
+    - 135.5
+    - -77.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_q_e5:
+    center:
+    - 225.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_e6:
+    center:
+    - 225.5
+    - -94.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_e7:
+    center:
+    - 135.5
+    - -99.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_q_e8:
+    center:
+    - 135.5
+    - -87.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_ps_q_bot_e1:
+    center:
+    - 331.1
+    - -117.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_ps_q_bot_e2:
+    center:
+    - 371.1
+    - -112.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol1_ps_q_bot_e3:
+    center:
+    - 411.1
+    - -117.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_ps_q_bot_e4:
+    center:
+    - 371.1
+    - -122.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol1_ps_q_top_e1:
+    center:
+    - 331.1
+    - -105.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_ps_q_top_e2:
+    center:
+    - 371.1
+    - -100.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol1_ps_q_top_e3:
+    center:
+    - 411.1
+    - -105.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_ps_q_top_e4:
+    center:
+    - 371.1
+    - -110.5
+    layer:
+    - 49
+    - 0
+    name: pol1_ps_q_top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol2_mzm_i_e1:
+    center:
+    - 45.5
+    - -166.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_e2:
+    center:
+    - 45.5
+    - -154.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_e3:
+    center:
+    - 135.5
+    - -161.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_i_e4:
+    center:
+    - 135.5
+    - -149.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_i_e5:
+    center:
+    - 225.5
+    - -154.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_e6:
+    center:
+    - 225.5
+    - -166.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_e7:
+    center:
+    - 135.5
+    - -171.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_i_e8:
+    center:
+    - 135.5
+    - -159.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_q_e1:
+    center:
+    - 45.5
+    - -277.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_e2:
+    center:
+    - 45.5
+    - -265.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_e3:
+    center:
+    - 135.5
+    - -272.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_q_e4:
+    center:
+    - 135.5
+    - -260.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_q_e5:
+    center:
+    - 225.5
+    - -265.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_e6:
+    center:
+    - 225.5
+    - -277.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_e7:
+    center:
+    - 135.5
+    - -282.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_q_e8:
+    center:
+    - 135.5
+    - -270.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_ps_q_bot_e1:
+    center:
+    - 331.1
+    - -300.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_ps_q_bot_e2:
+    center:
+    - 371.1
+    - -295.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol2_ps_q_bot_e3:
+    center:
+    - 411.1
+    - -300.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_ps_q_bot_e4:
+    center:
+    - 371.1
+    - -305.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol2_ps_q_top_e1:
+    center:
+    - 331.1
+    - -288.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_ps_q_top_e2:
+    center:
+    - 371.1
+    - -283.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  pol2_ps_q_top_e3:
+    center:
+    - 411.1
+    - -288.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_ps_q_top_e4:
+    center:
+    - 371.1
+    - -293.5
+    layer:
+    - 49
+    - 0
+    name: pol2_ps_q_top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coh_tx_single_pol_.yml
+++ b/tests/test_components/test_settings_coh_tx_single_pol_.yml
@@ -1,4 +1,317 @@
 name: coh_tx_single_pol
+ports:
+  mzm_i_e1:
+    center:
+    - 45.5
+    - 16.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_e2:
+    center:
+    - 45.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_e3:
+    center:
+    - 135.5
+    - 21.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_i_e4:
+    center:
+    - 135.5
+    - 33.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_i_e5:
+    center:
+    - 225.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_e6:
+    center:
+    - 225.5
+    - 16.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_e7:
+    center:
+    - 135.5
+    - 11.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_i_e8:
+    center:
+    - 135.5
+    - 23.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_q_e1:
+    center:
+    - 45.5
+    - -94.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_e2:
+    center:
+    - 45.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_e3:
+    center:
+    - 135.5
+    - -89.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e3
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_q_e4:
+    center:
+    - 135.5
+    - -77.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e4
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_q_e5:
+    center:
+    - 225.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_e6:
+    center:
+    - 225.5
+    - -94.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_e7:
+    center:
+    - 135.5
+    - -99.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e7
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_q_e8:
+    center:
+    - 135.5
+    - -87.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_e8
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  o1:
+    center:
+    - -62.75
+    - -55.75
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 473.85
+    - -55.75
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  ps_q_bot_e1:
+    center:
+    - 331.1
+    - -117.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  ps_q_bot_e2:
+    center:
+    - 371.1
+    - -112.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  ps_q_bot_e3:
+    center:
+    - 411.1
+    - -117.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  ps_q_bot_e4:
+    center:
+    - 371.1
+    - -122.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  ps_q_top_e1:
+    center:
+    - 331.1
+    - -105.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  ps_q_top_e2:
+    center:
+    - 371.1
+    - -100.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
+  ps_q_top_e3:
+    center:
+    - 411.1
+    - -105.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  ps_q_top_e4:
+    center:
+    - 371.1
+    - -110.5
+    layer:
+    - 49
+    - 0
+    name: ps_q_top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 80.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_compass_.yml
+++ b/tests/test_components/test_settings_compass_.yml
@@ -1,4 +1,53 @@
 name: compass
+ports:
+  e1:
+    center:
+    - -2.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  e2:
+    center:
+    - 0.0
+    - 1.0
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 4.0
+  e3:
+    center:
+    - 2.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: e3
+    orientation: 0
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  e4:
+    center:
+    - 0.0
+    - -1.0
+    layer:
+    - 1
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 4.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_compensation_path_.yml
+++ b/tests/test_components/test_settings_compensation_path_.yml
@@ -1,4 +1,29 @@
 name: compensation_path
+ports:
+  o1:
+    center:
+    - -40.0
+    - -18.869
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 40.0
+    - -18.869
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_component_lattice_.yml
+++ b/tests/test_components/test_settings_component_lattice_.yml
@@ -1,4 +1,101 @@
 name: component_lattice
+ports:
+  o1:
+    center:
+    - 0.0
+    - -120.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - -80.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 0.0
+    - -40.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 280.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o6:
+    center:
+    - 280.0
+    - -40.0
+    layer:
+    - 1
+    - 0
+    name: o6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o7:
+    center:
+    - 280.0
+    - -80.0
+    layer:
+    - 1
+    - 0
+    name: o7
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o8:
+    center:
+    - 280.0
+    - -120.0
+    layer:
+    - 1
+    - 0
+    name: o8
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_copy_layers_.yml
+++ b/tests/test_components/test_settings_copy_layers_.yml
@@ -1,4 +1,5 @@
 name: cross_layer2__0_copy_layers
+ports: {}
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_coupler90_.yml
+++ b/tests/test_components/test_settings_coupler90_.yml
@@ -1,4 +1,53 @@
 name: coupler90
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 10.7
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler90bend_.yml
+++ b/tests/test_components/test_settings_coupler90bend_.yml
@@ -1,4 +1,53 @@
 name: coupler90bend
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 10.7
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.7
+    - 10.7
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler90circular_.yml
+++ b/tests/test_components/test_settings_coupler90circular_.yml
@@ -1,4 +1,53 @@
 name: coupler90_528aa9f7
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 10.7
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     bend:

--- a/tests/test_components/test_settings_coupler_.yml
+++ b/tests/test_components/test_settings_coupler_.yml
@@ -1,4 +1,53 @@
 name: coupler
+ports:
+  o1:
+    center:
+    - -10.0
+    - -1.632
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 2.368
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 30.0
+    - 2.368
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 30.0
+    - -1.632
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_adiabatic_.yml
+++ b/tests/test_components/test_settings_coupler_adiabatic_.yml
@@ -1,4 +1,53 @@
 name: coupler_adiabatic
+ports:
+  o1:
+    center:
+    - -30.0
+    - -1.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.4
+  o2:
+    center:
+    - -30.0
+    - 1.77
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.6
+  o3:
+    center:
+    - 80.0
+    - 1.77
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 80.0
+    - -1.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_asymmetric_.yml
+++ b/tests/test_components/test_settings_coupler_asymmetric_.yml
@@ -1,4 +1,39 @@
 name: coupler_asymmetric
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer: WG
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.234
+  o2:
+    center:
+    - 10.0
+    - 0.367
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - -4.633
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_bend_.yml
+++ b/tests/test_components/test_settings_coupler_bend_.yml
@@ -1,4 +1,53 @@
 name: coupler_bend
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 17.927
+    - 10.35
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 10.7
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_full_.yml
+++ b/tests/test_components/test_settings_coupler_full_.yml
@@ -1,4 +1,53 @@
 name: coupler_full
+ports:
+  o1:
+    center:
+    - -10.0
+    - -2.5
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.4
+  o2:
+    center:
+    - -10.0
+    - 2.5
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.6
+  o3:
+    center:
+    - 50.0
+    - 2.5
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.4
+  o4:
+    center:
+    - 50.0
+    - -2.5
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.6
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_ring_.yml
+++ b/tests/test_components/test_settings_coupler_ring_.yml
@@ -1,4 +1,53 @@
 name: coupler_ring
+ports:
+  o1:
+    center:
+    - -9.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -9.0
+    - 5.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 5.0
+    - 5.7
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 5.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_straight_.yml
+++ b/tests/test_components/test_settings_coupler_straight_.yml
@@ -1,4 +1,53 @@
 name: coupler_straight
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.77
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 0.77
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_straight_asymmetric_.yml
+++ b/tests/test_components/test_settings_coupler_straight_asymmetric_.yml
@@ -1,4 +1,53 @@
 name: coupler_straight_asymmetric
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 0.0
+    - 1.02
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 1.02
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_coupler_symmetric_.yml
+++ b/tests/test_components/test_settings_coupler_symmetric_.yml
@@ -1,4 +1,53 @@
 name: coupler_symmetric
+ports:
+  o1:
+    center:
+    - 0.0
+    - -0.367
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 0.367
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 2.5
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - -2.5
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cross_.yml
+++ b/tests/test_components/test_settings_cross_.yml
@@ -1,4 +1,5 @@
 name: cross
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_crossing45_.yml
+++ b/tests/test_components/test_settings_crossing45_.yml
@@ -1,4 +1,53 @@
 name: crossing45
+ports:
+  o1:
+    center:
+    - -40.0
+    - -20.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -40.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 40.0
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 40.0
+    - -20.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_crossing_arm_.yml
+++ b/tests/test_components/test_settings_crossing_arm_.yml
@@ -1,4 +1,29 @@
 name: crossing_arm
+ports:
+  o1:
+    center:
+    - -4.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 4.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_crossing_etched_.yml
+++ b/tests/test_components/test_settings_crossing_etched_.yml
@@ -1,4 +1,53 @@
 name: crossing_etched
+ports:
+  o1:
+    center:
+    - -4.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 4.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 4.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - -4.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_crossing_from_taper_.yml
+++ b/tests/test_components/test_settings_crossing_from_taper_.yml
@@ -1,4 +1,53 @@
 name: crossing_from_taper
+ports:
+  o1:
+    center:
+    - -3.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 3.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 3.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - -3.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cutback_2x2_.yml
+++ b/tests/test_components/test_settings_cutback_2x2_.yml
@@ -1,4 +1,29 @@
 name: mmi2x2_cutback_2x2
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 438.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_cutback_bend180_.yml
+++ b/tests/test_components/test_settings_cutback_bend180_.yml
@@ -1,4 +1,29 @@
 name: cutback_bend180
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 203.28
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cutback_bend180circular_.yml
+++ b/tests/test_components/test_settings_cutback_bend180circular_.yml
@@ -1,4 +1,29 @@
 name: cutback_bend180_13911d77
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 142.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     bend180:

--- a/tests/test_components/test_settings_cutback_bend90_.yml
+++ b/tests/test_components/test_settings_cutback_bend90_.yml
@@ -1,4 +1,29 @@
 name: cutback_bend90
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 150.0
+    - -0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cutback_bend90circular_.yml
+++ b/tests/test_components/test_settings_cutback_bend90circular_.yml
@@ -1,4 +1,29 @@
 name: cutback_bend90_d1ad1beb
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 150.0
+    - -0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     bend90:

--- a/tests/test_components/test_settings_cutback_bend_.yml
+++ b/tests/test_components/test_settings_cutback_bend_.yml
@@ -1,4 +1,29 @@
 name: cutback_bend
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -250.0
+    - 150.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_cutback_component_.yml
+++ b/tests/test_components/test_settings_cutback_component_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_cutback_component
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 603.68
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_cutback_component_mirror_.yml
+++ b/tests/test_components/test_settings_cutback_component_mirror_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_cutback__09f119b8
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 603.68
+    - -160.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     mirror: true

--- a/tests/test_components/test_settings_cutback_splitter_.yml
+++ b/tests/test_components/test_settings_cutback_splitter_.yml
@@ -1,4 +1,29 @@
 name: mmi1x2_cutback_splitter
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 438.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_dbr_.yml
+++ b/tests/test_components/test_settings_dbr_.yml
@@ -1,4 +1,29 @@
 name: dbr
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.476
+  o2:
+    center:
+    - 3.18
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.524
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_dbr_tapered_.yml
+++ b/tests/test_components/test_settings_dbr_tapered_.yml
@@ -1,4 +1,29 @@
 name: dbr_tapered
+ports:
+  o1:
+    center:
+    - -25.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 25.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_delay_snake2_.yml
+++ b/tests/test_components/test_settings_delay_snake2_.yml
@@ -1,4 +1,29 @@
 name: delay_snake2
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 504.789
+    - -40.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_delay_snake3_.yml
+++ b/tests/test_components/test_settings_delay_snake3_.yml
@@ -1,4 +1,29 @@
 name: delay_snake3
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - -40.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_delay_snake_.yml
+++ b/tests/test_components/test_settings_delay_snake_.yml
@@ -1,4 +1,29 @@
 name: delay_snake
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 303.394
+    - -80.4
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_delay_snake_sbend_.yml
+++ b/tests/test_components/test_settings_delay_snake_sbend_.yml
@@ -1,4 +1,29 @@
 name: delay_snake_sbend
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -100.0
+    - -15.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_dicing_lane_.yml
+++ b/tests/test_components/test_settings_dicing_lane_.yml
@@ -1,4 +1,5 @@
 name: dicing_lane
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_die_.yml
+++ b/tests/test_components/test_settings_die_.yml
@@ -1,4 +1,5 @@
 name: die
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_die_bbox_.yml
+++ b/tests/test_components/test_settings_die_bbox_.yml
@@ -1,4 +1,5 @@
 name: rectangle_size1300__260_516de578
+ports: {}
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_die_bbox_frame_.yml
+++ b/tests/test_components/test_settings_die_bbox_frame_.yml
@@ -1,4 +1,5 @@
 name: die_bbox_frame
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_disk_.yml
+++ b/tests/test_components/test_settings_disk_.yml
@@ -1,4 +1,29 @@
 name: disk
+ports:
+  o1:
+    center:
+    - -15.55
+    - 5.35
+    layer:
+    - 1
+    - 10
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 26.25
+    - 5.35
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_disk_heater_.yml
+++ b/tests/test_components/test_settings_disk_heater_.yml
@@ -1,4 +1,53 @@
 name: disk_heater
+ports:
+  e1:
+    center:
+    - -22.55
+    - 0.251
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 33.25
+    - 0.251
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  o1:
+    center:
+    - -15.55
+    - 5.35
+    layer:
+    - 1
+    - 10
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 26.25
+    - 5.35
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_edge_coupler_array_.yml
+++ b/tests/test_components/test_settings_edge_coupler_array_.yml
@@ -1,4 +1,65 @@
 name: edge_coupler_array
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 127.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 0.0
+    - 254.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - 381.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 0.0
+    - 508.0
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_edge_coupler_array_with_loopback_.yml
+++ b/tests/test_components/test_settings_edge_coupler_array_with_loopback_.yml
@@ -1,4 +1,53 @@
 name: edge_coupler_array_with_loopback
+ports:
+  o1:
+    center:
+    - 0.0
+    - 254.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 381.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 0.0
+    - 508.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - 635.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_edge_coupler_silicon_.yml
+++ b/tests/test_components/test_settings_edge_coupler_silicon_.yml
@@ -1,4 +1,17 @@
 name: taper_abf5825d
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     length: 100

--- a/tests/test_components/test_settings_ellipse_.yml
+++ b/tests/test_components/test_settings_ellipse_.yml
@@ -1,4 +1,5 @@
 name: ellipse
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_extend_ports_.yml
+++ b/tests/test_components/test_settings_extend_ports_.yml
@@ -1,4 +1,41 @@
 name: mmi1x2_extend_ports
+ports:
+  o1:
+    center:
+    - -15.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.5
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 20.5
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_fiber_.yml
+++ b/tests/test_components/test_settings_fiber_.yml
@@ -1,4 +1,17 @@
 name: fiber
+ports:
+  F0:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F0
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_fiber_array_.yml
+++ b/tests/test_components/test_settings_fiber_array_.yml
@@ -1,4 +1,101 @@
 name: fiber_array
+ports:
+  F0:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F0
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F1
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F2:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F3:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F3
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F4:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F4
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F5:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F5
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F6:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F6
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
+  F7:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: F7
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_fiducial_squares_.yml
+++ b/tests/test_components/test_settings_fiducial_squares_.yml
@@ -1,4 +1,5 @@
 name: fiducial_squares
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ge_detector_straight_si_contacts_.yml
+++ b/tests/test_components/test_settings_ge_detector_straight_si_contacts_.yml
@@ -1,4 +1,113 @@
 name: ge_detector_straight_si_contacts
+ports:
+  bot_e1:
+    center:
+    - 0.0
+    - -7.5
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 20.0
+    - -2.5
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 40.0
+  bot_e3:
+    center:
+    - 40.0
+    - -7.5
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 20.0
+    - -12.5
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 40.0
+  o1:
+    center:
+    - -20.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - 0.0
+    - 7.5
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 20.0
+    - 12.5
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 40.0
+  top_e3:
+    center:
+    - 40.0
+    - 7.5
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 20.0
+    - 2.5
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 40.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_array_.yml
+++ b/tests/test_components/test_settings_grating_coupler_array_.yml
@@ -1,4 +1,77 @@
 name: grating_coupler_array
+ports:
+  o0:
+    center:
+    - -20.097
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o0
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1:
+    center:
+    - 106.903
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 233.903
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 360.903
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 487.903
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 614.903
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_dual_pol_.yml
+++ b/tests/test_components/test_settings_grating_coupler_dual_pol_.yml
@@ -1,4 +1,41 @@
 name: grating_coupler_dual_pol
+ports:
+  o1:
+    center:
+    - -155.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - -155.5
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  vertical_dual:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: vertical_dual
+    orientation: 0
+    port_type: vertical_dual
+    shear_angle: null
+    width: 11
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_elliptical
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1554_15:
+    center:
+    - 16.6
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1554_15
+    orientation: 0
+    port_type: opt_te_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_arbitrary_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_4a0b5da2
+ports:
+  o1:
+    center:
+    - 0.25
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1554_15:
+    center:
+    - 19.475
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1554_15
+    orientation: 0
+    port_type: opt_te_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_lumerical_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_9d85a0c6
+ports:
+  o1:
+    center:
+    - 0.24
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1554_5:
+    center:
+    - 19.67
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1554_5
+    orientation: 0
+    port_type: opt_te_1554_5
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_te_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_elliptical
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1554_15:
+    center:
+    - 16.6
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1554_15
+    orientation: 0
+    port_type: opt_te_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_tm_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_b6bd8130
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_tm_1554_15:
+    center:
+    - 30.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_tm_1554_15
+    orientation: 0
+    port_type: opt_tm_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed:
     grating_line_width: 0.707

--- a/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_trenches_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_7935cab4
+ports:
+  o1:
+    center:
+    - 0.471
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1530_15:
+    center:
+    - 26.74
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15
+    orientation: 0
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_elliptical_uniform_.yml
+++ b/tests/test_components/test_settings_grating_coupler_elliptical_uniform_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_6ff6af5d
+ports:
+  o1:
+    center:
+    - 0.188
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1554_15:
+    center:
+    - 24.006
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1554_15
+    orientation: 0
+    port_type: opt_te_1554_15
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
+++ b/tests/test_components/test_settings_grating_coupler_loss_fiber_array4_.yml
@@ -1,4 +1,5 @@
 name: grating_coupler_loss_fi_da445079
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
+++ b/tests/test_components/test_settings_grating_coupler_loss_fiber_array_.yml
@@ -1,4 +1,5 @@
 name: grating_coupler_loss_fiber_array
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
+++ b/tests/test_components/test_settings_grating_coupler_loss_fiber_single_.yml
@@ -1,4 +1,5 @@
 name: grating_coupler_ellipti_7645ee14
+ports: {}
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_grating_coupler_rectangular_.yml
+++ b/tests/test_components/test_settings_grating_coupler_rectangular_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_rectangular
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1550_15:
+    center:
+    - 157.219
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1550_15
+    orientation: 0
+    port_type: opt_te_1550_15
+    shear_angle: null
+    width: 11.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
+++ b/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_rectang_0b571e8d
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1550_15:
+    center:
+    - 153.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1550_15
+    orientation: 0
+    port_type: opt_te_1550_15
+    shear_angle: null
+    width: 11.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
+++ b/tests/test_components/test_settings_grating_coupler_rectangular_arbitrary_slab_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_rectang_c148e9a3
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1550_15:
+    center:
+    - 153.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1550_15
+    orientation: 0
+    port_type: opt_te_1550_15
+    shear_angle: null
+    width: 11.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_grating_coupler_te_.yml
+++ b/tests/test_components/test_settings_grating_coupler_te_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_dd7f7af4
+ports:
+  o1:
+    center:
+    - 0.471
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_te_1530_15:
+    center:
+    - 26.74
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15
+    orientation: 0
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
 settings:
   changed:
     taper_angle: 35

--- a/tests/test_components/test_settings_grating_coupler_tm_.yml
+++ b/tests/test_components/test_settings_grating_coupler_tm_.yml
@@ -1,4 +1,29 @@
 name: grating_coupler_ellipti_e07aa712
+ports:
+  o1:
+    center:
+    - 10.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt_tm_1530_15:
+    center:
+    - 32.68
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: opt_tm_1530_15
+    orientation: 0
+    port_type: opt_tm_1530_15
+    shear_angle: null
+    width: 10
 settings:
   changed:
     grating_line_width: 0.6

--- a/tests/test_components/test_settings_grating_coupler_tree_.yml
+++ b/tests/test_components/test_settings_grating_coupler_tree_.yml
@@ -1,4 +1,101 @@
 name: grating_coupler_tree
+ports:
+  opt-grating_coupler_elliptical-straight_array-o1:
+    center:
+    - -439.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o2:
+    center:
+    - -312.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o3:
+    center:
+    - -185.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o4:
+    center:
+    - -58.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o5:
+    center:
+    - 68.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o5
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o6:
+    center:
+    - 195.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o6
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o7:
+    center:
+    - 322.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o7
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_elliptical-straight_array-o8:
+    center:
+    - 449.5
+    - -34.2
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_elliptical-straight_array-o8
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_greek_cross_.yml
+++ b/tests/test_components/test_settings_greek_cross_.yml
@@ -1,4 +1,5 @@
 name: greek_cross
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_hline_.yml
+++ b/tests/test_components/test_settings_hline_.yml
@@ -1,4 +1,29 @@
 name: hline
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_interdigital_capacitor_.yml
+++ b/tests/test_components/test_settings_interdigital_capacitor_.yml
@@ -1,4 +1,29 @@
 name: interdigital_capacitor
+ports:
+  o1:
+    center:
+    - 0.0
+    - 13.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 5.0
+  o2:
+    center:
+    - 32.0
+    - 13.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 5.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_litho_calipers_.yml
+++ b/tests/test_components/test_settings_litho_calipers_.yml
@@ -1,4 +1,5 @@
 name: litho_calipers
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_litho_ruler_.yml
+++ b/tests/test_components/test_settings_litho_ruler_.yml
@@ -1,4 +1,5 @@
 name: litho_ruler
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_litho_steps_.yml
+++ b/tests/test_components/test_settings_litho_steps_.yml
@@ -1,4 +1,5 @@
 name: litho_steps
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_logo_.yml
+++ b/tests/test_components/test_settings_logo_.yml
@@ -1,4 +1,5 @@
 name: logo
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_loop_mirror_.yml
+++ b/tests/test_components/test_settings_loop_mirror_.yml
@@ -1,4 +1,17 @@
 name: loop_mirror
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
+++ b/tests/test_components/test_settings_loss_deembedding_ch12_34_.yml
@@ -1,4 +1,5 @@
 name: loss_deembedding_ch12_34
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
+++ b/tests/test_components/test_settings_loss_deembedding_ch13_24_.yml
@@ -1,4 +1,5 @@
 name: loss_deembedding_ch13_24
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
+++ b/tests/test_components/test_settings_loss_deembedding_ch14_23_.yml
@@ -1,4 +1,5 @@
 name: loss_deembedding_ch14_23
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_marker_te_.yml
+++ b/tests/test_components/test_settings_marker_te_.yml
@@ -1,4 +1,53 @@
 name: rectangle_db821636
+ports:
+  e1:
+    center:
+    - -5.2
+    - 0.0
+    layer:
+    - 203
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e2:
+    center:
+    - 0.0
+    - 5.2
+    layer:
+    - 203
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e3:
+    center:
+    - 5.2
+    - 0.0
+    layer:
+    - 203
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e4:
+    center:
+    - 0.0
+    - -5.2
+    layer:
+    - 203
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 10.4
 settings:
   changed:
     centered: true

--- a/tests/test_components/test_settings_marker_tm_.yml
+++ b/tests/test_components/test_settings_marker_tm_.yml
@@ -1,4 +1,53 @@
 name: rectangle_11b0bf80
+ports:
+  e1:
+    center:
+    - -5.2
+    - 0.0
+    layer:
+    - 204
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e2:
+    center:
+    - 0.0
+    - 5.2
+    layer:
+    - 204
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e3:
+    center:
+    - 5.2
+    - 0.0
+    layer:
+    - 204
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 10.4
+  e4:
+    center:
+    - 0.0
+    - -5.2
+    layer:
+    - 204
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 10.4
 settings:
   changed:
     centered: true

--- a/tests/test_components/test_settings_mmi1x2_.yml
+++ b/tests/test_components/test_settings_mmi1x2_.yml
@@ -1,4 +1,41 @@
 name: mmi1x2
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 15.5
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 15.5
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mmi1x2_with_sbend_.yml
+++ b/tests/test_components/test_settings_mmi1x2_with_sbend_.yml
@@ -1,4 +1,41 @@
 name: mmi1x2_with_sbend
+ports:
+  o1:
+    center:
+    - -0.25
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 13.25
+    - 2.35
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 13.25
+    - -2.35
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mmi2x2_.yml
+++ b/tests/test_components/test_settings_mmi2x2_.yml
@@ -1,4 +1,53 @@
 name: mmi2x2
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 15.5
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 15.5
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mmi2x2_with_sbend_.yml
+++ b/tests/test_components/test_settings_mmi2x2_with_sbend_.yml
@@ -1,4 +1,53 @@
 name: mmi2x2_with_sbend
+ports:
+  o1:
+    center:
+    - -12.0
+    - -2.45
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -12.0
+    - 2.45
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 20.0
+    - 2.45
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 20.0
+    - -2.45
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mmi_90degree_hybrid_.yml
+++ b/tests/test_components/test_settings_mmi_90degree_hybrid_.yml
@@ -1,4 +1,77 @@
 name: mmi_90degree_hybrid
+ports:
+  I_out1:
+    center:
+    - 215.0
+    - 3.75
+    layer:
+    - 1
+    - 0
+    name: I_out1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  I_out2:
+    center:
+    - 215.0
+    - -3.75
+    layer:
+    - 1
+    - 0
+    name: I_out2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  LO_in:
+    center:
+    - -40.0
+    - -1.25
+    layer:
+    - 1
+    - 0
+    name: LO_in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  Q_out1:
+    center:
+    - 215.0
+    - 1.25
+    layer:
+    - 1
+    - 0
+    name: Q_out1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  Q_out2:
+    center:
+    - 215.0
+    - -1.25
+    layer:
+    - 1
+    - 0
+    name: Q_out2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  signal_in:
+    center:
+    - -40.0
+    - 3.75
+    layer:
+    - 1
+    - 0
+    name: signal_in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mode_converter_.yml
+++ b/tests/test_components/test_settings_mode_converter_.yml
@@ -1,4 +1,53 @@
 name: mode_converter
+ports:
+  o1:
+    center:
+    - -11.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -11.0
+    - 3.05
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 21.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 21.0
+    - 3.05
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi1x2_2x2_.yml
+++ b/tests/test_components/test_settings_mzi1x2_2x2_.yml
@@ -1,4 +1,41 @@
 name: mzi_a62d3423
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 81.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 81.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     combiner:

--- a/tests/test_components/test_settings_mzi2x2_2x2_.yml
+++ b/tests/test_components/test_settings_mzi2x2_2x2_.yml
@@ -1,4 +1,53 @@
 name: mzi_d46c281f
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 81.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 81.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     combiner:

--- a/tests/test_components/test_settings_mzi_.yml
+++ b/tests/test_components/test_settings_mzi_.yml
@@ -1,4 +1,29 @@
 name: mzi
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 81.2
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi_arms_.yml
+++ b/tests/test_components/test_settings_mzi_arms_.yml
@@ -1,4 +1,29 @@
 name: mzi_arms
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 81.1
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi_coupler_.yml
+++ b/tests/test_components/test_settings_mzi_coupler_.yml
@@ -1,4 +1,53 @@
 name: mzi_1fc24805
+ports:
+  o1:
+    center:
+    - -10.0
+    - -1.632
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 2.368
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 110.2
+    - 2.368
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 110.2
+    - -1.632
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     combiner:

--- a/tests/test_components/test_settings_mzi_lattice_.yml
+++ b/tests/test_components/test_settings_mzi_lattice_.yml
@@ -1,4 +1,53 @@
 name: mzi_lattice
+ports:
+  o1:
+    center:
+    - -10.0
+    - -1.65
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 2.35
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 100.2
+    - 2.4
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 100.2
+    - -1.6
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi_lattice_mmi_.yml
+++ b/tests/test_components/test_settings_mzi_lattice_mmi_.yml
@@ -1,4 +1,53 @@
 name: mzi_lattice_mmi
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 81.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 81.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi_pads_center_.yml
+++ b/tests/test_components/test_settings_mzi_pads_center_.yml
@@ -1,4 +1,77 @@
 name: mzi_pads_center
+ports:
+  e1:
+    center:
+    - 19.5
+    - -80.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 19.5
+    - 60.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e3:
+    center:
+    - 551.5
+    - 60.625
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e4:
+    center:
+    - 551.5
+    - -80.625
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 581.1
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzi_phase_shifter_.yml
+++ b/tests/test_components/test_settings_mzi_phase_shifter_.yml
@@ -1,4 +1,53 @@
 name: mzi_7a18d033
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 251.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 281.1
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     length_x: 200

--- a/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
+++ b/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
@@ -1,4 +1,53 @@
 name: mzi_99ca1007
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 251.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 281.1
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     length_x: 200

--- a/tests/test_components/test_settings_mzit_.yml
+++ b/tests/test_components/test_settings_mzit_.yml
@@ -1,4 +1,53 @@
 name: mzit
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.6
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 1.4
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -11.0
+    - 21.4
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - -11.0
+    - 23.4
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_mzit_lattice_.yml
+++ b/tests/test_components/test_settings_mzit_lattice_.yml
@@ -1,4 +1,53 @@
 name: mzit_lattice
+ports:
+  o1:
+    center:
+    - -10.0
+    - -0.6
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 1.4
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -6.0
+    - 21.4
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - -6.0
+    - 23.4
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_nxn_.yml
+++ b/tests/test_components/test_settings_nxn_.yml
@@ -1,4 +1,65 @@
 name: nxn
+ports:
+  o1:
+    center:
+    - 0.0
+    - 4.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 8.0
+    - 6.75
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 8.0
+    - 4.917
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 8.0
+    - 3.083
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 8.0
+    - 1.25
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_optimal_90deg_.yml
+++ b/tests/test_components/test_settings_optimal_90deg_.yml
@@ -1,4 +1,29 @@
 name: optimal_90deg
+ports:
+  e1:
+    center:
+    - 50.0
+    - 581.746
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 100.0
+  e2:
+    center:
+    - 581.746
+    - 50.0
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_optimal_hairpin_.yml
+++ b/tests/test_components/test_settings_optimal_hairpin_.yml
@@ -1,4 +1,29 @@
 name: optimal_hairpin
+ports:
+  e1:
+    center:
+    - -9.11
+    - 0.3
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.2
+  e2:
+    center:
+    - -9.11
+    - -0.3
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.2
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_optimal_step_.yml
+++ b/tests/test_components/test_settings_optimal_step_.yml
@@ -1,4 +1,29 @@
 name: optimal_step
+ports:
+  e1:
+    center:
+    - -38.132
+    - 5.0
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 10
+  e2:
+    center:
+    - 112.672
+    - 11.0
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 22
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pad_.yml
+++ b/tests/test_components/test_settings_pad_.yml
@@ -1,4 +1,65 @@
 name: pad
+ports:
+  e1:
+    center:
+    - -50.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 100.0
+  e2:
+    center:
+    - 0.0
+    - 50.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 100.0
+  e3:
+    center:
+    - 50.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 100.0
+  e4:
+    center:
+    - 0.0
+    - -50.0
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 100.0
+  pad:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: pad
+    orientation: null
+    port_type: vertical_dc
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pad_array0_.yml
+++ b/tests/test_components/test_settings_pad_array0_.yml
@@ -1,4 +1,41 @@
 name: pad_array_3ceac6aa
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e21:
+    center:
+    - 0.0
+    - 150.0
+    layer:
+    - 49
+    - 0
+    name: e21
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e31:
+    center:
+    - 0.0
+    - 300.0
+    layer:
+    - 49
+    - 0
+    name: e31
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed:
     columns: 1

--- a/tests/test_components/test_settings_pad_array180_.yml
+++ b/tests/test_components/test_settings_pad_array180_.yml
@@ -1,4 +1,41 @@
 name: pad_array_bc0d660e
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e21:
+    center:
+    - 0.0
+    - 150.0
+    layer:
+    - 49
+    - 0
+    name: e21
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e31:
+    center:
+    - 0.0
+    - 300.0
+    layer:
+    - 49
+    - 0
+    name: e31
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed:
     columns: 1

--- a/tests/test_components/test_settings_pad_array270_.yml
+++ b/tests/test_components/test_settings_pad_array270_.yml
@@ -1,4 +1,77 @@
 name: pad_array
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e12:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e12
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e13:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e13
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e14:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e14
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e15:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e15
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e16:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e16
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pad_array90_.yml
+++ b/tests/test_components/test_settings_pad_array90_.yml
@@ -1,4 +1,77 @@
 name: pad_array_orientation90
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e12:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e12
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e13:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e13
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e14:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e14
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e15:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e15
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e16:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e16
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed:
     orientation: 90

--- a/tests/test_components/test_settings_pad_array_.yml
+++ b/tests/test_components/test_settings_pad_array_.yml
@@ -1,4 +1,77 @@
 name: pad_array
+ports:
+  e11:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e11
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e12:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e12
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e13:
+    center:
+    - 300.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e13
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e14:
+    center:
+    - 450.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e14
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e15:
+    center:
+    - 600.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e15
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  e16:
+    center:
+    - 750.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e16
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pad_gsg_open_.yml
+++ b/tests/test_components/test_settings_pad_gsg_open_.yml
@@ -1,4 +1,5 @@
 name: pad_gsg_short_shortFalse
+ports: {}
 settings:
   changed:
     short: false

--- a/tests/test_components/test_settings_pad_gsg_short_.yml
+++ b/tests/test_components/test_settings_pad_gsg_short_.yml
@@ -1,4 +1,5 @@
 name: pad_gsg_short
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pad_pdk_.yml
+++ b/tests/test_components/test_settings_pad_pdk_.yml
@@ -1,0 +1,80 @@
+name: pad_pdk
+ports:
+  e1:
+    center:
+    - -40.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 80.0
+  e2:
+    center:
+    - 0.0
+    - 40.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 80.0
+  e3:
+    center:
+    - 40.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 80.0
+  e4:
+    center:
+    - 0.0
+    - -40.0
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 80.0
+  pad:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: pad
+    orientation: null
+    port_type: vertical_dc
+    shear_angle: null
+    width: 80.0
+settings:
+  changed: {}
+  child: null
+  default:
+    pad_width: pad_width
+  full:
+    pad_width: pad_width
+  function_name: pad_pdk
+  info:
+    layer:
+    - 49
+    - 0
+    size:
+    - 80.0
+    - 80.0
+  info_version: 2
+  module: gdsfactory.components.pad
+  name: pad_pdk

--- a/tests/test_components/test_settings_pad_rectangular_.yml
+++ b/tests/test_components/test_settings_pad_rectangular_.yml
@@ -1,0 +1,93 @@
+name: pad_sizepad_size
+ports:
+  e1:
+    center:
+    - -40.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 80
+  e2:
+    center:
+    - 0.0
+    - 40.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 80
+  e3:
+    center:
+    - 40.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 80
+  e4:
+    center:
+    - 0.0
+    - -40.0
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 80
+  pad:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: pad
+    orientation: null
+    port_type: vertical_dc
+    shear_angle: null
+    width: 80
+settings:
+  changed:
+    size: pad_size
+  child: null
+  default:
+    bbox_layers: null
+    bbox_offsets: null
+    layer: MTOP
+    port_inclusion: 0
+    port_orientation: null
+    size:
+    - 100.0
+    - 100.0
+  full:
+    bbox_layers: null
+    bbox_offsets: null
+    layer: MTOP
+    port_inclusion: 0
+    port_orientation: null
+    size: pad_size
+  function_name: pad
+  info:
+    layer:
+    - 49
+    - 0
+    size:
+    - 80.0
+    - 80.0
+  info_version: 2
+  module: gdsfactory.components.pad
+  name: pad_sizepad_size

--- a/tests/test_components/test_settings_pads_shorted_.yml
+++ b/tests/test_components/test_settings_pads_shorted_.yml
@@ -1,4 +1,5 @@
 name: pads_shorted
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_pixel_.yml
+++ b/tests/test_components/test_settings_pixel_.yml
@@ -1,4 +1,5 @@
 name: pixel
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_qrcode_.yml
+++ b/tests/test_components/test_settings_qrcode_.yml
@@ -1,4 +1,5 @@
 name: qrcode
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ramp_.yml
+++ b/tests/test_components/test_settings_ramp_.yml
@@ -1,4 +1,29 @@
 name: ramp
+ports:
+  o1:
+    center:
+    - 0.0
+    - 2.5
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 5.0
+  o2:
+    center:
+    - 10.0
+    - 4.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 8.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_rectangle_.yml
+++ b/tests/test_components/test_settings_rectangle_.yml
@@ -1,4 +1,53 @@
 name: rectangle
+ports:
+  e1:
+    center:
+    - 0.0
+    - 1.0
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  e2:
+    center:
+    - 2.0
+    - 2.0
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 4.0
+  e3:
+    center:
+    - 4.0
+    - 1.0
+    layer:
+    - 1
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 2.0
+  e4:
+    center:
+    - 2.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 4.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_rectangle_with_slits_.yml
+++ b/tests/test_components/test_settings_rectangle_with_slits_.yml
@@ -1,4 +1,5 @@
 name: rectangle_with_slits
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_resistance_meander_.yml
+++ b/tests/test_components/test_settings_resistance_meander_.yml
@@ -1,4 +1,5 @@
 name: resistance_meander
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_resistance_sheet_.yml
+++ b/tests/test_components/test_settings_resistance_sheet_.yml
@@ -1,4 +1,29 @@
 name: resistance_sheet
+ports:
+  pad1:
+    center:
+    - -50.0
+    - 0.0
+    layer:
+    - 24
+    - 0
+    name: pad1
+    orientation: 180
+    port_type: vertical_dc
+    shear_angle: null
+    width: 10
+  pad2:
+    center:
+    - 50.0
+    - 0.0
+    layer:
+    - 24
+    - 0
+    name: pad2
+    orientation: 0
+    port_type: vertical_dc
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_.yml
+++ b/tests/test_components/test_settings_ring_.yml
@@ -1,4 +1,5 @@
 name: ring
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_crow_.yml
+++ b/tests/test_components/test_settings_ring_crow_.yml
@@ -1,4 +1,53 @@
 name: ring_crow
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -10.0
+    - 62.8
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 62.8
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_crow_couplers_.yml
+++ b/tests/test_components/test_settings_ring_crow_couplers_.yml
@@ -1,4 +1,53 @@
 name: ring_crow_couplers
+ports:
+  o1:
+    center:
+    - -10.0
+    - -2.5
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.4
+  o2:
+    center:
+    - 50.0
+    - -2.5
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.6
+  o3:
+    center:
+    - -10.0
+    - 77.5
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.6
+  o4:
+    center:
+    - 50.0
+    - 77.5
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.4
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_double_.yml
+++ b/tests/test_components/test_settings_ring_double_.yml
@@ -1,4 +1,53 @@
 name: ring_double
+ports:
+  o1:
+    center:
+    - -10.01
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -10.01
+    - 21.41
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 21.41
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_double_heater_.yml
+++ b/tests/test_components/test_settings_ring_double_heater_.yml
@@ -1,4 +1,77 @@
 name: ring_double_heater
+ports:
+  e1:
+    center:
+    - -2.01
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 4
+  e2:
+    center:
+    - 2.0
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 4
+  o1:
+    center:
+    - -10.01
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.01
+    - 21.41
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 10.0
+    - 21.41
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_double_pn_.yml
+++ b/tests/test_components/test_settings_ring_double_pn_.yml
@@ -1,4 +1,53 @@
 name: ring_double_pn
+ports:
+  o1:
+    center:
+    - -3.686
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 3.686
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 3.686
+    - 11.6
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - -3.686
+    - 11.6
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_section_based_.yml
+++ b/tests/test_components/test_settings_ring_section_based_.yml
@@ -1,4 +1,29 @@
 name: ring_section_based
+ports:
+  o1:
+    center:
+    - -4.988
+    - -0.807
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 5.512
+    - -0.807
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_.yml
+++ b/tests/test_components/test_settings_ring_single_.yml
@@ -1,4 +1,29 @@
 name: ring_single
+ports:
+  o1:
+    center:
+    - -14.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_array_.yml
+++ b/tests/test_components/test_settings_ring_single_array_.yml
@@ -1,4 +1,29 @@
 name: ring_single_array
+ports:
+  o1:
+    center:
+    - -15.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 50.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_bend_coupler_.yml
+++ b/tests/test_components/test_settings_ring_single_bend_coupler_.yml
@@ -1,4 +1,29 @@
 name: ring_single_bend_coupler
+ports:
+  o1:
+    center:
+    - -15.7
+    - 15.7
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 15.7
+    - 15.7
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_dut_.yml
+++ b/tests/test_components/test_settings_ring_single_dut_.yml
@@ -1,4 +1,29 @@
 name: ring_single_dut
+ports:
+  o1:
+    center:
+    - -9.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 5.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_heater_.yml
+++ b/tests/test_components/test_settings_ring_single_heater_.yml
@@ -1,4 +1,53 @@
 name: ring_single_heater
+ports:
+  e1:
+    center:
+    - -6.0
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 4
+  e2:
+    center:
+    - 2.0
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 4
+  o1:
+    center:
+    - -14.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_ring_single_pn_.yml
+++ b/tests/test_components/test_settings_ring_single_pn_.yml
@@ -1,4 +1,29 @@
 name: ring_single_pn
+ports:
+  o1:
+    center:
+    - -4.096
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 4.096
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_seal_ring_.yml
+++ b/tests/test_components/test_settings_seal_ring_.yml
@@ -1,4 +1,5 @@
 name: seal_ring
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_snspd_.yml
+++ b/tests/test_components/test_settings_snspd_.yml
@@ -1,4 +1,29 @@
 name: snspd
+ports:
+  e1:
+    center:
+    - -2.5
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 0.2
+  e2:
+    center:
+    - 7.5
+    - -8.4
+    layer:
+    - 1
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 0.2
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_double_.yml
+++ b/tests/test_components/test_settings_spiral_double_.yml
@@ -1,4 +1,29 @@
 name: spiral_double
+ports:
+  o1:
+    center:
+    - -0.0
+    - 22.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - -22.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_external_io_.yml
+++ b/tests/test_components/test_settings_spiral_external_io_.yml
@@ -1,4 +1,29 @@
 name: spiral_external_io
+ports:
+  o1:
+    center:
+    - 383.0
+    - -43.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 386.0
+    - -46.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_inner_io_.yml
+++ b/tests/test_components/test_settings_spiral_inner_io_.yml
@@ -1,4 +1,25 @@
 name: spiral_inner_io
+ports:
+  o1:
+    center:
+    - 0.0
+    - 50.0
+    layer: WG
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 127.0
+    - 50.0
+    layer: WG
+    name: o2
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
+++ b/tests/test_components/test_settings_spiral_inner_io_fiber_single_.yml
@@ -1,4 +1,29 @@
 name: spiral_inner_io_2a92e51_825ccbf1
+ports:
+  o1:
+    center:
+    - 0.0
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 210.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_spiral_racetrack_fixed_length_.yml
+++ b/tests/test_components/test_settings_spiral_racetrack_fixed_length_.yml
@@ -1,4 +1,27 @@
 name: spiral_racetrack_fixed_length
+ports:
+  o1:
+    center:
+    - -20.249
+    - 20.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 150.0
+    - 20.0
+    layer: WG
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_racetrack_heater_doped_.yml
+++ b/tests/test_components/test_settings_spiral_racetrack_heater_doped_.yml
@@ -1,4 +1,77 @@
 name: spiral_racetrack_heater_doped
+ports:
+  bot_e1:
+    center:
+    - 0.0
+    - 12.0
+    layer:
+    - 24
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 0.5
+  bot_e2:
+    center:
+    - 30.0
+    - 12.0
+    layer:
+    - 24
+    - 0
+    name: bot_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 0.5
+  o1:
+    center:
+    - 0.0
+    - 18.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 30.0
+    - -36.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - 30.0
+    - -30.0
+    layer:
+    - 24
+    - 0
+    name: top_e1
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 0.5
+  top_e2:
+    center:
+    - 0.0
+    - -30.0
+    layer:
+    - 24
+    - 0
+    name: top_e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_spiral_racetrack_heater_metal_.yml
+++ b/tests/test_components/test_settings_spiral_racetrack_heater_metal_.yml
@@ -1,4 +1,53 @@
 name: spiral_racetrack_heater_metal
+ports:
+  e1:
+    center:
+    - -5.625
+    - 11.0
+    layer:
+    - 47
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 2.5
+  e2:
+    center:
+    - -5.625
+    - -29.0
+    layer:
+    - 47
+    - 0
+    name: e2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 2.5
+  o1:
+    center:
+    - 0.0
+    - 16.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 30.0
+    - -34.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_splitter_chain_.yml
+++ b/tests/test_components/test_settings_splitter_chain_.yml
@@ -1,4 +1,65 @@
 name: mmi1x2_splitter_chain
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 15.5
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 52.0
+    - 2.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 88.5
+    - 4.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 88.5
+    - 5.875
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child:

--- a/tests/test_components/test_settings_splitter_tree_.yml
+++ b/tests/test_components/test_settings_splitter_tree_.yml
@@ -1,4 +1,65 @@
 name: splitter_tree
+ports:
+  o1_0_0:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_0_0
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_1:
+    center:
+    - 195.5
+    - -12.5
+    layer:
+    - 1
+    - 0
+    name: o2_1_1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_2:
+    center:
+    - 195.5
+    - -37.5
+    layer:
+    - 1
+    - 0
+    name: o2_1_2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_3:
+    center:
+    - 195.5
+    - 37.5
+    layer:
+    - 1
+    - 0
+    name: o2_1_3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_4:
+    center:
+    - 195.5
+    - 12.5
+    layer:
+    - 1
+    - 0
+    name: o2_1_4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_staircase_.yml
+++ b/tests/test_components/test_settings_staircase_.yml
@@ -1,4 +1,29 @@
 name: staircase
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 105.0
+    - 100.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_.yml
+++ b/tests/test_components/test_settings_straight_.yml
@@ -1,4 +1,29 @@
 name: straight
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_array_.yml
+++ b/tests/test_components/test_settings_straight_array_.yml
@@ -1,4 +1,101 @@
 name: straight_array
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 0.0
+    - 4.5
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 0.0
+    - 9.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.0
+    - 13.5
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o5:
+    center:
+    - 10.0
+    - 13.5
+    layer:
+    - 1
+    - 0
+    name: o5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o6:
+    center:
+    - 10.0
+    - 9.0
+    layer:
+    - 1
+    - 0
+    name: o6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o7:
+    center:
+    - 10.0
+    - 4.5
+    layer:
+    - 1
+    - 0
+    name: o7
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o8:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o8
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -1,4 +1,125 @@
 name: straight_heater_doped_rib
+ports:
+  bot_e1:
+    center:
+    - -0.2
+    - -20.0
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 154.8
+    - -15.0
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  bot_e3:
+    center:
+    - 309.8
+    - -20.0
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 154.8
+    - -25.0
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 310.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - -0.2
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 154.8
+    - 25.0
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  top_e3:
+    center:
+    - 309.8
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 154.8
+    - 15.0
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -1,4 +1,125 @@
 name: straight_heater_doped_r_fe4184db
+ports:
+  bot_e1:
+    center:
+    - -0.2
+    - -20.0
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 154.8
+    - -15.0
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  bot_e3:
+    center:
+    - 309.8
+    - -20.0
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 154.8
+    - -25.0
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 310.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - -0.2
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 154.8
+    - 25.0
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
+  top_e3:
+    center:
+    - 309.8
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 154.8
+    - 15.0
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 310.0
 settings:
   changed:
     cross_section_heater:

--- a/tests/test_components/test_settings_straight_heater_meander_.yml
+++ b/tests/test_components/test_settings_straight_heater_meander_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_meander
+ports:
+  e1:
+    center:
+    - -21.0
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 90.78
+    - 2.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -25.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 74.778
+    - 4.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_heater_meander_doped_.yml
+++ b/tests/test_components/test_settings_straight_heater_meander_doped_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_meander_doped
+ports:
+  e1:
+    center:
+    - 0.0
+    - 2.0
+    layer:
+    - 45
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 1.5
+  e2:
+    center:
+    - 69.78
+    - 2.0
+    layer:
+    - 45
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 1.5
+  o1:
+    center:
+    - -25.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 74.778
+    - 6.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_heater_metal_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_metal_u_5d466884
+ports:
+  e1:
+    center:
+    - -16.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 336.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     with_undercut: false

--- a/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_metal_u_e2b56ba0
+ports:
+  e1:
+    center:
+    - -10.5
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 330.5
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     port_orientation1: 90

--- a/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_metal_undercut
+ports:
+  e1:
+    center:
+    - -16.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 336.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -1,4 +1,53 @@
 name: straight_heater_metal_u_e2b56ba0
+ports:
+  e1:
+    center:
+    - -10.5
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 330.5
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     port_orientation1: 90

--- a/tests/test_components/test_settings_straight_pin_.yml
+++ b/tests/test_components/test_settings_straight_pin_.yml
@@ -1,4 +1,125 @@
 name: straight_pin
+ports:
+  bot_e1:
+    center:
+    - 0.0
+    - -6.0
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 240.0
+    - -1.0
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  bot_e3:
+    center:
+    - 480.0
+    - -6.0
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 240.0
+    - -11.0
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 490.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - 0.0
+    - 6.0
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 240.0
+    - 11.0
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  top_e3:
+    center:
+    - 480.0
+    - 6.0
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 240.0
+    - 1.0
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_pin_slot_.yml
+++ b/tests/test_components/test_settings_straight_pin_slot_.yml
@@ -1,4 +1,125 @@
 name: straight_pin_slot
+ports:
+  bot_e1:
+    center:
+    - 0.0
+    - -6.5
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 240.0
+    - -1.5
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  bot_e3:
+    center:
+    - 480.0
+    - -6.5
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 240.0
+    - -11.5
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 490.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - 0.0
+    - 6.5
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 240.0
+    - 11.5
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
+  top_e3:
+    center:
+    - 480.0
+    - 6.5
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 240.0
+    - 1.5
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 480.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_straight_pn_.yml
+++ b/tests/test_components/test_settings_straight_pn_.yml
@@ -1,4 +1,125 @@
 name: straight_pin_bacafc60
+ports:
+  bot_e1:
+    center:
+    - 0.0
+    - -6.0
+    layer:
+    - 49
+    - 0
+    name: bot_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e2:
+    center:
+    - 990.0
+    - -1.0
+    layer:
+    - 49
+    - 0
+    name: bot_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 1980.0
+  bot_e3:
+    center:
+    - 1980.0
+    - -6.0
+    layer:
+    - 49
+    - 0
+    name: bot_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  bot_e4:
+    center:
+    - 990.0
+    - -11.0
+    layer:
+    - 49
+    - 0
+    name: bot_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 1980.0
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 1990.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  top_e1:
+    center:
+    - 0.0
+    - 6.0
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e2:
+    center:
+    - 990.0
+    - 11.0
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 1980.0
+  top_e3:
+    center:
+    - 1980.0
+    - 6.0
+    layer:
+    - 49
+    - 0
+    name: top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  top_e4:
+    center:
+    - 990.0
+    - 1.0
+    layer:
+    - 49
+    - 0
+    name: top_e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 1980.0
 settings:
   changed:
     cross_section:

--- a/tests/test_components/test_settings_straight_rib_.yml
+++ b/tests/test_components/test_settings_straight_rib_.yml
@@ -1,4 +1,29 @@
 name: straight_b4efbeb4
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     cross_section:

--- a/tests/test_components/test_settings_straight_rib_tapered_.yml
+++ b/tests/test_components/test_settings_straight_rib_tapered_.yml
@@ -1,4 +1,29 @@
 name: straight_b4efbeb4_exten_40ee8edc
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_components/test_settings_switch_tree_.yml
+++ b/tests/test_components/test_settings_switch_tree_.yml
@@ -1,4 +1,137 @@
 name: splitter_tree_7c3f8531
+ports:
+  e1_0_1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_0_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_3:
+    center:
+    - 519.5
+    - -27.375
+    layer:
+    - 49
+    - 0
+    name: e1_1_3
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_7:
+    center:
+    - 519.5
+    - 72.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_7
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_0_2:
+    center:
+    - 371.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_0_2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_4:
+    center:
+    - 871.5
+    - -27.375
+    layer:
+    - 49
+    - 0
+    name: e2_1_4
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_8:
+    center:
+    - 871.5
+    - 72.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_8
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1_0_0:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1_0_0
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_10:
+    center:
+    - 1401.1
+    - 25.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_10
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_5:
+    center:
+    - 1401.1
+    - -25.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_6:
+    center:
+    - 1401.1
+    - -75.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_9:
+    center:
+    - 1401.1
+    - 75.0
+    layer:
+    - 1
+    - 0
+    name: o2_1_9
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     coupler:

--- a/tests/test_components/test_settings_taper2_.yml
+++ b/tests/test_components/test_settings_taper2_.yml
@@ -1,4 +1,29 @@
 name: taper_width23
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 3.0
 settings:
   changed:
     width2: 3

--- a/tests/test_components/test_settings_taper_.yml
+++ b/tests/test_components/test_settings_taper_.yml
@@ -1,4 +1,29 @@
 name: taper
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
+++ b/tests/test_components/test_settings_taper_0p5_to_3_l36_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 35.23
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 3.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_adiabatic_.yml
+++ b/tests/test_components/test_settings_taper_adiabatic_.yml
@@ -1,4 +1,29 @@
 name: taper_adiabatic
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 22.311
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 5.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -1,4 +1,29 @@
 name: taper_cross_section_lin_fb44ec23
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     linear: true

--- a/tests/test_components/test_settings_taper_cross_section_parabolic_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_parabolic_.yml
@@ -1,4 +1,29 @@
 name: taper_cross_section_4a5f6ea9
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     npoints: 101

--- a/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -1,4 +1,29 @@
 name: taper_cross_section_npoints101
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     npoints: 101

--- a/tests/test_components/test_settings_taper_from_csv_.yml
+++ b/tests/test_components/test_settings_taper_from_csv_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 35.23
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 3.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_parabolic_.yml
+++ b/tests/test_components/test_settings_taper_parabolic_.yml
@@ -1,4 +1,29 @@
 name: taper_parabolic
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 5.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_sc_nc_.yml
+++ b/tests/test_components/test_settings_taper_sc_nc_.yml
@@ -1,4 +1,29 @@
 name: taper_strip_to_ridge_daef8427
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 20.0
+    - 0.0
+    layer:
+    - 34
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed:
     layer_slab: WGN

--- a/tests/test_components/test_settings_taper_strip_to_ridge_.yml
+++ b/tests/test_components/test_settings_taper_strip_to_ridge_.yml
@@ -1,4 +1,29 @@
 name: taper_strip_to_ridge
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 3
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 6.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_strip_to_ridge_trenches_.yml
+++ b/tests/test_components/test_settings_taper_strip_to_ridge_trenches_.yml
@@ -1,4 +1,29 @@
 name: taper_strip_to_ridge_trenches
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_taper_w10_l100_.yml
+++ b/tests/test_components/test_settings_taper_w10_l100_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_d4e8fdfb
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 100.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10.0
 settings:
   changed:
     filepath: taper_strip_0p5_10_100

--- a/tests/test_components/test_settings_taper_w10_l150_.yml
+++ b/tests/test_components/test_settings_taper_w10_l150_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_04444c34
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 150.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10.0
 settings:
   changed:
     filepath: taper_strip_0p5_10_150

--- a/tests/test_components/test_settings_taper_w10_l200_.yml
+++ b/tests/test_components/test_settings_taper_w10_l200_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_66e0dfe8
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 200.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 10.0
 settings:
   changed:
     filepath: taper_strip_0p5_10_200

--- a/tests/test_components/test_settings_taper_w11_l200_.yml
+++ b/tests/test_components/test_settings_taper_w11_l200_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_0e222243
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 200.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     filepath: taper_strip_0p5_11_200

--- a/tests/test_components/test_settings_taper_w12_l200_.yml
+++ b/tests/test_components/test_settings_taper_w12_l200_.yml
@@ -1,4 +1,29 @@
 name: taper_from_csv_edb8f8fa
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 200.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 11.998
 settings:
   changed:
     filepath: taper_strip_0p5_12_200

--- a/tests/test_components/test_settings_terminator_.yml
+++ b/tests/test_components/test_settings_terminator_.yml
@@ -1,4 +1,17 @@
 name: terminator
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_text_.yml
+++ b/tests/test_components/test_settings_text_.yml
@@ -1,4 +1,5 @@
 name: text
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_text_freetype_.yml
+++ b/tests/test_components/test_settings_text_freetype_.yml
@@ -1,4 +1,5 @@
 name: text_freetype
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_text_lines_.yml
+++ b/tests/test_components/test_settings_text_lines_.yml
@@ -1,4 +1,5 @@
 name: text_lines
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_text_rectangular_.yml
+++ b/tests/test_components/test_settings_text_rectangular_.yml
@@ -1,4 +1,5 @@
 name: text_rectangular
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
+++ b/tests/test_components/test_settings_text_rectangular_multi_layer_.yml
@@ -1,4 +1,5 @@
 name: text_rectangular_layerM_02fd6d01
+ports: {}
 settings:
   changed:
     factory:

--- a/tests/test_components/test_settings_triangle_.yml
+++ b/tests/test_components/test_settings_triangle_.yml
@@ -1,4 +1,5 @@
 name: triangle
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_verniers_.yml
+++ b/tests/test_components/test_settings_verniers_.yml
@@ -1,4 +1,5 @@
 name: verniers
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via1_.yml
+++ b/tests/test_components/test_settings_via1_.yml
@@ -1,4 +1,5 @@
 name: via_enclosure2_layerVIA1
+ports: {}
 settings:
   changed:
     enclosure: 2

--- a/tests/test_components/test_settings_via2_.yml
+++ b/tests/test_components/test_settings_via2_.yml
@@ -1,4 +1,5 @@
 name: via_layerVIA2
+ports: {}
 settings:
   changed:
     layer: VIA2

--- a/tests/test_components/test_settings_via_.yml
+++ b/tests/test_components/test_settings_via_.yml
@@ -1,4 +1,5 @@
 name: via
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_corner_.yml
+++ b/tests/test_components/test_settings_via_corner_.yml
@@ -1,4 +1,29 @@
 name: via_corner
+ports:
+  m2_e1:
+    center:
+    - -5.0
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: m2_e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 10.0
+  m3_e2:
+    center:
+    - 0.0
+    - 5.0
+    layer:
+    - 49
+    - 0
+    name: m3_e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 10.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_cutback_.yml
+++ b/tests/test_components/test_settings_via_cutback_.yml
@@ -1,4 +1,5 @@
 name: via_cutback
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_stack_.yml
+++ b/tests/test_components/test_settings_via_stack_.yml
@@ -1,4 +1,53 @@
 name: via_stack
+ports:
+  e1:
+    center:
+    - -5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 0.0
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e3:
+    center:
+    - 5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e4:
+    center:
+    - 0.0
+    - -5.5
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_stack_from_rules_.yml
+++ b/tests/test_components/test_settings_via_stack_from_rules_.yml
@@ -1,4 +1,53 @@
 name: via_stack_from_rules
+ports:
+  e1:
+    center:
+    - -0.6
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 1.2
+  e2:
+    center:
+    - 0.0
+    - 0.6
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 1.2
+  e3:
+    center:
+    - 0.6
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 1.2
+  e4:
+    center:
+    - 0.0
+    - -0.6
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 1.2
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_stack_heater_m3_.yml
+++ b/tests/test_components/test_settings_via_stack_heater_m3_.yml
@@ -1,4 +1,53 @@
 name: via_stack_ab402aa5
+ports:
+  e1:
+    center:
+    - -5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 0.0
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e3:
+    center:
+    - 5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e4:
+    center:
+    - 0.0
+    - -5.5
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     layers:

--- a/tests/test_components/test_settings_via_stack_heater_mtop_.yml
+++ b/tests/test_components/test_settings_via_stack_heater_mtop_.yml
@@ -1,4 +1,53 @@
 name: via_stack_ab402aa5
+ports:
+  e1:
+    center:
+    - -5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 0.0
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e3:
+    center:
+    - 5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e4:
+    center:
+    - 0.0
+    - -5.5
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     layers:

--- a/tests/test_components/test_settings_via_stack_slab_m3_.yml
+++ b/tests/test_components/test_settings_via_stack_slab_m3_.yml
@@ -1,4 +1,53 @@
 name: via_stack_327a8764
+ports:
+  e1:
+    center:
+    - -5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 0.0
+    - 5.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e3:
+    center:
+    - 5.5
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e4:
+    center:
+    - 0.0
+    - -5.5
+    layer:
+    - 49
+    - 0
+    name: e4
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     layers:

--- a/tests/test_components/test_settings_via_stack_slot_.yml
+++ b/tests/test_components/test_settings_via_stack_slot_.yml
@@ -1,4 +1,53 @@
 name: via_stack_slot
+ports:
+  e1:
+    center:
+    - -6.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e2:
+    center:
+    - 0.0
+    - 6.5
+    layer:
+    - 45
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e3:
+    center:
+    - 6.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e4:
+    center:
+    - 0.0
+    - -6.5
+    layer:
+    - 45
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 13.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_stack_slot_m1_m2_.yml
+++ b/tests/test_components/test_settings_via_stack_slot_m1_m2_.yml
@@ -1,4 +1,53 @@
 name: via_stack_slot
+ports:
+  e1:
+    center:
+    - -6.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e1
+    orientation: 180
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e2:
+    center:
+    - 0.0
+    - 6.5
+    layer:
+    - 45
+    - 0
+    name: e2
+    orientation: 90
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e3:
+    center:
+    - 6.5
+    - 0.0
+    layer:
+    - 45
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: placement
+    shear_angle: null
+    width: 13.0
+  e4:
+    center:
+    - 0.0
+    - -6.5
+    layer:
+    - 45
+    - 0
+    name: e4
+    orientation: 270
+    port_type: placement
+    shear_angle: null
+    width: 13.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_via_stack_with_offset_.yml
+++ b/tests/test_components/test_settings_via_stack_with_offset_.yml
@@ -1,4 +1,17 @@
 name: via_stack_with_offset
+ports:
+  e1:
+    center:
+    - 0.0
+    - 10.0
+    layer:
+    - 41
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_viac_.yml
+++ b/tests/test_components/test_settings_viac_.yml
@@ -1,4 +1,5 @@
 name: via
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_wafer_.yml
+++ b/tests/test_components/test_settings_wafer_.yml
@@ -1,4 +1,5 @@
 name: wafer
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_wire_corner_.yml
+++ b/tests/test_components/test_settings_wire_corner_.yml
@@ -1,4 +1,29 @@
 name: wire_corner
+ports:
+  e1:
+    center:
+    - -5.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 0.0
+    - 5.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_wire_sbend_.yml
+++ b/tests/test_components/test_settings_wire_sbend_.yml
@@ -1,4 +1,29 @@
 name: wire_sbend
+ports:
+  e1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 30.0
+    - 20.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
 settings:
   changed: {}
   child: null

--- a/tests/test_components/test_settings_wire_straight_.yml
+++ b/tests/test_components/test_settings_wire_straight_.yml
@@ -1,4 +1,29 @@
 name: straight_cross_sectionm_56ce1600
+ports:
+  e1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
 settings:
   changed:
     cross_section: metal_routing

--- a/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
+++ b/tests/test_containers/test_settings_add_electrical_pads_shortest_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_add_electr_a06d446e
+ports:
+  elec-mzi_2e88f57c-1:
+    center:
+    - 19.5
+    - 122.625
+    layer:
+    - 49
+    - 0
+    name: elec-mzi_2e88f57c-1
+    orientation: null
+    port_type: vertical_dc
+    shear_angle: null
+    width: 100.0
+  elec-mzi_2e88f57c-2:
+    center:
+    - 87.6
+    - 122.625
+    layer:
+    - 49
+    - 0
+    name: elec-mzi_2e88f57c-2
+    orientation: null
+    port_type: vertical_dc
+    shear_angle: null
+    width: 100.0
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_electrical_pads_top_.yml
+++ b/tests/test_containers/test_settings_add_electrical_pads_top_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_add_electr_becb9632
+ports:
+  elec-mzi_2e88f57c-1:
+    center:
+    - 128.6
+    - 178.125
+    layer:
+    - 49
+    - 0
+    name: elec-mzi_2e88f57c-1
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  elec-mzi_2e88f57c-2:
+    center:
+    - -21.4
+    - 178.125
+    layer:
+    - 49
+    - 0
+    name: elec-mzi_2e88f57c-2
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 100.0
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -1,4 +1,101 @@
 name: mzi_2e88f57c_add_fiber__8b3364c2
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-loopback0:
+    center:
+    - -263.9
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-loopback0
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-loopback1:
+    center:
+    - 371.1
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-loopback1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o1:
+    center:
+    - -136.9
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o1
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o2:
+    center:
+    - -9.9
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o2
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o3:
+    center:
+    - 117.1
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o4:
+    center:
+    - 244.1
+    - -81.3
+    layer:
+    - 1
+    - 0
+    name: opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -1,4 +1,101 @@
 name: mzi_2e88f57c_move_3148a_b9b4a46c
+ports:
+  e1:
+    center:
+    - -23.25
+    - 29.5
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - -23.25
+    - 97.6
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  opt_te_1530_15-mzi_2e88f57c-0-0:
+    center:
+    - -25.6
+    - -59.068
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-0-0
+    orientation: 270
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
+  opt_te_1530_15-mzi_2e88f57c-0-1:
+    center:
+    - 24.4
+    - -59.068
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-0-1
+    orientation: 270
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
+  opt_te_1530_15-mzi_2e88f57c-1-0:
+    center:
+    - 24.4
+    - 186.269
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-1-0
+    orientation: 90
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
+  opt_te_1530_15-mzi_2e88f57c-2-0:
+    center:
+    - -25.6
+    - 186.269
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-2-0
+    orientation: 90
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
+  opt_te_1530_15-mzi_2e88f57c-loopback1:
+    center:
+    - -88.823
+    - -59.068
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-loopback1
+    orientation: 270
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
+  opt_te_1530_15-mzi_2e88f57c-loopback2:
+    center:
+    - -88.823
+    - 186.268
+    layer:
+    - 1
+    - 0
+    name: opt_te_1530_15-mzi_2e88f57c-loopback2
+    orientation: 90
+    port_type: opt_te_1530_15
+    shear_angle: null
+    width: 10
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_grating_couplers_.yml
+++ b/tests/test_containers/test_settings_add_grating_couplers_.yml
@@ -1,4 +1,5 @@
 name: mzi_2e88f57c_add_gratin_dd3bd915
+ports: {}
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/tests/test_containers/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_add_gratin_8f3eef46
+ports:
+  loopback1:
+    center:
+    - 175.253
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: loopback1
+    orientation: 270
+    port_type: loopback
+    shear_angle: null
+    width: 0.5
+  loopback2:
+    center:
+    - 175.253
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: loopback2
+    orientation: 90
+    port_type: loopback
+    shear_angle: null
+    width: 0.5
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_padding_container_.yml
+++ b/tests/test_containers/test_settings_add_padding_container_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_add_paddin_91e6753c
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_termination_.yml
+++ b/tests/test_containers/test_settings_add_termination_.yml
@@ -1,4 +1,29 @@
 name: mzi_2e88f57c_add_termin_d4f27b50
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_array_.yml
+++ b/tests/test_containers/test_settings_array_.yml
@@ -1,4 +1,437 @@
 name: array_564dd830
+ports:
+  e1_1_1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_2:
+    center:
+    - 169.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_3:
+    center:
+    - 319.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_3
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_4:
+    center:
+    - 469.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_4
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_5:
+    center:
+    - 619.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_5
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e1_1_6:
+    center:
+    - 769.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1_1_6
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_1:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_1
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_2:
+    center:
+    - 237.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_3:
+    center:
+    - 387.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_4:
+    center:
+    - 537.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_4
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_5:
+    center:
+    - 687.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2_1_6:
+    center:
+    - 837.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2_1_6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1_1_1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_2:
+    center:
+    - 140.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_3:
+    center:
+    - 290.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_4:
+    center:
+    - 440.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_5:
+    center:
+    - 590.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_5
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o1_1_6:
+    center:
+    - 740.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1_1_6
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_1:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_2:
+    center:
+    - 140.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_3:
+    center:
+    - 290.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_3
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_4:
+    center:
+    - 440.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_4
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_5:
+    center:
+    - 590.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_5
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2_1_6:
+    center:
+    - 740.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2_1_6
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_1:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_2:
+    center:
+    - 267.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_3:
+    center:
+    - 417.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_4:
+    center:
+    - 567.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_5:
+    center:
+    - 717.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3_1_6:
+    center:
+    - 867.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3_1_6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_1:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_1
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_2:
+    center:
+    - 267.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_3:
+    center:
+    - 417.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_4:
+    center:
+    - 567.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_5:
+    center:
+    - 717.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_5
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4_1_6:
+    center:
+    - 867.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4_1_6
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_bend_port_.yml
+++ b/tests/test_containers/test_settings_bend_port_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_bend_port_564dd830
+ports:
+  e1:
+    center:
+    - 87.6
+    - 2.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -10.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -10.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 117.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 117.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_cavity_.yml
+++ b/tests/test_containers/test_settings_cavity_.yml
@@ -1,4 +1,29 @@
 name: mzi_2e88f57c_cavity_564dd830
+ports:
+  o1:
+    center:
+    - -10.0
+    - -1.65
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.1
+    - -1.65
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_extend_ports_.yml
+++ b/tests/test_containers/test_settings_extend_ports_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_extend_por_d00b135f
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -15.0
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -15.0
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 122.2
+    - 0.625
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 122.2
+    - -0.625
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/tests/test_containers/test_settings_fanout2x2_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_fanout2x2_564dd830
+ports:
+  e1:
+    center:
+    - 19.5
+    - 22.5
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - 87.6
+    - 22.5
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - -30.0
+    - -10.25
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -30.0
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - 137.2
+    - 10.0
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 137.2
+    - -10.25
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_ring_single_dut_.yml
+++ b/tests/test_containers/test_settings_ring_single_dut_.yml
@@ -1,4 +1,29 @@
 name: ring_single_dut_564dd830
+ports:
+  o1:
+    center:
+    - -9.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 5.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_rotate_.yml
+++ b/tests/test_containers/test_settings_rotate_.yml
@@ -1,4 +1,77 @@
 name: mzi_2e88f57c_rotate_564dd830
+ports:
+  e1:
+    center:
+    - -22.625
+    - 19.5
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  e2:
+    center:
+    - -22.625
+    - 87.6
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  o1:
+    center:
+    - 0.625
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - -0.625
+    - -10.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 270
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o3:
+    center:
+    - -0.625
+    - 117.2
+    layer:
+    - 1
+    - 0
+    name: o3
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o4:
+    center:
+    - 0.625
+    - 117.2
+    layer:
+    - 1
+    - 0
+    name: o4
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     component:

--- a/tests/test_import_gds_markers/test_import_ports_center.yml
+++ b/tests/test_import_gds_markers/test_import_ports_center.yml
@@ -1,2 +1,23 @@
 name: straight_208aa46a
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer: PORT
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer: PORT
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings: {}

--- a/tests/test_import_gds_markers/test_import_ports_inside.yml
+++ b/tests/test_import_gds_markers/test_import_ports_inside.yml
@@ -1,2 +1,23 @@
 name: straight_1514d1a3
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer: PORT
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer: PORT
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings: {}

--- a/tests/test_import_gds_markers/test_import_ports_siepic.yml
+++ b/tests/test_import_gds_markers/test_import_ports_siepic.yml
@@ -1,2 +1,23 @@
 name: straight_aa0e8b9c
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer: PORT
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer: PORT
+    name: o2
+    orientation: 0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings: {}

--- a/tests/test_import_gds_with_hierarchy/test_read_gds_with_settings2.yml
+++ b/tests/test_import_gds_with_hierarchy/test_read_gds_with_settings2.yml
@@ -1,4 +1,29 @@
 name: mzi_6f76ede3
+ports:
+  o1:
+    center:
+    - -10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 81.2
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed:
     cross_section:

--- a/tests/test_paths/test_settings_rename_.yml
+++ b/tests/test_paths/test_settings_rename_.yml
@@ -1,4 +1,29 @@
 name: rename
+ports:
+  in:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 0
+    - 0
+    name: in
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  out:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 0
+    - 0
+    name: out
+    orientation: 90
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/tests/test_paths/test_settings_test_path_.yml
+++ b/tests/test_paths/test_settings_test_path_.yml
@@ -1,4 +1,29 @@
 name: test_path
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 0
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 1.0
+  o2:
+    center:
+    - 83.995
+    - 13.853
+    layer:
+    - 0
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 1.0
 settings:
   changed: {}
   child: null

--- a/tests/test_paths/test_settings_transition_.yml
+++ b/tests/test_paths/test_settings_transition_.yml
@@ -1,4 +1,5 @@
 name: transition
+ports: {}
 settings:
   changed: {}
   child: null

--- a/tests/test_serialize/test_settings.yml
+++ b/tests/test_serialize/test_settings.yml
@@ -1,4 +1,29 @@
 name: demo_cross_section_setting
+ports:
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 10.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
 settings:
   changed: {}
   child: null


### PR DESCRIPTION
- add port info to tests. By default `Component.to_dict()` exports ports information
- name pad_pdk to pad_rectangular