### PR TITLE
FEAT: Electrically valid routed components for piel examples

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -256,6 +256,7 @@ from gdsfactory.components.straight_heater_meander_doped import (
 from gdsfactory.components.straight_heater_metal import (
     straight_heater_metal,
     straight_heater_metal_90_90,
+    straight_heater_metal_simple,
     straight_heater_metal_undercut,
     straight_heater_metal_undercut_90_90,
 )
@@ -569,6 +570,7 @@ __all__ = [
     "straight_heater_doped_strip",
     "straight_heater_metal",
     "straight_heater_metal_90_90",
+    "straight_heater_metal_simple",
     "straight_heater_metal_undercut",
     "straight_heater_metal_undercut_90_90",
     "straight_heater_meander",

--- a/gdsfactory/components/mzi_phase_shifter.py
+++ b/gdsfactory/components/mzi_phase_shifter.py
@@ -8,7 +8,7 @@ from gdsfactory.components.straight_heater_metal import straight_heater_metal
 mzi_phase_shifter = partial(mzi, straight_x_top="straight_heater_metal", length_x=200)
 
 mzi2x2_2x2_phase_shifter = partial(
-    mzi2x2_2x2, straight_x_top="straight_heater_metal", length_x=200
+    mzi2x2_2x2, straight_x_top="straight_heater_metal_simple", length_x=200
 )
 
 mzi_phase_shifter_top_heater_metal = partial(

--- a/gdsfactory/components/straight_heater_metal.py
+++ b/gdsfactory/components/straight_heater_metal.py
@@ -139,6 +139,98 @@ def straight_heater_metal_undercut(
     return c
 
 
+@cell
+def straight_heater_metal_simple(
+    length: float = 320.0,
+    length_straight_input: float = 15.0,
+    heater_width: float = 2.5,
+    cross_section_heater: CrossSectionSpec = "heater_metal",
+    cross_section_waveguide_heater: CrossSectionSpec = "strip_heater_metal",
+    via_stack: ComponentSpec | None = "via_stack_heater_mtop",
+    port_orientation1: int | None = None,
+    port_orientation2: int | None = None,
+    heater_taper_length: float | None = 5.0,
+    ohms_per_square: float | None = None,
+    **kwargs,
+) -> Component:
+    """Returns a thermal phase shifter that has properly fixed electrical connectivity to extract a suitable electrical netlist and models.
+    dimensions from https://doi.org/10.1364/OE.27.010456
+    Args:
+        length: of the waveguide.
+        length_undercut_spacing: from undercut regions.
+        length_undercut: length of each undercut section.
+        length_straight_input: from input port to where trenches start.
+        heater_width: in um.
+        cross_section_heater: for heated sections. heater metal only.
+        cross_section_waveguide_heater: for heated sections.
+        cross_section_heater_undercut: for heated sections with undercut.
+        with_undercut: isolation trenches for higher efficiency.
+        via_stack: via stack.
+        port_orientation1: left via stack port orientation.
+        port_orientation2: right via stack port orientation.
+        heater_taper_length: minimizes current concentrations from heater to via_stack.
+        ohms_per_square: to calculate resistance.
+        cross_section: for waveguide ports.
+        kwargs: cross_section common settings.
+    """
+    c = Component()
+    straight_heater_section = gf.components.straight(
+        cross_section=cross_section_waveguide_heater,
+        length=length,
+        heater_width=heater_width,
+        # **kwargs # Note cross section is set from the provided, no more settings should be set
+    )
+
+    c.add_ref(straight_heater_section)
+    c.add_ports(straight_heater_section.ports)
+
+    if via_stack:
+        via = via_stackw = via_stacke = gf.get_component(via_stack)
+        via_stack_west_center = straight_heater_section.size_info.cw
+        via_stack_east_center = straight_heater_section.size_info.ce
+        dx = via_stackw.get_ports_xsize() / 2 + heater_taper_length or 0
+
+        via_stack_west = c << via_stackw
+        via_stack_east = c << via_stacke
+        via_stack_west.move(via_stack_west_center - (dx, 0))
+        via_stack_east.move(via_stack_east_center + (dx, 0))
+
+        valid_orientations = {p.orientation for p in via.ports.values()}
+        p1 = via_stack_west.get_ports_list(orientation=port_orientation1)
+        p2 = via_stack_east.get_ports_list(orientation=port_orientation2)
+
+        if not p1:
+            raise ValueError(
+                f"No ports for port_orientation1 {port_orientation1} in {valid_orientations}"
+            )
+        if not p2:
+            raise ValueError(
+                f"No ports for port_orientation2 {port_orientation2} in {valid_orientations}"
+            )
+
+        # c.add_ports(p1, prefix="l_")
+        # c.add_ports(p2, prefix="r_")
+        if heater_taper_length:
+            x = gf.get_cross_section(cross_section_heater, width=heater_width)
+            taper = gf.components.taper(
+                width1=via_stackw.ports["e1"].width,
+                width2=heater_width,
+                length=heater_taper_length,
+                cross_section=x,
+                port_order_name=("e1", "e2"),
+                port_order_types=("electrical", "electrical"),
+            )
+            taper1 = c << taper
+            taper2 = c << taper
+            taper1.connect("e1", via_stack_west.ports["e3"])
+            taper2.connect("e1", via_stack_east.ports["e1"])
+
+    c.info["resistance"] = (
+        ohms_per_square * heater_width * length if ohms_per_square else None
+    )
+    return c
+
+
 straight_heater_metal = partial(
     straight_heater_metal_undercut,
     with_undercut=False,

--- a/gdsfactory/components/taper.py
+++ b/gdsfactory/components/taper.py
@@ -19,6 +19,8 @@ def taper(
     with_bbox: bool = True,
     with_two_ports: bool = True,
     cross_section: CrossSectionSpec = "strip",
+    port_order_name: tuple | None = ("o1", "o2"),
+    port_order_types: tuple | None = ("optical", "optical"),
     **kwargs,
 ) -> Component:
     """Linear taper.
@@ -34,6 +36,8 @@ def taper(
         with_two_ports: includes a second port.
             False for terminator and edge coupler fiber interface.
         cross_section: specification (CrossSection, string, CrossSectionFactory dict).
+         port_order_name(tuple): Ordered tuple of port names. First port is default taper port, second name only if with_two_ports flags used.
+        port_order_types(tuple): Ordered tuple of port types. First port is default taper port, second name only if with_two_ports flags used.
         kwargs: cross_section settings.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -69,21 +73,23 @@ def taper(
             c.add_polygon((xpts, ypts), layer=gf.get_layer(layer))
 
     c.add_port(
-        name="o1",
+        name=port_order_name[0],
         center=(0, 0),
         width=width1,
         orientation=180,
         layer=x.layer,
         cross_section=x1,
+        port_type=port_order_types[0],
     )
     if with_two_ports:
         c.add_port(
-            name="o2",
+            name=port_order_name[1],
             center=(length, 0),
             width=width2,
             orientation=0,
             layer=x.layer,
             cross_section=x2,
+            port_type=port_order_types[1],
         )
 
     if with_bbox and length:

--- a/test-data-regression/test_settings_edge_coupler_silicon_.yml
+++ b/test-data-regression/test_settings_edge_coupler_silicon_.yml
@@ -22,6 +22,12 @@ settings:
     cross_section: strip
     length: 10.0
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: null
     with_bbox: true
@@ -30,6 +36,12 @@ settings:
     cross_section: strip
     length: 100
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: 0.2
     with_bbox: true

--- a/test-data-regression/test_settings_mzi2x2_2x2_phase_shifter_.yml
+++ b/test-data-regression/test_settings_mzi2x2_2x2_phase_shifter_.yml
@@ -1,4 +1,4 @@
-name: mzi_8feab63f
+name: mzi_214beef3
 ports:
   o1:
     center:
@@ -48,102 +48,30 @@ ports:
     port_type: optical
     shear_angle: null
     width: 0.5
-  top_l_e1:
+  top_e1:
     center:
-    - 19.5
+    - 35.5
     - 22.625
     layer:
-    - 49
+    - 47
     - 0
-    name: top_l_e1
+    name: top_e1
     orientation: 180.0
     port_type: electrical
     shear_angle: null
-    width: 11.0
-  top_l_e2:
+    width: 2.5
+  top_e2:
     center:
-    - 25.0
-    - 28.125
-    layer:
-    - 49
-    - 0
-    name: top_l_e2
-    orientation: 90.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  top_l_e3:
-    center:
-    - 30.5
+    - 235.5
     - 22.625
     layer:
-    - 49
+    - 47
     - 0
-    name: top_l_e3
+    name: top_e2
     orientation: 0.0
     port_type: electrical
     shear_angle: null
-    width: 11.0
-  top_l_e4:
-    center:
-    - 25.0
-    - 17.125
-    layer:
-    - 49
-    - 0
-    name: top_l_e4
-    orientation: 270.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  top_r_e1:
-    center:
-    - 240.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: top_r_e1
-    orientation: 180.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  top_r_e2:
-    center:
-    - 246.0
-    - 28.125
-    layer:
-    - 49
-    - 0
-    name: top_r_e2
-    orientation: 90.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  top_r_e3:
-    center:
-    - 251.5
-    - 22.625
-    layer:
-    - 49
-    - 0
-    name: top_r_e3
-    orientation: 0.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
-  top_r_e4:
-    center:
-    - 246.0
-    - 17.125
-    layer:
-    - 49
-    - 0
-    name: top_r_e4
-    orientation: 270.0
-    port_type: electrical
-    shear_angle: null
-    width: 11.0
+    width: 2.5
 settings:
   changed:
     combiner:
@@ -155,7 +83,7 @@ settings:
     port_e1_splitter: o3
     splitter:
       function: mmi2x2
-    straight_x_top: straight_heater_metal
+    straight_x_top: straight_heater_metal_simple
   child: null
   default:
     add_optical_ports_arms: false
@@ -204,11 +132,11 @@ settings:
     straight:
       function: straight
     straight_x_bot: null
-    straight_x_top: straight_heater_metal
+    straight_x_top: straight_heater_metal_simple
     straight_y: null
     with_splitter: true
   function_name: mzi
   info: {}
   info_version: 2
   module: gdsfactory.components.mzi
-  name: mzi_8feab63f
+  name: mzi_214beef3

--- a/test-data-regression/test_settings_straight_heater_metal_simple_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_simple_.yml
@@ -1,0 +1,81 @@
+name: straight_heater_metal_simple
+ports:
+  e1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 47
+    - 0
+    name: e1
+    orientation: 180.0
+    port_type: electrical
+    shear_angle: null
+    width: 2.5
+  e2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 47
+    - 0
+    name: e2
+    orientation: 0.0
+    port_type: electrical
+    shear_angle: null
+    width: 2.5
+  o1:
+    center:
+    - 0.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+  o2:
+    center:
+    - 320.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 0.5
+settings:
+  changed: {}
+  child: null
+  default:
+    cross_section_heater: heater_metal
+    cross_section_waveguide_heater: strip_heater_metal
+    heater_taper_length: 5.0
+    heater_width: 2.5
+    length: 320.0
+    length_straight_input: 15.0
+    ohms_per_square: null
+    port_orientation1: null
+    port_orientation2: null
+    via_stack: via_stack_heater_mtop
+  full:
+    cross_section_heater: heater_metal
+    cross_section_waveguide_heater: strip_heater_metal
+    heater_taper_length: 5.0
+    heater_width: 2.5
+    length: 320.0
+    length_straight_input: 15.0
+    ohms_per_square: null
+    port_orientation1: null
+    port_orientation2: null
+    via_stack: via_stack_heater_mtop
+  function_name: straight_heater_metal_simple
+  info:
+    resistance: null
+  info_version: 2
+  module: gdsfactory.components.straight_heater_metal
+  name: straight_heater_metal_simple

--- a/test-data-regression/test_settings_taper2_.yml
+++ b/test-data-regression/test_settings_taper2_.yml
@@ -32,6 +32,12 @@ settings:
     cross_section: strip
     length: 10.0
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: null
     with_bbox: true
@@ -40,6 +46,12 @@ settings:
     cross_section: strip
     length: 10.0
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: 3
     with_bbox: true

--- a/test-data-regression/test_settings_taper_.yml
+++ b/test-data-regression/test_settings_taper_.yml
@@ -31,6 +31,12 @@ settings:
     cross_section: strip
     length: 10.0
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: null
     with_bbox: true
@@ -39,6 +45,12 @@ settings:
     cross_section: strip
     length: 10.0
     port: null
+    port_order_name:
+    - o1
+    - o2
+    port_order_types:
+    - optical
+    - optical
     width1: 0.5
     width2: null
     with_bbox: true

--- a/tests/test_netlist_electrical.py
+++ b/tests/test_netlist_electrical.py
@@ -3,112 +3,7 @@ Tests that we get a suitable electrical netlist that represents the physical geo
 We use the `get_missing_models` function in `sax` to extract that it is representing our netlist component correctly.
 """
 import json  # NOQA : F401
-
-import sax
-
 import gdsfactory as gf
-
-
-def test_extract_electrical_netlist_straight_heater_metal():
-    """
-    This component is a good test because it contains electrical and optical ports, and we can see how effective the
-    implementation of adding ports is in this case.
-    What we want here is to extract all the electrical models required from our netlist. If our netlist is properly
-    composed, then it is possible to have a connectivity that actually represents electrical elements in our circuit,
-    and hence, eventually convert it to SPICE.
-    """
-    our_heater = gf.components.straight_heater_metal_simple()
-    our_heater.show()
-    our_heater_netlist = our_heater.get_netlist(
-        exclude_port_types="optical",
-        allow_multiple=True,
-    )
-    # print(our_heater_netlist)
-    # print(sax.get_required_circuit_models(our_heater_netlist))
-    # print(our_heater_netlist["instances"].keys())
-    # print(our_heater_netlist["ports"])
-    # print("connections out")
-    # print(our_heater_netlist["connections"])
-    assert sax.get_required_circuit_models(our_heater_netlist) == [
-        "straight",
-        "taper",
-        "via_stack",
-    ]
-
-    our_recursive_heater_netlist = our_heater.get_netlist_recursive(
-        exclude_port_types="optical",
-        allow_multiple=True,
-    )
-    # print(json.dumps(our_recursive_heater_netlist, sort_keys=True, indent=4))
-    # print(sax.get_required_circuit_models(our_recursive_heater_netlist))
-    assert {"straight", "taper", "compass"}.issubset(
-        set(sax.get_required_circuit_models(our_recursive_heater_netlist))
-    )
-
-
-def test_netlist_model_extraction():
-    """
-    Tests that our PIN placement allows the netlister and sax to extract our electrical component model in a composed circuit.
-    """
-
-    @gf.cell
-    def connected_metal():
-        test = gf.Component()
-        a = test << gf.components.straight(cross_section="metal1")
-        test.add_ports(a.ports)
-        return test
-
-    connected_metal().show()
-    models_list = sax.get_required_circuit_models(connected_metal().get_netlist())
-    # print(models_list)
-    assert models_list == ["straight"]
-
-    models_list_electrical_netlist = sax.get_required_circuit_models(
-        connected_metal().get_netlist(exclude_port_types="optical")
-    )
-    # print(models_list_electrical_netlist)
-    assert models_list == models_list_electrical_netlist
-
-
-def test_via_array_netlist_connectivity():
-    """
-    We want to test how the pins generated in a via array allow us to extract connectivity for its component in between metal layers.
-    """
-    our_via_stack = gf.components.via_stack()
-    our_via_stack.show()
-    pass
-
-
-def test_mzi2x2_2x2_phase_shifter():
-    """
-    We want to know how we extract the electrical netlist in a more hierarchical composed design.
-    """
-    our_mzi_phase_shifter = gf.components.mzi2x2_2x2_phase_shifter()
-    our_mzi_phase_shifter_netlist_electrical = our_mzi_phase_shifter.get_netlist(
-        exclude_port_types="optical",
-    )
-    our_mzi_phase_shifter.show()
-    assert sax.get_required_circuit_models(
-        our_mzi_phase_shifter_netlist_electrical
-    ) == ["straight_heater_metal_simple"]
-
-    # We need to extract only electrical models.
-    our_recursive_mzi_phase_shifter_netlist_electrical = (
-        our_mzi_phase_shifter.get_netlist_recursive(
-            exclude_port_types="optical",
-            allow_multiple=True,
-        )
-    )
-    assert {"straight", "taper", "compass"}.issubset(
-        set(
-            sax.get_required_circuit_models(
-                our_recursive_mzi_phase_shifter_netlist_electrical
-            )
-        )
-    )
-
-    # print(json.dumps(our_recursive_mzi_phase_shifter_netlist_electrical, sort_keys=True, indent=4))
-    # print(sax.get_required_circuit_models(our_recursive_mzi_phase_shifter_netlist_electrical))
 
 
 def test_no_effect_on_original_components():
@@ -118,13 +13,8 @@ def test_no_effect_on_original_components():
         exclude_port_types="optical",
     )
     assert passive_mzi_phase_shifter_netlist_electrical is not None
-    # print(passive_mzi_phase_shifter_netlist_electrical[list(passive_mzi_phase_shifter_netlist_electrical.keys())[0]]["instances"].keys())
 
 
 if __name__ == "__main__":
     # TODO turn all back on.
-    test_extract_electrical_netlist_straight_heater_metal()
-    test_mzi2x2_2x2_phase_shifter()
-    test_netlist_model_extraction()
     test_no_effect_on_original_components()
-    test_via_array_netlist_connectivity()

--- a/tests/test_netlist_electrical.py
+++ b/tests/test_netlist_electrical.py
@@ -1,0 +1,130 @@
+"""
+Tests that we get a suitable electrical netlist that represents the physical geometry of our circuit.
+We use the `get_missing_models` function in `sax` to extract that it is representing our netlist component correctly.
+"""
+import json  # NOQA : F401
+
+import sax
+
+import gdsfactory as gf
+
+
+def test_extract_electrical_netlist_straight_heater_metal():
+    """
+    This component is a good test because it contains electrical and optical ports, and we can see how effective the
+    implementation of adding ports is in this case.
+    What we want here is to extract all the electrical models required from our netlist. If our netlist is properly
+    composed, then it is possible to have a connectivity that actually represents electrical elements in our circuit,
+    and hence, eventually convert it to SPICE.
+    """
+    our_heater = gf.components.straight_heater_metal_simple()
+    our_heater.show()
+    our_heater_netlist = our_heater.get_netlist(
+        exclude_port_types="optical",
+        allow_multiple=True,
+    )
+    # print(our_heater_netlist)
+    # print(sax.get_required_circuit_models(our_heater_netlist))
+    # print(our_heater_netlist["instances"].keys())
+    # print(our_heater_netlist["ports"])
+    # print("connections out")
+    # print(our_heater_netlist["connections"])
+    assert sax.get_required_circuit_models(our_heater_netlist) == [
+        "straight",
+        "taper",
+        "via_stack",
+    ]
+
+    our_recursive_heater_netlist = our_heater.get_netlist_recursive(
+        exclude_port_types="optical",
+        allow_multiple=True,
+    )
+    # print(json.dumps(our_recursive_heater_netlist, sort_keys=True, indent=4))
+    # print(sax.get_required_circuit_models(our_recursive_heater_netlist))
+    assert {"straight", "taper", "compass"}.issubset(
+        set(sax.get_required_circuit_models(our_recursive_heater_netlist))
+    )
+
+
+def test_netlist_model_extraction():
+    """
+    Tests that our PIN placement allows the netlister and sax to extract our electrical component model in a composed circuit.
+    """
+
+    @gf.cell
+    def connected_metal():
+        test = gf.Component()
+        a = test << gf.components.straight(cross_section="metal1")
+        test.add_ports(a.ports)
+        return test
+
+    connected_metal().show()
+    models_list = sax.get_required_circuit_models(connected_metal().get_netlist())
+    # print(models_list)
+    assert models_list == ["straight"]
+
+    models_list_electrical_netlist = sax.get_required_circuit_models(
+        connected_metal().get_netlist(exclude_port_types="optical")
+    )
+    # print(models_list_electrical_netlist)
+    assert models_list == models_list_electrical_netlist
+
+
+def test_via_array_netlist_connectivity():
+    """
+    We want to test how the pins generated in a via array allow us to extract connectivity for its component in between metal layers.
+    """
+    our_via_stack = gf.components.via_stack()
+    our_via_stack.show()
+    pass
+
+
+def test_mzi2x2_2x2_phase_shifter():
+    """
+    We want to know how we extract the electrical netlist in a more hierarchical composed design.
+    """
+    our_mzi_phase_shifter = gf.components.mzi2x2_2x2_phase_shifter()
+    our_mzi_phase_shifter_netlist_electrical = our_mzi_phase_shifter.get_netlist(
+        exclude_port_types="optical",
+    )
+    our_mzi_phase_shifter.show()
+    assert sax.get_required_circuit_models(
+        our_mzi_phase_shifter_netlist_electrical
+    ) == ["straight_heater_metal_simple"]
+
+    # We need to extract only electrical models.
+    our_recursive_mzi_phase_shifter_netlist_electrical = (
+        our_mzi_phase_shifter.get_netlist_recursive(
+            exclude_port_types="optical",
+            allow_multiple=True,
+        )
+    )
+    assert {"straight", "taper", "compass"}.issubset(
+        set(
+            sax.get_required_circuit_models(
+                our_recursive_mzi_phase_shifter_netlist_electrical
+            )
+        )
+    )
+
+    # print(json.dumps(our_recursive_mzi_phase_shifter_netlist_electrical, sort_keys=True, indent=4))
+    # print(sax.get_required_circuit_models(our_recursive_mzi_phase_shifter_netlist_electrical))
+
+
+def test_no_effect_on_original_components():
+    passive_mzi = gf.components.mzi2x2_2x2()
+    passive_mzi.show()
+    passive_mzi_phase_shifter_netlist_electrical = passive_mzi.get_netlist_recursive(
+        exclude_port_types="optical",
+    )
+    assert passive_mzi_phase_shifter_netlist_electrical is not None
+    # print(passive_mzi_phase_shifter_netlist_electrical[list(passive_mzi_phase_shifter_netlist_electrical.keys())[0]]["instances"].keys())
+
+
+if __name__ == "__main__":
+    # TODO turn all back on.
+    test_extract_electrical_netlist_straight_heater_metal()
+    test_mzi2x2_2x2_phase_shifter()
+    test_netlist_model_extraction()
+    test_no_effect_on_original_components()
+    test_via_array_netlist_connectivity()


### PR DESCRIPTION
Hi Joaquin,

Hope all is well! There are some new examples in `piel` ie: https://piel.readthedocs.io/en/latest/examples/04_spice_cosimulation/04_spice_cosimulation.html and I realised that I had made some additions to my gdsfactory I needed to PR for them to run for others. Mainly, these are properly done electrical connectivity in the netlist so that it can be compiled to `hdl21` SPICE. Let me know if I need to fix something or check any issues on testing.

I also have some code not in this PR that puts pins I think compatible with Mentor Graphics Calibre to impelment a LVS check on the netlist connectivity. It's a bit of a major change on the default PDK but I might PR it for future improvements and testing too, as I haven't had the time to look into that even if useful.