### PR TITLE
Adding possibility to remove original polygons in over_under

### DIFF
--- a/gdsfactory/components/ring_section_based.py
+++ b/gdsfactory/components/ring_section_based.py
@@ -31,6 +31,7 @@ def ring_section_based(
     start_angle: Optional[float] = 10.0,
     drop_cross_section: Optional[CrossSectionSpec] = None,
     bus_cross_section: CrossSectionSpec = "strip",
+    ang_res: Optional[int] = 0.1,
 ) -> gf.Component:
     """Returns a ring made of the specified cross sections.
 
@@ -60,6 +61,7 @@ def ring_section_based(
         drop_cross_section: cross section for the drop port. If not indicated, we assume
             it is the same as init_cross_section.
         bus_cross_section: cross section for the bus waveguide.
+        ang_res: angular resolution to draw the bends for each section
     """
 
     c = gf.Component()
@@ -155,13 +157,23 @@ def ring_section_based(
 
     for key, xsec in cross_sections.items():
         ang = cross_sections_angles[key]
-        b = bend_circular(angle=ang, with_bbox=False, cross_section=xsec, radius=radius)
+        b = bend_circular(
+            angle=ang,
+            with_bbox=False,
+            cross_section=xsec,
+            radius=radius,
+            npoints=np.round(ang / ang_res) + 1 if ang_res is not None else None,
+        )
 
         sections_dict[key] = (b, "o1", "o2")
 
     if start_cross_section is not None:
         b = bend_circular(
-            angle=start_angle, with_bbox=False, cross_section=start_xs, radius=radius
+            angle=start_angle,
+            with_bbox=False,
+            cross_section=start_xs,
+            radius=radius,
+            npoints=np.round(ang / ang_res) + 1 if ang_res is not None else None,
         )
         if "0" in sections_dict:
             raise ValueError(
@@ -175,6 +187,7 @@ def ring_section_based(
             with_bbox=False,
             cross_section=gf.get_cross_section(drop_cross_section),
             radius=radius,
+            npoints=np.round(ang / ang_res) + 1 if ang_res is not None else None,
         )
         if "1" in sections_dict:
             raise ValueError(

--- a/gdsfactory/geometry/maskprep.py
+++ b/gdsfactory/geometry/maskprep.py
@@ -21,7 +21,6 @@ def get_polygons_over_under(
 ) -> List[gdstk.Polygon]:
     """Returns list polygons dilated and eroded by an offset.
     Cleans min width gap and acute angle DRC errors equal to distances.
-
     Args:
         component: Component containing polygons to offset.
         layers: list of layers to remove min gap errors.
@@ -36,10 +35,8 @@ def get_polygons_over_under(
           round joints, it indicates the curvature resolution in number of
           points per full circle.
         layer: Specific layer to put polygon geometry on.
-
     Returns:
         Component containing a polygon(s) with the specified offset applied.
-
     """
     polygons = []
 
@@ -73,53 +70,37 @@ def get_polygons_over_under(
 
 
 @gf.cell
-def over_under(
-    component: ComponentSpec,
-    layers: LayerSpecs,
-    remove_original: bool = False,
-    **kwargs,
-) -> Component:
+def over_under(component: ComponentSpec, layers: LayerSpecs, **kwargs) -> Component:
     c = Component()
     _component = gf.get_component(component)
-    p = get_polygons_over_under(component=_component, layers=layers, **kwargs)
-
     ref = c << _component
-
-    if remove_original:
-        new_c = c.remove_layers(layers)
-    else:
-        new_c = c
-
-    new_c.add(p)
-    new_c.copy_child_info(_component)
-    new_c.add_ports(ref.ports)
-    return new_c
+    p = get_polygons_over_under(component=_component, layers=layers, **kwargs)
+    c.add(p)
+    c.copy_child_info(_component)
+    c.add_ports(ref.ports)
+    return c
 
 
 if __name__ == "__main__":
     from functools import partial
     import gdsfactory as gf
 
-    over_under_slab = partial(
-        over_under, layers=((2, 0)), distances=(0.5,), remove_original=True
-    )
-
-    c = gf.components.coupler_ring(
-        cladding_layers=((2, 0)),
-        cladding_offsets=(0.2,),
-        decorator=over_under_slab,
-    )
-
-    # get_polygons_over_under_slab = partial(
-    #     get_polygons_over_under, layers=((2, 0)), distances=(0.5,)
-    # )
-
-    # c = gf.Component("compnent_clean")
-    # ref = c << gf.components.coupler_ring(
+    # over_under_slab = partial(over_under, layers=((2, 0)), distances=(0.5,))
+    # c = gf.components.coupler_ring(
     #     cladding_layers=((2, 0)),
-    #     cladding_offsets=(0.2,),  # decorator=over_under_slab_decorator
+    #     cladding_offsets=(0.2,),
+    #     decorator=over_under_slab,
     # )
-    # polygons = get_polygons_over_under_slab(ref)
-    # c.add(polygons)
+    get_polygons_over_under_slab = partial(
+        get_polygons_over_under, layers=((2, 0)), distances=(0.5,)
+    )
+
+    c = gf.Component("compnent_clean")
+    ref = c << gf.components.coupler_ring(
+        cladding_layers=((2, 0)),
+        cladding_offsets=(0.2,),  # decorator=over_under_slab_decorator
+    )
+    polygons = get_polygons_over_under_slab(ref)
+    c.add(polygons)
 
     c.show()

--- a/gdsfactory/geometry/maskprep.py
+++ b/gdsfactory/geometry/maskprep.py
@@ -73,37 +73,53 @@ def get_polygons_over_under(
 
 
 @gf.cell
-def over_under(component: ComponentSpec, layers: LayerSpecs, **kwargs) -> Component:
+def over_under(
+    component: ComponentSpec,
+    layers: LayerSpecs,
+    remove_original: bool = False,
+    **kwargs,
+) -> Component:
     c = Component()
     _component = gf.get_component(component)
-    ref = c << _component
     p = get_polygons_over_under(component=_component, layers=layers, **kwargs)
-    c.add(p)
-    c.copy_child_info(_component)
-    c.add_ports(ref.ports)
-    return c
+
+    ref = c << _component
+
+    if remove_original:
+        new_c = c.remove_layers(layers)
+    else:
+        new_c = c
+
+    new_c.add(p)
+    new_c.copy_child_info(_component)
+    new_c.add_ports(ref.ports)
+    return new_c
 
 
 if __name__ == "__main__":
     from functools import partial
     import gdsfactory as gf
 
-    # over_under_slab = partial(over_under, layers=((2, 0)), distances=(0.5,))
-    # c = gf.components.coupler_ring(
-    #     cladding_layers=((2, 0)),
-    #     cladding_offsets=(0.2,),
-    #     decorator=over_under_slab,
-    # )
-    get_polygons_over_under_slab = partial(
-        get_polygons_over_under, layers=((2, 0)), distances=(0.5,)
+    over_under_slab = partial(
+        over_under, layers=((2, 0)), distances=(0.5,), remove_original=True
     )
 
-    c = gf.Component("compnent_clean")
-    ref = c << gf.components.coupler_ring(
+    c = gf.components.coupler_ring(
         cladding_layers=((2, 0)),
-        cladding_offsets=(0.2,),  # decorator=over_under_slab_decorator
+        cladding_offsets=(0.2,),
+        decorator=over_under_slab,
     )
-    polygons = get_polygons_over_under_slab(ref)
-    c.add(polygons)
+
+    # get_polygons_over_under_slab = partial(
+    #     get_polygons_over_under, layers=((2, 0)), distances=(0.5,)
+    # )
+
+    # c = gf.Component("compnent_clean")
+    # ref = c << gf.components.coupler_ring(
+    #     cladding_layers=((2, 0)),
+    #     cladding_offsets=(0.2,),  # decorator=over_under_slab_decorator
+    # )
+    # polygons = get_polygons_over_under_slab(ref)
+    # c.add(polygons)
 
     c.show()


### PR DESCRIPTION
@joamatab @HelgeGehring 

Maskprep operations are amazing, thanks guys for all the work!

I just added an additional parameter to the `over_under` operation in `maskprep.py` that allows to remove the original polygons after the ouo operation.

If `remove_original=False`, the behavior is the previous one, which draws both the polygons resulting from the ouo operation and the original ones:

![image](https://user-images.githubusercontent.com/48526366/228899293-e1a9215b-cff4-4326-9245-e8429a5c8374.png)

If `remove_original=True`, then the original polygons are removed:

![image](https://user-images.githubusercontent.com/48526366/228899432-806c82d1-3d83-4c66-b580-3f19e596dbf4.png)

What do you guys think? Feel free to change the name of the parameter, I could not come up with a better name