### PR TITLE
remove offgrid port warnings and CrossSection.snap_to_grid

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -134,7 +134,6 @@ class CrossSection(BaseModel):
         min_length: defaults to 1nm = 10e-3um for routing.
         start_straight_length: straight length at the beginning of the route.
         end_straight_length: end length at the beginning of the route.
-        snap_to_grid: Optional snap points to grid when extruding paths (um).
         decorator: function when extruding component. For example add_pins.
         add_pins: Optional function to add pins.
         add_bbox: Optional function to add bounding box.
@@ -168,7 +167,6 @@ class CrossSection(BaseModel):
     min_length: float = 10e-3
     start_straight_length: float = 10e-3
     end_straight_length: float = 10e-3
-    snap_to_grid: float | None = None
     decorator: Callable | None = Field(default=None, exclude=True)
     add_pins: Callable | None = Field(default=None, exclude=True)
     add_bbox: Callable | None = Field(default=None, exclude=True)
@@ -284,7 +282,6 @@ class Transition(CrossSection):
         width: main Section width (um) or function parameterized from 0 to 1. \
                 the width at t==0 is the width at the beginning of the Path. \
                 the width at t==1 is the width at the end.
-        snap_to_grid: Optional snap points to grid when extruding paths (um).
         radius: main Section bend radius (um).
         width_wide: wide waveguides width (um) for low loss routing.
         auto_widen: taper to wide waveguides for low loss routing.
@@ -304,7 +301,6 @@ class Transition(CrossSection):
         min_length: defaults to 1nm = 10e-3um for routing.
         start_straight_length: straight length at the beginning of the route.
         end_straight_length: end length at the beginning of the route.
-        snap_to_grid: Optional snap points to grid when extruding paths (um).
         decorator: function when extruding component. For example add_pins.
         add_pins: Optional function to add pins.
         add_bbox: Optional function to add bounding box.
@@ -319,7 +315,6 @@ class Transition(CrossSection):
     sections: list[Section]
     layer: LayerSpec | None = None
     width: float | Callable | None = None
-    snap_to_grid: float | None = None
     port_names: tuple[str | None, str | None] = (None, None)
     port_types: tuple[str | None, str | None] = ("optical", "optical")
 
