### PR TITLE
FIX: component_lattice_generic validation network parameter

### DIFF
--- a/gdsfactory/components/component_lattice_generic.py
+++ b/gdsfactory/components/component_lattice_generic.py
@@ -28,7 +28,7 @@ def find_largest_component(component_list: list) -> Component:
 
 @cell
 def component_lattice_generic(
-    network: Optional[List[Component]] = None,
+    network: Optional[List[List]] = None,
 ) -> Component:
     """
     The shape of the `network` matrix determines the physical interconnection.


### PR DESCRIPTION
Hi Joaquin,

Thanks for the help! I was using the new `component_lattice_generic` component in the latest branch and there's a validation error when inputting the `network` parameter which is a minor change:

```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[3], line 1
----> 1 switch_circuit = gf.components.component_lattice_generic(network=example_component_lattice)
      2 switch_circuit

File ~\Documents\phd\software\gdsfactory\gdsfactory\cell.py:185, in cell_without_validator.<locals>._cell(*args, **kwargs)
    180 if not callable(func):
    181     raise ValueError(
    182         f"{func!r} is not callable! @cell decorator is only for functions"
    183     )
--> 185 component = func(*args, **kwargs)
    187 # if the component is already in the cache, but under a different alias,
    188 # make sure we use a copy, so we don't run into mutability errors
    189 if id(component) in [id(v) for v in CACHE.values()]:

File ~\mambaforge\lib\site-packages\pydantic\decorator.py:40, in pydantic.decorator.validate_arguments.validate.wrapper_function()

File ~\mambaforge\lib\site-packages\pydantic\decorator.py:133, in pydantic.decorator.ValidatedFunction.call()

File ~\mambaforge\lib\site-packages\pydantic\decorator.py:130, in pydantic.decorator.ValidatedFunction.init_model_instance()

File ~\mambaforge\lib\site-packages\pydantic\main.py:341, in pydantic.main.BaseModel.__init__()

ValidationError: 3 validation errors for ComponentLatticeGeneric
network -> 0
  TypeError, Got <class 'list'>, expecting Component (type=assertion_error)
network -> 1
  TypeError, Got <class 'list'>, expecting Component (type=assertion_error)
network -> 2
  TypeError, Got <class 'list'>, expecting Component (type=assertion_error)
```

So I've just changed it from:

```
network: Optional[List[Component]] = None,
```

to 

```
network: Optional[List[List]] = None,
```

And it works well now!