### PR TITLE
Add version of interdigital capacitor with CPWs and ground layer

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -760,6 +760,21 @@ coupler_bent
 
 
 
+coupler_broadband
+----------------------------------------------------
+
+.. autofunction:: gdsfactory.components.coupler_broadband
+
+.. plot::
+  :include-source:
+
+  import gdsfactory as gf
+
+  c = gf.components.coupler_broadband(w_sc=0.5, gap_sc=0.2, w_top=0.6, gap_pc=0.3, legnth_taper=1.0, length_coupler_straight=12.4, lenght_coupler_big_gap=4.7, cross_section='strip', radius=10.0)
+  c.plot()
+
+
+
 coupler_full
 ----------------------------------------------------
 
@@ -1760,6 +1775,21 @@ interdigital_capacitor
   import gdsfactory as gf
 
   c = gf.components.interdigital_capacitor(fingers=4, finger_length=20.0, finger_gap=2.0, thickness=5.0, layer='WG')
+  c.plot()
+
+
+
+interdigital_capacitor_enclosed
+----------------------------------------------------
+
+.. autofunction:: gdsfactory.components.interdigital_capacitor_enclosed
+
+.. plot::
+  :include-source:
+
+  import gdsfactory as gf
+
+  c = gf.components.interdigital_capacitor_enclosed(fingers=4, finger_length=20.0, finger_gap=2.0, thickness=5.0, cpw_dimensions=[10, 6], gap_to_ground=5, metal_layer='WG', gap_layer='DEEPTRENCH')
   c.plot()
 
 

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -160,6 +160,9 @@ from gdsfactory.components.greek_cross import (
 )
 from gdsfactory.components.hline import hline
 from gdsfactory.components.interdigital_capacitor import interdigital_capacitor
+from gdsfactory.components.interdigital_capacitor_enclosed import (
+    interdigital_capacitor_enclosed,
+)
 from gdsfactory.components.L import L
 from gdsfactory.components.litho_calipers import litho_calipers
 from gdsfactory.components.litho_ruler import litho_ruler
@@ -484,6 +487,7 @@ __all__ = [
     "greek_cross_offset_pads",
     "hline",
     "interdigital_capacitor",
+    "interdigital_capacitor_enclosed",
     "litho_calipers",
     "litho_ruler",
     "litho_steps",

--- a/gdsfactory/components/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_coupler_elliptical_lumerical.py
@@ -69,7 +69,7 @@ parameters = (
 def grating_coupler_elliptical_lumerical(
     parameters: Floats = parameters,
     layer: LayerSpec = "WG",
-    layer_slab: LayerSpec = "SLAB150",
+    layer_slab: LayerSpec | None = "SLAB150",
     taper_angle: float = 55,
     taper_length: float = 12.24 + 0.36,
     fiber_angle: float = 5,

--- a/gdsfactory/components/interdigital_capacitor_enclosed.py
+++ b/gdsfactory/components/interdigital_capacitor_enclosed.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Sequence
+
+import numpy as np
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.components.interdigital_capacitor import interdigital_capacitor
+from gdsfactory.typings import LayerSpec
+
+INTERDIGITAL_DEFAULTS = {
+    k: v.default
+    for k, v in inspect.signature(interdigital_capacitor).parameters.items()
+}
+
+
+@gf.cell
+def interdigital_capacitor_enclosed(
+    enclosure_box: Sequence[Sequence[float | int]] = [[-200, -200], [200, 200]],
+    fingers: int = INTERDIGITAL_DEFAULTS["fingers"],
+    finger_length: float | int = INTERDIGITAL_DEFAULTS["finger_length"],
+    finger_gap: float | int = INTERDIGITAL_DEFAULTS["finger_gap"],
+    thickness: float | int = INTERDIGITAL_DEFAULTS["thickness"],
+    cpw_dimensions: tuple[float | int, float | int] = (10, 6),
+    gap_to_ground: float | int = 5,
+    metal_layer: LayerSpec = INTERDIGITAL_DEFAULTS["layer"],
+    gap_layer: LayerSpec = "DEEPTRENCH",
+) -> Component:
+    """Generates an interdigital capacitor surrounded by a ground plane and coplanar waveguides with ports on both ends.
+    See for :func:`~interdigital_capacitor` for details.
+
+    Note:
+        ``finger_length=0`` effectively provides a plate capacitor.
+
+    Args:
+        enclosure_box: Bounding box dimensions for a ground metal enclosure.
+        fingers: total fingers of the capacitor.
+        finger_length: length of the probing fingers.
+        finger_gap: length of gap between the fingers.
+        thickness: Thickness of fingers and section before the fingers.
+        gap_to_ground: Size of gap from capacitor to ground metal.
+        cpw_dimensions: Dimensions for the trace width and gap width of connecting coplanar waveguides.
+        metal_layer: layer for metalization.
+        gap_layer: layer for trenching.
+    """
+    c = Component()
+    cap = interdigital_capacitor(
+        fingers, finger_length, finger_gap, thickness, metal_layer
+    ).ref_center()
+    c.add(cap)
+
+    gap = Component()
+    for port in cap.get_ports_list():
+        port2 = port.copy()
+        # TODO very bad check, should do vector according to orientation
+        direction = -1 if port.orientation > 0 else 1
+        port2.move((30 * direction, 0))
+        port2 = port2.flip()
+
+        cpw_a, cpw_b = cpw_dimensions
+        s1 = gf.Section(width=cpw_b, offset=(cpw_a + cpw_b) / 2, layer=gap_layer)
+        s2 = gf.Section(width=cpw_b, offset=-(cpw_a + cpw_b) / 2, layer=gap_layer)
+        x = gf.CrossSection(
+            width=cpw_a,
+            offset=0,
+            layer=metal_layer,
+            port_names=("in", "out"),
+            sections=[s1, s2],
+        )
+        route = gf.routing.get_route(
+            port,
+            port2,
+            cross_section=x,
+        )
+        c.add(route.references)
+
+        # TODO check size parameters, now they're maybe approximate
+        term = c << gf.components.bbox(
+            [[0, 0], [cpw_b, cpw_a + 2 * cpw_b]], layer=gap_layer
+        )
+        if direction < 0:
+            term.movex(-cpw_b)
+        term.move(
+            destination=route.ports[-1].move_copy(-1 * np.array([0, cpw_a / 2 + cpw_b]))
+        )
+
+        c.add_port(route.ports[-1])
+        c.auto_rename_ports()
+
+    gap.add_polygon(cap.get_polygon_enclosure(), layer=gap_layer)
+    gap = gap.offset(gap_to_ground, layer=gap_layer)
+    gap = gf.geometry.boolean(A=gap, B=c, operation="A-B", layer=gap_layer)
+
+    ground = gf.components.bbox(bbox=enclosure_box, layer=metal_layer)
+    ground = gf.geometry.boolean(
+        A=ground, B=[c, gap], operation="A-B", layer=metal_layer
+    )
+
+    c << ground
+
+    return c.flatten()
+
+
+if __name__ == "__main__":
+    c = interdigital_capacitor_enclosed()
+    c.show(show_ports=True)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -259,6 +259,7 @@ class Pdk(BaseModel):
         default_factory=dict
     )
     sparameters_path: PathType | None = None
+    capacitance_path: PathType | None = None
     modes_path: PathType | None = PATH.modes
     interconnect_cml_path: PathType | None = None
     warn_off_grid_ports: bool = False
@@ -291,7 +292,7 @@ class Pdk(BaseModel):
             "materials_index": {"exclude": True},
         }
 
-    @validator("sparameters_path")
+    @validator("sparameters_path", "capacitance_path")
     def is_pathlib_path(cls, path):
         return pathlib.Path(path)
 
@@ -741,6 +742,13 @@ def get_constant(constant_name: Any) -> Any:
         if isinstance(constant_name, str)
         else constant_name
     )
