### PR TITLE
Add connectivity information to  PDK and generate KLayoutTechnology

### DIFF
--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -39,6 +39,13 @@ LAYER_TRANSITIONS = {
     # (LAYER.)
 }
 
+LAYER_CONNECTIVITY = [
+    ("NPP", "VIAC", "M1"),
+    ("PPP", "VIAC", "M1"),
+    ("M1", "VIA1", "M2"),
+    ("M2", "VIA2", "M3"),
+]
+
 
 @cache
 def get_generic_pdk() -> Pdk:
@@ -64,6 +71,7 @@ def get_generic_pdk() -> Pdk:
         layer_transitions=LAYER_TRANSITIONS,
         materials_index=materials_index,
         constants=constants,
+        connectivity=LAYER_CONNECTIVITY,
     )
 
 

--- a/gdsfactory/generic_tech/layer_map.py
+++ b/gdsfactory/generic_tech/layer_map.py
@@ -4,10 +4,11 @@ Layer = tuple[int, int]
 
 
 class GenericLayerMap(LayerMap):
-    """Generic layermap based on book.
+    """Generic layermap based on the book:
 
     Lukas Chrostowski, Michael Hochberg, "Silicon Photonics Design",
     Cambridge University Press 2015, page 353
+
     You will need to create a new LayerMap with your specific foundry layers.
     """
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -6,7 +6,7 @@ import importlib
 import pathlib
 import warnings
 from collections.abc import Callable
-from functools import partial
+from functools import cached_property, partial
 from typing import Any, Literal
 
 import numpy as np
@@ -19,13 +19,13 @@ from gdsfactory.events import Event
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
 from gdsfactory.show import show
 from gdsfactory.symbols import floorplan_with_block_letters
-from gdsfactory.technology import LayerStack, LayerViews
+from gdsfactory.technology import LayerStack, LayerViews, klayout_tech
 from gdsfactory.typings import (
     CellSpec,
     Component,
     ComponentFactory,
     ComponentSpec,
-    ConductorViaConductorName
+    ConductorViaConductorName,
     CrossSection,
     CrossSectionOrFactory,
     CrossSectionSpec,
@@ -702,6 +702,27 @@ class Pdk(BaseModel):
             None,
         )
         return xs_name or cross_section.name
+
+    @cached_property
+    def klayout_technology(self) -> klayout_tech.KLayoutTechnology:
+        """Returns a KLayoutTechnology from the PDK.
+
+        Raises:
+            UserWarning if required properties for generating a KLayoutTechnology are not defined.
+        """
+        try:
+            return klayout_tech.KLayoutTechnology(
+                name=self.name,
+                layer_views=self.layer_views,
+                connectivity=self.connectivity,
+                layer_map=self.layers,
+                layer_stack=self.layer_stack,
+            )
+        except AttributeError as e:
+            raise UserWarning(
+                "Required properties for generating a KLayoutTechnology are not defined. "
+                "Check the error for missing property"
+            ) from e
 
 
 _ACTIVE_PDK = None

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -25,6 +25,7 @@ from gdsfactory.typings import (
     Component,
     ComponentFactory,
     ComponentSpec,
+    ConductorViaConductorName
     CrossSection,
     CrossSectionOrFactory,
     CrossSectionSpec,
@@ -241,6 +242,7 @@ class Pdk(BaseModel):
         oasis_settings: to write OASIS files.
         cell_decorator_settings: settings for cell_without_validator decorator function in gdsfactory.cell.
         bend_points_distance: default points distance for bends in um.
+        connectivity: defines connectivity between layers through vias.
 
     """
 
@@ -280,6 +282,7 @@ class Pdk(BaseModel):
     oasis_settings: OasisWriteSettings = OasisWriteSettings()
     cell_decorator_settings: CellDecoratorSettings = CellDecoratorSettings()
     bend_points_distance: float = 20 * nm
+    connectivity: list[ConductorViaConductorName] | None = None
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/gdsfactory/samples/demo/lvs.py
+++ b/gdsfactory/samples/demo/lvs.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     c = lib[0]
 
     l2n = kf.kdb.LayoutToNetlist(c.begin_shapes_rec(0))
-    for l_idx in c.kcl.layer_indices():
+    for l_idx in c.kcl.layer_indexes():
         l2n.connect(l2n.make_layer(l_idx, f"layer{l_idx}"))
     l2n.extract_netlist()
     print(l2n.netlist().to_s())

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 from gdsfactory.config import PATH
 from gdsfactory.technology import LayerStack, LayerViews
 from gdsfactory.technology.xml_utils import make_pretty_xml
-from gdsfactory.typings import PathType
+from gdsfactory.typings import ConductorViaConductorName, Layer, PathType
 
 try:
     import klayout.db as db
@@ -21,8 +21,6 @@ except ImportError as e:
     print("You can install `pip install klayout.")
     raise e
 
-Layer = tuple[int, int]
-ConductorViaConductorName = tuple[str, str, str]
 
 prefix_d25 = """<?xml version="1.0" encoding="utf-8"?>
 <klayout-macro>

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -184,6 +184,8 @@ MultiCrossSectionAngleSpec = list[tuple[CrossSectionSpec, tuple[int, ...]]]
 
 LabelListFactory = Callable[..., list[Label]]
 
+ConductorViaConductorName = tuple[str, str, str]
+
 
 class Route(BaseModel):
     references: list[ComponentReference]

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,4 +1,13 @@
+import pytest
+
 import gdsfactory as gf
+from gdsfactory.generic_tech import get_generic_pdk
+
+
+@pytest.fixture
+def pdk() -> gf.Pdk:
+    """Returns the generic PDK"""
+    return get_generic_pdk()
 
 
 def test_get_cross_section() -> None:
@@ -7,3 +16,19 @@ def test_get_cross_section() -> None:
     cross_section = {"cross_section": "xs_sc", "settings": {"width": 1}}
     xs = gf.get_cross_section(cross_section)
     assert xs.sections[0].width == 1
+
+
+def test_klayout_technology(pdk) -> None:
+    tech = pdk.klayout_technology
+    assert tech.name == pdk.name
+    assert tech.layer_views == pdk.layer_views
+    assert tech.connectivity == pdk.connectivity
+    assert tech.layer_map == pdk.layers
+    assert tech.layer_stack == pdk.layer_stack
+
+
+def test_klayout_technology_write(pdk, tmp_path) -> None:
+    tech = pdk.klayout_technology
+    tech.write_tech(tech_dir=tmp_path)
+    assert (tmp_path / "layers.lyp").exists()
+    assert (tmp_path / "tech.lyt").exists()


### PR DESCRIPTION
This PR enables
* Adding layer connectivity information to the PDK (currently only through VIAs as in KLayout)
* Generating a corresponding KLayoutTechnology file from the PDK with `Pdk.klayout_technology`