### PR TITLE
better via_stack_with_offset

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
           gf install klayout-integration
       - name: Test with pytest
         run: pytest
-  test_code_coverage:
+  test_code_coverage_python37:
     runs-on: ubuntu-latest
     needs: [pre-commit]
 
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: 3.7
       - name: Install dependencies
         run: |
           make install gdslib

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           make install gdslib

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.7", "3.10"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
           gf install klayout-integration
       - name: Test with pytest
         run: pytest
-  test_code_coverage_python37:
+  test_code_coverage:
     runs-on: ubuntu-latest
     needs: [pre-commit]
 

--- a/gdsfactory/components/ring_section_based.py
+++ b/gdsfactory/components/ring_section_based.py
@@ -13,12 +13,13 @@ import gdsfactory as gf
 from gdsfactory.typings import CrossSectionSpec, Union, List, Tuple, Floats
 from gdsfactory.components.bend_circular import bend_circular
 from gdsfactory.components.straight import straight
+from gdsfactory.cell import cell_without_validator
 
 def_dict = {"A": "rib", "B": "strip"}
 def_ang_dict = {"A": 6, "B": 6}
 
 
-@gf.cell
+@cell_without_validator
 def ring_section_based(
     gap: Union[float, Floats] = 0.3,
     radius: float = 5.0,
@@ -140,8 +141,6 @@ def ring_section_based(
                 "The specified sequence 2 angles do not result in an integer "
                 "number of sequences fitting in the ring."
             )
-
-        print(n_repeats_seq_0)
 
     # Now we are ready to construct the ring
 
@@ -306,4 +305,4 @@ if __name__ == "__main__":
     # c = ring_section_based(add_drop=True)
 
     c.show(show_ports=True)
-    print(c.info["ring_center"])
+    # print(c.info["ring_center"])

--- a/gdsfactory/components/via_stack.py
+++ b/gdsfactory/components/via_stack.py
@@ -114,7 +114,7 @@ def via_stack(
 
 
 @gf.cell
-def circular_via_stack(
+def via_stack_circular(
     radius: float = 10.0,
     angular_extent: float = 45,
     center_angle: float = 0,
@@ -124,6 +124,8 @@ def circular_via_stack(
     layer_port: LayerSpec = None,
 ) -> Component:
     """Circular via array stack.
+
+    FIXME! does not work.
 
     Constructs a circular via array stack. It does so
     by stacking rectangular via stacks offset by a small amount
@@ -159,8 +161,6 @@ def circular_via_stack(
     if end_angle > np.pi:
         end_angle = end_angle - 2 * np.pi
 
-    print(end_angle * 180 / np.pi)
-
     # We do this via-centric: we figure out the min spacing between vias,
     # and from that figure out all the metal dimensions
     # This will of course fail if no via information is provided,
@@ -172,10 +172,8 @@ def circular_via_stack(
 
         metal_bottom = layers[level]
         metal_top = layers[level + 1]
-
         via_type = gf.get_component(via_type)
 
-        # Get via info
         w, h = via_type.info["size"]
         g = via_type.info["enclosure"]
         pitch_x, pitch_y = via_type.info["spacing"]
@@ -204,7 +202,6 @@ def circular_via_stack(
 
             # Let's see if we can do something different
             x, y = pos
-            print(f"x={x}, y={y}")
 
             if x > 0:
                 new_y = y + pitch_y
@@ -230,14 +227,7 @@ def circular_via_stack(
                 print(new_y)
                 print(np.power(radius, 2) - np.power(new_y, 2))
             assert not np.isnan(new_x)
-
-            print(f"new x={new_x}, new y={new_y}")
             ang = np.arctan2(new_y, new_x)
-            print(f"new angle = {ang * 180 / np.pi}")
-
-            # input()
-
-        print("LAYER DONE")
 
     return c
 
@@ -280,7 +270,8 @@ def via_stack_from_rules(
 ) -> Component:
     """Rectangular via array stack, with optimized dimension for vias.
 
-    Uses inclusion, minimum width, and minimum spacing rules to place the maximum number of individual vias, each with maximum via area.
+    Uses inclusion, minimum width, and minimum spacing rules to place the maximum number of individual vias,
+    each with maximum via area.
 
     Args:
         size: of the layers, len(size).
@@ -444,15 +435,17 @@ via_stack_heater_mtop = via_stack_heater_m3 = gf.partial(
 
 
 if __name__ == "__main__":
-    c = via_stack_m1_m3(size=(1.0, 1.0))
-    # print(c.to_dict())
-    c.show(show_ports=True)
+    c = via_stack_heater_mtop(layer_offsets=(0, 1, 2))
 
-    # c = via_stack_from_rules()
-    # c = via_stack_heater_mtop()
+    # c = via_stack_circular()
+    # c = via_stack_m1_m3(size=(1.0, 1.0))
+    # print(c.to_dict())
     # c.show(show_ports=True)
 
-    # c = circular_via_stack(
+    # c = via_stack_from_rules()
+    # c.show(show_ports=True)
+
+    # c = via_stack_circular(
     #     radius=20.0,
     #     angular_extent=300,
     #     center_angle=0,
@@ -461,6 +454,4 @@ if __name__ == "__main__":
     #     vias=(via1, via2),
     #     layer_port=None,
     # )
-    # c.show()
-
-    # test_via_stack_from_rules()
+    c.show(show_ports=True)

--- a/gdsfactory/components/via_stack_with_offset.py
+++ b/gdsfactory/components/via_stack_with_offset.py
@@ -37,8 +37,10 @@ def via_stack_with_offset(
     for layer, via, size, offset in zip(layers, vias, sizes, offsets):
         width, height = size
         x0 = -width / 2
-        ref_bot = c << compass(size=size, layer=layer, port_type="electrical")
-        ref_bot.ymin = y0
+        ref_layer = c << compass(
+            size=(width, 2 * height), layer=layer, port_type="electrical"
+        )
+        ref_layer.ymin = y0
 
         if via:
             via = gf.get_component(via)
@@ -64,10 +66,8 @@ def via_stack_with_offset(
             ref.move((x00, y00))
 
         y0 += offset
-        ref_top = c << compass(size=size, layer=layer, port_type="electrical")
-        ref_top.ymin = y0
 
-    c.add_ports(ref_top.ports)
+    c.add_ports(ref_layer.ports)
     return c
 
 

--- a/gdsfactory/generic_tech/klayout/tech/layers.lyp
+++ b/gdsfactory/generic_tech/klayout/tech/layers.lyp
@@ -73,7 +73,7 @@
   <fill-color>#805000</fill-color>
   <frame-brightness>0</frame-brightness>
   <fill-brightness>0</fill-brightness>
-  <dither-pattern>I1</dither-pattern>
+  <dither-pattern>I3</dither-pattern>
   <line-style/>
   <valid>true</valid>
   <visible>true</visible>

--- a/gdsfactory/generic_tech/layer_views.yaml
+++ b/gdsfactory/generic_tech/layer_views.yaml
@@ -26,7 +26,7 @@ LayerViews:
   SLAB90:
     layer: [3, 0]
     layer_in_name: true
-    hatch_pattern: hollow
+    hatch_pattern: coarsely dotted
     transparent: true
     width: 1
     color: "#805000"

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -17,6 +17,7 @@ skip_test = {
     "pack_doe_grid",
     "crossing",
     "spiral_racetrack",
+    "ring_section_based",
 }
 
 

--- a/tests/test_components/test_settings_via_stack_with_offset_.yml
+++ b/tests/test_components/test_settings_via_stack_with_offset_.yml
@@ -2,13 +2,49 @@ name: via_stack_with_offset
 ports:
   e1:
     center:
-    - 0.0
-    - 10.0
+    - -5.0
+    - 5.0
     layer:
     - 41
     - 0
     name: e1
     orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10
+  e2:
+    center:
+    - 0.0
+    - 10.0
+    layer:
+    - 41
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 10
+  e3:
+    center:
+    - 5.0
+    - 5.0
+    layer:
+    - 41
+    - 0
+    name: e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10
+  e4:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 41
+    - 0
+    name: e4
+    orientation: 270
     port_type: electrical
     shear_angle: null
     width: 10
@@ -20,12 +56,10 @@ settings:
     - PPP
     - M1
     offsets: null
-    port_orientation: 180
-    sizes:
-    - - 10
-      - 10
-    - - 10
-      - 10
+    size:
+    - 10
+    - 10
+    sizes: null
     vias:
     - null
     - function: via
@@ -36,12 +70,10 @@ settings:
     - PPP
     - M1
     offsets: null
-    port_orientation: 180
-    sizes:
-    - - 10
-      - 10
-    - - 10
-      - 10
+    size:
+    - 10
+    - 10
+    sizes: null
     vias:
     - null
     - function: via

--- a/tests/test_components/test_settings_via_stack_with_offset_.yml
+++ b/tests/test_components/test_settings_via_stack_with_offset_.yml
@@ -3,7 +3,7 @@ ports:
   e1:
     center:
     - -5.0
-    - 5.0
+    - 10.0
     layer:
     - 41
     - 0
@@ -11,11 +11,11 @@ ports:
     orientation: 180
     port_type: electrical
     shear_angle: null
-    width: 10
+    width: 20
   e2:
     center:
     - 0.0
-    - 10.0
+    - 20.0
     layer:
     - 41
     - 0
@@ -27,7 +27,7 @@ ports:
   e3:
     center:
     - 5.0
-    - 5.0
+    - 10.0
     layer:
     - 41
     - 0
@@ -35,7 +35,7 @@ ports:
     orientation: 0.0
     port_type: electrical
     shear_angle: null
-    width: 10
+    width: 20
   e4:
     center:
     - 0.0


### PR DESCRIPTION
- better via_stack_with_offset, ports are now on top layer
- rename circular_via_stack to via_stack_circular for consistency. Marked as not working @mdecea 
- change test_coverage to python3.10

@simbilod 