+
+
+def get_capacitance_path() -> pathlib.Path:
+    PDK = get_active_pdk()
+    if PDK.capacitance_path is None:
+        raise ValueError(f"{_ACTIVE_PDK.name!r} has no capacitance_path")
+    return PDK.capacitance_path
 
 
 def get_sparameters_path() -> pathlib.Path:

--- a/test-data-regression/test_settings_interdigital_capacitor_enclosed_.yml
+++ b/test-data-regression/test_settings_interdigital_capacitor_enclosed_.yml
@@ -1,0 +1,66 @@
+name: interdigital_capacitor_enclosed
+ports:
+  o1:
+    center:
+    - -46.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o1
+    orientation: 180.0
+    port_type: optical
+    shear_angle: null
+    width: 10.0
+  o2:
+    center:
+    - 46.0
+    - 0.0
+    layer:
+    - 1
+    - 0
+    name: o2
+    orientation: 0.0
+    port_type: optical
+    shear_angle: null
+    width: 10.0
+settings:
+  changed: {}
+  child: null
+  default:
+    cpw_dimensions:
+    - 10
+    - 6
+    enclosure_box:
+    - - -200
+      - -200
+    - - 200
+      - 200
+    finger_gap: 2.0
+    finger_length: 20.0
+    fingers: 4
+    gap_layer: DEEPTRENCH
+    gap_to_ground: 5
+    metal_layer: WG
+    thickness: 5.0
+  full:
+    cpw_dimensions:
+    - 10
+    - 6
+    enclosure_box:
+    - - -200
+      - -200
+    - - 200
+      - 200
+    finger_gap: 2.0
+    finger_length: 20.0
+    fingers: 4
+    gap_layer: DEEPTRENCH
+    gap_to_ground: 5
+    metal_layer: WG
+    thickness: 5.0
+  function_name: interdigital_capacitor_enclosed
+  info: {}
+  info_version: 2
+  module: gdsfactory.components.interdigital_capacitor_enclosed
+  name: interdigital_capacitor_enclosed


### PR DESCRIPTION
This PR adds a version of interdigital capacitor with CPWs and ground layer.
Additionally, a `get_capacitance_path` method is added to PDK, similar to `get_sparameters_path`.

This is handy for testing capacitive simulations such as the ones enabled by https://github.com/gdsfactory/gplugins/pull/42

The code isn't very clean but please tell is something may be improved