### PR TITLE
Route s bend in the vertical direction

### DIFF
--- a/gdsfactory/components/bezier.py
+++ b/gdsfactory/components/bezier.py
@@ -68,7 +68,11 @@ def bezier(
     c.absorb(bend_ref)
     curv = curvature(path_points, t)
     length = gf.snap.snap_to_grid(path_length(path_points))
-    min_bend_radius = gf.snap.snap_to_grid(1 / max(np.abs(curv)))
+    if max(np.abs(curv)) == 0:
+        min_bend_radius = np.inf
+    else:
+        min_bend_radius = gf.snap.snap_to_grid(1 / max(np.abs(curv)))
+
     c.info["length"] = length
     c.info["min_bend_radius"] = min_bend_radius
     c.info["start_angle"] = path.start_angle

--- a/gdsfactory/routing/get_route_sbend.py
+++ b/gdsfactory/routing/get_route_sbend.py
@@ -36,7 +36,14 @@ def get_route_sbend(port1: Port, port2: Port, **kwargs) -> Route:
     """
     ysize = port2.center[1] - port1.center[1]
     xsize = port2.center[0] - port1.center[0]
-    size = (xsize, ysize)
+
+    # We need to act differently if the route is orthogonal in x
+    # or orthogonal in y
+
+    if port1.orientation == 0 or port1.orientation == 180:
+        size = (xsize, ysize)
+    else:
+        size = (ysize, -xsize)
 
     bend = bend_s(size=size, **kwargs)
 


### PR DESCRIPTION
I found that if an s bend is made in the vertical direction it does not work.

This code:

```
import gdsfactory as gf

  c = gf.Component("demo_route_sbend")
  mmi1 = c << gf.components.mmi1x2()
  mmi2 = c << gf.components.mmi1x2()

  mmi1.rotate(90)  # This was changed
  mmi2.rotate(90)  # This was changed
  mmi2.movey(50)  # This was changed
  mmi2.movex(-5)  # This was changed

  # mmi2.movex(50)
  # mmi2.movey(5)
  route = gf.routing.get_route_sbend(mmi1.ports["o2"], mmi2.ports["o1"])
  c.add(route.references)
  c.show()
```


Generates this layout:

![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/fc4ff7fc-e6d3-4a0a-9c53-7f4470a17106)


With this PR the right behavior is implemented and we get this layout:

![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/5b894f3a-9168-4c68-b19d-6b1365ed229e)


Additionally, I added a clause that sets the bend radius of a bezier curve to infinite if the curvature is 0 (captures a corner case)