### PR TITLE
gf watch: ipython functionality and minor fixes

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -390,7 +390,7 @@ class Pdk(BaseModel):
             if not dirpath.is_dir():
                 raise ValueError(f"{dirpath!r} needs to be a directory.")
 
-            for filepath in dirpath.glob("*/**/*.pic.yml"):
+            for filepath in dirpath.glob("**/*.pic.yml"):
                 name = filepath.stem.split(".")[0]
                 if not update and name in self.cells:
                     raise ValueError(


### PR DESCRIPTION
hi @joamatab ,

this MR adds ipython functionality to `gf watch` and also adds a few minor enhancements and fixes
- Fixes issue that dynamically loaded yaml cells appear to vanish from known cells if pdk is switched midway through execution
- Adds a convenience `show()` function to the context of the ipython watcher loop. That is to say, assuming you have a file called `TOP.pic.yml` somewhere in your file tree you are watching, you can type `show('TOP')` at the ipython terminal, and it will switch views to that cell for you. This will also work for any other registered python cells or any components you might create at the terminal...