### PR TITLE
wire components with bbox

### DIFF
--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -16,12 +16,13 @@ wire_straight = partial(straight, cross_section="metal_routing")
 
 @gf.cell
 def wire_corner(
-    cross_section: CrossSectionSpec = "metal_routing", **kwargs
+    cross_section: CrossSectionSpec = "metal_routing", with_bbox: bool = False, **kwargs
 ) -> Component:
     """Returns 45 degrees electrical corner wire.
 
     Args:
         cross_section: spec.
+        with_bbox: if True, includes the bbox layer and bbox offsets of the cross_section
         kwargs: cross_section settings.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -34,6 +35,21 @@ def wire_corner(
     ypts = [-a, -a, a, a]
 
     c.add_polygon([xpts, ypts], layer=layer)
+
+    corner_bbox = c.bbox
+    if with_bbox:
+        bbox_layers = x.bbox_layers
+        bbox_offsets = x.bbox_offsets
+        for layer, offset in zip(bbox_layers, bbox_offsets):
+            c << gf.components.bbox(
+                corner_bbox,
+                layer=layer,
+                top=offset,
+                bottom=offset,
+                left=offset,
+                right=offset,
+            )
+
     c.add_port(
         name="e1",
         center=(-a, 0),
@@ -57,12 +73,16 @@ def wire_corner(
 
 @gf.cell
 def wire_corner45(
-    cross_section: CrossSectionSpec = "metal_routing", radius: float = 10, **kwargs
+    cross_section: CrossSectionSpec = "metal_routing",
+    radius: float = 10,
+    with_bbox: bool = False,
+    **kwargs,
 ) -> Component:
     """Returns 90 degrees electrical corner wire.
 
     Args:
         cross_section: spec.
