### PR TITLE
Pydantic v1/v2 migration seems working based on latest Github version

### DIFF
--- a/docs/notebooks/03_layer_stack.py
+++ b/docs/notebooks/03_layer_stack.py
@@ -30,7 +30,7 @@
 #
 
 # %%
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing import Tuple
 
 import gdsfactory as gf

--- a/docs/notebooks/08_pdk.py
+++ b/docs/notebooks/08_pdk.py
@@ -42,7 +42,7 @@ import pathlib
 from typing import Callable, Tuple
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from gdsfactory.add_pins import add_pin_rectangle_inside

--- a/docs/notebooks/08_pdk_examples.py
+++ b/docs/notebooks/08_pdk_examples.py
@@ -12,7 +12,7 @@ import pathlib
 from typing import Callable, Tuple
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from gdsfactory.add_pins import add_pin_rectangle_inside

--- a/docs/notebooks/09_pdk_import.py
+++ b/docs/notebooks/09_pdk_import.py
@@ -231,7 +231,7 @@ print(gf.write_cells.get_import_gds_script("extra/gds", module="samplepdk.compon
 #
 # ```
 #
-# from pydantic import BaseModel
+# from pydantic.v1 import BaseModel
 #
 #
 # class LayerMap(BaseModel):

--- a/docs/notebooks/_0_python.py
+++ b/docs/notebooks/_0_python.py
@@ -22,7 +22,7 @@
 # In gdsfactory you will write functions instead of classes. Functions are easier to write and combine, and have clearly defined inputs and outputs.
 
 # %%
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 
 import gdsfactory as gf
 
@@ -88,7 +88,7 @@ component
 #
 # For that you will see a `@cell` decorator on many component functions.
 #
-# The validation functionality comes from the [pydantic](https://pydantic-docs.helpmanual.io/) package
+# The validation functionality comes from the [pydantic.v1](https://pydantic.v1-docs.helpmanual.io/) package
 # and is available to you automatically when using the `@cell` decorator
 
 

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -9,7 +9,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Type
 
 import toolz
-from pydantic import BaseModel, validate_arguments
+from pydantic.v1 import BaseModel, validate_arguments
 
 from gdsfactory.component import Component
 from gdsfactory.name import clean_name, get_name_short
@@ -240,7 +240,7 @@ def cell(func: _F) -> _F:
     """Decorator for Component functions.
 
     Wraps cell_without_validator
-    Validates type annotations with pydantic.
+    Validates type annotations with pydantic.v1.
 
     Implements a cache so that if a component has already been build
     it will return the component from the cache directly.

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -13,7 +13,7 @@ from functools import partial
 from inspect import getmembers
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TypeVar
 
-from pydantic import BaseModel, Field, validate_arguments
+from pydantic.v1 import BaseModel, Field, validate_arguments
 from typing_extensions import Literal
 from gdsfactory.add_pins import add_pins_inside1nm, add_pins_siepic_optical
 

--- a/gdsfactory/export/to_gerber.py
+++ b/gdsfactory/export/to_gerber.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 from typing import Optional, List, Dict, Tuple
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from gdsfactory import Component
 

--- a/gdsfactory/filestorage.py
+++ b/gdsfactory/filestorage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from io import BytesIO
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing_extensions import Literal
 
 from gdsfactory.config import PATH

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -12,7 +12,7 @@ from functools import lru_cache, partial
 
 import numpy as np
 from omegaconf import OmegaConf
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 
 from gdsfactory import ComponentReference
 from gdsfactory.cell import cell

--- a/gdsfactory/generic_tech/layer_map.py
+++ b/gdsfactory/generic_tech/layer_map.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 Layer = Tuple[int, int]
 

--- a/gdsfactory/geometry/write_connectivity.py
+++ b/gdsfactory/geometry/write_connectivity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import List
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 import gdsfactory as gf
 from gdsfactory.typings import CrossSectionSpec, Dict, Layer, LayerSpec

--- a/gdsfactory/labels/add_label_yaml.py
+++ b/gdsfactory/labels/add_label_yaml.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 import flatdict
-import pydantic
+import pydantic.v1
 
 import gdsfactory as gf
 from gdsfactory.name import clean_name
@@ -24,7 +24,7 @@ port_prefixes = [
 ]
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def add_label_yaml(
     component: gf.Component,
     port_prefixes: List[str] = ("opt_", "_elec"),

--- a/gdsfactory/labels/ehva.py
+++ b/gdsfactory/labels/ehva.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 
 import flatdict
-import pydantic
+import pydantic.v1
 
 import gdsfactory as gf
 from gdsfactory.name import clean_name
@@ -11,7 +11,7 @@ from gdsfactory.snap import snap_to_grid as snap
 from gdsfactory.typings import Layer
 
 
-class Dft(pydantic.BaseModel):
+class Dft(pydantic.v1.BaseModel):
     pad_size: Tuple[int, int] = (100, 100)
     pad_pitch: int = 125
     pad_width: int = 100
@@ -39,7 +39,7 @@ prefix_to_type_default = {
 }
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def add_label_ehva(
     component: gf.Component,
     die: str = "demo",

--- a/gdsfactory/name.py
+++ b/gdsfactory/name.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-import pydantic
+import pydantic.v1
 
 MAX_NAME_LENGTH = 32
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def get_name_short(name: str, max_name_length=MAX_NAME_LENGTH) -> str:
     """Returns a short name."""
     if len(name) > max_name_length:

--- a/gdsfactory/pack.py
+++ b/gdsfactory/pack.py
@@ -9,7 +9,7 @@ import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 
 import gdsfactory as gf
 from gdsfactory.component import Component

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -10,7 +10,7 @@ from gdsfactory.name import MAX_NAME_LENGTH
 
 import numpy as np
 from omegaconf import DictConfig
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from gdsfactory.config import PATH, logger
 from gdsfactory.containers import containers as containers_default

--- a/gdsfactory/picmodel.py
+++ b/gdsfactory/picmodel.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import AnyUrl, BaseModel, Extra, Field
+from pydantic.v1 import AnyUrl, BaseModel, Extra, Field
 
 import gdsfactory as gf
 

--- a/gdsfactory/routing/get_route.py
+++ b/gdsfactory/routing/get_route.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from functools import partial
 from typing import Callable, Optional, Union
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 
 import numpy as np
 

--- a/gdsfactory/samples/demo/layers.py
+++ b/gdsfactory/samples/demo/layers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pathlib
 from typing import Tuple, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from gdsfactory.technology import LayerLevel, LayerStack
 

--- a/gdsfactory/samples/pdk/fab_c.py
+++ b/gdsfactory/samples/pdk/fab_c.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 from typing import Callable
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 import gdsfactory as gf
 from gdsfactory.add_pins import add_pin_rectangle_inside

--- a/gdsfactory/samples/pdk/fab_d/phase_shifters.py
+++ b/gdsfactory/samples/pdk/fab_d/phase_shifters.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import pydantic
+import pydantic.v1
 
 import gdsfactory as gf
 from gdsfactory.typings import Layer
 
 
-@pydantic.dataclasses.dataclass
+@pydantic.v1.dataclasses.dataclass
 class LayerMap:
     WG: Layer = (2, 0)
     SLAB: Layer = (41, 0)

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 import gdstk
 import numpy as np
 import orjson
-import pydantic
+import pydantic.v1
 import toolz
 from omegaconf import DictConfig, OmegaConf
 
@@ -41,7 +41,7 @@ def clean_value_json(value: Any) -> Any:
     """Return JSON serializable object."""
     from gdsfactory.path import Path
 
-    if isinstance(value, pydantic.BaseModel):
+    if isinstance(value, pydantic.v1.BaseModel):
         return clean_dict(value.dict())
 
     elif hasattr(value, "get_component_spec"):

--- a/gdsfactory/simulation/devsim/doping.py
+++ b/gdsfactory/simulation/devsim/doping.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 import gdsfactory as gf
 from gdsfactory.types import Layer

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy.interpolate import griddata
 import pyvista as pv
 from devsim.python_packages import model_create, simple_physics
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 import tidy3d as td
 
 from gdsfactory.simulation.disable_print import disable_print, enable_print

--- a/gdsfactory/simulation/devsim/get_solver.py
+++ b/gdsfactory/simulation/devsim/get_solver.py
@@ -20,7 +20,7 @@ from devsim import (
     write_devices,
 )
 from devsim.python_packages import model_create, simple_physics
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.component import Component

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 
 import meep as mp
 import numpy as np
-import pydantic
+import pydantic.v1
 from omegaconf import OmegaConf
 from tqdm.auto import tqdm
 
@@ -110,7 +110,7 @@ def parse_port_eigenmode_coeff(port_name: str, ports: Dict[str, Port], sim_dict:
     return coeff_in, coeff_out
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def write_sparameters_meep(
     component: ComponentSpec,
     port_source_names: Optional[List[str]] = None,
@@ -371,7 +371,7 @@ def write_sparameters_meep(
     sp = {}  # Sparameters dict
     start = time.time()
 
-    @pydantic.validate_arguments
+    @pydantic.v1.validate_arguments
     def sparameter_calculation(
         port_source_name: str,
         component: Component,

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_batch.py
@@ -11,7 +11,7 @@ from pprint import pprint
 from typing import Dict, List, Optional
 
 import numpy as np
-import pydantic
+import pydantic.v1
 from tqdm.auto import tqdm
 
 import gdsfactory as gf
@@ -33,7 +33,7 @@ core_materials = multiprocessing.cpu_count()
 temp_dir_default = Path(sparameters_path) / "temp"
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def write_sparameters_meep_batch(
     jobs: List[Dict],
     cores_per_run: int = 2,

--- a/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
+++ b/gdsfactory/simulation/gmeep/write_sparameters_meep_mpi.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-import pydantic
+import pydantic.v1
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -39,7 +39,7 @@ def _python() -> str:
     return sys.executable
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def write_sparameters_meep_mpi(
     component: ComponentSpec,
     layer_stack: Optional[LayerStack] = None,

--- a/gdsfactory/simulation/gtidy3d/get_simulation.py
+++ b/gdsfactory/simulation/gtidy3d/get_simulation.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-import pydantic
+import pydantic.v1
 import tidy3d as td
 from tidy3d.plugins.mode import ModeSolver
 
@@ -22,7 +22,7 @@ from gdsfactory.technology import LayerStack
 from gdsfactory.typings import ComponentSpec, Float2
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def get_simulation(
     component: ComponentSpec,
     port_extension: Optional[float] = 4.0,

--- a/gdsfactory/simulation/gtidy3d/modes.py
+++ b/gdsfactory/simulation/gtidy3d/modes.py
@@ -17,7 +17,7 @@ import hashlib
 import itertools
 
 import numpy as np
-import pydantic
+import pydantic.v1
 import tidy3d as td
 from tidy3d.plugins import waveguide
 from typing_extensions import Literal
@@ -35,7 +35,7 @@ from gdsfactory.simulation.gtidy3d.materials import get_medium
 Precision = Literal["single", "double"]
 
 
-class Waveguide(pydantic.BaseModel):
+class Waveguide(pydantic.v1.BaseModel):
     """Waveguide Model.
 
     All dimensions must be specified in μm (1e-6 m).
@@ -126,15 +126,15 @@ class Waveguide(pydantic.BaseModel):
     max_grid_scaling: float = 1.2
     cache: bool = True
 
-    _cached_data = pydantic.PrivateAttr()
-    _waveguide = pydantic.PrivateAttr()
+    _cached_data = pydantic.v1.PrivateAttr()
+    _waveguide = pydantic.v1.PrivateAttr()
 
     class Config:
-        """pydantic config."""
+        """pydantic.v1 config."""
 
         extra = "forbid"
 
-    @pydantic.validator("wavelength")
+    @pydantic.v1.validator("wavelength")
     def _fix_wavelength_type(cls, value):
         return np.array(value, dtype=float)
 

--- a/gdsfactory/simulation/modes/find_coupling_vs_gap.py
+++ b/gdsfactory/simulation/modes/find_coupling_vs_gap.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import meep as mp
 import numpy as np
 import pandas as pd
-import pydantic
+import pydantic.v1
 from tqdm.auto import tqdm
 
 from gdsfactory.simulation.modes.find_modes import find_modes_coupler
@@ -32,7 +32,7 @@ def coupling_length(
     return wavelength / (np.pi * dneff) * np.arcsin(np.sqrt(power_ratio))
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def find_coupling(
     gap: float = 0.2, power_ratio: float = 1.0, wavelength: float = 1.55, **kwargs
 ) -> float:
@@ -57,7 +57,7 @@ def find_coupling(
     )
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def find_coupling_vs_gap(
     gap1: float = 0.2,
     gap2: float = 0.4,

--- a/gdsfactory/simulation/modes/find_neff_ng_dw_dh.py
+++ b/gdsfactory/simulation/modes/find_neff_ng_dw_dh.py
@@ -13,7 +13,7 @@ import pathlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import pydantic
+import pydantic.v1
 from scipy.interpolate import interp2d
 
 from gdsfactory.config import PATH
@@ -26,7 +26,7 @@ width0 = 465 * nm
 thickness0 = 215 * nm
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def find_neff_ng_dw_dh(
     width: float = width0,
     thickness: float = thickness0,

--- a/gdsfactory/simulation/modes/find_neff_vs_width.py
+++ b/gdsfactory/simulation/modes/find_neff_vs_width.py
@@ -6,14 +6,14 @@ import matplotlib.pyplot as plt
 import meep as mp
 import numpy as np
 import pandas as pd
-import pydantic
+import pydantic.v1
 from tqdm.auto import tqdm
 
 from gdsfactory.simulation.modes.find_modes import find_modes_waveguide
 from gdsfactory.typings import Optional, PathType
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def find_neff_vs_width(
     width1: float = 0.2,
     width2: float = 1.0,

--- a/gdsfactory/simulation/modes/get_mode_solver_coupler.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_coupler.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple, Union
 
 import meep as mp
 import numpy as np
-import pydantic
+import pydantic.v1
 from meep import mpb
 
 mpb.Verbosity(0)
@@ -17,7 +17,7 @@ tmp.mkdir(exist_ok=True)
 Floats = Tuple[float, ...]
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def get_mode_solver_coupler(
     core_width: float = 0.5,
     gap: float = 0.2,

--- a/gdsfactory/simulation/modes/get_mode_solver_cross_section.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_cross_section.py
@@ -5,7 +5,7 @@ import tempfile
 from typing import Dict, Optional, Union
 
 import meep as mp
-import pydantic
+import pydantic.v1
 from meep import mpb
 
 import gdsfactory as gf
@@ -22,7 +22,7 @@ tmp = pathlib.Path(tempfile.TemporaryDirectory().name).parent / "meep"
 tmp.mkdir(exist_ok=True)
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def get_mode_solver_cross_section(
     cross_section: CrossSectionSpec = "strip",
     sy: float = 2.0,

--- a/gdsfactory/simulation/modes/get_mode_solver_rib.py
+++ b/gdsfactory/simulation/modes/get_mode_solver_rib.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import meep as mp
 import numpy as np
-import pydantic
+import pydantic.v1
 from meep import mpb
 
 mpb.Verbosity(0)
@@ -15,7 +15,7 @@ tmp = pathlib.Path(tempfile.TemporaryDirectory().name).parent / "meep"
 tmp.mkdir(exist_ok=True)
 
 
-@pydantic.validate_arguments
+@pydantic.v1.validate_arguments
 def get_mode_solver_rib(
     core_width: float = 0.45,
     core_thickness: float = 0.22,

--- a/gdsfactory/simulation/modes/types.py
+++ b/gdsfactory/simulation/modes/types.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Optional, Union
 import matplotlib.pyplot as plt
 import numpy as np
 from meep import mpb
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from scipy.interpolate import RectBivariateSpline
 
 from gdsfactory.typings import Array

--- a/gdsfactory/simulation/sax/plot_model.py
+++ b/gdsfactory/simulation/sax/plot_model.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 from sax.typing_ import Model
 
 

--- a/gdsfactory/symbols.py
+++ b/gdsfactory/symbols.py
@@ -4,7 +4,7 @@ import functools
 from typing import Callable
 
 import gdstk
-from pydantic import validate_arguments
+from pydantic.v1 import validate_arguments
 
 from gdsfactory.cell import _F, cell_without_validator
 from gdsfactory.component import Component

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -7,7 +7,7 @@ import pathlib
 import xml.etree.ElementTree as ET
 from typing import List, Optional, Tuple, Dict
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from gdsfactory.config import PATH
 from gdsfactory.technology import LayerViews, LayerStack

--- a/gdsfactory/technology/layer_map.py
+++ b/gdsfactory/technology/layer_map.py
@@ -15,7 +15,7 @@ def lyp_to_dataclass(
         raise FileExistsError(f"You can delete {filepathout}")
 
     script = """
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from gdsfactory.typings import Layer
 
 

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple, Callable, Union
 from collections import defaultdict
 
 from typing_extensions import Literal
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from gdsfactory.technology.layer_views import LayerViews
 

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -13,13 +13,13 @@ import xml.etree.ElementTree as ET
 from typing import Dict, Optional, Set, Tuple, Union
 
 import numpy as np
-from pydantic import BaseModel, Field, validator
-from pydantic.color import Color, ColorType
+from pydantic.v1 import BaseModel, Field, validator
+from pydantic.v1.color import Color, ColorType
 
 from gdsfactory.config import logger
 
 if typing.TYPE_CHECKING:
-    from pydantic.typing import AbstractSetIntStr, DictStrAny, MappingIntStrAny
+    from pydantic.v1.typing import AbstractSetIntStr, DictStrAny, MappingIntStrAny
 
 PathLike = Union[pathlib.Path, str]
 

--- a/gdsfactory/technology/simulation_settings.py
+++ b/gdsfactory/technology/simulation_settings.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from gdsfactory.materials import MaterialSpec
 from gdsfactory.materials import (

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -37,7 +37,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gdstk
 import numpy as np
 from omegaconf import OmegaConf
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 from typing_extensions import Literal
 
 from gdsfactory.component import Component, ComponentReference

--- a/gdsfactory/utils/yaml_utils.py
+++ b/gdsfactory/utils/yaml_utils.py
@@ -1,6 +1,6 @@
 def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
     import yaml
-    from pydantic.color import Color
+    from pydantic.v1.color import Color
 
     from gdsfactory.utils.color_utils import ensure_six_digit_hex_color
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "omegaconf",
   "orjson",
   "pandas",
-  "pydantic",
+  "pydantic>=2.0a4",
   "pyyaml",
   "qrcode",
   "rectpack",

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 import gdsfactory as gf
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pydantic
+import pydantic.v1
 import pytest
 
 import gdsfactory as gf
@@ -29,7 +29,7 @@ def test_validator_fail_name_too_long() -> None:
     component = gf.Component(name="a" * 200)
 
     # component_with_straight(component=component)
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic.v1.ValidationError):
         component_with_straight(component=component)
 
 


### PR DESCRIPTION
Hi David and Joaquin,

I have done another clean go at the porting using the migration protocol described in https://github.com/pydantic/pydantic/issues/5771 which I think seems to work.

It mostly involved changing the imports from `pydantic` to `pydantic.v1` as David suggested. I am doing it so I can get my project fully integrated. It works from the latest github pydantic v2 version and I reckon this has already been deployed to PyPi, but I did run the migration_v1.sh script provided in my environment and I don't know if that is already automated on PyPi install. 

In any case, in case it is useful, I have made a pull request here. Pytest seems to complete and not dissimilar from the current `main` pytest. 

This said I wouldn't merge this until pydantic_v2 is more stable in terms of migration and also David has given this a proper check in terms of the logic required.