### PR TITLE
Fix transitions

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -72,7 +72,7 @@ class Section(BaseModel):
     width: Union[float, Callable]
     offset: Union[float, Callable] = 0
     insets: Optional[tuple] = None
-    layer: Optional[LayerSpec] = None
+    layer: Optional[Union[LayerSpec, LayerSpecs]] = None
     port_names: Tuple[Optional[str], Optional[str]] = (None, None)
     port_types: Tuple[str, str] = ("optical", "optical")
     name: Optional[str] = None

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -65,12 +65,12 @@ def test_transition_cross_section() -> None:
 
 def dummy_cladded_wg_cs(intent_layer, core_layer, core_width, clad_layer, clad_width):
     sections = (
-        Section(width=core_width, offset=0, layer=core_layer, name='core'),
-        Section(width=clad_width, offset=0, layer=clad_layer, name='clad'),
+        Section(width=core_width, offset=0, layer=core_layer, name="core"),
+        Section(width=clad_width, offset=0, layer=clad_layer, name="clad"),
     )
-    return gf.cross_section.cross_section(width=core_width,
-                                          sections=sections,
-                                          layer=intent_layer)
+    return gf.cross_section.cross_section(
+        width=core_width, sections=sections, layer=intent_layer
+    )
 
 
 def test_transition_cross_section_different_layers() -> None:
@@ -85,8 +85,20 @@ def test_transition_cross_section_different_layers() -> None:
     # in platforms with multiple waveguide types, it is useful to use separate intent layers for the different cross sections
     # this will simulate a transition between waveguides with different intent layers (which i just made up arbitrarily for this test)
     # but shared physical layers
-    cs1 = dummy_cladded_wg_cs(intent_layer=intent_layer_1, core_layer="WG", core_width=core_width, clad_layer="WGCLAD", clad_width=w1)
-    cs2 = dummy_cladded_wg_cs(intent_layer=intent_layer_2, core_layer="WG", core_width=core_width, clad_layer="WGCLAD", clad_width=w2)
+    cs1 = dummy_cladded_wg_cs(
+        intent_layer=intent_layer_1,
+        core_layer="WG",
+        core_width=core_width,
+        clad_layer="WGCLAD",
+        clad_width=w1,
+    )
+    cs2 = dummy_cladded_wg_cs(
+        intent_layer=intent_layer_2,
+        core_layer="WG",
+        core_width=core_width,
+        clad_layer="WGCLAD",
+        clad_width=w2,
+    )
     transition = gf.path.transition(cs1, cs2, port_names=(None, None))
 
     c = gf.components.straight(length=length, cross_section=transition)
@@ -101,6 +113,7 @@ def test_transition_cross_section_different_layers() -> None:
     # TODO: restore and replace after area() function is fixed
     # assert c.area() == expected_area
     assert c._cell.area(True)[gf.get_layer("WGCLAD")] == expected_area
+
 
 if __name__ == "__main__":
     test_transition_cross_section()

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory import Section
 from gdsfactory.generic_tech import LAYER
 
 
@@ -61,6 +62,45 @@ def test_transition_cross_section() -> None:
     assert c.ports["o1"].width == w1
     assert c.ports["o2"].width == w2
 
+
+def dummy_cladded_wg_cs(intent_layer, core_layer, core_width, clad_layer, clad_width):
+    sections = (
+        Section(width=core_width, offset=0, layer=core_layer, name='core'),
+        Section(width=clad_width, offset=0, layer=clad_layer, name='clad'),
+    )
+    return gf.cross_section.cross_section(width=core_width,
+                                          sections=sections,
+                                          layer=intent_layer)
+
+
+def test_transition_cross_section_different_layers() -> None:
+    core_width = 1
+    w1 = 1
+    w2 = 5
+    length = 10
+
+    intent_layer_1 = (852, 21)
+    intent_layer_2 = (853, 21)
+
+    # in platforms with multiple waveguide types, it is useful to use separate intent layers for the different cross sections
+    # this will simulate a transition between waveguides with different intent layers (which i just made up arbitrarily for this test)
+    # but shared physical layers
+    cs1 = dummy_cladded_wg_cs(intent_layer=intent_layer_1, core_layer="WG", core_width=core_width, clad_layer="WGCLAD", clad_width=w1)
+    cs2 = dummy_cladded_wg_cs(intent_layer=intent_layer_2, core_layer="WG", core_width=core_width, clad_layer="WGCLAD", clad_width=w2)
+    transition = gf.path.transition(cs1, cs2, port_names=(None, None))
+
+    c = gf.components.straight(length=length, cross_section=transition)
+    c.show()
+    assert c.ports["o1"].width == core_width
+    assert c.ports["o2"].width == core_width
+    assert c.ports["o1"].layer == intent_layer_1
+    assert c.ports["o2"].layer == intent_layer_2
+
+    # area of a trapezoid
+    expected_area = (w1 + w2) / 2 * length
+    # TODO: restore and replace after area() function is fixed
+    # assert c.area() == expected_area
+    assert c._cell.area(True)[gf.get_layer("WGCLAD")] == expected_area
 
 if __name__ == "__main__":
     test_transition_cross_section()


### PR DESCRIPTION
Hi @joamatab ,

I noticed when trying to upgrade that transitions were broken when going between waveguides with different intent layers. There were no tests for this case, so I added a test which was previously broken but fixed by this MR (basically it was just a pydantic issue).

A few other notes...
- I noticed while making the test that the `area()` function is also pretty badly broken... I'll make a new issue for this
- We should probably add a tutorial on how to work in platforms which transition between multiple waveguide types (and maybe expand the generic PDK to cover this case).