+        with_bbox: if True, includes the bbox layer and bbox offsets of the cross_section
         kwargs: cross_section settings.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -82,6 +102,21 @@ def wire_corner45(
     ypts = [-a, radius, radius + np.sqrt(2) * width, -a]
 
     c.add_polygon([xpts, ypts], layer=layer)
+
+    corner_bbox = c.bbox
+    if with_bbox:
+        bbox_layers = x.bbox_layers
+        bbox_offsets = x.bbox_offsets
+        for layer, offset in zip(bbox_layers, bbox_offsets):
+            c << gf.components.bbox(
+                corner_bbox,
+                layer=layer,
+                top=offset,
+                bottom=offset,
+                left=offset,
+                right=offset,
+            )
+
     c.add_port(
         name="e1",
         center=(0, 0),
@@ -105,6 +140,7 @@ def wire_corner45(
 @gf.cell
 def wire_corner_sections(
     cross_section: CrossSectionSpec = "metal_routing",
+    with_bbox: bool = False,
     **kwargs,
 ) -> Component:
     """Returns 90 degrees electrical corner wire, where all cross_section sections properly represented.
@@ -113,6 +149,7 @@ def wire_corner_sections(
 
     Args:
         cross_section: spec.
+        with_bbox: if True, includes the bbox layer and bbox offsets of the cross_section
         kwargs: cross_section settings.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -148,6 +185,20 @@ def wire_corner_sections(
 
         c.add_polygon([xpts, ypts], layer=layer)
 
+    corner_bbox = c.bbox
+    if with_bbox:
+        bbox_layers = x.bbox_layers
+        bbox_offsets = x.bbox_offsets
+        for layer, offset in zip(bbox_layers, bbox_offsets):
+            c << gf.components.bbox(
+                corner_bbox,
+                layer=layer,
+                top=offset,
+                bottom=offset,
+                left=offset,
+                right=offset,
+            )
+
     c.add_port(
         name="e1",
         center=(xmin, -(xmin + ymax) / 2),
@@ -169,32 +220,55 @@ def wire_corner_sections(
 
 if __name__ == "__main__":
     # c = wire_straight()
-    # c = wire_corner()
-    section1 = gf.cross_section.Section(width=0.4, layer="M1", offset=0.5)
-    section2 = gf.cross_section.Section(width=0.4, layer="M1", offset=-0.5)
-    xsection = gf.cross_section.cross_section(
-        width=0.4, offset=0, layer="M1", sections=[section1, section2]
-    )
+
+    # xsection = gf.cross_section.cross_section(
+    #     width=1,
+    #     offset=0,
+    #     layer="M3",
+    #     bbox_layers = ("M1", "M2"),
+    #     bbox_offsets = (1, 2),
+    # )
+
+    # c = wire_corner(cross_section=xsection, with_bbox=True)
+    # c.show(show_ports=True)
+    # section1 = gf.cross_section.Section(width=0.4, layer="M1", offset=0.5)
+    # section2 = gf.cross_section.Section(width=0.4, layer="M1", offset=-0.5)
+    # xsection = gf.cross_section.cross_section(
+    #     width=0.4, offset=0, layer="M1", sections=[section1, section2]
+    # )
     from gdsfactory.cross_section import metal_slotted
 
-    c = wire_corner_sections(cross_section=metal_slotted)
-    c.show(show_ports=True)
-    # c.pprint_ports()
-    # c.pprint()
+    # # c = wire_corner_sections(cross_section=metal_slotted)
+    # # c.show(show_ports=True)
+    # # c.pprint_ports()
+    # # c.pprint()
 
-    # port1 = gf.Port(name="init", orientation=270, center=(0, 0), cross_section=metal_slotted)
-    # port2 = gf.Port(
-    #     name="final", orientation=0, center=(-20, -20), cross_section=metal_slotted
-    # )
+    metal_slotted_bbox = metal_slotted(
+        bbox_layers=("M1", "M2"),
+        bbox_offsets=(2, 4),
+    )
 
-    # c = gf.Component()
-    # route = gf.routing.get_route_electrical(
-    #     input_port=port1,
-    #     output_port=port2,
-    #     bend=wire_corner_sections(cross_section=xsection),
-    #     cross_section=xsection,
-    # )
-    # c.add(route.references)
-    # c.show()
+    port1 = gf.Port(
+        name="init",
+        orientation=270,
+        center=(0, 0),
+        cross_section=gf.get_cross_section(metal_slotted),
+    )
+    port2 = gf.Port(
+        name="final",
+        orientation=0,
+        center=(-100, -100),
+        cross_section=gf.get_cross_section(metal_slotted),
+    )
+
+    c = gf.Component()
+    route = gf.routing.get_route_electrical(
+        input_port=port1,
+        output_port=port2,
+        bend=wire_corner_sections(cross_section=metal_slotted_bbox, with_bbox=False),
+        cross_section=metal_slotted_bbox,
+    )
+    c.add(route.references)
+    c.show()
 
     # print(yaml.dump(c.to_dict()))

--- a/tests/test_components/test_settings_wire_corner45_.yml
+++ b/tests/test_components/test_settings_wire_corner45_.yml
@@ -30,9 +30,11 @@ settings:
   default:
     cross_section: metal_routing
     radius: 10
+    with_bbox: false
   full:
     cross_section: metal_routing
     radius: 10
+    with_bbox: false
   function_name: wire_corner45
   info:
     length: 14.142

--- a/tests/test_components/test_settings_wire_corner_.yml
+++ b/tests/test_components/test_settings_wire_corner_.yml
@@ -29,8 +29,10 @@ settings:
   child: null
   default:
     cross_section: metal_routing
+    with_bbox: false
   full:
     cross_section: metal_routing
+    with_bbox: false
   function_name: wire_corner
   info:
     dy: 10.0


### PR DESCRIPTION
Manhattan routing using `wire.py` components (`wire_corner`, `wire45`, and `wire_corner_sections`) currently does not handle cross_section bbox:

```
    from gdsfactory.cross_section import metal_slotted

    metal_slotted_bbox = metal_slotted(
        bbox_layers=("M1", "M2"),
        bbox_offsets=(2, 4),
    )
```

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/958f7a95-9b90-432a-82ab-2bb8fa5d3e73)

With this PR, there is a new `with_bbox` argument to the wire components that allows cross_section bbox to be carried over (defaults to False to conserve old behaviour):

```
    c = gf.Component()
    route = gf.routing.get_route_electrical(
        input_port=port1,
        output_port=port2,
        bend=wire_corner_sections(cross_section=metal_slotted_bbox, with_bbox=False),
        cross_section=metal_slotted_bbox,
    )
    c.add(route.references)
    c.show()
```

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/9ca765e6-1658-4911-9c02-8503003e379d)
