### PR TITLE
Add option to inset individual Sections when extruding Paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
 
+## 6.85.0
+
+- add section inset [PR](https://github.com/gdsfactory/gdsfactory/pull/1555)
+
 ## 6.84.0
 
 - better_cutback component [PR](https://github.com/gdsfactory/gdsfactory/pull/1554)

--- a/docs/notebooks/03_waveguides_paths_crossections.py
+++ b/docs/notebooks/03_waveguides_paths_crossections.py
@@ -1,18 +1,20 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
 #   jupytext:
+#     custom_cell_magics: kql
 #     text_representation:
 #       extension: .py
-#       format_name: light
-#       format_version: '1.5'
-#       jupytext_version: 1.14.4
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 # ---
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # # Path and CrossSection
 #
 # You can create a `Path` in gdsfactory and extrude it with an arbitrary `CrossSection`.
@@ -30,7 +32,7 @@
 # Let's start out by creating a blank `Path` and using the built-in functions to
 # make a few smooth turns.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -55,31 +57,31 @@ P.append(gf.path.straight(length=10))
 
 f = P.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 p2 = P.copy().rotate()
 f = p2.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P.points - p2.points
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # You can also modify our Path in the same ways as any other gdsfactory object:
 #
 # - Manipulation with `move()`, `rotate()`, `mirror()`, etc
 # - Accessing properties like `xmin`, `y`, `center`, `bbox`, etc
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P.movey(10)
 P.xmin = 20
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # You can also check the length of the curve with the `length()` method:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P.length()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## CrossSection
 #
 # Now that you've got your path defined, the next step is to define the cross-section of the path. To do this, you can create a blank `CrossSection` and add whatever cross-sections you want to it.
@@ -90,34 +92,34 @@ P.length()
 #
 # The simplest option is to just set the cross-section to be a constant width by passing a number to `extrude()` like so:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Extrude the Path and the CrossSection
 c = gf.path.extrude(P, layer=(1, 0), width=1.5)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ### Option 2: Linearly-varying width
 #
 # A slightly more advanced version is to make the cross-section width vary linearly from start to finish by passing a 2-element list to `extrude()` like so:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Extrude the Path and the CrossSection
 c = gf.path.extrude(P, layer=(1, 0), widths=(1, 3))
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ### Option 3: Arbitrary Cross-section
 #
 # You can also extrude an arbitrary cross_section
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Now, what if we want a more complicated straight?  For instance, in some
 # photonic applications it's helpful to have a shallow etch that appears on either
 # side of the straight (often called a trench or sleeve).  Additionally, it might be nice
 # to have a Port on either end of the center section so we can snap other
 # geometries to it.  Let's try adding something like that in:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 p = gf.path.straight()
 
 # Add a few "sections" to the cross-section
@@ -130,14 +132,14 @@ x = gf.CrossSection(
 c = gf.path.extrude(p, cross_section=x)
 c
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 p = gf.path.arc()
 
 # Combine the Path and the CrossSection
 b = gf.path.extrude(p, cross_section=x)
 b
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Building Paths quickly
 #
 # You can pass `append()` lists of path segments.  This makes it easy to combine
@@ -146,7 +148,7 @@ b
 # **Example 1:** Assemble a complex path by making a list of Paths and passing it
 # to `append()`
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path()
 
 # Create the basic Path components
@@ -171,11 +173,11 @@ P.append(
 
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # **Example 2:** Create an "S-turn" just by making a list of `[left_turn,
 # right_turn]`
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path()
 
 # Create an "S-turn" just by making a list
@@ -184,11 +186,11 @@ s_turn = [left_turn, right_turn]
 P.append(s_turn)
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # **Example 3:** Repeat the S-turn 3 times by nesting our S-turn list in another
 # list
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path()
 
 # Create an "S-turn" using a list
@@ -200,24 +202,24 @@ triple_s_turn = [s_turn, s_turn, s_turn]
 P.append(triple_s_turn)
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Note you can also use the Path() constructor to immediately construct your Path:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path([straight, left_turn, straight, right_turn, straight])
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Waypoint smooth paths
 #
 # You can also build smooth paths between waypoints with the `smooth()` function
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 points = np.array([(20, 10), (40, 10), (20, 40), (50, 40), (50, 20), (70, 20)])
 plt.plot(points[:, 0], points[:, 1], ".-")
 plt.axis("equal")
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 points = np.array([(20, 10), (40, 10), (20, 40), (50, 40), (50, 20), (70, 20)])
 
 P = gf.path.smooth(
@@ -228,21 +230,21 @@ P = gf.path.smooth(
 )
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Waypoint sharp paths
 #
 # It's also possible to make more traditional angular paths (e.g. electrical wires) in a few different ways.
 #
 # **Example 1:** Using a simple list of points
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path([(20, 10), (30, 10), (40, 30), (50, 30), (50, 20), (70, 20)])
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # **Example 2:** Using the "turn and move" method, where you manipulate the end angle of the Path so that when you append points to it, they're in the correct direction.  *Note: It is crucial that the number of points per straight section is set to 2 (`pp.straight(length, num_pts = 2)`) otherwise the extrusion algorithm will show defects.*
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path()
 P.append(gf.path.straight(length=10, npoints=2))
 P.end_angle += 90  # "Turn" 90 deg (left)
@@ -253,7 +255,7 @@ P.end_angle = 0  # Force the direction to be 0 degrees
 P.append(gf.path.straight(length=10, npoints=2))  # "Walk" length of 10
 f = P.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 s1 = gf.Section(width=1.5, offset=2.5, layer=(2, 0))
 s2 = gf.Section(width=1.5, offset=-2.5, layer=(3, 0))
 X = gf.CrossSection(width=1, offset=0, layer=(1, 0), sections=[s1, s2])
@@ -261,7 +263,7 @@ component = gf.path.extrude(P, X)
 component
 
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Custom curves
 #
 # Now let's have some fun and try to make a loop-de-loop structure with parallel
@@ -275,7 +277,7 @@ component
 # path.
 
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 def looploop(num_pts=1000):
     """Simple limacon looping curve"""
     t = np.linspace(-np.pi, 0, num_pts)
@@ -304,17 +306,17 @@ X = gf.CrossSection(
 c = gf.path.extrude(P, X)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # You can create Paths from any array of points -- just be sure that they form
 # smooth curves!  If we examine our path `P` we can see that all we've simply
 # created a long list of points:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 path_points = P.points  # Curve points are stored as a numpy array in P.points
 print(np.shape(path_points))  # The shape of the array is Nx2
 print(len(P))  # Equivalently, use len(P) to see how many points are inside
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Simplifying / reducing point usage
 #
 # One of the chief concerns of generating smooth curves is that too many points
@@ -331,30 +333,30 @@ print(len(P))  # Equivalently, use len(P) to see how many points are inside
 # within `1e-3` distance from the original (for the default 1 micron unit size,
 # this corresponds to 1 nanometer resolution):
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # The remaining points form a identical line to within `1e-3` from the original
 c = gf.path.extrude(p=P, cross_section=X, simplify=1e-3)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Let's say we need fewer points.  We can increase the simplify tolerance by
 # specifying `simplify = 1e-1`.  This drops the number of points to ~400 points
 # form a line that is identical to within `1e-1` distance from the original:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c = gf.path.extrude(P, cross_section=X, simplify=1e-1)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Taken to absurdity, what happens if we set `simplify = 0.3`?  Once again, the
 # ~200 remaining points form a line that is within `0.3` units from the original
 # -- but that line looks pretty bad.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c = gf.path.extrude(P, cross_section=X, simplify=0.3)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Curvature calculation
 #
 # The `Path` class has a `curvature()` method that computes the curvature `K` of
@@ -368,7 +370,7 @@ c
 # interpolated, and sudden changes in point density along the curve can cause
 # discontinuities.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 straight_points = 100
 
 P = gf.Path()
@@ -393,33 +395,33 @@ P.append(
 
 f = P.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Arc paths are equivalent to `bend_circular` and euler paths are equivalent to `bend_euler`
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 s, K = P.curvature()
 plt.plot(s, K, ".-")
 plt.xlabel("Position along curve (arc length)")
 plt.ylabel("Curvature")
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.path.euler(radius=3, angle=90, p=1.0, use_eff=False)
 P.append(gf.path.euler(radius=3, angle=90, p=0.2, use_eff=False))
 P.append(gf.path.euler(radius=3, angle=90, p=0.0, use_eff=False))
 P.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 s, K = P.curvature()
 plt.plot(s, K, ".-")
 plt.xlabel("Position along curve (arc length)")
 plt.ylabel("Curvature")
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # You can compare two 90 degrees euler bend with 180 euler bend.
 #
 # A 180 euler bend is shorter, and has less loss than two 90 degrees euler bend.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 straight_points = 100
 
 P = gf.Path()
@@ -434,13 +436,13 @@ P.append(
 
 f = P.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 s, K = P.curvature()
 plt.plot(s, K, ".-")
 plt.xlabel("Position along curve (arc length)")
 plt.ylabel("Curvature")
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Transitioning between cross-sections
 #
 # Often a critical element of building paths is being able to transition between
@@ -454,7 +456,7 @@ plt.ylabel("Curvature")
 # function will try to match names between the two input cross-sections, and any
 # names not present in both inputs will be skipped.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Create our first CrossSection
 s1 = gf.Section(width=2.2, offset=0, layer=(3, 0), name="etch")
 s2 = gf.Section(width=1.1, offset=3, layer=(1, 0), name="wg2")
@@ -494,13 +496,13 @@ wg2ref.movex(7.5)
 
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Now let's create the transitional CrossSection by calling `transition()` with
 # these two CrossSections as input. If we want the width to vary as a smooth
 # sinusoid between the sections, we can set `width_type` to `'sine'`
 # (alternatively we could also use `'linear'`).
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Create the transitional CrossSection
 Xtrans = gf.path.transition(cross_section1=X1, cross_section2=X2, width_type="sine")
 # Create a Path for the transitional CrossSection to follow
@@ -509,17 +511,17 @@ P3 = gf.path.straight(length=15, npoints=100)
 straight_transition = gf.path.extrude(P3, Xtrans)
 straight_transition
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 wg1
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 wg2
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Now that we have all of our components, let's `connect()` everything and see
 # what it looks like
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c = gf.Component("transition_demo")
 
 wg1ref = c << wg1
@@ -531,11 +533,11 @@ wg2ref.connect("o1", wgtref.ports["o2"])
 
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Note that since `transition()` outputs a `CrossSection`, we can make the
 # transition follow an arbitrary path:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Transition along a curving Path
 P4 = gf.path.euler(radius=25, angle=45, p=0.5, use_eff=False)
 wg_trans = gf.path.extrude(P4, Xtrans)
@@ -551,7 +553,7 @@ wg2_ref.connect("o1", wgt_ref.ports["o2"])
 c
 
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Variable width / offset
 #
 # In some instances, you may want to vary the width or offset of the path's cross-
@@ -563,7 +565,7 @@ c
 # Path and the width at `t==1` is the width at the end.
 
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 def my_custom_width_fun(t):
     # Note: Custom width/offset functions MUST be vectorizable--you must be able
     # to call them with an array input like my_custom_width_fun([0, 0.1, 0.2, 0.3, 0.4])
@@ -583,11 +585,11 @@ c = gf.path.extrude(P, cross_section=X)
 c
 
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # We can do the same thing with the offset argument:
 
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 def my_custom_offset_fun(t):
     # Note: Custom width/offset functions MUST be vectorizable--you must be able
     # to call them with an array input like my_custom_offset_fun([0, 0.1, 0.2, 0.3, 0.4])
@@ -609,7 +611,7 @@ c = gf.path.extrude(P, cross_section=X)
 c
 
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Offsetting a Path
 #
 # Sometimes it's convenient to start with a simple Path and offset the line it
@@ -618,7 +620,7 @@ c
 # function to directly modify each Path.
 
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 def my_custom_offset_fun(t):
     # Note: Custom width/offset functions MUST be vectorizable--you must be able
     # to call them with an array input like my_custom_offset_fun([0, 0.1, 0.2, 0.3, 0.4])
@@ -635,10 +637,10 @@ P2.mirror((1, 0))  # reflect across X-axis
 
 f = P1.plot()
 
-# + tags=[]
+# %% tags=[]
 f2 = P2.plot()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Modifying a CrossSection
 #
 # In case you need to modify the CrossSection, it can be done simply by specifying
@@ -646,7 +648,7 @@ f2 = P2.plot()
 # Here is an example where we name one of thee cross-sectional elements
 # `'myelement1'` and `'myelement2'`:
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Create the Path
 P = gf.path.arc(radius=10, angle=45)
 
@@ -665,11 +667,11 @@ X = gf.CrossSection(
 c = gf.path.extrude(P, X)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # In case we want to change any of the CrossSection elements, we simply access the
 # Python dictionary that specifies that element and modify the values
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Create our first CrossSection
 s1 = gf.Section(width=2.2, offset=0, layer=(3, 0), name="etch")
 s2 = gf.Section(width=1.1, offset=3, layer=(1, 0), name="wg2")
@@ -717,17 +719,17 @@ wg2_ref.connect("o1", wgt_ref.ports["o2"])
 
 c
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 len(c.references)
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # **Note**
 #
 # Any unnamed section in the CrossSection won't be transitioned.
 #
 # If you don't add any named sections in a cross-section it will give you an error when making a transition
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.Path()
 P.append(gf.path.arc(radius=10, angle=90))  # Circular arc
 P.append(gf.path.straight(length=10))  # Straight section
@@ -740,17 +742,17 @@ P.append(gf.path.straight(length=10))
 
 f = P.plot()
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 X1 = gf.CrossSection(width=1, offset=0, layer=(2, 0))
 c = gf.path.extrude(P, X1)
 c
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 X2 = gf.CrossSection(width=2, offset=0, layer=(2, 0))
 c = gf.path.extrude(P, X2)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # For example this will give you an error
 # ```
 # T = gf.path.transition(X, X2)
@@ -758,7 +760,7 @@ c
 #
 # **Solution**
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.path.straight(length=10, npoints=101)
 
 s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90)
@@ -773,22 +775,22 @@ X1 = gf.CrossSection(
 c = gf.path.extrude(P, X1)
 c
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 X2 = gf.CrossSection(
     width=3, offset=0, layer=gf.LAYER.WG, name="core", port_names=("o1", "o2")
 )
 c2 = gf.path.extrude(P, X2)
 c2
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 T = gf.path.transition(X1, X2)
 c3 = gf.path.extrude(P, T)
 c3
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c4 = gf.Component("demo_transition2")
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 start_ref = c4 << c
 trans_ref = c4 << c3
 end_ref = c4 << c2
@@ -796,10 +798,10 @@ end_ref = c4 << c2
 trans_ref.connect("o1", start_ref.ports["o2"])
 end_ref.connect("o1", trans_ref.ports["o2"])
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c4
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## cross-section
 #
 # You can create functions that return a cross_section in 2 ways:
@@ -809,10 +811,10 @@ c4
 #
 # What parameters do `cross_section` take?
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 help(gf.cross_section.cross_section)
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 pin = gf.partial(
     gf.cross_section.strip,
     layer=(2, 0),
@@ -822,18 +824,18 @@ pin = gf.partial(
     ),
 )
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c = gf.components.straight(cross_section=pin)
 c
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 pin5 = gf.components.straight(cross_section=pin, length=5)
 pin5
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # finally, you can also pass most components Dict that define the cross-section
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 gf.components.straight(
     layer=(1, 0),
     width=0.5,
@@ -843,7 +845,7 @@ gf.components.straight(
     ),
 )
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 # Create our first CrossSection
 s1 = gf.Section(width=0.2, offset=0, layer=(3, 0), name="slab")
 X1 = gf.CrossSection(
@@ -878,15 +880,15 @@ P3 = gf.path.straight(length=15, npoints=100)
 straight_transition = gf.path.extrude(P3, Xtrans)
 straight_transition
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 s = straight_transition.to_3d()
 s.show()
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ## Waveguides with Shear Faces
 # By default, an extruded path will end in a face orthogonal to the direction of the path. In some cases, it is desired to have a sheared face that tilts at a given angle from this orthogonal baseline. This can be done by supplying the parameters `shear_angle_start` and `shear_angle_end` to the `extrude()` function.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.path.straight(length=10)
 
 s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90)
@@ -901,35 +903,35 @@ X1 = gf.CrossSection(
 c = gf.path.extrude(P, X1, shear_angle_start=10, shear_angle_end=45)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # By default, the shear angle parameters are `None`, in which case shearing will not be applied to the face.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 c = gf.path.extrude(P, X1, shear_angle_start=None, shear_angle_end=10)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # Shearing should work on paths of arbitrary orientation, as long as their end segments are sufficiently long.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 angle = 45
 P = gf.path.straight(length=10).rotate(angle)
 c = gf.path.extrude(P, X1, shear_angle_start=angle, shear_angle_end=angle)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # For a non-linear path or width profile, the algorithm will intersect the path when sheared inwards and extrapolate linearly going outwards.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 angle = 15
 P = gf.path.euler()
 c = gf.path.extrude(P, X1, shear_angle_start=angle, shear_angle_end=angle)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # The port location, width and orientation remains the same for a sheared component. However, an additional property, `shear_angle` is set to the value of the shear angle. In general, shear ports can be safely connected together.
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.path.straight(length=10)
 P_skinny = gf.path.straight(length=0.5)
 
@@ -957,12 +959,12 @@ print(c1.ports["o1"].to_dict())
 print(c3.ports["o2"].to_dict())
 circuit
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # ### Transitions with Shear faces
 #
 # You can also create a transition with a shear face
 
-# + pycharm={"name": "#%%\n"} tags=[]
+# %% pycharm={"name": "#%%\n"} tags=[]
 P = gf.path.straight(length=10)
 
 s = gf.Section(width=3, offset=0, layer=gf.LAYER.SLAB90, name="slab")
@@ -987,16 +989,16 @@ t = gf.path.transition(X1, X2, width_type="linear")
 c = gf.path.extrude(P, t, shear_angle_start=10, shear_angle_end=45)
 c
 
-# + [markdown] pycharm={"name": "#%% md\n"}
+# %% [markdown] pycharm={"name": "#%% md\n"}
 # This will also work with curves and non-linear width profiles. Keep in mind that points outside the original geometry will be extrapolated linearly.
 
-# + tags=[]
+# %% tags=[]
 angle = 15
 P = gf.path.euler()
 c = gf.path.extrude(P, t, shear_angle_start=angle, shear_angle_end=angle)
 c
-# -
 
+# %% [markdown]
 # ## bbox_layers vs cladding_layers
 #
 # For extruding waveguides you have two options:
@@ -1004,12 +1006,65 @@ c
 # 1. bbox_layers for squared bounding box
 # 2. cladding_layers for extruding a layer that follows the shape of the path.
 
-# + tags=[]
+# %% tags=[]
 xs_bbox = gf.cross_section.cross_section(bbox_layers=[(3, 0)], bbox_offsets=[3])
 w1 = gf.components.bend_euler(cross_section=xs_bbox, with_bbox=True)
 w1
-# -
 
+# %%
 xs_clad = gf.cross_section.cross_section(cladding_layers=[(3, 0)], cladding_offsets=[3])
 w2 = gf.components.bend_euler(cross_section=xs_clad)
 w2
+
+# %% [markdown]
+# ## Insets
+#
+# It's handy to be able to extrude a `CrossSection` along a `Path`, while each `Section` may have a particular inset relative to the main `Section`. An example of this is a waveguide with a heater.
+
+# %%
+import gdsfactory as gf
+
+
+@gf.xsection
+def xs_waveguide_heater():
+    return gf.cross_section.cross_section(
+        layer="WG",
+        width=0.5,
+        sections=(
+            gf.cross_section.Section(
+                name="heater",
+                width=1,
+                layer="HEATER",
+                insets=(1, 2),
+            ),
+        ),
+    )
+
+
+c = gf.components.straight(cross_section=xs_waveguide_heater)
+c
+
+
+# %%
+@gf.xsection
+def xs_waveguide_heater_with_ports():
+    return gf.cross_section.cross_section(
+        layer="WG",
+        width=0.5,
+        sections=(
+            gf.cross_section.Section(
+                name="heater",
+                width=1,
+                layer="HEATER",
+                insets=(1, 2),
+                port_names=("e1", "e2"),
+                port_types=("electrical", "electrical"),
+            ),
+        ),
+    )
+
+
+c = gf.components.straight(cross_section=xs_waveguide_heater_with_ports)
+c
+
+# %%

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -33,7 +33,7 @@ from gdsfactory.cell import cell_without_validator
 from gdsfactory.cell import clear_cache
 from gdsfactory.show import show
 from gdsfactory.read.import_gds import import_gds
-from gdsfactory.cross_section import CrossSection, Section
+from gdsfactory.cross_section import CrossSection, Section, xsection
 from gdsfactory.component_layout import Label
 from gdsfactory import decorators
 from gdsfactory import cross_section
@@ -143,6 +143,7 @@ __all__ = (
     "typings",
     "technology",
     "write_cells",
+    "xsection",
     "PATH",
 )
 __version__ = "6.84.0"

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -41,6 +41,8 @@ class Section(BaseModel):
         offset: center offset (um) or function parameterized function from 0 to 1.
              the offset at t==0 is the offset at the beginning of the Path.
              the offset at t==1 is the offset at the end.
+        insets: distance (um) in x to inset section relative to end of the Path
+             (i.e. (start inset, stop_inset)).
         layer: layer spec. If None does not draw the main section.
         port_names: Optional port names.
         port_types: optical, electrical, ...
@@ -61,6 +63,7 @@ class Section(BaseModel):
 
     width: Union[float, Callable]
     offset: Union[float, Callable] = 0
+    insets: Optional[tuple] = None
     layer: Optional[LayerSpec] = None
     port_names: Tuple[Optional[str], Optional[str]] = (None, None)
     port_types: Tuple[str, str] = ("optical", "optical")

--- a/tests/test_components/test_settings_ring_double_pn_.yml
+++ b/tests/test_components/test_settings_ring_double_pn_.yml
@@ -58,6 +58,7 @@ settings:
       settings:
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -122,6 +123,7 @@ settings:
       settings:
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_ring_single_pn_.yml
+++ b/tests/test_components/test_settings_ring_single_pn_.yml
@@ -33,6 +33,7 @@ settings:
       settings:
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -96,6 +97,7 @@ settings:
       settings:
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_straight_heater_doped_rib_.yml
+++ b/tests/test_components/test_settings_straight_heater_doped_rib_.yml
@@ -130,6 +130,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -196,6 +197,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_straight_heater_doped_strip_.yml
+++ b/tests/test_components/test_settings_straight_heater_doped_strip_.yml
@@ -145,6 +145,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -211,6 +212,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_taper_cross_section_linear_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_linear_.yml
@@ -36,6 +36,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -52,6 +53,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -73,6 +75,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -89,6 +92,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_taper_cross_section_parabolic_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_parabolic_.yml
@@ -36,6 +36,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -52,6 +53,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -73,6 +75,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -89,6 +92,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0

--- a/tests/test_components/test_settings_taper_cross_section_sine_.yml
+++ b/tests/test_components/test_settings_taper_cross_section_sine_.yml
@@ -35,6 +35,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -51,6 +52,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -72,6 +74,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0
@@ -88,6 +91,7 @@ settings:
         radius: 20
         sections:
         - hidden: false
+          insets: null
           layer: SLAB90
           name: slab
           offset: 0


### PR DESCRIPTION
It's handy to be able to extrude a `CrossSection` along a `Path`, while each `Section` may have a particular inset relative to the main `Section`. An example of this is a waveguide with a heater, though it would require adding the `port_names` and `port_types` to `Section` rather than `CrossSection`. At the moment this will return a component with optical ports everywhere:
```
def waveguide_with_heater():
    return gf.cross_section.cross_section(
        layer="WG",
        width=0.5,
        sections=(
            gf.cross_section.Section(
                name="heater",
                width=1,
                layer="HEATER",
                insets=(0.5, 0.5),
                ),
            ),
        )
c = straight(cross_section=waveguide_with_heater)
c.show()
```