### PR TITLE
Ring boolean

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -55,7 +55,7 @@ from gdsfactory.components.coupler90bend import coupler90bend
 from gdsfactory.components.coupler_adiabatic import coupler_adiabatic
 from gdsfactory.components.coupler_asymmetric import coupler_asymmetric
 from gdsfactory.components.coupler_full import coupler_full
-from gdsfactory.components.coupler_ring import coupler_ring
+from gdsfactory.components.coupler_ring import coupler_ring, coupler_ring_point
 from gdsfactory.components.coupler_straight import coupler_straight
 from gdsfactory.components.coupler_straight_asymmetric import (
     coupler_straight_asymmetric,
@@ -328,6 +328,7 @@ _factory_passives = dict(
     coupler_asymmetric=coupler_asymmetric,
     coupler_full=coupler_full,
     coupler_ring=coupler_ring,
+    coupler_ring_point=coupler_ring_point,
     coupler_symmetric=coupler_symmetric,
     crossing=crossing,
     crossing45=crossing45,
@@ -410,6 +411,7 @@ __all__ = [
     "coupler_asymmetric",
     "coupler_full",
     "coupler_ring",
+    "coupler_ring_point",
     "coupler_straight",
     "coupler_straight_asymmetric",
     "coupler_symmetric",

--- a/gdsfactory/components/coupler_ring.py
+++ b/gdsfactory/components/coupler_ring.py
@@ -8,7 +8,12 @@ from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.coupler90 import coupler90
 from gdsfactory.components.coupler_straight import coupler_straight
 from gdsfactory.components.straight import straight
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from gdsfactory.typings import (
+    ComponentSpec,
+    CrossSectionSpec,
+    LayerSpecs,
+    Coordinates,
+)
 
 
 @gf.cell
@@ -22,6 +27,8 @@ def coupler_ring(
     cross_section: CrossSectionSpec = "strip",
     bend_cross_section: Optional[CrossSectionSpec] = None,
     length_extension: float = 3,
+    layers_open: LayerSpecs = None,
+    sizes_open: Coordinates = None,
     **kwargs,
 ) -> Component:
     r"""Coupler for ring.
@@ -99,10 +106,46 @@ def coupler_ring(
     return c
 
 
+@gf.cell
+def coupler_ring_point(
+    coupler_ring: ComponentSpec,
+    open_layers: LayerSpecs = None,
+    open_sizes: Coordinates = None,
+):
+    """Coupler ring, where some layers are removed at the coupling region to allow for very short interaction lengths (point couplers).
+
+    Arguments:
+        coupler_ring: coupler_ring component to process
+        open_layers: layers to perform the boolean operations on
+        open_sizes: sizes of the boxes to use to remove layers, centered at bus center
+    """
+    c = gf.Component()
+
+    open_layers_tuples = [gf.get_layer(open_layer) for open_layer in open_layers]
+    untouched_layers = list(set(coupler_ring.get_layers()) - set(open_layers_tuples))
+
+    for layer, size in zip(open_layers, open_sizes):
+        subcomponent = coupler_ring.extract(layers=[layer])
+        rectangle = gf.components.rectangle(size=size, layer=layer, centered=True)
+        c << gf.geometry.boolean(subcomponent, rectangle, "A-B", layer=layer)
+
+    coupler_ref = c << coupler_ring.extract(layers=untouched_layers)
+
+    c.add_ports(coupler_ring.get_ports_list())
+    c.absorb(coupler_ref)
+
+    return c
+
+
 if __name__ == "__main__":
-    c = coupler_ring()
+    # c = coupler_ring()
     # c = coupler_ring(width=1, layer=(2, 0), length_x=20)
-    # c = coupler_ring(cross_section="strip_heater_metal", length_x=20)
+    c = coupler_ring(
+        cross_section="strip_heater_metal",
+        length_x=0,
+        bend=gf.components.bend_circular,
+    )
+    d = coupler_ring_point(c, open_layers=("HEATER",), open_sizes=((5, 7),))
 
     # c = gf.Component()
     # c1 = coupler_ring(cladding_layers=[(111, 0)], cladding_offsets=[0.5])
@@ -111,4 +154,4 @@ if __name__ == "__main__":
     # c3 = gf.geometry.offset(c2, distance=-d, layer=(111, 0))
     # c << c1
     # c << c3
-    c.show(show_ports=True)
+    d.show(show_ports=True)

--- a/gdsfactory/components/coupler_ring.py
+++ b/gdsfactory/components/coupler_ring.py
@@ -27,8 +27,6 @@ def coupler_ring(
     cross_section: CrossSectionSpec = "strip",
     bend_cross_section: Optional[CrossSectionSpec] = None,
     length_extension: float = 3,
-    layers_open: LayerSpecs = None,
-    sizes_open: Coordinates = None,
     **kwargs,
 ) -> Component:
     r"""Coupler for ring.

--- a/gdsfactory/components/coupler_ring.py
+++ b/gdsfactory/components/coupler_ring.py
@@ -108,9 +108,10 @@ def coupler_ring(
 
 @gf.cell
 def coupler_ring_point(
-    coupler_ring: ComponentSpec,
+    coupler_ring: ComponentSpec = coupler_ring,
     open_layers: LayerSpecs = None,
     open_sizes: Coordinates = None,
+    **kwargs,
 ):
     """Coupler ring, where some layers are removed at the coupling region to allow for very short interaction lengths (point couplers).
 
@@ -121,17 +122,21 @@ def coupler_ring_point(
     """
     c = gf.Component()
 
+    coupler_ring_component = coupler_ring(**kwargs)
+
     open_layers_tuples = [gf.get_layer(open_layer) for open_layer in open_layers]
-    untouched_layers = list(set(coupler_ring.get_layers()) - set(open_layers_tuples))
+    untouched_layers = list(
+        set(coupler_ring_component.get_layers()) - set(open_layers_tuples)
+    )
 
     for layer, size in zip(open_layers, open_sizes):
-        subcomponent = coupler_ring.extract(layers=[layer])
+        subcomponent = coupler_ring_component.extract(layers=[layer])
         rectangle = gf.components.rectangle(size=size, layer=layer, centered=True)
         c << gf.geometry.boolean(subcomponent, rectangle, "A-B", layer=layer)
 
-    coupler_ref = c << coupler_ring.extract(layers=untouched_layers)
+    coupler_ref = c << coupler_ring_component.extract(layers=untouched_layers)
 
-    c.add_ports(coupler_ring.get_ports_list())
+    c.add_ports(coupler_ring_component.get_ports_list())
     c.absorb(coupler_ref)
 
     return c
@@ -154,4 +159,4 @@ if __name__ == "__main__":
     # c3 = gf.geometry.offset(c2, distance=-d, layer=(111, 0))
     # c << c1
     # c << c3
-    d.show(show_ports=True)
+    c.show(show_ports=True)

--- a/gdsfactory/components/ring_double_heater.py
+++ b/gdsfactory/components/ring_double_heater.py
@@ -5,7 +5,7 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_euler import bend_euler
-from gdsfactory.components.coupler_ring import coupler_ring
+from gdsfactory.components.coupler_ring import coupler_ring, coupler_ring_point
 from gdsfactory.components.straight import straight
 from gdsfactory.components.via_stack import via_stack_heater_m3
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
@@ -20,6 +20,7 @@ def ring_double_heater(
     length_x: float = 0.01,
     length_y: float = 0.01,
     coupler_ring: ComponentSpec = coupler_ring,
+    coupler_ring_top: ComponentSpec = None,
     straight: ComponentSpec = straight,
     bend: ComponentSpec = bend_euler,
     cross_section_heater: CrossSectionSpec = "heater_metal",
@@ -41,6 +42,7 @@ def ring_double_heater(
         length_x: ring coupler length.
         length_y: vertical straight length.
         coupler_ring: ring coupler spec.
+        coupler_ring_top: ring coupler spec for coupler away from vias (defaults to coupler_ring)
         straight: straight spec.
         bend: bend spec.
         cross_section_heater: for heater.
@@ -63,8 +65,20 @@ def ring_double_heater(
     """
     gap = gf.snap.snap_to_grid(gap, nm=2)
 
+    coupler_ring_top = coupler_ring_top or coupler_ring
+
     coupler_component = gf.get_component(
         coupler_ring,
+        gap=gap,
+        radius=radius,
+        length_x=length_x,
+        bend=bend,
+        cross_section=cross_section,
+        bend_cross_section=cross_section_waveguide_heater,
+        **kwargs,
+    )
+    coupler_component_top = gf.get_component(
+        coupler_ring_top,
         gap=gap,
         radius=radius,
         length_x=length_x,
@@ -82,7 +96,7 @@ def ring_double_heater(
 
     c = Component()
     cb = c.add_ref(coupler_component)
-    ct = c.add_ref(coupler_component)
+    ct = c.add_ref(coupler_component_top)
     sl = c.add_ref(straight_component)
     sr = c.add_ref(straight_component)
 
@@ -127,6 +141,18 @@ def ring_double_heater(
 
 if __name__ == "__main__":
     # c = ring_double_heater(width=1, layer=(2, 0), length_y=3)
-    c = ring_double_heater(length_x=5, port_orientation=-90)
+    c = ring_double_heater(
+        length_x=0,
+        port_orientation=90,
+        bend=gf.components.bend_circular,
+        via_stack_offset=(2, 0),
+        coupler_ring_top=coupler_ring,
+        coupler_ring=gf.partial(
+            coupler_ring_point,
+            coupler_ring=coupler_ring,
+            open_layers=("HEATER",),
+            open_sizes=((5, 7),),
+        ),
+    )
     c.show(show_ports=True)
     # c.pprint()

--- a/tests/test_components/test_settings_coupler_ring_.yml
+++ b/tests/test_components/test_settings_coupler_ring_.yml
@@ -61,11 +61,9 @@ settings:
       function: coupler_straight
     cross_section: strip
     gap: 0.2
-    layers_open: null
     length_extension: 3
     length_x: 4.0
     radius: 5.0
-    sizes_open: null
   full:
     bend:
       function: bend_euler
@@ -76,11 +74,9 @@ settings:
       function: coupler_straight
     cross_section: strip
     gap: 0.2
-    layers_open: null
     length_extension: 3
     length_x: 4.0
     radius: 5.0
-    sizes_open: null
   function_name: coupler_ring
   info: {}
   info_version: 2

--- a/tests/test_components/test_settings_coupler_ring_.yml
+++ b/tests/test_components/test_settings_coupler_ring_.yml
@@ -61,9 +61,11 @@ settings:
       function: coupler_straight
     cross_section: strip
     gap: 0.2
+    layers_open: null
     length_extension: 3
     length_x: 4.0
     radius: 5.0
+    sizes_open: null
   full:
     bend:
       function: bend_euler
@@ -74,9 +76,11 @@ settings:
       function: coupler_straight
     cross_section: strip
     gap: 0.2
+    layers_open: null
     length_extension: 3
     length_x: 4.0
     radius: 5.0
+    sizes_open: null
   function_name: coupler_ring
   info: {}
   info_version: 2

--- a/tests/test_components/test_settings_ring_double_heater_.yml
+++ b/tests/test_components/test_settings_ring_double_heater_.yml
@@ -80,6 +80,7 @@ settings:
       function: bend_euler
     coupler_ring:
       function: coupler_ring
+    coupler_ring_top: null
     cross_section: strip
     cross_section_heater: heater_metal
     cross_section_waveguide_heater: strip_heater_metal
@@ -117,6 +118,7 @@ settings:
       function: bend_euler
     coupler_ring:
       function: coupler_ring
+    coupler_ring_top: null
     cross_section: strip
     cross_section_heater: heater_metal
     cross_section_waveguide_heater: strip_heater_metal


### PR DESCRIPTION
(accidentally pushed to main, here is the real PR)

New component that can carve out some layers in the ring_coupler, for instance to define point couplers with heaters.

Originally:

`    c = coupler_ring(
        cross_section="strip_heater_metal",
        length_x=0,
        bend=gf.components.bend_circular,
    )`

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/b25ac976-21b7-436e-b710-709a0899608c)

New component:

`    d = coupler_ring_point(c, open_layers=("HEATER",), open_sizes=((5, 7),))
`

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/f01b4a01-574e-4e0a-8aa2-ae836ac3c41e)

So now we can make DRC-clean point coupler heater rings:

Current behaviour has a short :(

```
c = ring_double_heater(
        length_x=0,
        port_orientation=90,
        bend=gf.components.bend_circular,
        via_stack_offset=(2, 0),
        coupler_ring=coupler_ring
    )
    c.show(show_ports=True)
```

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/80535284-7be5-4436-8817-d7090feddd56)

With new open layers:

```
    c = ring_double_heater(
        length_x=0,
        port_orientation=90,
        bend=gf.components.bend_circular,
        via_stack_offset=(2, 0),
        coupler_ring_top=coupler_ring,
        coupler_ring=gf.partial(
            coupler_ring_point,
            coupler_ring=coupler_ring,
            open_layers=("HEATER",),
            open_sizes=((5, 7),),
        ),
    )
    c.show(show_ports=True)

```
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/4b5731cf-5189-456b-a550-4d16f96f5a6e)