@@ -406,7 +401,6 @@ def cross_section(
     min_length: float = 10e-3,
     start_straight_length: float = 10e-3,
     end_straight_length: float = 10e-3,
-    snap_to_grid: float | None = None,
     bbox_layers: list[LayerSpec] | None = None,
     bbox_offsets: list[float] | None = None,
     cladding_layers: LayerSpecs | None = None,
@@ -441,7 +435,6 @@ def cross_section(
         min_length: defaults to 1nm = 10e-3um for routing.
         start_straight_length: straight length at the beginning of the route.
         end_straight_length: end length at the beginning of the route.
-        snap_to_grid: can snap points to grid when extruding the path.
         bbox_layers: list of layers for rectangular bounding box.
         bbox_offsets: list of bounding box offsets.
         cladding_layers: list of layers to extrude.
@@ -486,7 +479,6 @@ def cross_section(
         min_length=min_length,
         start_straight_length=start_straight_length,
         end_straight_length=end_straight_length,
-        snap_to_grid=snap_to_grid,
         port_types=port_types,
         port_names=port_names,
         info=info or {},
@@ -586,7 +578,6 @@ def slot(
         min_length: defaults to 1nm = 10e-3um for routing.
         start_straight_length: straight length at the beginning of the route.
         end_straight_length: end length at the beginning of the route.
-        snap_to_grid: can snap points to grid when extruding the path.
         bbox_layers: list of layers for rectangular bounding box.
         bbox_offsets: list of bounding box offsets.
         cladding_layers: list of layers to extrude.

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -233,7 +233,6 @@ class Pdk(BaseModel):
         sparameters_path: to store Sparameters simulations.
         modes_path: to store Sparameters simulations.
         interconnect_cml_path: path to interconnect CML (optional).
-        warn_off_grid_ports: raises warning when extruding paths with offgrid ports.
         constants: dict of constants for the PDK.
         materials_index: material spec names to material spec, which can be:
             string: material name.
@@ -277,7 +276,6 @@ class Pdk(BaseModel):
     interconnect_cml_path: PathType | None = Field(
         default=None, description="This field is deprecated."
     )
-    warn_off_grid_ports: bool = False
     constants: dict[str, Any] = constants
     materials_index: dict[str, MaterialSpec] = Field(default_factory=dict)
     routing_strategies: dict[str, Callable] | None = None

--- a/gdsfactory/read/from_gdspaths.py
+++ b/gdsfactory/read/from_gdspaths.py
@@ -23,7 +23,7 @@ def from_gdspaths(cells: tuple[ComponentOrPath, ...]) -> Component:
             c = import_gds(c)
 
         assert isinstance(c, Component)
-        component << c
+        _ = component << c
 
     return component
 

--- a/gdsfactory/read/from_phidl.py
+++ b/gdsfactory/read/from_phidl.py
@@ -20,7 +20,6 @@ def from_gdstk(cell: gdstk.Cell, **kwargs) -> Component:
 
     Keyword Args:
         cellname: cell of the name to import (None) imports top cell.
-        snap_to_grid_nm: snap to different nm grid (does not snap if False).
         gdsdir: optional GDS directory.
         read_metadata: loads metadata if it exists.
         hashed_name: appends a hash to a shortened component name.
@@ -44,7 +43,6 @@ def from_phidl(component, port_layer: Layer = (1, 0), **kwargs) -> Component:
 
     Keyword Args:
         cellname: cell of the name to import (None) imports top cell.
-        snap_to_grid_nm: snap to different nm grid (does not snap if False).
         gdsdir: optional GDS directory.
         read_metadata: loads metadata if it exists.
         hashed_name: appends a hash to a shortened component name.

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
@@ -146,7 +146,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 1.0

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
@@ -161,7 +161,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 1.0

--- a/gdsfactory/samples/snap_bends.py
+++ b/gdsfactory/samples/snap_bends.py
@@ -9,5 +9,5 @@ if __name__ == "__main__":
     b1 = c << gf.c.bend_euler(angle=37)
     b2 = c << gf.c.bend_euler(angle=37)
     b2.connect("o1", b1.ports["o2"])
-    c = c.flatten_invalid_refs()
+    # c = c.flatten_invalid_refs()
     c.show()

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -66,7 +66,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.45
@@ -124,7 +123,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.45
@@ -182,7 +180,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -240,7 +237,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -313,7 +309,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -369,7 +364,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -425,7 +419,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -481,7 +474,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.55
@@ -537,7 +529,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.45

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -60,7 +60,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -115,7 +114,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -55,7 +55,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -113,7 +112,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -172,7 +170,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -227,7 +224,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -282,7 +278,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_ring_single_array_.yml
+++ b/test-data-regression/test_netlists_ring_single_array_.yml
@@ -57,7 +57,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_connections_.yml
+++ b/test-data-regression/test_netlists_sample_connections_.yml
@@ -47,7 +47,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -102,7 +101,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_different_link_factory_.yml
+++ b/test-data-regression/test_netlists_sample_different_link_factory_.yml
@@ -69,7 +69,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -142,7 +141,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -215,7 +213,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -288,7 +285,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -361,7 +357,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -434,7 +429,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -507,7 +501,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -580,7 +573,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -653,7 +645,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -726,7 +717,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -799,7 +789,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -872,7 +861,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -976,7 +964,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1061,7 +1048,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1146,7 +1132,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1231,7 +1216,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1316,7 +1300,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1401,7 +1384,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1486,7 +1468,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1571,7 +1552,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1656,7 +1636,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1741,7 +1720,6 @@ instances:
         - optical
         radius: 10
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_docstring_.yml
+++ b/test-data-regression/test_netlists_sample_docstring_.yml
@@ -55,7 +55,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -112,7 +111,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -176,7 +174,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -231,7 +228,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -286,7 +282,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_mirror_simple_.yml
+++ b/test-data-regression/test_netlists_sample_mirror_simple_.yml
@@ -60,7 +60,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_mmis_.yml
+++ b/test-data-regression/test_netlists_sample_mmis_.yml
@@ -55,7 +55,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -112,7 +111,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -176,7 +174,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -231,7 +228,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -286,7 +282,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_netlists_sample_waypoints_.yml
+++ b/test-data-regression/test_netlists_sample_waypoints_.yml
@@ -73,7 +73,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -146,7 +145,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -219,7 +217,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -292,7 +289,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -365,7 +361,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -438,7 +433,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -511,7 +505,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -584,7 +577,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -668,7 +660,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -753,7 +744,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -838,7 +828,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -923,7 +912,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1008,7 +996,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1093,7 +1080,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1178,7 +1164,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1263,7 +1248,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1348,7 +1332,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -1433,7 +1416,6 @@ instances:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5

--- a/test-data-regression/test_settings.yml
+++ b/test-data-regression/test_settings.yml
@@ -118,7 +118,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_add_grating_couplers_.yml
+++ b/test-data-regression/test_settings_add_grating_couplers_.yml
@@ -60,7 +60,6 @@ settings:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -150,7 +149,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_add_trenches90_.yml
+++ b/test-data-regression/test_settings_add_trenches90_.yml
@@ -97,7 +97,6 @@ settings:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -171,7 +170,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_bend_euler180_.yml
+++ b/test-data-regression/test_settings_bend_euler180_.yml
@@ -92,7 +92,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_bend_euler_.yml
+++ b/test-data-regression/test_settings_bend_euler_.yml
@@ -91,7 +91,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_bend_euler_trenches_.yml
+++ b/test-data-regression/test_settings_bend_euler_trenches_.yml
@@ -97,7 +97,6 @@ settings:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -171,7 +170,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_coupler_full_.yml
+++ b/test-data-regression/test_settings_coupler_full_.yml
@@ -103,7 +103,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_straight_.yml
+++ b/test-data-regression/test_settings_straight_.yml
@@ -82,7 +82,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_straight_rib_.yml
+++ b/test-data-regression/test_settings_straight_rib_.yml
@@ -142,7 +142,6 @@ settings:
       - optical
       radius: 20
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_straight_rib_tapered_.yml
+++ b/test-data-regression/test_settings_straight_rib_tapered_.yml
@@ -171,7 +171,6 @@ settings:
         - optical
         radius: 20
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -293,7 +292,6 @@ settings:
       - optical
       radius: 20
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/test-data-regression/test_settings_tapers_.yml
+++ b/test-data-regression/test_settings_tapers_.yml
@@ -127,7 +127,6 @@ settings:
           - optical
           radius: 10.0
           sections: null
-          snap_to_grid: null
           start_straight_length: 0.01
           taper_length: 10.0
           width: 2
@@ -207,7 +206,6 @@ settings:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 2
@@ -317,7 +315,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 2

--- a/test-data-regression/test_settings_wire_straight_.yml
+++ b/test-data-regression/test_settings_wire_straight_.yml
@@ -84,7 +84,6 @@ settings:
             - electrical
             radius: null
             sections: null
-            snap_to_grid: null
             start_straight_length: 0.01
             taper_length: 10.0
             width: 10.0
@@ -103,7 +102,6 @@ settings:
         radius: null
         sections: []
         simplify: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         vias: []
@@ -116,17 +114,16 @@ settings:
         ''cladding_layers'': None, ''cladding_offsets'': None, ''cladding_simplify'':
         None, ''sections'': [], ''port_names'': [''e1'', ''e2''], ''port_types'':
         [''electrical'', ''electrical''], ''gap'': 5.0, ''min_length'': 5.0, ''start_straight_length'':
-        0.01, ''end_straight_length'': 0.01, ''snap_to_grid'': None, ''info'': {''settings'':
-        {''width'': 10.0, ''offset'': 0, ''layer'': ''M3'', ''width_wide'': None,
-        ''auto_widen'': False, ''auto_widen_minimum_length'': 200.0, ''taper_length'':
-        10.0, ''radius'': None, ''sections'': None, ''port_names'': [''e1'', ''e2''],
-        ''port_types'': [''electrical'', ''electrical''], ''gap'': 5, ''min_length'':
-        5, ''start_straight_length'': 0.01, ''end_straight_length'': 0.01, ''snap_to_grid'':
-        None, ''bbox_layers'': None, ''bbox_offsets'': None, ''cladding_layers'':
-        None, ''cladding_offsets'': None, ''cladding_simplify'': None, ''info'': None,
-        ''decorator'': None, ''add_pins'': None, ''add_bbox'': None, ''mirror'': False,
-        ''name'': None}, ''function_name'': ''cross_section''}, ''name'': None, ''mirror'':
-        False, ''vias'': []}_length'
+        0.01, ''end_straight_length'': 0.01, ''info'': {''settings'': {''width'':
+        10.0, ''offset'': 0, ''layer'': ''M3'', ''width_wide'': None, ''auto_widen'':
+        False, ''auto_widen_minimum_length'': 200.0, ''taper_length'': 10.0, ''radius'':
+        None, ''sections'': None, ''port_names'': [''e1'', ''e2''], ''port_types'':
+        [''electrical'', ''electrical''], ''gap'': 5, ''min_length'': 5, ''start_straight_length'':
+        0.01, ''end_straight_length'': 0.01, ''bbox_layers'': None, ''bbox_offsets'':
+        None, ''cladding_layers'': None, ''cladding_offsets'': None, ''cladding_simplify'':
+        None, ''info'': None, ''decorator'': None, ''add_pins'': None, ''add_bbox'':
+        None, ''mirror'': False, ''name'': None}, ''function_name'': ''cross_section''},
+        ''name'': None, ''mirror'': False, ''vias'': []}_length'
       : 10.0
     settings:
       add_bbox: null
@@ -155,7 +152,6 @@ settings:
       - electrical
       radius: null
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 10.0

--- a/tests/gds/straight.yml
+++ b/tests/gds/straight.yml
@@ -58,7 +58,6 @@ cells:
         - optical
         radius: 10.0
         sections: null
-        snap_to_grid: null
         start_straight_length: 0.01
         taper_length: 10.0
         width: 0.5
@@ -153,7 +152,6 @@ settings:
       - optical
       radius: 10.0
       sections: null
-      snap_to_grid: null
       start_straight_length: 0.01
       taper_length: 10.0
       width: 0.5

--- a/tests/test_import_gds2.py
+++ b/tests/test_import_gds2.py
@@ -32,18 +32,15 @@ def test_read_gds_equivalent() -> None:
     d2.pop("name")
     d = jsondiff.diff(d1, d2)
 
-    # pprint(d1)
-    # pprint(d2)
-    # pprint(d)
-    assert len(d) == 0, f"{c1.name} != {c2.name}"
+    assert len(d) == 0, d
 
 
 def test_build_and_import() -> None:
     """Create a cell and then import the same cell from GDS."""
     gdspath = gf.PATH.gdsdir / "straight.gds"
     c = gf.Component("build_and_import")
-    c << gf.components.straight(length=1.234)
-    c << gf.import_gds(gdspath, unique_names=False)
+    _ = c << gf.components.straight(length=1.234)
+    _ = c << gf.import_gds(gdspath, unique_names=False)
     c.write_gds()
 
 
@@ -51,8 +48,8 @@ def test_import_and_build() -> None:
     """Import a same cell from GDS and then create the same cell."""
     gdspath = gf.PATH.gdsdir / "straight.gds"
     c = gf.Component("build_and_import")
-    c << gf.import_gds(gdspath, unique_names=False)
-    c << gf.components.straight(length=1.234)
+    _ = c << gf.import_gds(gdspath, unique_names=False)
+    _ = c << gf.components.straight(length=1.234)
     c.write_gds()
 
 
@@ -65,6 +62,7 @@ def _write() -> None:
 
 
 if __name__ == "__main__":
+    _write()
     # c1 = gf.components.straight(length=1.234)
     # gdspath = gf.PATH.gdsdir / "straight.gds"
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -140,11 +140,18 @@ def test_layers1() -> None:
 
 
 def test_layers2() -> None:
+    from gdsfactory.pdk import get_active_pdk
+
+    pdk = get_active_pdk()
+    pdk.grid_size = 0.005
+
     P = gf.path.straight(length=10.001)
-    X = gf.cross_section.strip(snap_to_grid=5e-3)
+    X = gf.cross_section.strip()
     c = gf.path.extrude(P, X, simplify=5e-3)
     assert c.ports["o1"].layer == (1, 0)
     assert c.ports["o2"].center[0] == 10.0, c.ports["o2"].center[0]
+
+    pdk.grid_size = 0.001
 
 
 def test_copy() -> None:
@@ -173,13 +180,14 @@ def test_path_add() -> None:
 
 
 if __name__ == "__main__":
+    test_layers2()
     # test_append()
     # c = transition()
 
-    p1 = gf.path.straight(length=5)
-    p2 = gf.path.euler(radius=5, angle=45, p=0.5, use_eff=False)
-    p = p2 + p1
+    # p1 = gf.path.straight(length=5)
+    # p2 = gf.path.euler(radius=5, angle=45, p=0.5, use_eff=False)
+    # p = p2 + p1
     # assert p.start_angle == 45
     # assert p.end_angle == 0
-    c = p.extrude(cross_section="strip")
-    c.show(show_ports=False)
+    # c = p.extrude(cross_section="strip")
+    # c.show(show_ports=False)


### PR DESCRIPTION
- Remove off grid ports warning when extruding paths
- Remove CrossSection.snap_to_grid