### PR TITLE
Give layerlevels a name field

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -44,6 +44,7 @@ class LayerLevel(BaseModel):
         orientation: of the wafer (Miller indices of the plane)
     """
 
+    name: str | None = None
     layer: tuple[int, int] | None = None
     thickness: float
     thickness_tolerance: float | None = None


### PR DESCRIPTION
Layerlevels names are in principle independent of a particular layer stack, so they should own this property. Downstream applications can then access it directly instead of having to index into a layerstack.