### PR TITLE
wire_corner with sections

### DIFF
--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -105,8 +105,6 @@ def wire_corner45(
 @gf.cell
 def wire_corner_sections(
     cross_section: CrossSectionSpec = "metal_routing",
-    mirror_e1: bool = False,
-    mirror_e2: bool = False,
     **kwargs,
 ) -> Component:
     """Returns 90 degrees electrical corner wire, where all cross_section sections properly represented.
@@ -115,8 +113,6 @@ def wire_corner_sections(
 
     Args:
         cross_section: spec.
-        mirror_e1: whether to mirror the e1 port cross_section w.r.t. input xsection
-        mirror_e2: whether to mirror the e2 port cross_section w.r.t. input xsection
         kwargs: cross_section settings.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -179,8 +175,8 @@ if __name__ == "__main__":
     xsection = gf.cross_section.cross_section(
         width=0.4, offset=0, layer="M1", sections=[section1, section2]
     )
-    c = wire_corner_sections(cross_section=xsection)
-    c.show(show_ports=True)
+    # c = wire_corner_sections(cross_section=xsection)
+    # c.show(show_ports=True)
     # c.pprint_ports()
     # c.pprint()
 

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -152,15 +152,15 @@ def wire_corner_sections(
         name="e1",
         center=(xmin, -(xmin + ymax) / 2),
         orientation=180,
-        cross_section=cross_section,
-        layer=cross_section.layer,
+        cross_section=x,
+        layer=x.layer,
     )
     c.add_port(
         name="e2",
         center=((xmin + ymax) / 2, ymax),
         orientation=90,
-        cross_section=cross_section,
-        layer=cross_section.layer,
+        cross_section=x,
+        layer=x.layer,
     )
     c.info["length"] = ymax - xmin
     c.info["dy"] = ymax - xmin
@@ -175,24 +175,26 @@ if __name__ == "__main__":
     xsection = gf.cross_section.cross_section(
         width=0.4, offset=0, layer="M1", sections=[section1, section2]
     )
-    # c = wire_corner_sections(cross_section=xsection)
-    # c.show(show_ports=True)
+    from gdsfactory.cross_section import metal_slotted
+
+    c = wire_corner_sections(cross_section=metal_slotted)
+    c.show(show_ports=True)
     # c.pprint_ports()
     # c.pprint()
 
-    port1 = gf.Port(name="init", orientation=270, center=(0, 0), cross_section=xsection)
-    port2 = gf.Port(
-        name="final", orientation=0, center=(-20, -20), cross_section=xsection
-    )
+    # port1 = gf.Port(name="init", orientation=270, center=(0, 0), cross_section=metal_slotted)
+    # port2 = gf.Port(
+    #     name="final", orientation=0, center=(-20, -20), cross_section=metal_slotted
+    # )
 
-    c = gf.Component()
-    route = gf.routing.get_route_electrical(
-        input_port=port1,
-        output_port=port2,
-        bend=wire_corner_sections(cross_section=xsection),
-        cross_section=xsection,
-    )
-    c.add(route.references)
-    c.show()
+    # c = gf.Component()
+    # route = gf.routing.get_route_electrical(
+    #     input_port=port1,
+    #     output_port=port2,
+    #     bend=wire_corner_sections(cross_section=xsection),
+    #     cross_section=xsection,
+    # )
+    # c.add(route.references)
+    # c.show()
 
     # print(yaml.dump(c.to_dict()))

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -102,11 +102,101 @@ def wire_corner45(
     return c
 
 
+@gf.cell
+def wire_corner_sections(
+    cross_section: CrossSectionSpec = "metal_routing",
+    mirror_e1: bool = False,
+    mirror_e2: bool = False,
+    **kwargs,
+) -> Component:
+    """Returns 90 degrees electrical corner wire, where all cross_section sections properly represented.
+
+    Works well with symmetric cross_sections, not quite ready for asymmetric.
+
+    Args:
+        cross_section: spec.
+        mirror_e1: whether to mirror the e1 port cross_section w.r.t. input xsection
+        mirror_e2: whether to mirror the e2 port cross_section w.r.t. input xsection
+        kwargs: cross_section settings.
+    """
+    x = gf.get_cross_section(cross_section, **kwargs)
+
+    xmin, ymax = x.get_xmin_xmax()
+
+    main_section = gf.cross_section.Section(
+        width=x.width,
+        layer=x.layer,
+        offset=x.offset,
+    )
+
+    all_sections = [main_section]
+    all_sections.extend(x.sections)
+
+    c = Component()
+
+    for section in all_sections:
+        layer = section.layer
+        width = section.width
+        offset = section.offset
+        b = width / 2
+
+        xpts = [xmin, offset - b, offset - b, offset + b, offset + b, xmin]
+        ypts = [
+            -offset + b,
+            -offset + b,
+            ymax,
+            ymax,
+            -offset - b,
+            -offset - b,
+        ]
+
+        c.add_polygon([xpts, ypts], layer=layer)
+
+    c.add_port(
+        name="e1",
+        center=(xmin, -(xmin + ymax) / 2),
+        orientation=180,
+        cross_section=cross_section,
+        layer=cross_section.layer,
+    )
+    c.add_port(
+        name="e2",
+        center=((xmin + ymax) / 2, ymax),
+        orientation=90,
+        cross_section=cross_section,
+        layer=cross_section.layer,
+    )
+    c.info["length"] = ymax - xmin
+    c.info["dy"] = ymax - xmin
+    return c
+
+
 if __name__ == "__main__":
     # c = wire_straight()
-    c = wire_corner()
-    # c.show(show_ports=True)
+    # c = wire_corner()
+    section1 = gf.cross_section.Section(width=0.4, layer="M1", offset=0.5)
+    section2 = gf.cross_section.Section(width=0.4, layer="M1", offset=-0.5)
+    xsection = gf.cross_section.cross_section(
+        width=0.4, offset=0, layer="M1", sections=[section1, section2]
+    )
+    c = wire_corner_sections(cross_section=xsection)
+    c.show(show_ports=True)
     # c.pprint_ports()
-    c.pprint()
+    # c.pprint()
+
+    port1 = gf.Port(name="init", orientation=270, center=(0, 0), cross_section=xsection)
+    port2 = gf.Port(
+        name="final", orientation=0, center=(-20, -20), cross_section=xsection
+    )
+
+    c = gf.Component()
+    route = gf.routing.get_route_electrical(
+        input_port=port1,
+        output_port=port2,
+        bend=wire_corner_sections(cross_section=xsection),
+        cross_section=xsection,
+    )
+    c.add(route.references)
+    c.show()
 
     # print(yaml.dump(c.to_dict()))

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -253,6 +253,20 @@ class CrossSection(BaseModel):
                 c.add_polygon(points, layer=layer)
         return c
 
+    def get_xmin_xmax(self):
+        """Returns the min and max extent of the cross_section across all sections."""
+        main_width = self.width
+        main_offset = self.offset
+        xmin = main_offset - main_width / 2
+        xmax = main_offset + main_width / 2
+        for section in self.sections:
+            width = section.width
+            offset = section.offset
+            xmin = min(xmin, offset - width / 2)
+            xmax = max(xmax, offset + width / 2)
+
+        return xmin, xmax
+
 
 CrossSectionSpec = Union[CrossSection, Callable, Dict[str, Any]]
 
@@ -773,6 +787,17 @@ heater_metal = partial(
 metal3_with_bend = partial(metal1, layer="M3", radius=10)
 metal_routing = metal3
 npp = partial(metal1, layer="NPP", width=0.5)
+
+metal_slotted = partial(
+    cross_section,
+    width=10,
+    offset=0,
+    layer="M3",
+    sections=[
+        Section(width=10, layer="M3", offset=11),
+        Section(width=10, layer="M3", offset=-11),
+    ],
+)
 
 
 @xsection

--- a/tests/test_components/test_settings_wire_corner_sections.yml
+++ b/tests/test_components/test_settings_wire_corner_sections.yml
@@ -28,12 +28,12 @@ settings:
   changed: {}
   child: null
   default:
-    cross_section: metal_routing
+    cross_section: metal_slotted
     radius: 10
   full:
-    cross_section: metal_routing
+    cross_section: metal_slotted
     radius: 10
-  function_name: wire_corner45
+  function_name: wire_corner_sections
   info:
     length: 14.142
   info_version: 2

--- a/tests/test_components/test_settings_wire_corner_sections.yml
+++ b/tests/test_components/test_settings_wire_corner_sections.yml
@@ -1,0 +1,41 @@
+name: wire_corner_sections
+ports:
+  e1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 49
+    - 0
+    name: e1
+    orientation: 180
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+  e2:
+    center:
+    - 10.0
+    - 10.0
+    layer:
+    - 49
+    - 0
+    name: e2
+    orientation: 90
+    port_type: electrical
+    shear_angle: null
+    width: 10.0
+settings:
+  changed: {}
+  child: null
+  default:
+    cross_section: metal_routing
+    radius: 10
+  full:
+    cross_section: metal_routing
+    radius: 10
+  function_name: wire_corner45
+  info:
+    length: 14.142
+  info_version: 2
+  module: gdsfactory.components.wire
+  name: wire_corner_sections


### PR DESCRIPTION
New wire_corner component that handles sections. Useful for slotted wiring for high power lines under maximum width DRC (I also considered bundle routing with subports, but this seemed more userful)

Works well with symmetric sections, not quite there for asymmetric.

```
    section1 = gf.cross_section.Section(width=0.4, layer="M1", offset=0.5)
    section2 = gf.cross_section.Section(width=0.4, layer="M1", offset=-0.5)
    xsection = gf.cross_section.cross_section(
        width=0.4, offset=0, layer="M1", sections=[section1, section2]
    )
    c = wire_corner_sections(cross_section=xsection)
    c.show(show_ports=True)
```
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/4bb23286-b086-4d3f-95e8-247a8073ce7f)

With routing:
```
    port1 = gf.Port(name="init", orientation=270, center=(0, 0), cross_section=xsection)
    port2 = gf.Port(
        name="final", orientation=0, center=(-20, -20), cross_section=xsection
    )

    c = gf.Component()
    route = gf.routing.get_route_electrical(
        input_port=port1,
        output_port=port2,
        bend=wire_corner_sections(cross_section=xsection),
        cross_section=xsection,
    )
    c.add(route.references)
    c.show()
```
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/ef2de121-a5ce-42df-b255-25d2a4a3ca63)

