### PR TITLE
Define components along a path through CrossSection

### DIFF
--- a/docs/notebooks/03_Path_CrossSection.py
+++ b/docs/notebooks/03_Path_CrossSection.py
@@ -126,6 +126,26 @@ b = gf.path.extrude(p, cross_section=x)
 b.plot()
 # -
 
+# An arbitrary cross-section can also help place components along a path.
+# This feature can be useful for defining wiring vias.
+
+# +
+# Create the path
+p = gf.path.straight()
+p += gf.path.arc(10)
+p += gf.path.straight()
+
+# Define a cross-section with a via
+from gdsfactory.typings import ComponentSpec
+gf.Via.update_forward_refs(**{"ComponentSpec": ComponentSpec})
+via = gf.Via(feature=gf.c.rectangle(size=(1, 1), centered=True), spacing=5, padding=2)
+x = gf.CrossSection(width=0.5, offset=0, layer=(1, 0), port_names=("in", "out"), vias=[via])
+
+# Combine the path with the cross-section
+c = gf.path.extrude(p, cross_section=x)
+c.plot()
+# -
+
 # ## Building Paths quickly
 #
 # You can pass `append()` lists of path segments.  This makes it easy to combine

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -32,7 +32,7 @@ from gdsfactory.cell import cell_without_validator
 from gdsfactory.cell import clear_cache
 from gdsfactory.show import show
 from gdsfactory.read.import_gds import import_gds
-from gdsfactory.cross_section import CrossSection, Section, xsection
+from gdsfactory.cross_section import CrossSection, Section, Via, xsection
 from gdsfactory.component_layout import Label
 from gdsfactory.polygon import Polygon
 from gdsfactory.difftest import difftest, diff


### PR DESCRIPTION
This PR addresses #1959 by adding a `Via` class (similar to `Section`) for `CrossSection`. Any time `extrude` is called with this cross section, the via components are placed along the path.

I added an example. In it there is some funny business about import order and needing to call `gf.Via.update_forward_refs(**{"ComponentSpec": ComponentSpec})`

If this solution looks reasonable, let me know how I should fix.