### PR TITLE
Fix extrude serialization

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -378,12 +378,13 @@ class Path(_GeometryHelper):
         magic_offset = 0.17048614
 
         final_hash = hashlib.sha1()
-        p = np.ascontiguousarray(
-            (self.points / precision) + magic_offset, dtype=np.int64
-        )
-        final_hash.update(p)
-        p = np.ascontiguousarray((self.start_angle, self.end_angle), dtype=np.float64)
-        final_hash.update(p)
+        points = np.ascontiguousarray(
+            (self.points / precision) + magic_offset, dtype=np.float64
+        ).round().astype(np.int64)
+        final_hash.update(points)
+        angles = (np.ascontiguousarray((self.start_angle, self.end_angle), dtype=np.float64) / precision
+                  ).round().astype(np.int64)
+        final_hash.update(angles)
         return final_hash.hexdigest()
 
     @classmethod

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -378,12 +378,24 @@ class Path(_GeometryHelper):
         magic_offset = 0.17048614
 
         final_hash = hashlib.sha1()
-        points = np.ascontiguousarray(
-            (self.points / precision) + magic_offset, dtype=np.float64
-        ).round().astype(np.int64)
+        points = (
+            np.ascontiguousarray(
+                (self.points / precision) + magic_offset, dtype=np.float64
+            )
+            .round()
+            .astype(np.int64)
+        )
         final_hash.update(points)
-        angles = (np.ascontiguousarray((self.start_angle, self.end_angle), dtype=np.float64) / precision
-                  ).round().astype(np.int64)
+        angles = (
+            (
+                np.ascontiguousarray(
+                    (self.start_angle, self.end_angle), dtype=np.float64
+                )
+                / precision
+            )
+            .round()
+            .astype(np.int64)
+        )
         final_hash.update(angles)
         return final_hash.hexdigest()
 


### PR DESCRIPTION
Hi @joamatab ,

This PR should fix the issue we were seeing with `extrude` components getting different names on different platforms a few weeks back...

The key was to fix how `Path` objects get serialized. One of the arguments for `extrude` is a path, and I think it was getting serialized inconsistently on different systems with paths at odd angles. Previously, points of the path were being rounded, but the angles were not, so the hash was being determined on the numbers with full float precision...