### PR TITLE
fix snapping

### DIFF
--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import gdsfactory as gf
 from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
-from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import CrossSectionSpec
 
 
@@ -30,7 +29,6 @@ def straight(
         o1 -------------- o2
                 length
     """
-    length = snap_to_grid(length)
     p = gf.path.straight(length=length, npoints=npoints)
     x = gf.get_cross_section(cross_section, **kwargs)
 

--- a/tests/test_components/test_settings_spiral_racetrack_fixed_length_.yml
+++ b/tests/test_components/test_settings_spiral_racetrack_fixed_length_.yml
@@ -2,7 +2,7 @@ name: spiral_racetrack_fixed_length
 ports:
   o1:
     center:
-    - -20.249
+    - -20.25
     - 20.0
     layer:
     - 1
@@ -59,11 +59,11 @@ settings:
     with_inner_ports: false
   function_name: spiral_racetrack_fixed_length
   info:
-    length: 999.9950000000001
+    length: 999.9992836540061
     spiral_center:
     - 35.231
     - -2.5
-    straight_length: 65.46149936
+    straight_length: 65.46153546
   info_version: 2
   module: gdsfactory.components.spiral_heater
   name: spiral_racetrack_fixed_length

--- a/tests/test_import_gds_markers_labels/test_import_ports_markers_labels.yml
+++ b/tests/test_import_gds_markers_labels/test_import_ports_markers_labels.yml
@@ -36,7 +36,7 @@ ports:
     width: 10.0
   opt_te_1530_15-straight_aa0e8b9c-loopback2:
     center:
-    - -127.66800000000002
+    - -127.66799999999999
     - -63.22299999999998
     layer:
     - 1


### PR DESCRIPTION
remove snapping in waveguides to fix 1nm snapping issues

fixes https://github.com/gdsfactory/gdsfactory/issues/1666

now it works as as charm! thank you Troy!
@tvt173 