### PR TITLE
Add bounds property to layerlevel

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -66,6 +66,15 @@ class LayerLevel(BaseModel):
     background_doping_ion: str | None = None
     orientation: str | None = "100"
 
+    @property
+    def bounds(self) -> tuple[float, float]:
+        """Calculates and returns the bounds of the layer level in the z-direction.
+
+        Returns:
+            tuple: A tuple containing the minimum and maximum z-values of the layer level.
+        """
+        return tuple(sorted([self.zmin, self.zmin + self.thickness]))
+
 
 class LayerStack(BaseModel):
     """For simulation and 3D rendering. Captures design intent of the chip layers after fabrication.


### PR DESCRIPTION
Add `LayerLevel` property for its bounds. Reason is that `zmin` does not necessarily represent the actual minimum z-value if `thickness < 0`, although allowing a negative thickness can be useful for process considerations.
The `bounds` property provides an unambiguous value for the minimum and maximum z-values of the layer which downstream applications can reference instead of having to implement their own logic to figure this out.
