### PR TITLE
fix rotation when port orientation is None

### DIFF
--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -434,16 +434,7 @@ class ComponentReference(_GeometryHelper):
 
     def __repr__(self) -> str:
         """Return a string representation of the object."""
-        return (
-            'ComponentReference (parent Component "{}", ports {}, origin {}, rotation {},'
-            " x_reflection {})".format(
-                self.parent.name,
-                list(self.ports.keys()),
-                self.origin,
-                self.rotation,
-                self.x_reflection,
-            )
-        )
+        return f'ComponentReference (parent Component "{self.parent.name}", ports {list(self.ports.keys())}, origin {self.origin}, rotation {self.rotation}, x_reflection {self.x_reflection})'
 
     def to_dict(self):
         d = self.parent.to_dict()
@@ -554,7 +545,7 @@ class ComponentReference(_GeometryHelper):
             new_orientation = None if orientation is None else -orientation
         if rotation is not None:
             new_point = _rotate_points(new_point, angle=rotation, center=[0, 0])
-            if  orientation is not None:
+            if orientation is not None:
                 new_orientation += rotation
         if origin is not None:
             new_point = new_point + np.array(origin)
@@ -870,70 +861,6 @@ class ComponentReference(_GeometryHelper):
         ports_ccw = self.get_ports_list(clockwise=False, **kwargs)
         return ports_ccw[0].y - ports_cw[0].y
 
-
-def test_move() -> None:
-    import gdsfactory as gf
-
-    c = gf.Component()
-    mzi = c.add_ref(gf.components.mzi())
-    bend = c.add_ref(gf.components.bend_euler())
-    bend.move("o1", mzi.ports["o2"])
-
-
-def test_get_polygons() -> None:
-    import gdsfactory as gf
-
-    ref = gf.components.straight()
-    p0 = ref.get_polygons(by_spec="WG", as_array=False)
-    p1 = ref.get_polygons(by_spec=(1, 0), as_array=True)
-    p2 = ref.get_polygons(by_spec=(1, 0), as_array=False)
-
-    p3 = ref.get_polygons(by_spec=True, as_array=True)[(1, 0)]
-    p4 = ref.get_polygons(by_spec=True, as_array=False)[(1, 0)]
-
-    assert len(p1) == len(p2) == len(p3) == len(p4) == 1 == len(p0)
-    assert p1[0].dtype == p3[0].dtype == float
-    assert isinstance(p2[0], Polygon)
-    assert isinstance(p4[0], Polygon)
-
-
-def test_get_polygons_ref() -> None:
-    import gdsfactory as gf
-
-    ref = gf.components.straight().ref()
-    p0 = ref.get_polygons(by_spec="WG", as_array=False)
-    p1 = ref.get_polygons(by_spec=(1, 0), as_array=True)
-    p2 = ref.get_polygons(by_spec=(1, 0), as_array=False)
-
-    p3 = ref.get_polygons(by_spec=True, as_array=True)[(1, 0)]
-    p4 = ref.get_polygons(by_spec=True, as_array=False)[(1, 0)]
-
-    assert len(p1) == len(p2) == len(p3) == len(p4) == 1 == len(p0)
-    assert p1[0].dtype == p3[0].dtype == float
-    assert isinstance(p2[0], Polygon)
-    assert isinstance(p4[0], Polygon)
-
-
-def test_pads_no_orientation() -> None:
-    import gdsfactory as gf
-
-    c = gf.Component("pads_no_orientation")
-    pt = c << gf.components.pad()
-    pb = c << gf.components.pad()
-    pb.connect("pad", pt["pad"])
-    
-def test_rotation_of_ports_with_no_orientation():
-    import gdsfactory as gf
-    c = gf.Component("pads_with_routes_with_wire_corners_no_orientation") # from docs
-    pt = c << gf.components.pad_array(orientation=None, columns=3)
-    pb = c << gf.components.pad_array(orientation=None, columns=3)
-    pt.move((70, 200))
-    pt.rotate(90)
-    route = gf.routing.get_route_electrical(
-        pt.ports["e11"], pb.ports["e11"], bend="wire_corner"
-    )
-    c.add(route.references)
-    c.plot()
 
 if __name__ == "__main__":
     # test_get_polygons_ref()

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -552,9 +552,10 @@ class ComponentReference(_GeometryHelper):
         if x_reflection:
             new_point[1] = -new_point[1]
             new_orientation = None if orientation is None else -orientation
