### PR TITLE
Bugfix: Copy the properties of the polygon

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -11,6 +11,7 @@ import math
 import pathlib
 import uuid
 import warnings
+from copy import deepcopy
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
@@ -1002,6 +1003,8 @@ class Component(_GeometryHelper):
             else:
                 layer, datatype = _parse_layer(layer)
                 polygon = Polygon(polygon.points, layer, datatype)
+            
+            polygon.properties = deepcopy(points.properties)
             self._add_polygons(polygon)
             return polygon
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1004,7 +1004,9 @@ class Component(_GeometryHelper):
                 layer, datatype = _parse_layer(layer)
                 polygon = Polygon(polygon.points, layer, datatype)
             
-            polygon.properties = deepcopy(points.properties)
+            if hasattr(points, "properties"):
+                polygon.properties = deepcopy(points.properties)
+                
             self._add_polygons(polygon)
             return polygon
 


### PR DESCRIPTION
In the current implementation the  `gdstk.Polygon.properties` of the `gdstk.Polygon` is not copied.
This fixes it by adding: 

```python
polygon.properties = deepcopy(points.properties)
``` 