### PR TITLE
Improve difftest

### DIFF
--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -111,7 +111,7 @@ def diff(
                         region_xor = region_ref ^ region_run
                         diff.shapes(layer_id).insert(region_xor)
                         is_sliver = region_xor.sized(-1).is_empty()
-                        message = f'{test_name}: XOR difference on layer {layer}'
+                        message = f"{test_name}: XOR difference on layer {layer}"
                         if is_sliver:
                             message += " (sliver)"
                         print(message)
@@ -119,12 +119,12 @@ def diff(
                     layer = run.layer(layer)
                     region = kdb.Region(run.begin_shapes_rec(layer))
                     diff.shapes(layer).insert(region)
-                    print(f'{test_name}: layer {layer} only exists in updated cell')
+                    print(f"{test_name}: layer {layer} only exists in updated cell")
                 elif layer in ref.kcl.layer_infos():
                     layer = ref.layer(layer)
                     region = kdb.Region(ref.begin_shapes_rec(layer))
                     diff.shapes(layer).insert(region)
-                    print(f'{test_name}: layer {layer} missing from updated cell')
+                    print(f"{test_name}: layer {layer} missing from updated cell")
 
             c << diff
 

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -107,16 +107,24 @@ def diff(
                     region_diff = region_run - region_ref
 
                     if not region_diff.is_empty():
+                        layer_id = c.layer(layer)
                         region_xor = region_ref ^ region_run
-                        diff.shapes(layer_ref).insert(region_xor)
+                        diff.shapes(layer_id).insert(region_xor)
+                        is_sliver = region_xor.sized(-1).is_empty()
+                        message = f'{test_name}: XOR difference on layer {layer}'
+                        if is_sliver:
+                            message += " (sliver)"
+                        print(message)
                 elif layer in run.kcl.layer_infos():
                     layer = run.layer(layer)
                     region = kdb.Region(run.begin_shapes_rec(layer))
                     diff.shapes(layer).insert(region)
-                else:
+                    print(f'{test_name}: layer {layer} only exists in updated cell')
+                elif layer in ref.kcl.layer_infos():
                     layer = ref.layer(layer)
                     region = kdb.Region(ref.begin_shapes_rec(layer))
                     diff.shapes(layer).insert(region)
+                    print(f'{test_name}: layer {layer} missing from updated cell')
 
             c << diff
 


### PR DESCRIPTION
Hi @joamatab ,

This PR makes a few improvements to difftest:
- fixes issue that XOR shapes do not always go to the correct layer on output gds
- adds extra messages during the test to show if there are XOR differences, and if so, distinguishes between sliver differences (<1 dbu wide) and more substantial differences (see snapshot below)

 
Snapshot of test report for a given cell. Note how all XOR results are reported by layer, and layers with only sliver differences are distinguished from more substantial differences
![image](https://github.com/gdsfactory/gdsfactory/assets/3070522/f561bf1d-c308-4885-9823-0d8cb374b432)
