### PR TITLE
Use j2lint for gdsfactory YAML files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,10 @@ repos:
         args: [--autofix]
 
   - repo: https://github.com/aristanetworks/j2lint.git
-    rev: v1.1.0
+    rev: 742a25ef5da996b9762f167ebae9bc8223e8382e
     hooks:
       - id: j2lint
-        args: [--ignore, jinja-statements-delimiter, jinja-statements-indentation, --]
+        types: [file]
+        files: \.(j2|yml|yaml)$
+        args: [--extensions, "j2,yml,yaml", --ignore, jinja-statements-delimiter, jinja-statements-indentation, --]
+        exclude: .github/.*


### PR DESCRIPTION
This PR extends the allowed filetypes for j2lint to also lint gdsfactory YAML files

Closes #1914