### PR TITLE
Added CellDecoratorSettings to give ability to change default behavior of cell_without_validator function

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -64,6 +64,17 @@ class Settings(BaseModel):
     child: Optional[Dict[str, Any]] = None
 
 
+class CellDecoratorSettings:
+    with_hash = False
+    autoname = True
+    name = None
+    cache = True
+    flatten = False
+    info = {}
+    prefix = None
+    max_name_length = MAX_NAME_LENGTH
+
+
 def cell_without_validator(func) -> Callable[CellSettings, Component]:
     """Decorator for Component functions.
 
@@ -76,14 +87,14 @@ def cell_without_validator(func) -> Callable[CellSettings, Component]:
     def _cell(*args, **kwargs):
         from gdsfactory.pdk import _ACTIVE_PDK
 
-        with_hash = kwargs.pop("with_hash", False)
-        autoname = kwargs.pop("autoname", True)
-        name = kwargs.pop("name", None)
-        cache = kwargs.pop("cache", True)
-        flatten = kwargs.pop("flatten", False)
-        info = kwargs.pop("info", {})
-        prefix = kwargs.pop("prefix", func.__name__)
-        max_name_length = kwargs.pop("max_name_length", MAX_NAME_LENGTH)
+        with_hash = kwargs.pop("with_hash", CellDecoratorSettings.with_hash)
+        autoname = kwargs.pop("autoname", CellDecoratorSettings.autoname)
+        name = kwargs.pop("name", CellDecoratorSettings.name)
+        cache = kwargs.pop("cache", CellDecoratorSettings.cache)
+        flatten = kwargs.pop("flatten", CellDecoratorSettings.flatten)
+        info = kwargs.pop("info", CellDecoratorSettings.info)
+        prefix = kwargs.pop("prefix", func.__name__ if CellDecoratorSettings.prefix is None else CellDecoratorSettings.prefix)
+        max_name_length = kwargs.pop("max_name_length", CellDecoratorSettings.max_name_length)
 
         sig = inspect.signature(func)
         args_as_kwargs = dict(zip(sig.parameters.keys(), args))

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -11,7 +11,7 @@ import toolz
 from pydantic import BaseModel, validate_arguments
 
 from gdsfactory.component import Component
-from gdsfactory.name import MAX_NAME_LENGTH, clean_name, get_name_short
+from gdsfactory.name import clean_name, get_name_short
 from gdsfactory.serialization import clean_dict, clean_value_name
 
 CACHE: Dict[str, Component] = {}
@@ -64,17 +64,6 @@ class Settings(BaseModel):
     child: Optional[Dict[str, Any]] = None
 
 
-class CellDecoratorSettings:
-    with_hash = False
-    autoname = True
-    name = None
-    cache = True
-    flatten = False
-    info = {}
-    prefix = None
-    max_name_length = MAX_NAME_LENGTH
-
-
 def cell_without_validator(func) -> Callable[CellSettings, Component]:
     """Decorator for Component functions.
 
@@ -86,15 +75,16 @@ def cell_without_validator(func) -> Callable[CellSettings, Component]:
     @functools.wraps(func)
     def _cell(*args, **kwargs):
         from gdsfactory.pdk import _ACTIVE_PDK
+        cell_decorator_settings = _ACTIVE_PDK.cell_decorator_settings
 
