### PR TITLE
Component with net layers

### DIFF
--- a/gdsfactory/simulation/gmsh/xyz_mesh.py
+++ b/gdsfactory/simulation/gmsh/xyz_mesh.py
@@ -66,9 +66,6 @@ def xyz_mesh(
 
     """
     # Fuse and cleanup polygons of same layer in case user overlapped them
-    print(layerstack)
-    print(component.get_layer_names())
-
     layer_polygons_dict = cleanup_component(
         component, layerstack, round_tol, simplify_tol
     )
@@ -106,20 +103,29 @@ if __name__ == "__main__":
 
     # Generate a new component and layerstack with new logical layers
     layerstack = get_layer_stack()
-
-    print("init ", layerstack.layers.keys())
-
     c = layerstack.get_component_with_net_layers(
         c,
         portnames=["r_e2", "l_e4"],
         delimiter="#",
     )
 
-    print("net ", layerstack.layers.keys())
-
-    filtered_layerstack = layerstack.filtered_from_layerspec(layerspecs=c.get_layers())
-
-    print("filtered ", filtered_layerstack.layers.keys())
+    # FIXME: .filtered returns all layers
+    # filtered_layerstack = layerstack.filtered_from_layerspec(layerspecs=c.get_layers())
+    filtered_layerstack = LayerStack(
+        layers={
+            k: layerstack.layers[k]
+            for k in (
+                "via1",
+                "clad",
+                "metal2",
+                "metal3#l_e4",
+                "heater",
+                "via2",
+                "core",
+                "metal3#r_e2",
+            )
+        }
+    )
 
     resolutions = {
         "core": {"resolution": 0.1},

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -195,12 +195,13 @@ class LayerStack(BaseModel):
         """
         import gdstk
 
+        # Initialize returned component
+        net_component = component.copy()
+
+        # For each port to consider, convert relevant polygons
         for i, (portname, port) in enumerate(component.get_ports_dict().items()):
-            # Initialize if needed
-            if i == 0:
-                net_component = component
             if portname in portnames:
-                # Get port layer polygons, and modify a new component without that layer
+                # Get original port layer polygons, and modify a new component without that layer
                 polygons = component.extract(layers=[port.layer]).get_polygons()
                 net_component = net_component.remove_layers(layers=[port.layer])
                 for polygon in polygons:
@@ -214,6 +215,8 @@ class LayerStack(BaseModel):
                     # Otherwise put the polygon back on the same layer
                     else:
                         net_component.add_polygon(polygon, layer=port.layer)
+
+        net_component.name = f"{component.name}_net_layers"
 
         return net_component
 
@@ -426,6 +429,16 @@ class LayerStack(BaseModel):
 
     def filtered(self, layers):
         return type(self)(layers={k: self.layers[k] for k in layers})
+
+    def filtered_from_layerspec(self, layerspecs):
+        """Filtered layerstack, given LayerSpec input."""
+        layers_to_layername = self.get_layer_to_layername()
+        layers = [
+            layers_to_layername[layer]
+            for layer in layerspecs
+            if layer in layers_to_layername
+        ]
+        return self.filtered(layers)
 
 
 if __name__ == "__main__":

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from gdsfactory.technology.layer_views import LayerViews
+import copy
 
 MaterialSpec = Union[str, float, Tuple[float, float], Callable]
 
@@ -174,6 +175,47 @@ class LayerStack(BaseModel):
         component_derived.add_ports(component.ports)
         component_derived.name = f"{component.name}_derived_layers"
         return component_derived
+
+    def get_component_with_net_layers(
+        self,
+        component,
+        portnames: List[str],
+        delimiter: str = "#",
+        new_layers_init: Tuple[int, int] = (10000, 10),
+    ):
+        """Returns component with new layers that combine port names and original layers, and modifies the layerstack accordingly.
+
+        Uses port's "layer" attribute to decide which polygons need to be renamed. New layers are named "layername{delimiter}portname".
+
+        Arguments
+            component: to process
+            portnames: list of portnames to process into new layers.
+            delimiter: the new layer created is called "layername{delimiter}portname"
+            new_layers_init: layer numbers for the temporary new layers. Purpose is incremented.
+        """
+        import gdstk
+
+        for i, (portname, port) in enumerate(component.get_ports_dict().items()):
+            # Initialize if needed
+            if i == 0:
+                net_component = component
+            if portname in portnames:
+                # Get port layer polygons, and modify a new component without that layer
+                polygons = component.extract(layers=[port.layer]).get_polygons()
+                net_component = net_component.remove_layers(layers=[port.layer])
+                for polygon in polygons:
+                    # If polygon belongs to port, create a unique new layer, and add the polygon to it
+                    if gdstk.inside([port.center], gdstk.Polygon(polygon))[0]:
+                        old_layername = self.get_layer_to_layername()[port.layer]
+                        new_layer = copy.deepcopy(self.layers[old_layername])
+                        new_layer.layer = (new_layers_init[0], new_layers_init[1] + i)
+                        self.layers[f"{old_layername}{delimiter}{portname}"] = new_layer
+                        net_component.add_polygon(polygon, layer=new_layer.layer)
+                    # Otherwise put the polygon back on the same layer
+                    else:
+                        net_component.add_polygon(polygon, layer=port.layer)
+
+        return net_component
 
     def get_layer_to_zmin(self) -> Dict[Tuple[int, int], float]:
         """Returns layer tuple to z min position (um)."""
@@ -387,7 +429,23 @@ class LayerStack(BaseModel):
 
 
 if __name__ == "__main__":
-    from gdsfactory.config import PATH
+    import gdsfactory as gf
+    from gdsfactory.generic_tech import get_generic_pdk
+
+    PDK = get_generic_pdk()
+    PDK.activate()
+
+    from gdsfactory.generic_tech import LAYER_STACK
+
+    layer_stack = LAYER_STACK
+
+    c = layer_stack.get_component_with_net_layers(
+        gf.components.straight_heater_metal(), portnames=["r_e2", "l_e4"]
+    )
+
+    print(layer_stack.layers.keys())
+
+    c.show()
 
     # import gdsfactory as gf
     # from gdsfactory.generic_tech import LAYER_STACK
@@ -405,22 +463,22 @@ if __name__ == "__main__":
     # )
     # ls_json = filepath.read_bytes()
     # ls2 = LayerStack.parse_raw(ls_json)
-    from gdsfactory.generic_tech import LAYER_STACK
-    from gdsfactory.technology.klayout_tech import KLayoutTechnology
+    # from gdsfactory.generic_tech import LAYER_STACK
+    # from gdsfactory.technology.klayout_tech import KLayoutTechnology
 
-    lyp = LayerViews.from_lyp(str(PATH.klayout_lyp))
+    # lyp = LayerViews.from_lyp(str(PATH.klayout_lyp))
 
-    # str_xml = open(PATH.klayout_tech / "tech.lyt").read()
-    # new_tech = db.Technology.technology_from_xml(str_xml)
-    # generic_tech = KLayoutTechnology(layer_views=lyp)
-    connectivity = [("M1", "VIA1", "M2"), ("M2", "VIA2", "M3")]
+    # # str_xml = open(PATH.klayout_tech / "tech.lyt").read()
+    # # new_tech = db.Technology.technology_from_xml(str_xml)
+    # # generic_tech = KLayoutTechnology(layer_views=lyp)
+    # connectivity = [("M1", "VIA1", "M2"), ("M2", "VIA2", "M3")]
 
-    c = generic_tech = KLayoutTechnology(
-        name="generic_tech", layer_views=lyp, connectivity=connectivity
-    )
-    tech_dir = PATH.klayout_tech
-    # tech_dir = pathlib.Path("/home/jmatres/.klayout/salt/gdsfactory/tech/")
-    tech_dir.mkdir(exist_ok=True, parents=True)
-    generic_tech.write_tech(tech_dir=tech_dir, layer_stack=LAYER_STACK)
+    # c = generic_tech = KLayoutTechnology(
+    #     name="generic_tech", layer_views=lyp, connectivity=connectivity
+    # )
+    # tech_dir = PATH.klayout_tech
+    # # tech_dir = pathlib.Path("/home/jmatres/.klayout/salt/gdsfactory/tech/")
+    # tech_dir.mkdir(exist_ok=True, parents=True)
+    # generic_tech.write_tech(tech_dir=tech_dir, layer_stack=LAYER_STACK)
 
     # yaml_test()

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -201,6 +201,10 @@ class LayerStack(BaseModel):
         """Returns layer tuple to info dict."""
         return {level.layer: level.info for level in self.layers.values()}
 
+    def get_layer_to_layername(self) -> Dict[Tuple[int, int], str]:
+        """Returns layer tuple to layername."""
+        return {level.layer: level_name for level_name, level in self.layers.items()}
+
     def to_dict(self) -> Dict[str, Dict[str, Any]]:
         return {level_name: dict(level) for level_name, level in self.layers.items()}
 

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -199,8 +199,7 @@ class LayerStack(BaseModel):
         net_component = component.copy()
 
         # For each port to consider, convert relevant polygons
-        i = 0
-        for portname in portnames:
+        for i, portname in enumerate(portnames):
             port = component.ports[portname]
             # Get original port layer polygons, and modify a new component without that layer
             polygons = net_component.extract(layers=[port.layer]).get_polygons()
@@ -216,7 +215,6 @@ class LayerStack(BaseModel):
                 # Otherwise put the polygon back on the same layer
                 else:
                     net_component.add_polygon(polygon, layer=port.layer)
-            i += 1
 
         net_component.name = f"{component.name}_net_layers"
 
@@ -440,7 +438,6 @@ class LayerStack(BaseModel):
             for layer in layerspecs
             if layer in layers_to_layername
         ]
