### PR TITLE
Fix small typos in documentation

### DIFF
--- a/gdsfactory/components/extension.py
+++ b/gdsfactory/components/extension.py
@@ -41,9 +41,7 @@ def line(
 
 
 def move_polar_rad_copy(pos: Coordinate, angle: float, length: float) -> ndarray:
-    """Returns the points of a position (pos) with angle, by shifted by certain.
-
-    length.
+    """Returns the points of a position (pos) with angle, shifted by length.
 
     Args:
         pos: position.

--- a/gdsfactory/plugins/web/server_jupyter.py
+++ b/gdsfactory/plugins/web/server_jupyter.py
@@ -23,6 +23,6 @@ def _server_is_running() -> bool:
 
 
 def start() -> None:
-    """Start a jupyter_server if it's nor already started."""
+    """Start a jupyter_server if it's not already started."""
     if not _server_is_running():
         _run()


### PR DESCRIPTION
This commit fixes a couple of documentation typos. The docstring summary of `move_polar_rad_copy` is shortened by one word so it fits on one line (80 chars).

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!