### PR TITLE
mzi does not rename electrical ports

### DIFF
--- a/gdsfactory/components/bend_port.py
+++ b/gdsfactory/components/bend_port.py
@@ -40,7 +40,9 @@ def bend_port(
     c.component = component
 
     if port_name not in component.ports:
-        raise ValueError(f"port_name {port_name} not in {list(component.ports.keys())}")
+        raise ValueError(
+            f"port_name {port_name!r} not in {list(component.ports.keys())}"
+        )
 
     extension_length = extension_length or abs(
         component.ports[port_name2].center[0] - component.ports[port_name].center[0]
@@ -75,5 +77,7 @@ if __name__ == "__main__":
     # c = gf.components.straight_heater_metal()
     # c = bend_port(component=c, port_name="e1")
     # c = bend_port(component=gf.components.mzi_phase_shifter)
-    c = bend_port()
+
+    c = gf.components.mzi2x2_2x2(straight_x_top="straight_heater_metal")
+    c = bend_port(c)
     c.show(show_ports=True)

--- a/gdsfactory/components/mzi.py
+++ b/gdsfactory/components/mzi.py
@@ -170,14 +170,17 @@ def mzi(
     cp2.name = "cp2"
 
     if with_splitter:
-        c.add_ports(cp1.get_ports_list(orientation=180), prefix="in")
+        c.add_ports(cp1.get_ports_list(orientation=180), prefix="in_")
     else:
         c.add_port("o1", port=b1.ports["o1"])
         c.add_port("o2", port=b5.ports["o1"])
-    c.add_ports(cp2.get_ports_list(orientation=0), prefix="out")
-    c.add_ports(sxt.get_ports_list(port_type="electrical"), prefix="top")
-    c.add_ports(sxb.get_ports_list(port_type="electrical"), prefix="bot")
-    c.auto_rename_ports()
+    c.add_ports(cp2.get_ports_list(orientation=0), prefix="ou_")
+
+    c.add_ports(sxt.get_ports_list(port_type="electrical"), prefix="top_")
+    c.add_ports(sxb.get_ports_list(port_type="electrical"), prefix="bot_")
+    c.add_ports(sxt.get_ports_list(port_type="placement"), prefix="top_")
+    c.add_ports(sxb.get_ports_list(port_type="placement"), prefix="bot_")
+    c.auto_rename_ports(port_type="optical", prefix="o")
     return c
 
 

--- a/gdsfactory/components/mzi_pads_center.py
+++ b/gdsfactory/components/mzi_pads_center.py
@@ -16,10 +16,10 @@ def mzi_pads_center(
     pad: ComponentSpec = pad_function,
     length_x: float = 500,
     length_y: float = 40,
-    mzi_sig_top: str = "e3",
-    mzi_gnd_top: str = "e2",
-    mzi_sig_bot: str = "e1",
-    mzi_gnd_bot: str = "e4",
+    mzi_sig_top: str = "top_e2",
+    mzi_gnd_top: str = "top_e1",
+    mzi_sig_bot: str = "bot_e1",
+    mzi_gnd_bot: str = "bot_e2",
     pad_sig_bot: str = "e1_1_1",
     pad_sig_top: str = "e3_1_3",
     pad_gnd_bot: str = "e4_1_2",
@@ -125,13 +125,14 @@ def mzi_pads_center(
         width=metal_route_width,
     )
     c.add(route_sig_top.references)
+
     c.add_ports(m.ports)
     return c
 
 
 if __name__ == "__main__":
-    mzi_ps_fa = gf.compose(gf.routing.add_fiber_array, mzi_pads_center)
-    mzi_ps_fs = gf.compose(gf.routing.add_fiber_single, mzi_pads_center)
+    # mzi_ps_fa = gf.compose(gf.routing.add_fiber_array, mzi_pads_center)
+    # mzi_ps_fs = gf.compose(gf.routing.add_fiber_single, mzi_pads_center)
     # c = mzi_ps_fs()
     c = mzi_pads_center()
     c.show(show_ports=True)

--- a/gdsfactory/components/straight_heater_metal.py
+++ b/gdsfactory/components/straight_heater_metal.py
@@ -24,7 +24,6 @@ def straight_heater_metal_undercut(
     port_orientation2: int = 0,
     heater_taper_length: Optional[float] = 5.0,
     ohms_per_square: Optional[float] = None,
-    cross_section: Optional[CrossSectionSpec] = None,
     **kwargs,
 ) -> Component:
     """Returns a thermal phase shifter.
@@ -51,6 +50,7 @@ def straight_heater_metal_undercut(
     """
     period = length_undercut + length_undercut_spacing
     n = int((length - 2 * length_straight_input) // period)
+    kwargs.pop("cross_section", "")
 
     length_straight_input = (length - n * period) / 2
 
@@ -162,6 +162,6 @@ if __name__ == "__main__":
 
     c = straight_heater_metal(length=40)
     # n = c.get_netlist()
-    # c.show(show_ports=True)
-    scene = c.to_3d()
-    scene.show()
+    c.show(show_ports=True)
+    # scene = c.to_3d()
+    # scene.show()

--- a/gdsfactory/containers.py
+++ b/gdsfactory/containers.py
@@ -9,7 +9,6 @@ from gdsfactory.components.add_grating_couplers import (
     add_grating_couplers_with_loopback_fiber_single,
 )
 from gdsfactory.components.array_component import array
-from gdsfactory.components.bend_port import bend_port
 from gdsfactory.components.cavity import cavity
 from gdsfactory.components.extension import extend_ports
 from gdsfactory.components.pack_doe import pack_doe, pack_doe_grid
@@ -32,7 +31,6 @@ __all__ = [
     "add_padding_container",
     "add_termination",
     "array",
-    "bend_port",
     "cavity",
     "extend_ports",
     "fanout2x2",

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -603,7 +603,11 @@ def get_grid_size() -> float:
 
 def get_constant(constant_name: Any) -> Any:
     """If constant_name is a string returns a the value from the dict."""
-    return get_active_pdk().get_constant(constant_name)
+    return (
+        get_active_pdk().get_constant(constant_name)
+        if isinstance(constant_name, str)
+        else constant_name
+    )
 
 
 def get_sparameters_path() -> pathlib.Path:

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -36,7 +36,7 @@ def add_pads_bot(
     pad: ComponentSpec = pad_rectangular,
     bend: ComponentSpec = "wire_corner",
     straight_separation: float = 15.0,
-    pad_spacing: Union[str, float] = "pad_spacing",
+    pad_spacing: Union[float, str] = "pad_spacing",
     **kwargs,
 ) -> Component:
     """Returns new component with ports connected bottom pads.
@@ -87,6 +87,8 @@ def add_pads_bot(
     """
     component_new = Component()
     component = gf.get_component(component)
+
+    pad_spacing = gf.get_constant(pad_spacing)
 
     cref = component_new << component
     ports = [cref[port_name] for port_name in port_names] if port_names else None
@@ -227,6 +229,6 @@ if __name__ == "__main__":
     c = gf.components.straight_heater_metal(length=100.0)
     # c = gf.components.straight(length=100.0)
 
-    cc = add_pads_top(component=c, port_names=("e1",))
-    # cc = add_pads_top(component=c, port_names=("e1", "e4"), fanout_length=50)
+    # cc = add_pads_top(component=c, port_names=("e1",))
+    cc = add_pads_top(component=c, port_names=("e1", "e2"), fanout_length=50)
     cc.show(show_ports=True)

--- a/tests/test_add_pads/test_settings_test_type0_.yml
+++ b/tests/test_add_pads/test_settings_test_type0_.yml
@@ -84,7 +84,6 @@ settings:
         with_undercut: false
       child: null
       default:
-        cross_section: null
         cross_section_heater: heater_metal
         cross_section_heater_undercut: strip_heater_metal_undercut
         cross_section_waveguide_heater: strip_heater_metal
@@ -100,7 +99,6 @@ settings:
         via_stack: via_stack_heater_mtop
         with_undercut: true
       full:
-        cross_section: null
         cross_section_heater: heater_metal
         cross_section_heater_undercut: strip_heater_metal_undercut
         cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_bend_port_.yml
+++ b/tests/test_components/test_settings_bend_port_.yml
@@ -55,7 +55,6 @@ settings:
       with_undercut: false
     child: null
     default:
-      cross_section: null
       cross_section_heater: heater_metal
       cross_section_heater_undercut: strip_heater_metal_undercut
       cross_section_waveguide_heater: strip_heater_metal
@@ -71,7 +70,6 @@ settings:
       via_stack: via_stack_heater_mtop
       with_undercut: true
     full:
-      cross_section: null
       cross_section_heater: heater_metal
       cross_section_heater_undercut: strip_heater_metal_undercut
       cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_coh_tx_dual_pol_.yml
+++ b/tests/test_components/test_settings_coh_tx_dual_pol_.yml
@@ -36,194 +36,194 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
-  pol1_mzm_i_e1:
+  pol1_mzm_i_top_bot_e1:
     center:
     - 45.5
     - 16.625
     layer:
     - 49
     - 0
-    name: pol1_mzm_i_e1
+    name: pol1_mzm_i_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol1_mzm_i_e2:
-    center:
-    - 45.5
-    - 28.625
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_i_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol1_mzm_i_e3:
+  pol1_mzm_i_top_bot_e2:
     center:
     - 135.5
     - 21.625
     layer:
     - 49
     - 0
-    name: pol1_mzm_i_e3
+    name: pol1_mzm_i_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol1_mzm_i_e4:
-    center:
-    - 135.5
-    - 33.625
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_i_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  pol1_mzm_i_e5:
-    center:
-    - 225.5
-    - 28.625
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_i_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol1_mzm_i_e6:
+  pol1_mzm_i_top_bot_e3:
     center:
     - 225.5
     - 16.625
     layer:
     - 49
     - 0
-    name: pol1_mzm_i_e6
+    name: pol1_mzm_i_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol1_mzm_i_e7:
+  pol1_mzm_i_top_bot_e4:
     center:
     - 135.5
     - 11.625
     layer:
     - 49
     - 0
-    name: pol1_mzm_i_e7
+    name: pol1_mzm_i_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol1_mzm_i_e8:
+  pol1_mzm_i_top_top_e1:
+    center:
+    - 45.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_top_top_e2:
+    center:
+    - 135.5
+    - 33.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_i_top_top_e3:
+    center:
+    - 225.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_i_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_i_top_top_e4:
     center:
     - 135.5
     - 23.625
     layer:
     - 49
     - 0
-    name: pol1_mzm_i_e8
+    name: pol1_mzm_i_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol1_mzm_q_e1:
+  pol1_mzm_q_top_bot_e1:
     center:
     - 45.5
     - -94.875
     layer:
     - 49
     - 0
-    name: pol1_mzm_q_e1
+    name: pol1_mzm_q_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol1_mzm_q_e2:
-    center:
-    - 45.5
-    - -82.875
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_q_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol1_mzm_q_e3:
+  pol1_mzm_q_top_bot_e2:
     center:
     - 135.5
     - -89.875
     layer:
     - 49
     - 0
-    name: pol1_mzm_q_e3
+    name: pol1_mzm_q_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol1_mzm_q_e4:
-    center:
-    - 135.5
-    - -77.875
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_q_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  pol1_mzm_q_e5:
-    center:
-    - 225.5
-    - -82.875
-    layer:
-    - 49
-    - 0
-    name: pol1_mzm_q_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol1_mzm_q_e6:
+  pol1_mzm_q_top_bot_e3:
     center:
     - 225.5
     - -94.875
     layer:
     - 49
     - 0
-    name: pol1_mzm_q_e6
+    name: pol1_mzm_q_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol1_mzm_q_e7:
+  pol1_mzm_q_top_bot_e4:
     center:
     - 135.5
     - -99.875
     layer:
     - 49
     - 0
-    name: pol1_mzm_q_e7
+    name: pol1_mzm_q_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol1_mzm_q_e8:
+  pol1_mzm_q_top_top_e1:
+    center:
+    - 45.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_top_top_e2:
+    center:
+    - 135.5
+    - -77.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol1_mzm_q_top_top_e3:
+    center:
+    - 225.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: pol1_mzm_q_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol1_mzm_q_top_top_e4:
     center:
     - 135.5
     - -87.875
     layer:
     - 49
     - 0
-    name: pol1_mzm_q_e8
+    name: pol1_mzm_q_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
@@ -324,194 +324,194 @@ ports:
     port_type: electrical
     shear_angle: null
     width: 80.0
-  pol2_mzm_i_e1:
+  pol2_mzm_i_top_bot_e1:
     center:
     - 45.5
     - -166.375
     layer:
     - 49
     - 0
-    name: pol2_mzm_i_e1
+    name: pol2_mzm_i_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol2_mzm_i_e2:
-    center:
-    - 45.5
-    - -154.375
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_i_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol2_mzm_i_e3:
+  pol2_mzm_i_top_bot_e2:
     center:
     - 135.5
     - -161.375
     layer:
     - 49
     - 0
-    name: pol2_mzm_i_e3
+    name: pol2_mzm_i_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol2_mzm_i_e4:
-    center:
-    - 135.5
-    - -149.375
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_i_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  pol2_mzm_i_e5:
-    center:
-    - 225.5
-    - -154.375
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_i_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol2_mzm_i_e6:
+  pol2_mzm_i_top_bot_e3:
     center:
     - 225.5
     - -166.375
     layer:
     - 49
     - 0
-    name: pol2_mzm_i_e6
+    name: pol2_mzm_i_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol2_mzm_i_e7:
+  pol2_mzm_i_top_bot_e4:
     center:
     - 135.5
     - -171.375
     layer:
     - 49
     - 0
-    name: pol2_mzm_i_e7
+    name: pol2_mzm_i_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol2_mzm_i_e8:
+  pol2_mzm_i_top_top_e1:
+    center:
+    - 45.5
+    - -154.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_top_top_e2:
+    center:
+    - 135.5
+    - -149.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_i_top_top_e3:
+    center:
+    - 225.5
+    - -154.375
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_i_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_i_top_top_e4:
     center:
     - 135.5
     - -159.375
     layer:
     - 49
     - 0
-    name: pol2_mzm_i_e8
+    name: pol2_mzm_i_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol2_mzm_q_e1:
+  pol2_mzm_q_top_bot_e1:
     center:
     - 45.5
     - -277.875
     layer:
     - 49
     - 0
-    name: pol2_mzm_q_e1
+    name: pol2_mzm_q_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol2_mzm_q_e2:
-    center:
-    - 45.5
-    - -265.875
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_q_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol2_mzm_q_e3:
+  pol2_mzm_q_top_bot_e2:
     center:
     - 135.5
     - -272.875
     layer:
     - 49
     - 0
-    name: pol2_mzm_q_e3
+    name: pol2_mzm_q_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol2_mzm_q_e4:
-    center:
-    - 135.5
-    - -260.875
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_q_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  pol2_mzm_q_e5:
-    center:
-    - 225.5
-    - -265.875
-    layer:
-    - 49
-    - 0
-    name: pol2_mzm_q_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  pol2_mzm_q_e6:
+  pol2_mzm_q_top_bot_e3:
     center:
     - 225.5
     - -277.875
     layer:
     - 49
     - 0
-    name: pol2_mzm_q_e6
+    name: pol2_mzm_q_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  pol2_mzm_q_e7:
+  pol2_mzm_q_top_bot_e4:
     center:
     - 135.5
     - -282.875
     layer:
     - 49
     - 0
-    name: pol2_mzm_q_e7
+    name: pol2_mzm_q_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  pol2_mzm_q_e8:
+  pol2_mzm_q_top_top_e1:
+    center:
+    - 45.5
+    - -265.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_top_top_e2:
+    center:
+    - 135.5
+    - -260.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  pol2_mzm_q_top_top_e3:
+    center:
+    - 225.5
+    - -265.875
+    layer:
+    - 49
+    - 0
+    name: pol2_mzm_q_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  pol2_mzm_q_top_top_e4:
     center:
     - 135.5
     - -270.875
     layer:
     - 49
     - 0
-    name: pol2_mzm_q_e8
+    name: pol2_mzm_q_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null

--- a/tests/test_components/test_settings_coh_tx_single_pol_.yml
+++ b/tests/test_components/test_settings_coh_tx_single_pol_.yml
@@ -1,193 +1,193 @@
 name: coh_tx_single_pol
 ports:
-  mzm_i_e1:
+  mzm_i_top_bot_e1:
     center:
     - 45.5
     - 16.625
     layer:
     - 49
     - 0
-    name: mzm_i_e1
+    name: mzm_i_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  mzm_i_e2:
-    center:
-    - 45.5
-    - 28.625
-    layer:
-    - 49
-    - 0
-    name: mzm_i_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  mzm_i_e3:
+  mzm_i_top_bot_e2:
     center:
     - 135.5
     - 21.625
     layer:
     - 49
     - 0
-    name: mzm_i_e3
+    name: mzm_i_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  mzm_i_e4:
-    center:
-    - 135.5
-    - 33.625
-    layer:
-    - 49
-    - 0
-    name: mzm_i_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  mzm_i_e5:
-    center:
-    - 225.5
-    - 28.625
-    layer:
-    - 49
-    - 0
-    name: mzm_i_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  mzm_i_e6:
+  mzm_i_top_bot_e3:
     center:
     - 225.5
     - 16.625
     layer:
     - 49
     - 0
-    name: mzm_i_e6
+    name: mzm_i_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  mzm_i_e7:
+  mzm_i_top_bot_e4:
     center:
     - 135.5
     - 11.625
     layer:
     - 49
     - 0
-    name: mzm_i_e7
+    name: mzm_i_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  mzm_i_e8:
+  mzm_i_top_top_e1:
+    center:
+    - 45.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_top_top_e2:
+    center:
+    - 135.5
+    - 33.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_i_top_top_e3:
+    center:
+    - 225.5
+    - 28.625
+    layer:
+    - 49
+    - 0
+    name: mzm_i_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_i_top_top_e4:
     center:
     - 135.5
     - 23.625
     layer:
     - 49
     - 0
-    name: mzm_i_e8
+    name: mzm_i_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  mzm_q_e1:
+  mzm_q_top_bot_e1:
     center:
     - 45.5
     - -94.875
     layer:
     - 49
     - 0
-    name: mzm_q_e1
+    name: mzm_q_top_bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 10.0
-  mzm_q_e2:
-    center:
-    - 45.5
-    - -82.875
-    layer:
-    - 49
-    - 0
-    name: mzm_q_e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  mzm_q_e3:
+  mzm_q_top_bot_e2:
     center:
     - 135.5
     - -89.875
     layer:
     - 49
     - 0
-    name: mzm_q_e3
+    name: mzm_q_top_bot_e2
     orientation: 90
     port_type: electrical
     shear_angle: null
     width: 180.0
-  mzm_q_e4:
-    center:
-    - 135.5
-    - -77.875
-    layer:
-    - 49
-    - 0
-    name: mzm_q_e4
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 180.0
-  mzm_q_e5:
-    center:
-    - 225.5
-    - -82.875
-    layer:
-    - 49
-    - 0
-    name: mzm_q_e5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 10.0
-  mzm_q_e6:
+  mzm_q_top_bot_e3:
     center:
     - 225.5
     - -94.875
     layer:
     - 49
     - 0
-    name: mzm_q_e6
+    name: mzm_q_top_bot_e3
     orientation: 0.0
     port_type: electrical
     shear_angle: null
     width: 10.0
-  mzm_q_e7:
+  mzm_q_top_bot_e4:
     center:
     - 135.5
     - -99.875
     layer:
     - 49
     - 0
-    name: mzm_q_e7
+    name: mzm_q_top_bot_e4
     orientation: 270
     port_type: electrical
     shear_angle: null
     width: 180.0
-  mzm_q_e8:
+  mzm_q_top_top_e1:
+    center:
+    - 45.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_top_top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_top_top_e2:
+    center:
+    - 135.5
+    - -77.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_top_top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 180.0
+  mzm_q_top_top_e3:
+    center:
+    - 225.5
+    - -82.875
+    layer:
+    - 49
+    - 0
+    name: mzm_q_top_top_e3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  mzm_q_top_top_e4:
     center:
     - 135.5
     - -87.875
     layer:
     - 49
     - 0
-    name: mzm_q_e8
+    name: mzm_q_top_top_e4
     orientation: 270
     port_type: electrical
     shear_angle: null

--- a/tests/test_components/test_settings_mzi_pads_center_.yml
+++ b/tests/test_components/test_settings_mzi_pads_center_.yml
@@ -1,49 +1,25 @@
 name: mzi_pads_center
 ports:
-  e1:
+  bot_e1:
     center:
     - 19.5
     - -80.625
     layer:
     - 49
     - 0
-    name: e1
+    name: bot_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 11.0
-  e2:
-    center:
-    - 19.5
-    - 60.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e3:
-    center:
-    - 551.5
-    - 60.625
-    layer:
-    - 49
-    - 0
-    name: e3
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e4:
+  bot_e2:
     center:
     - 551.5
     - -80.625
     layer:
     - 49
     - 0
-    name: e4
+    name: bot_e2
     orientation: 0.0
     port_type: electrical
     shear_angle: null
@@ -72,6 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 60.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 551.5
+    - 60.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed: {}
   child: null
@@ -85,10 +85,10 @@ settings:
     metal_route_width: 10
     mzi:
       function: mzi
-    mzi_gnd_bot: e4
-    mzi_gnd_top: e2
-    mzi_sig_bot: e1
-    mzi_sig_top: e3
+    mzi_gnd_bot: bot_e2
+    mzi_gnd_top: top_e1
+    mzi_sig_bot: bot_e1
+    mzi_sig_top: top_e2
     pad:
       function: pad
     pad_gnd_bot: e4_1_2
@@ -115,10 +115,10 @@ settings:
     metal_route_width: 10
     mzi:
       function: mzi
-    mzi_gnd_bot: e4
-    mzi_gnd_top: e2
-    mzi_sig_bot: e1
-    mzi_sig_top: e3
+    mzi_gnd_bot: bot_e2
+    mzi_gnd_top: top_e1
+    mzi_sig_bot: bot_e1
+    mzi_sig_top: top_e2
     pad:
       function: pad
     pad_gnd_bot: e4_1_2

--- a/tests/test_components/test_settings_mzi_phase_shifter_.yml
+++ b/tests/test_components/test_settings_mzi_phase_shifter_.yml
@@ -1,29 +1,5 @@
 name: mzi_7a18d033
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 251.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - -10.0
@@ -48,6 +24,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 251.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     length_x: 200

--- a/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
+++ b/tests/test_components/test_settings_mzi_phase_shifter_top_heater_metal_.yml
@@ -1,29 +1,5 @@
 name: mzi_99ca1007
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 251.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - -10.0
@@ -48,6 +24,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 251.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     length_x: 200

--- a/tests/test_components/test_settings_straight_heater_metal_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_.yml
@@ -53,7 +53,6 @@ settings:
     with_undercut: false
   child: null
   default:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal
@@ -69,7 +68,6 @@ settings:
     via_stack: via_stack_heater_mtop
     with_undercut: true
   full:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_90_90_.yml
@@ -55,7 +55,6 @@ settings:
     with_undercut: false
   child: null
   default:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal
@@ -71,7 +70,6 @@ settings:
     via_stack: via_stack_heater_mtop
     with_undercut: true
   full:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_undercut_.yml
@@ -52,7 +52,6 @@ settings:
   changed: {}
   child: null
   default:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal
@@ -68,7 +67,6 @@ settings:
     via_stack: via_stack_heater_mtop
     with_undercut: true
   full:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/tests/test_components/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -55,7 +55,6 @@ settings:
     with_undercut: false
   child: null
   default:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal
@@ -71,7 +70,6 @@ settings:
     via_stack: via_stack_heater_mtop
     with_undercut: true
   full:
-    cross_section: null
     cross_section_heater: heater_metal
     cross_section_heater_undercut: strip_heater_metal_undercut
     cross_section_waveguide_heater: strip_heater_metal

--- a/tests/test_components/test_settings_switch_tree_.yml
+++ b/tests/test_components/test_settings_switch_tree_.yml
@@ -1,77 +1,5 @@
 name: splitter_tree_7c3f8531
 ports:
-  e1_0_1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_0_1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_3:
-    center:
-    - 519.5
-    - -27.375
-    layer:
-    - 49
-    - 0
-    name: e1_1_3
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_7:
-    center:
-    - 519.5
-    - 72.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_7
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_0_2:
-    center:
-    - 371.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_0_2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_4:
-    center:
-    - 871.5
-    - -27.375
-    layer:
-    - 49
-    - 0
-    name: e2_1_4
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_8:
-    center:
-    - 871.5
-    - 72.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_8
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1_0_0:
     center:
     - -10.0
@@ -132,6 +60,78 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1_0_1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_0_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_3:
+    center:
+    - 519.5
+    - -27.375
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_3
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_7:
+    center:
+    - 519.5
+    - 72.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_7
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_0_2:
+    center:
+    - 371.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_0_2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_4:
+    center:
+    - 871.5
+    - -27.375
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_4
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_8:
+    center:
+    - 871.5
+    - 72.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_8
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     coupler:

--- a/tests/test_containers/test_settings_add_fiber_array_.yml
+++ b/tests/test_containers/test_settings_add_fiber_array_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_add_fiber__8b3364c2
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 87.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   opt-grating_coupler_ellipti_dd7f7af4-mzi_2e88f57c-loopback0:
     center:
     - -263.9
@@ -96,6 +72,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_fiber_single_.yml
+++ b/tests/test_containers/test_settings_add_fiber_single_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_move_3148a_b9b4a46c
 ports:
-  e1:
-    center:
-    - -23.25
-    - 29.5
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 270
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - -23.25
-    - 97.6
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   opt_te_1530_15-mzi_2e88f57c-0-0:
     center:
     - -25.6
@@ -96,6 +72,30 @@ ports:
     port_type: opt_te_1530_15
     shear_angle: null
     width: 10
+  top_e1:
+    center:
+    - -23.25
+    - 29.5
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - -23.25
+    - 97.6
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_padding_container_.yml
+++ b/tests/test_containers/test_settings_add_padding_container_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_add_paddin_91e6753c
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 87.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - -10.0
@@ -72,6 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_add_termination_.yml
+++ b/tests/test_containers/test_settings_add_termination_.yml
@@ -1,25 +1,25 @@
 name: mzi_2e88f57c_add_termin_d4f27b50
 ports:
-  e1:
+  top_e1:
     center:
     - 19.5
     - 22.625
     layer:
     - 49
     - 0
-    name: e1
+    name: top_e1
     orientation: 180
     port_type: electrical
     shear_angle: null
     width: 11.0
-  e2:
+  top_e2:
     center:
     - 87.6
     - 22.625
     layer:
     - 49
     - 0
-    name: e2
+    name: top_e2
     orientation: 0.0
     port_type: electrical
     shear_angle: null

--- a/tests/test_containers/test_settings_array_.yml
+++ b/tests/test_containers/test_settings_array_.yml
@@ -1,149 +1,5 @@
 name: array_564dd830
 ports:
-  e1_1_1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_2:
-    center:
-    - 169.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_2
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_3:
-    center:
-    - 319.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_3
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_4:
-    center:
-    - 469.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_4
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_5:
-    center:
-    - 619.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_5
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e1_1_6:
-    center:
-    - 769.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1_1_6
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_1:
-    center:
-    - 87.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_1
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_2:
-    center:
-    - 237.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_3:
-    center:
-    - 387.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_3
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_4:
-    center:
-    - 537.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_4
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_5:
-    center:
-    - 687.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_5
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2_1_6:
-    center:
-    - 837.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2_1_6
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1_1_1:
     center:
     - -10.0
@@ -432,6 +288,150 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1_1_1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_2:
+    center:
+    - 169.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_2
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_3:
+    center:
+    - 319.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_3
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_4:
+    center:
+    - 469.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_4
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_5:
+    center:
+    - 619.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_5
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e1_1_6:
+    center:
+    - 769.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1_1_6
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_1:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_1
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_2:
+    center:
+    - 237.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_3:
+    center:
+    - 387.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_3
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_4:
+    center:
+    - 537.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_4
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_5:
+    center:
+    - 687.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_5
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2_1_6:
+    center:
+    - 837.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2_1_6
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_extend_ports_.yml
+++ b/tests/test_containers/test_settings_extend_ports_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_extend_por_d00b135f
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 87.6
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - -15.0
@@ -72,6 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 87.6
+    - 22.625
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_fanout2x2_.yml
+++ b/tests/test_containers/test_settings_fanout2x2_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_fanout2x2_564dd830
 ports:
-  e1:
-    center:
-    - 19.5
-    - 22.5
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 180
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - 87.6
-    - 22.5
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - -30.0
@@ -72,6 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - 19.5
+    - 22.5
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - 87.6
+    - 22.5
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:

--- a/tests/test_containers/test_settings_rotate_.yml
+++ b/tests/test_containers/test_settings_rotate_.yml
@@ -1,29 +1,5 @@
 name: mzi_2e88f57c_rotate_564dd830
 ports:
-  e1:
-    center:
-    - -22.625
-    - 19.5
-    layer:
-    - 49
-    - 0
-    name: e1
-    orientation: 270
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  e2:
-    center:
-    - -22.625
-    - 87.6
-    layer:
-    - 49
-    - 0
-    name: e2
-    orientation: 90
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
   o1:
     center:
     - 0.625
@@ -72,6 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
+  top_e1:
+    center:
+    - -22.625
+    - 19.5
+    layer:
+    - 49
+    - 0
+    name: top_e1
+    orientation: 270
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
+  top_e2:
+    center:
+    - -22.625
+    - 87.6
+    layer:
+    - 49
+    - 0
+    name: top_e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 11.0
 settings:
   changed:
     component:


### PR DESCRIPTION
- `gf.components.mzi` does not rename electrical ports and adds placement ports as well as electrical ports
- `gf.get_constant` only checks for constant if it receives a string