-        with_hash = kwargs.pop("with_hash", CellDecoratorSettings.with_hash)
-        autoname = kwargs.pop("autoname", CellDecoratorSettings.autoname)
-        name = kwargs.pop("name", CellDecoratorSettings.name)
-        cache = kwargs.pop("cache", CellDecoratorSettings.cache)
-        flatten = kwargs.pop("flatten", CellDecoratorSettings.flatten)
-        info = kwargs.pop("info", CellDecoratorSettings.info)
-        prefix = kwargs.pop("prefix", func.__name__ if CellDecoratorSettings.prefix is None else CellDecoratorSettings.prefix)
-        max_name_length = kwargs.pop("max_name_length", CellDecoratorSettings.max_name_length)
+        with_hash = kwargs.pop("with_hash", cell_decorator_settings.with_hash)
+        autoname = kwargs.pop("autoname", cell_decorator_settings.autoname)
+        name = kwargs.pop("name", cell_decorator_settings.name)
+        cache = kwargs.pop("cache", cell_decorator_settings.cache)
+        flatten = kwargs.pop("flatten", cell_decorator_settings.flatten)
+        info = kwargs.pop("info", cell_decorator_settings.info)
+        prefix = kwargs.pop("prefix", func.__name__ if cell_decorator_settings.prefix is None else cell_decorator_settings.prefix)
+        max_name_length = kwargs.pop("max_name_length", cell_decorator_settings.max_name_length)
 
         sig = inspect.signature(func)
         args_as_kwargs = dict(zip(sig.parameters.keys(), args))

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -6,6 +6,7 @@ import warnings
 from functools import partial
 from typing import Any, Callable, Optional, Union, Tuple
 from typing_extensions import Literal
+from gdsfactory.name import MAX_NAME_LENGTH
 
 import numpy as np
 from omegaconf import DictConfig
@@ -105,6 +106,43 @@ class OasisWriteSettings(BaseModel):
     )
 
 
+class CellDecoratorSettings(BaseModel):
+    """Settings for cell_without_validator decorator function in gdsfactory.cell."""
+
+    with_hash: bool = Field(
+        default=False,
+        description="If true, will append a hash of the cell to the cell name.",
+    )
+    autoname: bool = Field(
+        default=True,
+        description="If true, will automatically name the cell based on its parameters.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="If set, will override the cell name with this value.",
+    )
+    cache: bool = Field(
+        default=True,
+        description="If true, will cache the cell in the gdsfactory.cell.CACHE",
+    )
+    flatten: bool = Field(
+        default=False,
+        description="If true, will flatten the cell before returning it.",
+    )
+    info: Dict[str, Any] = Field(
+        default={},
+        description="Additional information to store in the cell.",
+    )
+    prefix: Optional[str] = Field(
+        default=None,
+        description="If set, will prepend this string to the cell name.",
+    )
+    max_name_length: int = Field(
+        default=MAX_NAME_LENGTH,
+        description="Maximum length of the cell name.",
+    )
+
+
 class Pdk(BaseModel):
     """Store layers, cross_sections, cell functions, simulation_settings ...
 
@@ -140,6 +178,7 @@ class Pdk(BaseModel):
         circuit_yaml_parser: can parse different YAML formats.
         gds_write_settings: to write GDSII files.
         oasis_settings: to write OASIS files.
+        cell_decorator_settings: settings for cell_without_validator decorator function in gdsfactory.cell.
         bend_points_distance: default points distance for bends in um.
 
     """
@@ -168,6 +207,7 @@ class Pdk(BaseModel):
     circuit_yaml_parser: Callable = cell_from_yaml
     gds_write_settings: GdsWriteSettings = GdsWriteSettings()
     oasis_settings: OasisWriteSettings = OasisWriteSettings()
+    cell_decorator_settings: CellDecoratorSettings = CellDecoratorSettings()
     bend_points_distance: float = 20 * nm
 
     @property


### PR DESCRIPTION
I was challenging to define the setting everywhere in my code when using this to turn off cache or always do flatten.
This way user will be able to change the default behavior of `cell_without_validator` by just updating the `CellDecoratorSettings` class variables.

For example: If the use do not want to use cache for some reason then (My use case is related to that)
This way cache can be turned off defaultly everywhere just by:

```python
pdk = get_active_pdk()
pdk.cell_decorator_settings.cache = False
``` 
Instead of adding `cache=False` in every argument or clearing cache with `gf.clear_cache()` everywhere.