-        if rotation is not None and orientation is not None:
+        if rotation is not None:
             new_point = _rotate_points(new_point, angle=rotation, center=[0, 0])
-            new_orientation += rotation
+            if  orientation is not None:
+                new_orientation += rotation
         if origin is not None:
             new_point = new_point + np.array(origin)
 
@@ -920,7 +921,19 @@ def test_pads_no_orientation() -> None:
     pt = c << gf.components.pad()
     pb = c << gf.components.pad()
     pb.connect("pad", pt["pad"])
-
+    
+def test_rotation_of_ports_with_no_orientation():
+    import gdsfactory as gf
+    c = gf.Component("pads_with_routes_with_wire_corners_no_orientation") # from docs
+    pt = c << gf.components.pad_array(orientation=None, columns=3)
+    pb = c << gf.components.pad_array(orientation=None, columns=3)
+    pt.move((70, 200))
+    pt.rotate(90)
+    route = gf.routing.get_route_electrical(
+        pt.ports["e11"], pb.ports["e11"], bend="wire_corner"
+    )
+    c.add(route.references)
+    c.plot()
 
 if __name__ == "__main__":
     # test_get_polygons_ref()

--- a/tests/test_component_reference.py
+++ b/tests/test_component_reference.py
@@ -1,0 +1,59 @@
+from gdstk import Polygon
+
+import gdsfactory as gf
+
+
+def test_move() -> None:
+    c = gf.Component()
+    mzi = c.add_ref(gf.components.mzi())
+    bend = c.add_ref(gf.components.bend_euler())
+    bend.move("o1", mzi.ports["o2"])
+
+
+def test_get_polygons() -> None:
+    ref = gf.components.straight()
+    p0 = ref.get_polygons(by_spec="WG", as_array=False)
+    p1 = ref.get_polygons(by_spec=(1, 0), as_array=True)
+    p2 = ref.get_polygons(by_spec=(1, 0), as_array=False)
+
+    p3 = ref.get_polygons(by_spec=True, as_array=True)[(1, 0)]
+    p4 = ref.get_polygons(by_spec=True, as_array=False)[(1, 0)]
+
+    assert len(p1) == len(p2) == len(p3) == len(p4) == 1 == len(p0)
+    assert p1[0].dtype == p3[0].dtype == float
+    assert isinstance(p2[0], Polygon)
+    assert isinstance(p4[0], Polygon)
+
+
+def test_get_polygons_ref() -> None:
+    ref = gf.components.straight().ref()
+    p0 = ref.get_polygons(by_spec="WG", as_array=False)
+    p1 = ref.get_polygons(by_spec=(1, 0), as_array=True)
+    p2 = ref.get_polygons(by_spec=(1, 0), as_array=False)
+
+    p3 = ref.get_polygons(by_spec=True, as_array=True)[(1, 0)]
+    p4 = ref.get_polygons(by_spec=True, as_array=False)[(1, 0)]
+
+    assert len(p1) == len(p2) == len(p3) == len(p4) == 1 == len(p0)
+    assert p1[0].dtype == p3[0].dtype == float
+    assert isinstance(p2[0], Polygon)
+    assert isinstance(p4[0], Polygon)
+
+
+def test_pads_no_orientation() -> None:
+    c = gf.Component()
+    pt = c << gf.components.pad()
+    pb = c << gf.components.pad()
+    pb.connect("pad", pt["pad"])
+
+
+def test_rotation_of_ports_with_no_orientation():
+    c = gf.Component()
+    pt = c << gf.components.pad_array(orientation=None, columns=3)
+    pb = c << gf.components.pad_array(orientation=None, columns=3)
+    pt.move((70, 200))
+    pt.rotate(90)
+    route = gf.routing.get_route_electrical(
+        pt.ports["e11"], pb.ports["e11"], bend="wire_corner"
+    )
+    c.add(route.references)


### PR DESCRIPTION
Relating to bug: 
https://github.com/gdsfactory/gdsfactory/pull/890 

with fix included in PR:
https://github.com/gdsfactory/gdsfactory/pull/893/files#diff-c02353b57e3923855d38d4ed09c545a5b873374511eee7292fb2545926f287c1R700
 
The issue is unresolved. Rotation is not applied correctly in the case the port has orientation None.