-        print("iside ", layers)
         return self.filtered(layers)
 
 
@@ -455,10 +452,11 @@ if __name__ == "__main__":
 
     layer_stack = LAYER_STACK
 
+    # c = gf.components.straight_heater_metal()
+
     c = layer_stack.get_component_with_net_layers(
         gf.components.straight_heater_metal(), portnames=["r_e2", "l_e4"]
     )
-
     print(layer_stack.layers.keys())
 
     c.show()

--- a/tests/test_layerstack.py
+++ b/tests/test_layerstack.py
@@ -22,8 +22,8 @@ def test_component_with_net_layers():
     # Check we have two new layers in the LayerStack
     assert len(layernames_after - layernames_before) == 2
 
-    # Check we have two new layers in Component
-    assert len(net_component.get_layers()) == len(net_component.get_layers()) + 2
+    # Check we have one new layer in Component (all metal3 is removed by these operations)
+    assert len(net_component.get_layers()) == len(original_component.get_layers()) + 1
 
     # Check new layer is the same as old layer, apart from layer number and name
     old_layer = LAYER_STACK.layers["metal3"]

--- a/tests/test_layerstack.py
+++ b/tests/test_layerstack.py
@@ -1,9 +1,40 @@
 from gdsfactory.generic_tech import LAYER_STACK
