### PR TITLE
Account for different coupling lengths in ring_crow_couplers.py

### DIFF
--- a/gdsfactory/components/ring_crow_couplers.py
+++ b/gdsfactory/components/ring_crow_couplers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_circular import bend_circular
@@ -80,11 +82,46 @@ def ring_crow_couplers(
         bend3 = c.add_ref(bend_c, alias=f"top_left_bend_ring_{index}")
         bend4 = c.add_ref(bend_c, alias=f"bot_left_bend_ring_{index}")
 
-        bend1.connect("o1", couplers_refs[index].ports["o3"])
-        bend2.connect("o1", bend1.ports["o2"])
-        couplers_refs[index + 1].connect("o4", bend2.ports["o2"])
-        bend3.connect("o1", couplers_refs[index + 1].ports["o1"])
-        bend4.connect("o1", bend3.ports["o2"])
+        # We need to account for the chance that the top and bottom couplers
+        # have a different length --> In this case we need to add straights
+        coup1_extent = couplers_refs[index].xmax - couplers_refs[index].xmin
+        coup2_extent = couplers_refs[index + 1].xmax - couplers_refs[index + 1].xmin
+
+        if coup1_extent == coup2_extent:
+            # Length of the couplers is the same -- we are good
+            bend1.connect("o1", couplers_refs[index].ports["o3"])
+            bend2.connect("o1", bend1.ports["o2"])
+            couplers_refs[index + 1].connect("o4", bend2.ports["o2"])
+            bend3.connect("o1", couplers_refs[index + 1].ports["o1"])
+            bend4.connect("o1", bend3.ports["o2"])
+
+        else:
+            str_len = np.abs(coup1_extent - coup2_extent) / 2
+            str_sec = gf.components.straight(
+                cross_section=cross_section, length=str_len
+            )
+
+            str1 = c << str_sec
+            str2 = c << str_sec
+
+            if coup1_extent > coup2_extent:
+                # The straight are connected to coupler 2
+                bend1.connect("o1", couplers_refs[index].ports["o3"])
+                bend2.connect("o1", bend1.ports["o2"])
+                str1.connect("o1", bend2.ports["o2"])
+                couplers_refs[index + 1].connect("o4", str1.ports["o2"])
+                str2.connect("o1", couplers_refs[index + 1].ports["o1"])
+                bend3.connect("o1", str2.ports["o2"])
+                bend4.connect("o1", bend3.ports["o2"])
+            else:
+                # The straights are connected to coupler 1
+                str1.connect("o1", couplers_refs[index].ports["o3"])
+                str2.connect("o1", couplers_refs[index].ports["o2"])
+                bend1.connect("o1", str1.ports["o2"])
+                bend2.connect("o1", bend1.ports["o2"])
+                couplers_refs[index + 1].connect("o4", bend2.ports["o2"])
+                bend3.connect("o1", couplers_refs[index + 1].ports["o1"])
+                bend4.connect("o1", bend3.ports["o2"])
 
     # Output bus
     c.add_port(name="o3", port=couplers_refs[-1].ports["o2"])


### PR DESCRIPTION
the previous implementation of ring_crow_couplers did not account for the possibility of having couplers of different length. If that's the case, then we have unclosed gaps or colliding waveguides.

With this PR we account for different coupler lengths and just add a straight section to connect everything.