### PR TITLE
Move codespell ignore list to `pyproject.toml` and decapitalize

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
     rev: af69927c7d3965d3fe8f68007e12cd971847573f
     hooks:
       - id: codespell
-        args: ["-L TE,TE/TM,te,ba,FPR,fpr_spacing,ro,nd,donot,schem"]
         additional_dependencies:
           - tomli
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,9 @@ include = '\.pyi?$'
 line-length = 88
 target-version = ['py310']
 
+[tool.codespell]
+ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem"
+
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.1.0"


### PR DESCRIPTION
Decapitalise words due to codespell-project/codespell#2375. Additionally, move the list to the recent TOML format. This has the benefit of now using the same list if codespell is run manually (as opposed to using the hook).

Closes #1912 