### PR TITLE
Extrude can have off grid ports

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -24,8 +24,8 @@ from gdsfactory.component_layout import (
     _reflect_points,
     _rotate_points,
 )
-from gdsfactory.cross_section import CrossSection, Section, Transition
 from gdsfactory.config import CONF
+from gdsfactory.cross_section import CrossSection, Section, Transition
 from gdsfactory.port import Port
 from gdsfactory.typings import (
     ComponentSpec,

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -25,6 +25,7 @@ from gdsfactory.component_layout import (
     _rotate_points,
 )
 from gdsfactory.cross_section import CrossSection, Section, Transition
+from gdsfactory.config import CONF
 from gdsfactory.port import Port
 from gdsfactory.typings import (
     ComponentSpec,
@@ -714,6 +715,7 @@ def extrude(
     simplify: float | None = None,
     shear_angle_start: float | None = None,
     shear_angle_end: float | None = None,
+    enforce_ports_on_grid: bool | None = None,
 ) -> Component:
     """Returns Component extruding a Path with a cross_section.
 
@@ -735,6 +737,9 @@ def extrude(
         get_cross_section,
         get_layer,
     )
+
+    if enforce_ports_on_grid is None:
+        enforce_ports_on_grid = CONF.enforce_ports_on_grid
 
     if cross_section is None and layer is None:
         raise ValueError("CrossSection or layer needed")
@@ -904,6 +909,7 @@ def extrude(
                     if hasattr(x, "cross_section1")
                     else x,
                     shear_angle=shear_angle_start,
+                    enforce_ports_on_grid=enforce_ports_on_grid,
                 )
             )
             port1.info["face"] = face
@@ -926,6 +932,7 @@ def extrude(
                     if hasattr(x, "cross_section2")
                     else x,
                     shear_angle=shear_angle_end,
+                    enforce_ports_on_grid=enforce_ports_on_grid,
                 )
             )
             port2.info["face"] = face
@@ -1561,7 +1568,7 @@ if __name__ == "__main__":
     P = gf.path.straight(length=10)
 
     s0 = gf.Section(
-        width=1, offset=0, layer=(1, 0), name="core", port_names=("o1", "o2")
+        width=0.415, offset=0, layer=(1, 0), name="core", port_names=("o1", "o2")
     )
     s1 = gf.Section(width=3, offset=0, layer=(3, 0), name="slab")
     X1 = gf.CrossSection(sections=(s0, s1))


### PR DESCRIPTION
Allow you to create off grid ports when extruding

```python
import gdsfactory as gf

p = gf.path.arc(radius=10, angle=90, npoints=100)
s = gf.Section(width=0.415, offset=0, layer=(2, 0), port_names=["o1", "o2"])
x = gf.CrossSection(sections=[s])
c = gf.path.extrude(p, x, enforce_ports_on_grid=False)
c.show(show_ports=True)
```

addresses https://github.com/gdsfactory/gdsfactory/issues/2162

@Wsssl97 
@sebastian-goeldi 
@tvt173 
