### PR TITLE
Background tag for xyz meshing

### DIFF
--- a/gdsfactory/simulation/gmsh/xyz_mesh.py
+++ b/gdsfactory/simulation/gmsh/xyz_mesh.py
@@ -104,7 +104,7 @@ def xyz_mesh(
             layers=layerstack.layers
             | {
                 background_tag: LayerLevel(
-                    layer=(99, 99),  # TODO something like LAYERS.BACKGROUND?
+                    layer=(9999, 0),  # TODO something like LAYERS.BACKGROUND?
                     thickness=(zmax + background_padding[5])
                     - (zmin - background_padding[2]),
                     zmin=zmin - background_padding[2],


### PR DESCRIPTION
`background_tag` argument generalized for 3D (xyz) meshing

@simbilod, does the implementation seem reasonable? There is currently a magic layer of (99, 99) and a big number for `mesh_order`, as infinity was not allowed by pydantic for ints.

Closes #1860 
