### PR TITLE
Remove unused `prune_z` arguments

### DIFF
--- a/gdsfactory/samples/notebooks/femwell_02_heater.py
+++ b/gdsfactory/samples/notebooks/femwell_02_heater.py
@@ -39,7 +39,7 @@ filename = "mesh"
 
 def mesh_with_physicals(mesh, filename):
     mesh_from_file = meshio.read(f"{filename}.msh")
-    return create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+    return create_physical_mesh(mesh_from_file, "triangle")
 
 
 # -

--- a/gdsfactory/samples/notebooks/meshing_01_intro.py
+++ b/gdsfactory/samples/notebooks/meshing_01_intro.py
@@ -86,7 +86,7 @@ filename = "mesh"
 
 def mesh_with_physicals(mesh, filename):
     mesh_from_file = meshio.read(f"{filename}.msh")
-    return create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+    return create_physical_mesh(mesh_from_file, "triangle")
 
 
 # -
@@ -115,7 +115,7 @@ mesh.draw().plot()
 # +
 mesh_from_file = meshio.read("mesh.msh")
 
-triangle_mesh = create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+triangle_mesh = create_physical_mesh(mesh_from_file, "triangle")
 meshio.write("mesh.xdmf", triangle_mesh)
 
 mesh = mesh_with_physicals(triangle_mesh, filename)
@@ -128,7 +128,7 @@ mesh.draw().plot()
 # ![](https://imgur.com/zBn5596.png)
 
 # +
-line_mesh = create_physical_mesh(mesh_from_file, "line", prune_z=True)
+line_mesh = create_physical_mesh(mesh_from_file, "line")
 meshio.write("facet_mesh.xdmf", line_mesh)
 
 mesh = mesh_with_physicals(line_mesh, filename)

--- a/gdsfactory/samples/notebooks/meshing_02_2D_xy_mesh.py
+++ b/gdsfactory/samples/notebooks/meshing_02_2D_xy_mesh.py
@@ -36,7 +36,7 @@ filename = "mesh"
 
 def mesh_with_physicals(mesh, filename):
     mesh_from_file = meshio.read(f"{filename}.msh")
-    return create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+    return create_physical_mesh(mesh_from_file, "triangle")
 
 
 # -

--- a/gdsfactory/samples/notebooks/meshing_03_2D_uz_mesh.py
+++ b/gdsfactory/samples/notebooks/meshing_03_2D_uz_mesh.py
@@ -44,7 +44,7 @@ filename = "mesh"
 
 def mesh_with_physicals(mesh, filename):
     mesh_from_file = meshio.read(f"{filename}.msh")
-    return create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+    return create_physical_mesh(mesh_from_file, "triangle")
 
 
 # -

--- a/gdsfactory/samples/notebooks/meshing_04_refinement.py
+++ b/gdsfactory/samples/notebooks/meshing_04_refinement.py
@@ -51,7 +51,7 @@ filename = "mesh"
 
 def mesh_with_physicals(mesh, filename):
     mesh_from_file = meshio.read(f"{filename}.msh")
-    return create_physical_mesh(mesh_from_file, "triangle", prune_z=True)
+    return create_physical_mesh(mesh_from_file, "triangle")
 
 
 # -

--- a/gdsfactory/simulation/gmsh/mesh.py
+++ b/gdsfactory/simulation/gmsh/mesh.py
@@ -190,7 +190,7 @@ def mesh_from_polygons(
     return mesh
 
 
-def create_physical_mesh(mesh, cell_type, prune_z=True):
+def create_physical_mesh(mesh, cell_type):
     cells = mesh.get_cells_type(cell_type)
     cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
     points = mesh.points
@@ -314,7 +314,7 @@ if __name__ == "__main__":
 
     mesh_from_file = meshio.read("mesh.msh")
 
-    def create_mesh(mesh, cell_type, prune_z=True):
+    def create_mesh(mesh, cell_type):
         cells = mesh.get_cells_type(cell_type)
         cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
         points = mesh.points
@@ -324,8 +324,8 @@ if __name__ == "__main__":
             cell_data={"name_to_read": [cell_data]},
         )
 
