### PR TITLE
Bug Fix, Pdk.activate() checks _ACTIVE_PDK

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -252,7 +252,11 @@ class Pdk(BaseModel):
                 )
 
     def activate(self) -> None:
-        """Set current pdk to as the active pdk."""
+        """Set current pdk to the active pdk (if not already active)."""
+        global _ACTIVE_PDK
+        if self is _ACTIVE_PDK:
+            return None
+        
         from gdsfactory.cell import clear_cache
 
         logger.info(f"{self.name!r} PDK is now active")


### PR DESCRIPTION
This is a bug referenced in OpenFASOC [issue210](https://github.com/idea-fasoc/OpenFASOC/issues/210) by @vijayshankarr and GDSFactory [issue1772](https://github.com/gdsfactory/gdsfactory/issues/1772).

- Pdk.activate() now checks if self is the active Pdk, in which case cache is not cleared.

Please provide feedback and let me know if I should make any changes.