### PR TITLE
Allow tuples and iterators in `Component.add_ports`

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -12,7 +12,7 @@ import pathlib
 import uuid
 import warnings
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING
@@ -959,7 +959,7 @@ class Component(_GeometryHelper):
 
     def add_ports(
         self,
-        ports: Union[List[Port], Dict[str, Port]],
+        ports: Union[Iterable[Port], Dict[str, Port]],
         prefix: str = "",
         suffix: str = "",
         **kwargs,
@@ -973,8 +973,8 @@ class Component(_GeometryHelper):
             prefix: to prepend to each port name.
             suffix: to append to each port name.
         """
-        ports = ports if isinstance(ports, list) else ports.values()
-        for port in list(ports):
+        ports = ports.values() if isinstance(ports, Mapping) else ports
+        for port in ports:
             name = f"{prefix}{port.name}{suffix}"
             self.add_port(name=name, port=port, **kwargs)
 


### PR DESCRIPTION
This PR generalises the types in `Component.add_ports` to support Iterables and better notices dict-likes (such as OrderedDict).
Effectively, this allows supporting the tuple output from Route.ports and, consequently, closes #1882.
Generators should also work now, as the inner implementation only does a for-loop.