### PR TITLE
1851 logical layers for meshing

### DIFF
--- a/gdsfactory/simulation/gmsh/xyz_mesh.py
+++ b/gdsfactory/simulation/gmsh/xyz_mesh.py
@@ -115,25 +115,30 @@ if __name__ == "__main__":
         layers={
             k: layerstack.layers[k]
             for k in (
-                "via1",
+                # "via1",
+                "box",
                 "clad",
-                "metal2",
+                # "metal2",
                 "metal3#l_e4",
                 "heater",
                 "via2",
                 "core",
                 "metal3#r_e2",
+                # "metal3",
+                # "via_contact",
+                # "metal1"
             )
         }
     )
 
     resolutions = {
-        "core": {"resolution": 0.1},
+        "core": {"resolution": 0.3},
     }
     geometry = xyz_mesh(
         component=c,
         layerstack=filtered_layerstack,
         resolutions=resolutions,
         filename="mesh.msh",
+        default_characteristic_length=5,
         verbosity=5,
     )

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -179,7 +179,7 @@ class LayerStack(BaseModel):
         component,
         portnames: List[str],
         delimiter: str = "#",
-        new_layers_init: Tuple[int, int] = (10000, 10),
+        new_layers_init: Tuple[int, int] = (10010, 0),
     ):
         """Returns component with new layers that combine port names and original layers, and modifies the layerstack accordingly.
 
@@ -189,7 +189,7 @@ class LayerStack(BaseModel):
             component: to process
             portnames: list of portnames to process into new layers.
             delimiter: the new layer created is called "layername{delimiter}portname"
-            new_layers_init: layer numbers for the temporary new layers. Purpose is incremented.
+            new_layers_init: nitial layer number for the temporary new layers.
         """
         import gdstk
 
@@ -207,7 +207,7 @@ class LayerStack(BaseModel):
                 if gdstk.inside([port.center], gdstk.Polygon(polygon))[0]:
                     old_layername = self.get_layer_to_layername()[port.layer]
                     new_layer = copy.deepcopy(self.layers[old_layername])
-                    new_layer.layer = (new_layers_init[0], new_layers_init[1] + i)
+                    new_layer.layer = (new_layers_init[0] + i, new_layers_init[1])
                     self.layers[f"{old_layername}{delimiter}{portname}"] = new_layer
                     net_component.add_polygon(polygon, layer=new_layer.layer)
                 # Otherwise put the polygon back on the same layer


### PR DESCRIPTION
@nikosavola @HelgeGehring fixed the bug, now it meshes properly with distinct physicals

Fixes #1851 

Example:

```
   import gdsfactory as gf

    from gdsfactory.pdk import get_layer_stack
    from gdsfactory.generic_tech import LAYER

    # Choose some component
    c = gf.component.Component()
    waveguide = c << gf.get_component(gf.components.straight_heater_metal(length=40))
    c.add_ports(waveguide.get_ports_list())

    # Add wafer / vacuum (could be automated)
    wafer = c << gf.components.bbox(bbox=waveguide.bbox, layer=LAYER.WAFER)

    # Generate a new component and layerstack with new logical layers
    layerstack = get_layer_stack()
    c = layerstack.get_component_with_net_layers(
        c,
        portnames=["r_e2", "l_e4"],
        delimiter="#",
    )

    # FIXME: .filtered returns all layers
    # filtered_layerstack = layerstack.filtered_from_layerspec(layerspecs=c.get_layers())
    filtered_layerstack = LayerStack(
        layers={
            k: layerstack.layers[k]
            for k in (
                # "via1",
                "box",
                "clad",
                # "metal2",
                "metal3#l_e4",
                "heater",
                "via2",
                "core",
                "metal3#r_e2",
                # "metal3",
                # "via_contact",
                # "metal1"
            )
        }
    )

    resolutions = {
        "core": {"resolution": 0.3},
    }
    geometry = xyz_mesh(
        component=c,
        layerstack=filtered_layerstack,
        resolutions=resolutions,
        filename="mesh.msh",
        default_characteristic_length=5,
        verbosity=5,
    )
```

![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/0e0f39ff-5f91-49f6-bcef-737f6127824b)
![image](https://github.com/gdsfactory/gdsfactory/assets/46427609/e0ed82f3-9fe6-4dd7-bb3c-60d826af0db4)

