### PR TITLE
remove flatten invalid refs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/gdsfactory/gdsfactory/compare/v7.2.0...main)
 
+- remove inflatten refs
+
 ## [7.2.1](https://github.com/gdsfactory/gdsfactory/compare/v7.2.1...v7.2.0)
 
 - add `from_image`

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1904,9 +1904,7 @@ class Component(_GeometryHelper):
             """
             import json
 
-            if netlist_function is not None:
-                pass
-            else:
+            if netlist_function is None:
                 from gdsfactory.get_netlist import get_netlist
 
                 netlist_function = get_netlist

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1350,6 +1350,20 @@ class Component(_GeometryHelper):
         new_component = transformed(ref, decorator=None)
         self.add_ref(new_component, alias=ref.name)
 
+    def flatten_invalid_refs(
+        self,
+        grid_size: float | None = None,
+        updated_components=None,
+        traversed_components=None,
+    ) -> Component:
+        """Returns new component with flattened references."""
+        return flatten_invalid_refs_recursive(
+            self,
+            grid_size=grid_size,
+            updated_components=updated_components,
+            traversed_components=traversed_components,
+        )
+
     def add_ref(
         self, component: Component, alias: str | None = None, **kwargs
     ) -> ComponentReference:
@@ -2665,18 +2679,24 @@ def flatten_invalid_refs_recursive(
     grid_size: float | None = None,
     updated_components=None,
     traversed_components=None,
-):
-    """Recursively flattens component references which have invalid transformations (i.e. non-90 deg rotations or sub-grid translations) and returns a copy if any subcells have been modified.
+) -> Component:
+    """Recursively flattens component references which have invalid transformations
+    (i.e. non-90 deg rotations or sub-grid translations)
+    returns a copy if any subcells have been modified.
 
-    WARNING: this function will produce same-name copies of cells. It is strictly meant to be used on write of the GDS file and
-    should not be mixed with other cells, or you will likely experience issues with duplicate cells
+    WARNING: this function will produce same-name copies of cells.
+    It is strictly meant to be used on write of the GDS file and
+    should not be mixed with other cells,
+    or you will likely experience issues with duplicate cells
 
     Args:
         component: the component to fix (in place).
         grid_size: the GDS grid size, in um, defaults to active PDK.get_grid_size()
             any translations with higher resolution than this are considered invalid.
-        updated_components: the running dictionary of components which have been modified by this transformation. Should always be None, except for recursive invocations.
-        traversed_components: the set of component names which have been traversed. Should always be None, except for recursive invocations.
+        updated_components: dict of components transformed.
+            Should always be None, except for recursive.
+        traversed_components: the set of component names which have been traversed.
+            Should always be None, except for recursive invocations.
     """
     from gdsfactory.decorators import is_invalid_ref
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -129,7 +129,7 @@ class GdsWriteSettings(BaseModel):
                         "overwrite": overwrite all duplicate cells with one of the duplicates, without warning.""",
     )
     flatten_invalid_refs: bool = Field(
-        default=True,
+        default=False,
         description="If true, will auto-correct (and flatten) cell references which are off-grid or rotated by non-manhattan angles.",
     )
     max_points: int = Field(

--- a/gdsfactory/routing/all_angle.py
+++ b/gdsfactory/routing/all_angle.py
@@ -929,20 +929,26 @@ def get_bundle_all_angle(
 if __name__ == "__main__":
     import gdsfactory as gf
 
-    c = gf.Component("demo")
+    @gf.cell
+    def demo_issue() -> gf.Component:
+        c = gf.Component()
 
-    mmi = gf.components.mmi2x2(width_mmi=10, gap_mmi=3)
-    mmi1 = c << mmi
-    mmi2 = c << mmi
+        mmi = gf.components.mmi2x2(width_mmi=10, gap_mmi=3)
+        mmi1 = c << mmi
+        mmi2 = c << mmi
 
-    mmi2.move((100, 30))
-    mmi2.rotate(30)
+        mmi2.move((100, 30))
+        mmi2.rotate(30)
 
-    routes = gf.routing.get_bundle_all_angle(
-        mmi1.get_ports_list(orientation=0),
-        [mmi2.ports["o2"], mmi2.ports["o1"]],
-        connector=None,
-    )
-    for route in routes:
-        c.add(route.references)
+        routes = gf.routing.get_bundle_all_angle(
+            mmi1.get_ports_list(orientation=0),
+            [mmi2.ports["o2"], mmi2.ports["o1"]],
+            connector=None,
+        )
+        for route in routes:
+            c.add(route.references)
+
+        return c
+
+    c = demo_issue(decorator=gf.decorators.flatten_invalid_refs)
     c.show()

--- a/gdsfactory/routing/all_angle.py
+++ b/gdsfactory/routing/all_angle.py
@@ -950,5 +950,7 @@ if __name__ == "__main__":
 
         return c
 
-    c = demo_issue(decorator=gf.decorators.flatten_invalid_refs)
+    # c = demo_issue(decorator=gf.decorators.flatten_invalid_refs)
+    c = demo_issue()
+    c = c.flatten_invalid_refs()
     c.show()


### PR DESCRIPTION
flatten invalid refs by default can change the component sizes, for example vias, which can create DRC errors
don't flatten invalid refs by default
if you want to flatten invalid refs you can pass the decorator


another option added is 

c = Component.flatten_invalid_refs()


@tvt173 
@sebastian-goeldi 



