### PR TITLE
Use `kj.port` to dynamically infer kweb port

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1463,7 +1463,7 @@ class Component(_GeometryHelper):
             layer_props = get_layer_views()
             layer_props.to_lyp(filepath=lyp_path)
 
-            src = f"http://127.0.0.1:8000/gds?gds_file={escape(str(gdspath))}&layer_props={escape(str(lyp_path))}"
+            src = f"http://127.0.0.1:{kj.port}/gds?gds_file={escape(str(gdspath))}&layer_props={escape(str(lyp_path))}"
             logger.debug(src)
 
             if kj.jupyter_server and not os.environ.get("DOCS", False):


### PR DESCRIPTION
As far as I can see the newest version of kweb defaults to port 8081 for the jupyter version. To avoid future problems I suggest dynamically using the portnumber provided by `kj.port` for the IFrame src.