### PR TITLE
FEAT: Suggested developer installation README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ For that you can install gdsfactory locally on your computer in `-e` edit mode.
 git clone https://github.com/gdsfactory/gdsfactory.git
 cd gdsfactory
 pip install -e . pre-commit
+# pip install -e .[full,gmsh,tidy3d,devsim,meow,database] # Install all plugins
 pre-commit install
 gf install klayout-genericpdk
 ```


### PR DESCRIPTION
Hi Joaquin,

I am automating my environment installation in a few multiple machines and whilst doing it I realized that this line of code on the GDSFactory developer Readme installation might help developers automate the install of all plugins. Just added a: `# pip install -e .[full,gmsh,tidy3d,devsim,meow,database] # Install all plugins ` on the developer installation README.