### PR TITLE
Added ability to change library name in gds file

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1916,7 +1916,7 @@ class Component(_GeometryHelper):
         #     print(cell.name, type(cell))
 
         lib = gdstk.Library(
-            unit=write_settings.unit, precision=write_settings.precision
+            name=write_settings.lib_name, unit=write_settings.unit, precision=write_settings.precision
         )
         lib.add(top_cell._cell)
         lib.add(*top_cell._cell.dependencies(True))

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -57,6 +57,10 @@ class GdsWriteSettings(BaseModel):
     """Settings to use when writing to GDS."""
 
     on_uncached_component: Literal["warn", "error", "ignore"] = "ignore"
+    lib_name: str = Field(
+        default="library",
+        description="Name of the GDS library to write to. Default is 'library'.",
+    )
     unit: float = Field(
         default=1e-6,
         description="The units of coordinates in the database. The default is 1e-6 (1 micron).",


### PR DESCRIPTION
This gives ability to change library name of the gds file.

Since certain software like Beamer require library name to be set as "Layout_Engine.db".