### PR TITLE
rib_with_trenches can handled partial adding sections

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -578,7 +578,7 @@ def rib_with_trenches(
     trench_offset = width / 2 + width_trench / 2
     if "sections" in kwargs:
         sections = kwargs["sections"]
-        kwargs["sections"] += [Section(width=width_slab, layer=layer, name="slab")]
+        sections += [Section(width=width_slab, layer=layer, name="slab")]
         del kwargs["sections"]
     else:
         sections = [Section(width=width_slab, layer=layer, name="slab")]


### PR DESCRIPTION
`rib_with_trenches` no longer throws `TypeError: gdsfactory.cross_section.CrossSection() got multiple values for keyword argument 'sections'` when modifying the sections of a cross_section with gdsfactory.partial