### PR TITLE
add rib-strip routing example notebook

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # [Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased](https://github.com/gdsfactory/gdsfactory/compare/v6.103.1...main)
+## [Unreleased](https://github.com/gdsfactory/gdsfactory/compare/v6.109.0...main)
+
+## [6.110.0](https://github.com/gdsfactory/gdsfactory/compare/v6.110.0...v6.109.0)
+
+- add rib-strip routing example notebook [PR](https://github.com/gdsfactory/gdsfactory/pull/1808)
 
 ## [6.109.0](https://github.com/gdsfactory/gdsfactory/compare/v6.109.0...v6.108.1)
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -39,6 +39,7 @@ parts:
         - file: notebooks/04_routing
         - file: notebooks/041_routing_electrical
         - file: notebooks/042_non-manhattan-router
+        - file: notebooks/rib_strip_autotransition
         - file: notebooks/common_mistakes
         - file: notebooks/dataprep
     - file: verification

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1601,7 +1601,7 @@ class Component(_GeometryHelper):
 
         quickplot(self, **kwargs)
 
-    def plot(self, plotter: str | None = None, **kwargs) -> None:
+    def plot(self, plotter: str | None = None, **kwargs):
         """Returns component plot using klayout, matplotlib, holoviews or qt.
 
         We recommend using klayout.

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -1,7 +1,8 @@
 import pathlib
 from inspect import Parameter, Signature, signature
 from io import IOBase
-from typing import IO, Any, Callable, Dict, Iterable, Optional, Tuple, Union, Component
+from typing import IO, Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from gdsfactory.component import Component
 
 import jinja2
 import yaml

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -1,7 +1,7 @@
 import pathlib
 from inspect import Parameter, Signature, signature
 from io import IOBase
-from typing import IO, Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import IO, Any, Callable, Dict, Iterable, Optional, Tuple, Union, Component
 
 import jinja2
 import yaml
@@ -14,10 +14,10 @@ def split_default_settings_from_yaml(yaml_lines: Iterable[str]) -> Tuple[str, st
     Note: 'default settings' MUST be at the TOP of the file.
 
     Args:
-        yaml_lines: the lines of text in the yaml file
+        yaml_lines: the lines of text in the yaml file.
 
     Returns:
-        a tuple of (main file contents), (setting block), both as multi-line strings
+        a tuple of (main file contents), (setting block), both as multi-line strings.
     """
     settings_lines = []
     other_lines = []
@@ -66,11 +66,12 @@ def cell_from_yaml_template(
     """Gets a PIC factory function from a yaml definition, which can optionally be a jinja template.
 
     Args:
-        filename: the filepath of the pic yaml template
-        name: the name of the component to create
-        routing_strategy: a dictionary of routing functions
+        filename: the filepath of the pic yaml template.
+        name: the name of the component to create.
+        routing_strategy: a dictionary of routing functions.
+
     Returns:
-         a factory function for the component
+         a factory function for the component.
     """
     from gdsfactory.pdk import get_routing_strategies
 
@@ -97,15 +98,16 @@ def get_default_settings_dict(default_settings):
     return settings
 
 
-def yaml_cell(yaml_definition, name, routing_strategy):
+def yaml_cell(yaml_definition, name: str, routing_strategy) -> Callable[..., Component]:
     """The "cell" decorator equivalent for yaml files. Generates a proper cell function for yaml-defined circuits.
 
     Args:
-        yaml_definition: the filename to the pic yaml definition
-        name: the name of the pic to create
-        routing_strategy: a dictionary of routing strategies to use for pic generation
+        yaml_definition: the filename to the pic yaml definition.
+        name: the name of the pic to create.
+        routing_strategy: a dictionary of routing strategies to use for pic generation.
+
     Returns:
-        a dynamically-generated function for the yaml file
+        a dynamically-generated function for the yaml file.
     """
     from gdsfactory.cell import cell_without_validator
 
@@ -151,13 +153,16 @@ def _evaluate_yaml_template(main_file, default_settings, settings):
     return template.render(**complete_settings)
 
 
-def _pic_from_templated_yaml(evaluated_text, name, routing_strategy):
-    """Creates a component from a  *.pic.yml file. This is a lower-level function. See from_yaml_template() for more common usage.
+def _pic_from_templated_yaml(evaluated_text, name, routing_strategy) -> Component:
+    """Creates a component from a  *.pic.yml file.
+
+    This is a lower-level function. See from_yaml_template() for more common usage.
 
     Args:
-        name: the pic name
-        routing_strategy: a dictionary of route factories
-    Returns: the component
+        name: the pic name.
+        routing_strategy: a dictionary of route factories.
+
+    Returns: the component.
     """
     from gdsfactory.read.from_yaml import from_yaml
 

--- a/gdsfactory/samples/notebooks/04_routing.py
+++ b/gdsfactory/samples/notebooks/04_routing.py
@@ -1124,6 +1124,10 @@ c.plot()
 # ### get bundle with different orientation ports
 #
 # When trying to route ports with different orientations you need to bring them to a common `x` or `y`
+#
+#
+# 1. Use `route_ports_to_side` to bring all the ports to a common angle orientation and x or y.
+# 2. Use `get_bundle` to connect to the other group of ports.
 
 # %%
 from gdsfactory.samples.big_device import big_device

--- a/gdsfactory/samples/notebooks/rib_strip_autotransition.py
+++ b/gdsfactory/samples/notebooks/rib_strip_autotransition.py
@@ -1,12 +1,29 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: base
+#     language: python
+#     name: python3
+# ---
+
 # %% [markdown]
-# # Platforms with Multiple Waveguide Cross-Sections
+# # Routing with different CrossSections
 #
-# When working in a platform with multiple waveguide cross-sections, it is useful to differentiate intent layers for the different waveguide types
+# When working in a technologies with multiple waveguide cross-sections, it is useful to differentiate intent layers for the different waveguide types
 # and assign default transitions between those layers. In this way, you can easily autotransition between the different cross-section types.
 #
 # ## Setting up your PDK
 #
-# Let's first set up a sample PDK with the following key features
+# Let's first set up a sample PDK with the following key features:
+#
 # 1. Rib and strip cross-sections with differentiated intent layers.
 # 2. Default transitions for each individual cross-section type (width tapers), and also a rib-to-strip transition component to switch between them.
 # 3. Preferred routing cross-sections defined for the all-angle router.
@@ -19,10 +36,12 @@ from functools import partial
 from gdsfactory.cross_section import strip, rib_conformal
 from gdsfactory.typings import CrossSectionSpec
 from gdsfactory.routing import all_angle
+from gdsfactory.read import cell_from_yaml_template
 
 gf.clear_cache()
 gf.config.rich_output()
 generic_pdk = get_generic_pdk()
+generic_pdk.circuit_yaml_parser = cell_from_yaml_template
 
 # define our rib and strip waveguide intent layers
 RIB_INTENT_LAYER = (2000, 11)
@@ -134,7 +153,7 @@ rib_wg = c << gf.c.straight(cross_section="rib", width=rib_width)
 taper = c << strip_to_rib(width1=strip_width, width2=rib_width)
 taper.connect("o1", strip_wg.ports["o2"])
 rib_wg.connect("o1", taper.ports["o2"])
-c
+c.plot()
 
 # %% [markdown]
 # ## Autotransitioning with the All-Angle Router
@@ -168,12 +187,22 @@ basic_sample_fn = sample_dir / "aar_indirect.pic.yml"
 show_yaml_pic(basic_sample_fn)
 
 
+# %%
+c = gf.read.from_yaml(yaml_str=basic_sample_fn.read_text())
+c.plot()
+
 # %% [markdown]
 # You can see that since `gap` is defined in our cross-sections, the bundle router also intelligently picks the appropriate bundle spacing for the cross section used.
 #
 # Notice how the strip waveguide bundles are much more tightly packed than the rib waveguide bundles in the example below.
 
 # %%
-show_yaml_pic(sample_dir / "aar_bundles03.pic.yml")
+basic_sample_fn2 = sample_dir / "aar_bundles03.pic.yml"
+show_yaml_pic(basic_sample_fn2)
+
+# %%
+f = cell_from_yaml_template(basic_sample_fn2, name="sample_transition")
+c = f()
+c.plot()
 
 # %%

--- a/gdsfactory/samples/notebooks/rib_strip_autotransition.py
+++ b/gdsfactory/samples/notebooks/rib_strip_autotransition.py
@@ -1,0 +1,179 @@
+# %% [markdown]
+# # Platforms with Multiple Waveguide Cross-Sections
+#
+# When working in a platform with multiple waveguide cross-sections, it is useful to differentiate intent layers for the different waveguide types
+# and assign default transitions between those layers. In this way, you can easily autotransition between the different cross-section types.
+#
+# ## Setting up your PDK
+#
+# Let's first set up a sample PDK with the following key features
+# 1. Rib and strip cross-sections with differentiated intent layers.
+# 2. Default transitions for each individual cross-section type (width tapers), and also a rib-to-strip transition component to switch between them.
+# 3. Preferred routing cross-sections defined for the all-angle router.
+
+# %%
+from gdsfactory.decorators import has_valid_transformations
+import gdsfactory as gf
+from gdsfactory.generic_tech import get_generic_pdk
+from functools import partial
+from gdsfactory.cross_section import strip, rib_conformal
+from gdsfactory.typings import CrossSectionSpec
+from gdsfactory.routing import all_angle
+
+gf.clear_cache()
+gf.config.rich_output()
+generic_pdk = get_generic_pdk()
+
+# define our rib and strip waveguide intent layers
+RIB_INTENT_LAYER = (2000, 11)
+STRIP_INTENT_LAYER = (2001, 11)
+
+# create strip and rib cross-sections, with differentiated intent layers
+strip_with_intent = partial(
+    strip,
+    layer="STRIP_INTENT",
+    cladding_layers=["WG"],  # keeping WG layer is nice for compatibility
+    cladding_offsets=[0],
+    gap=2,
+)
+
+rib_with_intent = partial(
+    rib_conformal,
+    layer="RIB_INTENT",
+    cladding_layers=["WG"],  # keeping WG layer is nice for compatibility
+    cladding_offsets=[0],
+    gap=5,
+)
+
+
+# create strip->rib transition component
+@gf.cell
+def strip_to_rib(width1: float = 0.5, width2: float = 0.5):
+    c = gf.Component()
+    taper = c << gf.c.taper_strip_to_ridge(width1=width1, width2=width2)
+    c.add_port(
+        "o1",
+        port=taper.ports["o1"],
+        layer="STRIP_INTENT",
+        cross_section=strip_with_intent(width=width1),
+    )
+    c.add_port(
+        "o2",
+        port=taper.ports["o2"],
+        layer="RIB_INTENT",
+        cross_section=rib_with_intent(width=width2),
+    )
+    c.info.update(taper.info)
+    return c
+
+
+# also define a rib->strip component for transitioning the other way
+@gf.cell
+def rib_to_strip(width1: float = 0.5, width2: float = 0.5):
+    c = gf.Component()
+    taper = c << strip_to_rib(width1=width2, width2=width1)
+    c.add_port("o1", port=taper.ports["o2"])
+    c.add_port("o2", port=taper.ports["o1"])
+    c.info.update(taper.info)
+    return c
+
+
+# create single-layer taper components
+@gf.cell
+def taper_single_cross_section(
+    cross_section: CrossSectionSpec = "strip", width1: float = 0.5, width2: float = 1.0
+):
+    cs1 = gf.get_cross_section(cross_section, width=width1)
+    cs2 = gf.get_cross_section(cross_section, width=width2)
+    length = abs(width1 - width2) * 10
+    c = gf.c.taper_cross_section_linear(cs1, cs2, length=length).copy()
+    c.info["length"] = length
+    return c
+
+
+taper_strip = partial(taper_single_cross_section, cross_section="strip")
+taper_rib = partial(taper_single_cross_section, cross_section="rib")
+
+# make a new PDK with our required layers, cross-sections, and default transitions
+multi_wg_pdk = gf.Pdk(
+    base_pdk=generic_pdk,
+    name="multi_wg_demo",
+    layers={
+        "RIB_INTENT": RIB_INTENT_LAYER,
+        "STRIP_INTENT": STRIP_INTENT_LAYER,
+    },
+    cross_sections={
+        "rib": rib_with_intent,
+        "strip": strip_with_intent,
+    },
+    layer_transitions={
+        RIB_INTENT_LAYER: taper_rib,
+        STRIP_INTENT_LAYER: taper_strip,
+        (RIB_INTENT_LAYER, STRIP_INTENT_LAYER): rib_to_strip,
+        (STRIP_INTENT_LAYER, RIB_INTENT_LAYER): strip_to_rib,
+    },
+    layer_views=generic_pdk.layer_views,
+)
+
+# activate our new PDK
+multi_wg_pdk.activate()
+
+# set to prefer rib routing when there is enough space
+all_angle.LOW_LOSS_CROSS_SECTIONS.insert(0, "rib")
+
+# %% [markdown]
+# Let's quickly demonstrate our new cross-sections and transition component.
+
+# %%
+# demonstrate rib and strip waveguides in our new PDK
+strip_width = 1
+rib_width = 0.7
+c = gf.Component()
+strip_wg = c << gf.c.straight(cross_section="strip", width=strip_width)
+rib_wg = c << gf.c.straight(cross_section="rib", width=rib_width)
+taper = c << strip_to_rib(width1=strip_width, width2=rib_width)
+taper.connect("o1", strip_wg.ports["o2"])
+rib_wg.connect("o1", taper.ports["o2"])
+c
+
+# %% [markdown]
+# ## Autotransitioning with the All-Angle Router
+#
+# Now that our PDK and settings are all configured, we can see how the all-angle router will
+# auto-transition for us between different cross sections.
+#
+# Because we are using the low-loss connector by default, and the highest priority cross section is rib,
+# we will see rib routing anywhere there is enough space to transition.
+
+# %%
+from gdsfactory.read import cell_from_yaml_template
+from IPython.display import Code
+from pathlib import Path
+from IPython.display import display
+
+
+def show_yaml_pic(filepath):
+    gf.clear_cache()
+    cell_name = filepath.stem
+    return display(
+        Code(filename=filepath, language="yaml+jinja"),
+        cell_from_yaml_template(filepath, name=cell_name)(),
+    )
+
+
+# load a yaml PIC, and see how it looks with our new technology
+sample_dir = Path("yaml_pics")
+
+basic_sample_fn = sample_dir / "aar_indirect.pic.yml"
+show_yaml_pic(basic_sample_fn)
+
+
+# %% [markdown]
+# You can see that since `gap` is defined in our cross-sections, the bundle router also intelligently picks the appropriate bundle spacing for the cross section used.
+#
+# Notice how the strip waveguide bundles are much more tightly packed than the rib waveguide bundles in the example below.
+
+# %%
+show_yaml_pic(sample_dir / "aar_bundles03.pic.yml")
+
+# %%

--- a/gdsfactory/samples/notebooks/yaml_pics/aar_bundles03.pic.yml
+++ b/gdsfactory/samples/notebooks/yaml_pics/aar_bundles03.pic.yml
@@ -1,0 +1,55 @@
+default_settings:
+  n_bundle:
+    value: 3
+    description: "The number of routes in the bundle"
+
+instances:
+{% for i in range(n_bundle) %}
+    wg_start_{{ i }}:
+      component: straight
+    wg_end_{{ i }}:
+      component: straight
+{% endfor %}
+
+placements:
+{% for i in range(n_bundle) %}
+    wg_end_{{ i }}:
+        rotation: 180
+        y: {{ i * 4 }}
+    wg_start_{{ i }}:
+        port: o1
+        rotation: {{ 20 - i * 5 }}  # ports need not be aligned
+        x: wg_end_0,o1
+        y: wg_end_0,o1
+        dx: 120
+        dy: {{ 80 + i * 4 }}
+{% endfor %}
+
+routes:
+    optical:
+        routing_strategy: get_bundle_all_angle
+        settings:
+          steps:
+            - ds: 65
+              exit_angle: 90
+            - ds: 110
+              exit_angle: 0
+            - ds: 81.5
+              exit_angle: -65
+            - ds: 52
+              exit_angle: -158
+              cross_section: strip  # explicitly using strip routing
+            - ds: 47.5
+              exit_angle: 140
+              cross_section:  # explicitly using strip routing with custom width
+                cross_section: strip
+                settings:
+                  width: 1.2
+        links:
+{% for i in [2, 1, 0] %}
+            wg_end_{{ i }},o1: wg_start_{{ i }},o1
+{% endfor %}
+
+ports:
+    o1: wg_start_0,o2
+    o2: wg_end_0,o2


### PR DESCRIPTION
Hi @joamatab ,

This MR addresses #1742. It adds an example notebook that

1. Creates a new PDK capable of rib-to-strip auto-routing.
2. Demonstrates this with a few sample PICs, using the all-angle router.