### PR TITLE
Enable kweb (gf web) from online codespace

### DIFF
--- a/gdsfactory/plugins/web/main.py
+++ b/gdsfactory/plugins/web/main.py
@@ -42,9 +42,10 @@ def load_pdk() -> gf.Pdk:
         active_pdk.activate()
     return active_pdk
 
+
 def get_url(request: Request) -> str:
     port_mod = ""
-    if request.url.port is not None and len(str(request.url).split("."))<3:
+    if request.url.port is not None and len(str(request.url).split(".")) < 3:
         port_mod = ":" + str(request.url.port)
 
     hostname = request.url.hostname
@@ -61,6 +62,7 @@ def get_url(request: Request) -> str:
     )
 
     return url
+
 
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request):

--- a/gdsfactory/plugins/web/middleware.py
+++ b/gdsfactory/plugins/web/middleware.py
@@ -1,0 +1,59 @@
+from typing import List, Tuple
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+Headers = List[Tuple[bytes, bytes]]
+
+# original developed by researchers at university of cambridge:
+# https://pypi.org/project/fastapi-proxiedheadersmiddleware/
+
+# modification to resolve Connection: keep-alive vs. upgrade conflict
+# conflict described here: https://github.com/orgs/community/discussions/57596
+# doesn't seem to work as intended, as the upgrade decision is made 
+# before the request goes through the middleware
+
+class ProxiedHeadersMiddleware:
+    """
+    A middleware that modifies the request to ensure that FastAPI uses the
+    X-Forwarded-* headers when creating URLs used to reference this application.
+
+    We are very permissive in allowing all X-Forwarded-* headers to be used, as
+    we know that this API will be published behind the API Gateway, and is
+    therefore not prone to redirect hijacking.
+
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope["headers"] = self.remap_headers(scope.get("headers", {}))
+
+        await self.app(scope, receive, send)
+        return
+
+    def remap_headers(self, source: Headers) -> Headers:
+        """
+        Map X-Forwarded-Host to host and X-Forwarded-Prefix to prefix.
+
+        """
+        upgrade = len([q for p, q in source 
+            if "connection" in str(p) and "upgrade" in str(q)])
+
+        source = dict(source)
+        if upgrade: #resolve conflict with priority of upgrade
+            source[b"connection"] = b"upgrade"
+
+        if b'x-forwarded-host' in source:
+            source.update({b'host': source[b'x-forwarded-host']})
+            source.pop(b'x-forwarded-host')
+
+        if b'x-forwarded-prefix' in source:
+            source.update({
+                b'host': source[b'host'] + source[b'x-forwarded-prefix']
+            })
+            source.pop(b'x-forwarded-prefix')
+
+        source = [(k, v) for k, v in source.items()]
+        
+        return source

--- a/gdsfactory/plugins/web/middleware.py
+++ b/gdsfactory/plugins/web/middleware.py
@@ -9,8 +9,9 @@ Headers = List[Tuple[bytes, bytes]]
 
 # modification to resolve Connection: keep-alive vs. upgrade conflict
 # conflict described here: https://github.com/orgs/community/discussions/57596
-# doesn't seem to work as intended, as the upgrade decision is made 
+# doesn't seem to work as intended, as the upgrade decision is made
 # before the request goes through the middleware
+
 
 class ProxiedHeadersMiddleware:
     """
@@ -37,23 +38,22 @@ class ProxiedHeadersMiddleware:
         Map X-Forwarded-Host to host and X-Forwarded-Prefix to prefix.
 
         """
-        upgrade = len([q for p, q in source 
-            if "connection" in str(p) and "upgrade" in str(q)])
+        upgrade = len(
+            [q for p, q in source if "connection" in str(p) and "upgrade" in str(q)]
+        )
 
         source = dict(source)
-        if upgrade: #resolve conflict with priority of upgrade
+        if upgrade:  # resolve conflict with priority of upgrade
             source[b"connection"] = b"upgrade"
 
-        if b'x-forwarded-host' in source:
-            source.update({b'host': source[b'x-forwarded-host']})
-            source.pop(b'x-forwarded-host')
+        if b"x-forwarded-host" in source:
+            source.update({b"host": source[b"x-forwarded-host"]})
+            source.pop(b"x-forwarded-host")
 
-        if b'x-forwarded-prefix' in source:
-            source.update({
-                b'host': source[b'host'] + source[b'x-forwarded-prefix']
-            })
-            source.pop(b'x-forwarded-prefix')
+        if b"x-forwarded-prefix" in source:
+            source.update({b"host": source[b"host"] + source[b"x-forwarded-prefix"]})
+            source.pop(b"x-forwarded-prefix")
 
         source = [(k, v) for k, v in source.items()]
-        
+
         return source


### PR DESCRIPTION
kweb so far didn't work in a purely online mode with github codespaces for three reasons:
1. The port forwarding was leaving the host header set to localhost even with `--proxy-headers` for uvicorn. The remote host was only written to `x-forwarded-host`. Thus `url_for` in the starlette templating was generating localhost addresses, inaccessible via the codespaces port forwarding: 
https://github.com/gdsfactory/gdsfactory/blob/fce05bfec6cb4e96336b698075c8a785b586afc9/gdsfactory/plugins/web/templates/viewer.html#L43
This was **resolved by** introducing a middleware, that rewrites the `x-forwarded-host` to the `host` header.

2. The second problem was with establishing the websocket connection. In particular a duplication of the `connection` header took place as described here: https://github.com/orgs/community/discussions/57596
The solution as also described in the discussion was to redirect to `*.app.github.*` from `*.preview.app.github.*`, which is the default forwarded port url.

3. The case when no port is present in the url had top be considered.

With the proposed changes `gf web` should be accessible from codespaces opened in the web version of vscode.
