### PR TITLE
Less general error catching in LayerViews

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -898,18 +898,17 @@ class LayerViews(BaseModel):
             return self.layer_views[name]
 
     def __getitem__(self, val: str):
-        """Allows accessing to the layer names like ls['gold2'].
+        """Allows accessing LayerViews with the syntax ``ls['gold2']``.
 
         Args:
             val: Layer name to access within the LayerViews.
 
         Returns:
             self.layers[val]: LayerView in the LayerViews.
-
         """
         try:
             return self.get_layer_views()[val]
-        except Exception as error:
+        except KeyError as error:
             raise ValueError(
                 f"LayerView {val!r} not in LayerViews {list(self.layer_views.keys())}"
             ) from error


### PR DESCRIPTION
Small change caught while doing https://github.com/gdsfactory/gplugins/issues/187.

Catching Exception is bad practice and would hide unexpected problems here.