### PR TITLE
Allow ComponentAlongPath to be specified using a ComponentSpec

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -29,6 +29,7 @@ from gdsfactory.cross_section import CrossSection, Section, Transition
 from gdsfactory.port import Port
 from gdsfactory.typings import (
     Coordinates,
+    ComponentSpec,
     CrossSectionSpec,
     Float2,
     LayerSpec,
@@ -737,7 +738,7 @@ def transition(
 @cell
 def along_path(
     p: Path,
-    component: Component,
+    component: ComponentSpec,
     spacing: float,
     padding: float,
 ) -> Component:
@@ -754,6 +755,10 @@ def along_path(
         spacing: distance between component placements.
         padding: minimum distance from the path start to the first component.
     """
+    from gdsfactory.pdk import get_component
+
+    component = get_component(component)
+
     length = p.length()
     number = (length - 2 * padding) // spacing + 1
 


### PR DESCRIPTION
Currently to put components along a path, `component` in `ComponentAlongPath(component, spacing, padding, offset)` must be a `Component` object. 

This PR allows `component` to be specified by the more general `ComponentSpec` and does not modify the previous behavior.