### PR TITLE
Define `MaterialSpec` only in typings module

### DIFF
--- a/gdsfactory/materials.py
+++ b/gdsfactory/materials.py
@@ -1,11 +1,12 @@
 """Register materials."""
 from __future__ import annotations
 
-from typing import Callable, Dict, Tuple, Union
+from typing import Dict, TYPE_CHECKING
 
 import numpy as np
 
-MaterialSpec = Union[str, float, Tuple[float, float], Callable]
+if TYPE_CHECKING:
+    from gdsfactory.typings import MaterialSpec
 
 material_name_to_meep: Dict[str, MaterialSpec] = {
     "si": "Si",

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -15,13 +15,13 @@ from typing_extensions import Literal
 from gdsfactory.config import PATH, logger
 from gdsfactory.containers import containers as containers_default
 from gdsfactory.events import Event
-from gdsfactory.typings import MaterialSpec
 from gdsfactory.materials import materials_index as materials_index_default
 from gdsfactory.name import MAX_NAME_LENGTH
 from gdsfactory.read import cell_from_yaml
 from gdsfactory.show import show
 from gdsfactory.symbols import floorplan_with_block_letters
 from gdsfactory.technology import LayerStack, LayerViews
+
 from gdsfactory.typings import (
     CellSpec,
     Component,
@@ -35,6 +35,7 @@ from gdsfactory.typings import (
     LayerSpec,
     PathType,
     Transition,
+    MaterialSpec,
 )
 
 component_settings = ["function", "component", "settings"]

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -15,7 +15,7 @@ from typing_extensions import Literal
 from gdsfactory.config import PATH, logger
 from gdsfactory.containers import containers as containers_default
 from gdsfactory.events import Event
-from gdsfactory.materials import MaterialSpec
+from gdsfactory.typings import MaterialSpec
 from gdsfactory.materials import materials_index as materials_index_default
 from gdsfactory.name import MAX_NAME_LENGTH
 from gdsfactory.read import cell_from_yaml

--- a/gdsfactory/simulation/devsim/get_simulation_xsection.py
+++ b/gdsfactory/simulation/devsim/get_simulation_xsection.py
@@ -12,7 +12,7 @@ From Chrostowski, L., & Hochberg, M. (2015). Silicon Photonics Design: From Devi
 from __future__ import annotations
 
 import warnings
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import devsim
 import matplotlib.pyplot as plt
@@ -26,7 +26,9 @@ from scipy.interpolate import griddata
 from gdsfactory.simulation.disable_print import disable_print, enable_print
 from gdsfactory.simulation.gtidy3d.materials import get_nk
 from gdsfactory.simulation.gtidy3d.modes import Precision, Waveguide
-from gdsfactory.typings import MaterialSpec
+
+if TYPE_CHECKING:
+    from gdsfactory.typings import MaterialSpec
 
 nm = 1e-9
 um = 1e-6

--- a/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 
 import shutil
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 
 import numpy as np
 import yaml
 
 import gdsfactory as gf
 from gdsfactory.config import __version__, logger
-from gdsfactory.typings import MaterialSpec
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_lumerical as get_sparameters_path,
@@ -20,7 +19,9 @@ from gdsfactory.technology import (
     LayerStack,
     SimulationSettingsLumericalFdtd,
 )
-from gdsfactory.typings import ComponentSpec, PathType
+
+if TYPE_CHECKING:
+    from gdsfactory.typings import ComponentSpec, PathType, MaterialSpec
 
 run_false_warning = """
 You have passed run=False to debug the simulation

--- a/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
+++ b/gdsfactory/simulation/lumerical/write_sparameters_lumerical.py
@@ -10,7 +10,7 @@ import yaml
 
 import gdsfactory as gf
 from gdsfactory.config import __version__, logger
-from gdsfactory.materials import MaterialSpec
+from gdsfactory.typings import MaterialSpec
 from gdsfactory.pdk import get_layer_stack
 from gdsfactory.simulation.get_sparameters_path import (
     get_sparameters_path_lumerical as get_sparameters_path,

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -1,12 +1,10 @@
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from gdsfactory.technology.layer_views import LayerViews
-
-MaterialSpec = Union[str, float, Tuple[float, float], Callable]
 
 
 class LayerLevel(BaseModel):

--- a/gdsfactory/technology/simulation_settings.py
+++ b/gdsfactory/technology/simulation_settings.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from pydantic import BaseModel
 
-from gdsfactory.materials import MaterialSpec
+from gdsfactory.typings import MaterialSpec
 from gdsfactory.materials import (
     material_name_to_lumerical as material_name_to_lumerical_default,
 )

--- a/gdsfactory/technology/simulation_settings.py
+++ b/gdsfactory/technology/simulation_settings.py
@@ -1,8 +1,11 @@
-from typing import Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict
 
 from pydantic import BaseModel
 
-from gdsfactory.typings import MaterialSpec
+if TYPE_CHECKING:
+    from gdsfactory.typings import MaterialSpec
 from gdsfactory.materials import (
     material_name_to_lumerical as material_name_to_lumerical_default,
 )


### PR DESCRIPTION
This PR removes an unnecessary `MaterialSpec` definition in _gdsfactory/technology/layer_stack.py_ and removes the redefinition in _gdsfactory/materials.py_.

Closes #1855 