-    line_mesh = create_mesh(mesh_from_file, "line", prune_z=True)
+    line_mesh = create_mesh(mesh_from_file, "line")
     meshio.write("facet_mesh.xdmf", line_mesh)
 
-    triangle_mesh = create_mesh(mesh_from_file, "triangle", prune_z=True)
+    triangle_mesh = create_mesh(mesh_from_file, "triangle")
     meshio.write("mesh.xdmf", triangle_mesh)

--- a/gdsfactory/simulation/gmsh/meshtracker.py
+++ b/gdsfactory/simulation/gmsh/meshtracker.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
 
     mesh_from_file = meshio.read("mesh.msh")
 
-    def create_mesh(mesh, cell_type, prune_z=True):
+    def create_mesh(mesh, cell_type):
         cells = mesh.get_cells_type(cell_type)
         cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
         points = mesh.points
@@ -306,8 +306,8 @@ if __name__ == "__main__":
             cell_data={"name_to_read": [cell_data]},
         )
 
-    line_mesh = create_mesh(mesh_from_file, "line", prune_z=True)
+    line_mesh = create_mesh(mesh_from_file, "line")
     meshio.write("facet_mesh.xdmf", line_mesh)
 
-    triangle_mesh = create_mesh(mesh_from_file, "triangle", prune_z=True)
+    triangle_mesh = create_mesh(mesh_from_file, "triangle")
     meshio.write("mesh.xdmf", triangle_mesh)

--- a/gdsfactory/simulation/gmsh/scratch/mesh3D.py
+++ b/gdsfactory/simulation/gmsh/scratch/mesh3D.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
 
     mesh_from_file = meshio.read("mesh.msh")
 
-    def create_mesh(mesh, cell_type, prune_z=False):
+    def create_mesh(mesh, cell_type):
         cells = mesh.get_cells_type(cell_type)
         cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
         points = mesh.points
@@ -302,10 +302,10 @@ if __name__ == "__main__":
             cell_data={"name_to_read": [cell_data]},
         )
 
-    # line_mesh = create_mesh(mesh_from_file, "line", prune_z=True)
+    # line_mesh = create_mesh(mesh_from_file, "line")
     # meshio.write("facet_mesh.xdmf", line_mesh)
 
-    triangle_mesh = create_mesh(mesh_from_file, "triangle", prune_z=True)
+    triangle_mesh = create_mesh(mesh_from_file, "triangle")
     meshio.write("mesh.xdmf", triangle_mesh)
 
     # for layer, polygons in heaters.get_polygons(by_spec=True).items():

--- a/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
+++ b/gdsfactory/simulation/gmsh/xy_xsection_mesh.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
 
     mesh_from_file = meshio.read("mesh.msh")
 
-    def create_mesh(mesh, cell_type, prune_z=False):
+    def create_mesh(mesh, cell_type):
         cells = mesh.get_cells_type(cell_type)
         cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
         points = mesh.points
@@ -185,10 +185,10 @@ if __name__ == "__main__":
             cell_data={"name_to_read": [cell_data]},
         )
 
-    line_mesh = create_mesh(mesh_from_file, "line", prune_z=True)
+    line_mesh = create_mesh(mesh_from_file, "line")
     meshio.write("facet_mesh.xdmf", line_mesh)
 
-    triangle_mesh = create_mesh(mesh_from_file, "triangle", prune_z=True)
+    triangle_mesh = create_mesh(mesh_from_file, "triangle")
     meshio.write("mesh.xdmf", triangle_mesh)
 
     # # for layer, polygons in heaters.get_polygons(by_spec=True).items():


### PR DESCRIPTION
This PR removes all unused `prune_z` arguments for meshing and keeps the one used one. 

Closes #1849 