### PR TITLE
wire_corner45

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -296,7 +296,7 @@ from gdsfactory.components.via_stack import (
 from gdsfactory.components.via_stack_slot import via_stack_slot, via_stack_slot_m1_m2
 from gdsfactory.components.via_stack_with_offset import via_stack_with_offset
 from gdsfactory.components.wafer import wafer
-from gdsfactory.components.wire import wire_corner, wire_straight
+from gdsfactory.components.wire import wire_corner, wire_straight, wire_corner45
 from gdsfactory.components.wire_sbend import wire_sbend
 from gdsfactory.get_factories import get_cells
 
@@ -594,6 +594,7 @@ __all__ = [
     "via_corner",
     "wafer",
     "wire_corner",
+    "wire_corner45",
     "wire_sbend",
     "wire_straight",
 ]

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -6,6 +6,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight
 from gdsfactory.typings import CrossSectionSpec
+import numpy as np
 
 wire_straight = gf.partial(straight, cross_section="metal_routing")
 
@@ -48,6 +49,52 @@ def wire_corner(
     )
     c.info["length"] = width
     c.info["dy"] = width
+    return c
+
+
+@gf.cell
+def wire_corner45(
+    cross_section: CrossSectionSpec = "metal_routing", radius: float = 10, **kwargs
+) -> Component:
+    """Returns 90 degrees electrical corner wire.
+
+    Args:
+        cross_section: spec.
+        kwargs: cross_section settings.
+    """
+    x = gf.get_cross_section(cross_section, **kwargs)
+    layer = x.layer
+    width = x.width
+    radius = x.radius if radius is None else radius
+    if radius is None:
+        raise ValueError(
+            "Radius needs to be specified in wire_corner45 or in the cross_section."
+        )
+
+    c = Component()
+    a = width / 2
+
+    xpts = [0, radius - a, radius + a, 0]
+    ypts = [a, radius, radius, -a]
+
+    c.add_polygon([xpts, ypts], layer=layer)
+    c.add_port(
+        name="e1",
+        center=(0, 0),
+        width=width,
+        orientation=180,
+        layer=layer,
+        port_type="electrical",
+    )
+    c.add_port(
+        name="e2",
+        center=(radius, radius),
+        width=width,
+        orientation=90,
+        layer=layer,
+        port_type="electrical",
+    )
+    c.info["length"] = np.sqrt(2) * radius
     return c
 
 


### PR DESCRIPTION
Electrical wire corner that turns with 45 degrees

Could be better than a sharp corner at RF, and comply with non-freeform DRC

``` import gdsfactory as gf

    c = gf.Component("sample_connect")
    mmi1 = c << gf.components.mmi1x2()
    mmi2 = c << gf.components.mmi1x2()
    mmi2.move((200, 50))

    from gdsfactory.components.wire import wire_corner45

    route = gf.routing.get_route(
        mmi1.ports["o3"],
        mmi2.ports["o1"],
        cross_section=gf.cross_section.strip(),
        bend=wire_corner45,
        auto_widen=True,
        width_wide=2,
        auto_widen_minimum_length=100,
        radius=30,
    )
    c.add(route.references)
    c.show()
```

![image](https://user-images.githubusercontent.com/46427609/230097330-7cf8d7ea-f643-4571-847d-159b8709bafe.png)
