### PR TITLE
Add linting for Markdown files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
     hooks:
       - id: j2lint
         args: [--ignore, jinja-statements-delimiter, jinja-statements-indentation, --]
+
+  - repo: https://github.com/markdownlint/markdownlint.git
+    rev: v0.12.0
+    hooks:
+      - id: markdownlint
+        args: [--rules, '~MD007,~MD012,~MD013,~MD026,~MD029,~MD033,~MD034']
+        exclude: '^docs/CHANGELOG.md$'

--- a/gdsfactory/generic_tech/klayout/lvs/README.md
+++ b/gdsfactory/generic_tech/klayout/lvs/README.md
@@ -14,7 +14,9 @@ Explains how to use the runset.
  ```
 
 ## **Prerequisites**
+
 You need the following set of tools installed to be able to run GENERIC TECH LVS:
+
 - Python 3.6+
 - KLayout 0.28.4+
 
@@ -28,6 +30,7 @@ The `run_lvs.py` script takes your input gds and netlist files to run LVS rule d
 ```
 
 Example:
+
 ```bash
     python3 testing/testcases/unit/heater_devices/layout/straight_heater_metal.py
     python3 run_lvs.py --layout=testing/testcases/unit/heater_devices/layout/straight_heater_metal.gds --netlist=testing/testcases/unit/heater_devices/netlist/straight_heater_metal.spice --run_mode=deep --run_dir=lvs_straight_heater_metal
@@ -86,7 +89,7 @@ You could find the run results at your run directory if you previously specified
  ```
 
 The result is a database file (`<your_design_name>.lvsdb`) contains LVS extractions and comparison results.
-You could view it on your file using: `klayout <input_gds_file> -mn <resut_db_file> `, or you could view it on your gds file via netlist browser option in tools menu using klayout GUI.
+You could view it on your file using: `klayout <input_gds_file> -mn <resut_db_file>`, or you could view it on your gds file via netlist browser option in tools menu using klayout GUI.
 
 You could also find the extracted netlist generated from your design at (`<your_design_name>.cir`) in your run directory.
 

--- a/gdsfactory/generic_tech/klayout/lvs/drc_malformed/README.md
+++ b/gdsfactory/generic_tech/klayout/lvs/drc_malformed/README.md
@@ -12,11 +12,14 @@ Explains how to use the runset.
  ```
 
 ## **Prerequisites**
+
 You need the following set of tools installed to be able to run DRC:
+
 - Python 3.6+
 - KLayout 0.28.4+
 
 ## Run Malformed-DRC Usage
+
 The `run_drc.py` script takes a gds file to run DRC rule decks with switches to select subsets of all checks.
 
 ```bash
@@ -62,6 +65,6 @@ You could find the run results at your run directory if you previously specified
  ```
 
 The result is a database file (`<your_design_name>.lyrdb`) contains all violations.
-You could view it on your file using: `klayout <input_gds_file> -m <result_db_file> `, or you could view it on your gds file via marker browser option in tools menu using klayout GUI as shown below.
+You could view it on your file using: `klayout <input_gds_file> -m <result_db_file>`, or you could view it on your gds file via marker browser option in tools menu using klayout GUI as shown below.
 
 ![image](https://user-images.githubusercontent.com/91015308/219004873-be7c1e81-7085-4e82-8cd4-8303bc021e13.png)


### PR DESCRIPTION
This PR adds basic linting for Markdown files in the pre-commit hook and disables some unreasonable rules and ones which would make sense after changing the default parameters.

A more thorough markdown style with paramaters could be created with a `.mdlrc` file, including [editing parameters ](https://github.com/markdownlint/markdownlint/blob/main/docs/creating_styles.md#parameters) which I didn't find for just the arguments.

Closes #2000