### PR TITLE
Make Pdk.validate_layers() More Generic

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -243,6 +243,8 @@ class Pdk(BaseModel):
 
     def validate_layers(self, layers_required: Optional[List[Layer]] = None):
         """Raises ValueError if layers_required are not in Pdk."""
+        if layers_required is None:
+            layers_required = []
         for layer in layers_required:
             if layer not in self.layers:
                 raise ValueError(

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -39,7 +39,6 @@ from gdsfactory.typings import (
 
 component_settings = ["function", "component", "settings"]
 cross_section_settings = ["function", "cross_section", "settings"]
-layers_required = []
 
 constants = {
     "fiber_array_spacing": 127.0,
@@ -242,7 +241,8 @@ class Pdk(BaseModel):
     def is_pathlib_path(cls, path):
         return pathlib.Path(path)
 
-    def validate_layers(self):
+    def validate_layers(self, layers_required: Optional[List[Layer]] = None):
+        """Raises ValueError if layers_required are not in Pdk."""
         for layer in layers_required:
             if layer not in self.layers:
                 raise ValueError(
@@ -276,7 +276,8 @@ class Pdk(BaseModel):
 
             if not self.default_decorator:
                 self.default_decorator = self.base_pdk.default_decorator
-        self.validate_layers()
+        layers_required = []
+        self.validate_layers(layers_required)
         _set_active_pdk(self)
 
     def register_cells(self, **kwargs) -> None:


### PR DESCRIPTION
This PR addresses [issue1731](https://github.com/gdsfactory/gdsfactory/issues/1731). 

- Pdk.validate_layers() now accepts layers_required argument. 
- The Pdk.activate() method --where Pdk.validate_layers() is called-- now has a layers_required list which is currently empty. This list can be populated in the future if necessary

Please provide feedback and let me know if I should make any changes.