### PR TITLE
safer names

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -187,7 +187,7 @@ def cell_without_validator(func):
             component_name = name
 
         if autoname and not hasattr(component, "imported_gds"):
-            component.name = component_name
+            component._cell.name = component_name
 
         if component.info is None:
             component.info = {}

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -184,10 +184,10 @@ class Component(_GeometryHelper):
         self.uid = str(uuid.uuid4())[:8]
 
         if name:
-            warnings.warn(_manual_naming)
+            warnings.warn(_manual_naming, stacklevel=3)
+            name += f"_{self.uid}"
 
         name = name or "Unnamed"
-        name += f"_{self.uid}"
 
         self._cell = gdstk.Cell(name=name)
         self.name = name
@@ -229,7 +229,7 @@ class Component(_GeometryHelper):
 
     @name.setter
     def name(self, value):
-        warnings.warn(_manual_naming)
+        warnings.warn(_manual_naming, stacklevel=3)
         self._cell.name = value
 
     def __iter__(self):

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -184,13 +184,13 @@ class Component(_GeometryHelper):
         self.uid = str(uuid.uuid4())[:8]
 
         if name:
-            warnings.warn(_manual_naming, stacklevel=3)
+            warnings.warn(_manual_naming, stacklevel=2)
             name += f"_{self.uid}"
 
         name = name or "Unnamed"
 
         self._cell = gdstk.Cell(name=name)
-        self.name = name
+        self._cell.name = name
         self.info: Dict[str, Any] = {}
 
         self.settings: Dict[str, Any] = {}
@@ -229,7 +229,7 @@ class Component(_GeometryHelper):
 
     @name.setter
     def name(self, value):
-        warnings.warn(_manual_naming, stacklevel=3)
+        warnings.warn(_manual_naming, stacklevel=2)
         self._cell.name = value
 
     def __iter__(self):

--- a/gdsfactory/samples/demo/pcell.py
+++ b/gdsfactory/samples/demo/pcell.py
@@ -18,6 +18,6 @@ def mzi_with_bend(radius: float = 10):
 
 
 if __name__ == "__main__":
-    c = mzi_with_bend(radius=25)
+    c = mzi_with_bend(radius=100)
     # c = gf.routing.add_fiber_single(c)
     c.show(show_ports=True)

--- a/tests/test_get_route_error.py
+++ b/tests/test_get_route_error.py
@@ -6,9 +6,10 @@ import gdsfactory as gf
 from gdsfactory.routing.manhattan import RouteWarning
 
 
+@gf.cell
 def test_route_error():
     """Ensures that an impossible route raises RouteWarning."""
-    c = gf.Component("test_route_error")
+    c = gf.Component()
     w = gf.components.straight()
     left = c << w
     right = c << w


### PR DESCRIPTION
- if you manually pass the name we append a `uuid` and raise a warning
- only names coming from the cell decorator won't raise warnings


some tests are still failing

Solutions:

- use `Component.rename` that makes sure it's not on the cache


TODO:

- we should avoid bad behaviors in our own documentation


@tvt173 
@simbilod 
