### PR TITLE
optional flag to explicitly set name of returned components from operations

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -942,8 +942,14 @@ class Component(_GeometryHelper):
     def extract(
         self,
         layers: List[Union[Tuple[int, int], str]],
+        name: str = None,
     ) -> Component:
-        """Extract polygons from a Component and returns a new Component."""
+        """Extract polygons from a Component and returns a new Component.
+
+        Arguments:
+            layers: to extract
+            name: optional name to give the returned component
+        """
         from gdsfactory.pdk import get_layer
 
         if type(layers) not in (list, tuple):
@@ -953,7 +959,11 @@ class Component(_GeometryHelper):
         # component = self.copy()
         # component._cell.filter(spec=layers, remove=False)
 
-        component = Component()
+        if name is None:
+            component = Component()
+        else:
+            component = Component(name)
+
         poly_dict = self.get_polygons(by_spec=True, include_paths=False)
 
         for layer in layers:

--- a/gdsfactory/geometry/boolean.py
+++ b/gdsfactory/geometry/boolean.py
@@ -19,6 +19,7 @@ def boolean(
     operation: str,
     precision: float = 1e-4,
     layer: LayerSpec = (1, 0),
+    name: str = None,
 ) -> Component:
     """Performs boolean operations between 2 Component/Reference/list objects.
 
@@ -34,6 +35,7 @@ def boolean(
         operation: {'not', 'and', 'or', 'xor', 'A-B', 'B-A', 'A+B'}.
         precision: float Desired precision for rounding vertex coordinates.
         layer: Specific layer to put polygon geometry on.
+        name: optional name to give the returned component
 
     Returns: Component with polygon(s) of the boolean operations between
       the 2 input Components performed.
@@ -45,7 +47,10 @@ def boolean(
     'B-A' is equivalent to 'not' with the operands switched.
 
     """
-    D = Component()
+    if name is None:
+        D = Component()
+    else:
+        D = Component(name)
     A_polys = []
     B_polys = []
     A = list(A) if isinstance(A, (list, tuple)) else [A]


### PR DESCRIPTION
booleans and extract for now. Extra safety beyond absorbing and naming references