### PR TITLE
enforce UTF-8 encoding for DRC macro writing

### DIFF
--- a/gdsfactory/geometry/write_drc.py
+++ b/gdsfactory/geometry/write_drc.py
@@ -319,7 +319,7 @@ deep
     dirpath = filepath.parent
     dirpath.mkdir(parents=True, exist_ok=True)
     filepath = pathlib.Path(filepath)
-    filepath.write_text(script)
+    filepath.write_text(script, encoding="UTF-8")
     print(f"Wrote DRC deck to {str(filepath)!r} with shortcut {shortcut!r}")
     return script
 


### PR DESCRIPTION
This will fix the problem for when locales that don't support `µ` or `²` (unlikely for the latter though) are configured. With the default setting `encoding=None` the locale is grabbed and the file encoded with that.

Enforcing UTF-8 makes sense in this case because it shouldn't be a problem since the file is not intended for user interaction but rather just copying to klayout.