### PR TITLE
manhattanize hits vertices

### DIFF
--- a/gdsfactory/geometry/manhattanize.py
+++ b/gdsfactory/geometry/manhattanize.py
@@ -31,7 +31,7 @@ def manhattanize_polygon(
         else:
             num_x_steps = abs(int(np.ceil(dx / target_step)))
             num_y_steps = abs(int(np.ceil(dy / target_step)))
-            num_steps = np.min([num_x_steps, num_y_steps])
+            num_steps = np.min([num_x_steps, num_y_steps]) + 1
             x_step = dx / num_steps
             y_step = dy / num_steps
             cur_x = pt1[0]
@@ -67,10 +67,8 @@ def test_manhattanize():
     init_poly = c.add_polygon(poly, layer=1)
     final_poly = c.add_polygon(manhattanize_polygon(poly, target_step=0.05), layer=2)
 
-    print(len(final_poly.points))
-
     assert len(init_poly.points) == 4
-    assert len(final_poly.points) == 342
+    assert len(final_poly.points) == 354
 
 
 if __name__ == "__main__":
@@ -86,4 +84,4 @@ if __name__ == "__main__":
 
     c.show()
 
-    test_manhattanize()
+    # test_manhattanize()

--- a/gdsfactory/geometry/manhattanize.py
+++ b/gdsfactory/geometry/manhattanize.py
@@ -33,7 +33,7 @@ def manhattanize_polygon(
             num_steps = np.min([num_x_steps, num_y_steps])
             x_step = dx / num_steps
             y_step = dy / num_steps
-            cur_x = pt1[0] - 0.5 * x_step
+            cur_x = pt1[0]
             cur_y = pt1[1]
             for _ in range(num_steps):
                 p_manhattan.extend(

--- a/gdsfactory/geometry/manhattanize.py
+++ b/gdsfactory/geometry/manhattanize.py
@@ -6,7 +6,7 @@ import gdstk
 
 def manhattanize_polygon(
     p: Polygon,
-    min_step: float = 0.05,
+    target_step: float = 0.05,
 ):
     """Return a Manhattanized version of the input polygon (where non-x and non-y parallel segments are decomposed into a staircase of small x and y-parallel segments)
 
@@ -14,7 +14,7 @@ def manhattanize_polygon(
 
     Arguments:
         p: input polygon
-        min_step: minimum
+        target_step: target staircase step size
 
     Returns:
         manhattanized polygon
@@ -22,28 +22,40 @@ def manhattanize_polygon(
     p_manhattan = []
     points = list(p.points)
     points.append(p.points[0])
+    x_polarity = 0
     for pt1, pt2 in zip(points[:-1], points[1:]):
         dx = pt2[0] - pt1[0]
         dy = pt2[1] - pt1[1]
         if dx == 0 or dy == 0:
             p_manhattan.append(pt1)
         else:
-            num_x_steps = abs(int(np.floor(dx / min_step)))
-            num_y_steps = abs(int(np.floor(dy / min_step)))
+            num_x_steps = abs(int(np.ceil(dx / target_step)))
+            num_y_steps = abs(int(np.ceil(dy / target_step)))
             num_steps = np.min([num_x_steps, num_y_steps])
             x_step = dx / num_steps
             y_step = dy / num_steps
             cur_x = pt1[0]
             cur_y = pt1[1]
             for _ in range(num_steps):
-                p_manhattan.extend(
-                    (
-                        (cur_x + x_step, cur_y),
-                        (cur_x + x_step, cur_y + y_step),
+                if not x_polarity % 2:
+                    p_manhattan.extend(
+                        (
+                            (cur_x + 0.5 * x_step, cur_y),
+                            (cur_x + 0.5 * x_step, cur_y + y_step),
+                            (cur_x + x_step, cur_y + y_step),
+                        )
                     )
-                )
+                else:
+                    p_manhattan.extend(
+                        (
+                            (cur_x, cur_y + 0.5 * y_step),
+                            (cur_x + x_step, cur_y + 0.5 * y_step),
+                            (cur_x + x_step, cur_y + y_step),
+                        )
+                    )
                 cur_x += x_step
                 cur_y += y_step
+            x_polarity += 1
     return gdstk.Polygon(p_manhattan)
 
 
@@ -53,10 +65,12 @@ def test_manhattanize():
     poly.rotate(np.pi / 4)
     poly.scale(1, 0.5)
     init_poly = c.add_polygon(poly, layer=1)
-    final_poly = c.add_polygon(manhattanize_polygon(poly, min_step=0.05), layer=2)
+    final_poly = c.add_polygon(manhattanize_polygon(poly, target_step=0.05), layer=2)
+
+    print(len(final_poly.points))
 
     assert len(init_poly.points) == 4
-    assert len(final_poly.points) == 228
+    assert len(final_poly.points) == 342
 
 
 if __name__ == "__main__":

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -26,7 +26,7 @@ def route_quad(
     width1: Optional[float] = None,
     width2: Optional[float] = None,
     layer: gf.typings.LayerSpec = "M1",
-    manhattan_min_step: float = None,
+    manhattan_target_step: float = None,
 ) -> gf.Component:
     """Routes a basic quadrilateral polygon directly between two ports.
 
@@ -77,10 +77,11 @@ def route_quad(
     vertices = [vert for _, vert in sorted(zip(angles, vertices), key=lambda x: x[0])]
 
     component = gf.Component()
-    if manhattan_min_step:
+    if manhattan_target_step:
         poly = gdstk.Polygon(vertices)
         component.add_polygon(
-            points=manhattanize_polygon(poly, min_step=manhattan_min_step), layer=layer
+            points=manhattanize_polygon(poly, target_step=manhattan_target_step),
+            layer=layer,
         )
     else:
         component.add_polygon(points=vertices, layer=layer)
@@ -112,10 +113,12 @@ def test_manhattan_route_quad():
         pad2.ports["e4"],
         width1=None,
         width2=None,
-        manhattan_min_step=0.1,
+        manhattan_target_step=0.1,
     )
 
-    assert np.shape(route_gnd.get_polygons()) == (1, 802, 2)
+    print(np.shape(route_gnd.get_polygons()))
+
+    assert np.shape(route_gnd.get_polygons()) == (1, 1202, 2)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -79,8 +79,12 @@ def route_quad(
     component = gf.Component()
     if manhattan_target_step:
         poly = gdstk.Polygon(vertices)
+        polygon_to_add = gdstk.offset(
+            manhattanize_polygon(poly, target_step=manhattan_target_step),
+            distance=manhattan_target_step,
+        )
         component.add_polygon(
-            points=manhattanize_polygon(poly, target_step=manhattan_target_step),
+            points=polygon_to_add,
             layer=layer,
         )
     else:

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -120,9 +120,7 @@ def test_manhattan_route_quad():
         manhattan_target_step=0.1,
     )
 
-    print(np.shape(route_gnd.get_polygons()))
-
-    assert np.shape(route_gnd.get_polygons()) == (1, 1202, 2)
+    assert np.shape(route_gnd.get_polygons()) == (1, 807, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
make sure that the manhattanization hits the vertices to avoid gaps when routing to ports

change from "min length" to "target length"

add some grow operation to fill in small gaps when routing (there's probably a better solution for this)