### PR TITLE
Fix get_bundle regressions

### DIFF
--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -77,7 +77,7 @@ def get_bundle(
         start_straight_length: straight length at the beginning of the route. If None, uses default value for the routing CrossSection.
         end_straight_length: end length at the beginning of the route. If None, uses default value for the routing CrossSection.
         path_length_match_loops: Integer number of loops to add to bundle
-            for path length matching. Pathlength matching won't be attempted if None).
+            for path length matching. Path-length matching won't be attempted if this is set to None.
         path_length_match_extra_length: Extra length to add
             to path length matching loops (requires path_length_match_loops != None).
         path_length_match_modify_segment_i: Index of straight segment to add path

--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -52,8 +52,8 @@ def get_bundle(
     with_sbend: bool = False,
     sort_ports: bool = True,
     cross_section: Union[CrossSectionSpec, MultiCrossSectionAngleSpec] = "strip",
-    start_straight_length: float = 0.0,
-    end_straight_length: float = 0.0,
+    start_straight_length: Optional[float] = None,
+    end_straight_length: Optional[float] = None,
     path_length_match_loops: Optional[int] = None,
     path_length_match_extra_length: float = 0.0,
     path_length_match_modify_segment_i: int = -2,
@@ -74,10 +74,10 @@ def get_bundle(
         with_sbend: use s_bend routing when there is no space for manhattan routing.
         sort_ports: sort port coordinates.
         cross_section: CrossSection or function that returns a cross_section.
-        start_straight_length: straight length at the beginning of the route.
-        end_straight_length: end length at the beginning of the route.
+        start_straight_length: straight length at the beginning of the route. If None, uses default value for the routing CrossSection.
+        end_straight_length: end length at the beginning of the route. If None, uses default value for the routing CrossSection.
         path_length_match_loops: Integer number of loops to add to bundle
-            for path length matching (won't try to match if None).
+            for path length matching. Pathlength matching won't be attempted if None).
         path_length_match_extra_length: Extra length to add
             to path length matching loops (requires path_length_match_loops != None).
         path_length_match_modify_segment_i: Index of straight segment to add path
@@ -180,9 +180,9 @@ def get_bundle(
         raise ValueError(f"All start port angles {start_port_angles} must be equal")
 
     path_length_match_params = {
-        "path_length_match_loops",
-        "path_length_match_modify_segment_i",
-        "path_length_match_extra_length",
+        "path_length_match_loops": path_length_match_loops,
+        "path_length_match_extra_length": path_length_match_extra_length,
+        "path_length_match_modify_segment_i": path_length_match_modify_segment_i,
     }
     params = {
         "ports1": ports1,
@@ -191,12 +191,13 @@ def get_bundle(
         "bend": bend,
         "straight": straight,
         "cross_section": cross_section,
-        "path_length_match_loops": path_length_match_loops,
-        "path_length_match_extra_length": path_length_match_extra_length,
-        "path_length_match_modify_segment_i": path_length_match_modify_segment_i,
-        "end_straight_length": end_straight_length,
-        "start_straight_length": start_straight_length,
     }
+    if path_length_match_loops is not None:
+        params.update(path_length_match_params)
+    if end_straight_length is not None:
+        params["end_straight_length"] = end_straight_length
+    if start_straight_length is not None:
+        params["start_straight_length"] = start_straight_length
     params.update(**kwargs)
 
     start_angle = ports1[0].orientation
@@ -244,9 +245,12 @@ def get_bundle(
 
     elif end_angle == (start_angle + 180) % 360:
         # print("get_bundle_uindirect")
-        for param in path_length_match_params:
-            params.pop(param, None)
-        return get_bundle_uindirect(extension_length=extension_length, **params)
+        params_without_pathlength = {
+            k: v for k, v in params.items() if k not in path_length_match_params
+        }
+        return get_bundle_uindirect(
+            extension_length=extension_length, **params_without_pathlength
+        )
     else:
         raise NotImplementedError("This should never happen")
 


### PR DESCRIPTION
Hi @joamatab, I found that the changes from v6.107.2->3 caused many, many regressions for me in bundle routing. This patch fixes those regressions by more robustly handling of the new keyword args you added for pathlength matching and start/end straight lengths, when they are not explicitly specified, so that it matches previous behavior