+from gdsfactory.components import straight_heater_metal
 
 
 def test_layerstack() -> None:
     assert LAYER_STACK.get_klayout_3d_script()
 
 
+def test_component_with_net_layers():
+    # Hardcoded settings for now
+    delimiter = "#"
+    portnames_to_test = ["r_e2", "l_e4"]
+    layernames_before = set(LAYER_STACK.layers.keys())
+    original_component = straight_heater_metal()
+
+    # Run the function
+    net_component = LAYER_STACK.get_component_with_net_layers(
+        original_component, portnames=portnames_to_test, delimiter=delimiter
+    )
+    layernames_after = set(LAYER_STACK.layers.keys())
+
+    # Check we have two new layers in the LayerStack
+    assert len(layernames_after - layernames_before) == 2
+
+    # Check we have two new layers in Component
+    assert len(net_component.get_layers()) == len(net_component.get_layers()) + 2
+
+    # Check new layer is the same as old layer, apart from layer number and name
+    old_layer = LAYER_STACK.layers["metal3"]
+    new_layer = LAYER_STACK.layers[f"metal3{delimiter}{portnames_to_test[0]}"]
+
+    for varname in vars(LAYER_STACK.layers["metal3"]):
+        if varname == "layer":
+            continue
+        else:
+            assert getattr(old_layer, varname) == getattr(new_layer, varname)
+
+
 if __name__ == "__main__":
-    test_layerstack()
+    test_component_with_net_layers()


### PR DESCRIPTION
Partially addresses #1851 

The Component and LayerStack are properly modified, but the meshing module still has some issues with the new component I need to troubleshoot

E.g. for this component with ports on `metal3`:

```
    c = gf.components.straight_heater_metal()
    c.show()
```

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/b40c9b36-92a2-4ba1-8229-1b8fe88a6f11)

```
    c = layer_stack.get_component_with_net_layers(
        gf.components.straight_heater_metal(), portnames=["r_e2", "l_e4"], delimiter="#"
    )
    print(layer_stack.layers.keys())
    c.show()
```

Output (note new layers `{port_layer}{delimiter}{portname}`, these layers have the same attributes as the original metal3 and so would render identically in the mesh, just with these new names):

`dict_keys(['substrate', 'box', 'core', 'shallow_etch', 'deep_etch', 'clad', 'slab150', 'slab90', 'nitride', 'ge', 'undercut', 'via_contact', 'metal1', 'heater', 'via1', 'metal2', 'via2', 'metal3', 'metal3#r_e2', 'metal3#l_e4'])
`
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/a3e43aeb-be37-4295-a1be-2b2851344f21)
and
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/0a5c467e-fd95-4152-904c-a0bbd401f0d5)
