### PR TITLE
Gc array loopback

### DIFF
--- a/gdsfactory/components/grating_coupler_array.py
+++ b/gdsfactory/components/grating_coupler_array.py
@@ -13,15 +13,17 @@ def grating_coupler_array(
     n: int = 6,
     port_name: str = "o1",
     rotation: int = 0,
+    with_loopback: bool = False,
 ) -> Component:
-    """Array of rectangular pads.
+    """Array of grating couplers.
 
     Args:
         grating_coupler: ComponentSpec.
         pitch: x spacing.
-        n: number of pads.
+        n: number of grating couplers.
         port_name: port name.
         rotation: rotation angle for each reference.
+        with_loopback: if True, adds a loopback between edge GCs. Only works for rotation = 90 for now.
     """
     c = Component()
     grating_coupler = gf.get_component(grating_coupler)
@@ -33,9 +35,43 @@ def grating_coupler_array(
         port_name_new = f"o{i}"
         c.add_port(port=gc.ports[port_name], name=port_name_new)
 
+    if with_loopback:
+        if rotation != 90:
+            raise ValueError(
+                "with_loopback is currently only programmed to work with rotation = 90"
+            )
+        if grating_coupler.get_ports_list()[0].cross_section is None:
+            routing_xs = gf.cross_section.cross_section(
+                layer=grating_coupler.get_ports_list()[0].layer,
+                width=grating_coupler.get_ports_list()[0].width,
+                radius=10,
+            )
+        else:
+            routing_xs = gf.get_cross_section(
+                grating_coupler.get_ports_list()[0].cross_section
+            )
+        radius = routing_xs.radius
+
+        steps = (
+            {"dy": -radius},
+            {"dx": -gc.xsize / 2 - radius},
+            {"dy": gc.ysize + 2 * radius},
+            {"dx": c.xsize + 2 * radius},
+            {"dy": -gc.ysize - 2 * radius},
+            {"dx": -gc.xsize / 2 - radius},
+        )
+
+        route = gf.routing.get_route_from_steps(
+            port1=c.ports["o0"],
+            port2=c.ports[f"o{n-1}"],
+            steps=steps,
+            cross_section=routing_xs,
+        )
+        c.add(route.references)
+
     return c
 
 
 if __name__ == "__main__":
-    c = grating_coupler_array()
+    c = grating_coupler_array(rotation=90, with_loopback=True)
     c.show(show_ports=True)

--- a/gdsfactory/components/grating_coupler_array.py
+++ b/gdsfactory/components/grating_coupler_array.py
@@ -69,6 +69,9 @@ def grating_coupler_array(
         )
         c.add(route.references)
 
+        c.ports.pop("o0")
+        c.ports.pop(f"o{n-1}")
+
     return c
 
 

--- a/tests/test_components/test_settings_grating_coupler_array_.yml
+++ b/tests/test_components/test_settings_grating_coupler_array_.yml
@@ -82,6 +82,7 @@ settings:
     pitch: 127.0
     port_name: o1
     rotation: 0
+    with_loopback: false
   full:
     grating_coupler:
       function: grating_coupler_elliptical
@@ -89,6 +90,7 @@ settings:
     pitch: 127.0
     port_name: o1
     rotation: 0
+    with_loopback: false
   function_name: grating_coupler_array
   info: {}
   info_version: 2


### PR DESCRIPTION
there's a lot of code to route components to GCs in gdsfactory.routing, including fiber loopbacks

but for some reason the gc array component did not have a loopback option, so here's one for those times you want to be more manual with the routing (like routing two separate components to the same fiber array)