### PR TITLE
fixing gf watch for watching directories

### DIFF
--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -70,7 +70,12 @@ def watch(
     from gdsfactory.watch import watch
 
     path = pathlib.Path(path)
-    path = path.parent if path.is_dir() else path
+    if path.is_file():
+        path = path.parent
+    elif path.is_dir():
+        pass  # the typical case
+    elif not path.exists():
+        raise ValueError(f"Invalid path passed to watch command: {path}")
     watch(str(path), pdk=pdk)
 
 

--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -69,14 +69,11 @@ def watch(
     """Filewatch a folder for changes in *.py or *.pic.yml files."""
     from gdsfactory.watch import watch
 
-    path = pathlib.Path(path)
-    if path.is_file():
-        path = path.parent
-    elif path.is_dir():
-        pass  # the typical case
-    elif not path.exists():
-        raise ValueError(f"Invalid path passed to watch command: {path}")
-    watch(str(path), pdk=pdk)
+    p = pathlib.Path(path)
+    if not p.exists():
+        raise ValueError(f"Invalid path passed to watch command: {p}")
+    p = p.parent if p.is_file() else p
+    watch(str(p), pdk=pdk)
 
 
 @app.command()

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -18,6 +18,7 @@ from gdsfactory.cell import CACHE
 from gdsfactory.config import cwd
 from gdsfactory.pdk import get_active_pdk, on_pdk_activated
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
+from gdsfactory.typings import ComponentSpec
 
 
 class FileWatcher(FileSystemEventHandler):
@@ -168,6 +169,13 @@ def watch(path: pathlib.Path | str | None = cwd, pdk: str | None = None) -> None
     )
     embed()
     watcher.stop()
+
+
+def show(component: ComponentSpec) -> None:
+    import gdsfactory as gf
+
+    c = gf.get_component(component)
+    c.show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently `gf watch` is watching the parent of the path specified when a directory is given. i.e. if you tell it to watch `../projects/my_project` it instead watches the entirety of `../projects`. I think the logic in the if/else was flipped. This PR fixes that issue.