### PR TITLE
Small fix to routing logic

### DIFF
--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -395,7 +395,6 @@ def _generate_route_manhattan_points(
                     -p[0] - (end_straight_length + 2 * bs1 + bs2 + min_straight_length)
                     > -threshold
                 ):
-                    print("here2")
                     # go sufficiently up, and then east
                     p = (
                         p[0],

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -388,13 +388,14 @@ def _generate_route_manhattan_points(
 
                     p = (p[0], sigp * _y)
                     if count == 1:  # take care of the start_straight case
-                        p = (p[0], -sigp * max(start_straight_length, _y))
+                        p = (p[0], sigp * max(start_straight_length, _y))
 
                     a = 180
                 elif (
                     -p[0] - (end_straight_length + 2 * bs1 + bs2 + min_straight_length)
                     > -threshold
                 ):
+                    print("here2")
                     # go sufficiently up, and then east
                     p = (
                         p[0],
@@ -1082,8 +1083,12 @@ if __name__ == "__main__":
     s = gf.c.straight()
     pt = c << s
     pb = c << s
+    pb.rotate(90)
     pt.move((400, 50))
-    route = gf.routing.get_route(
+
+    pb.movex(400)
+    pb.movey(100)  # -10
+    route = route_manhattan(
         pb.ports["o2"],
         pt.ports["o1"],
         cross_section="xs_sc_auto_widen",

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -336,7 +336,9 @@ def route_fiber_array(
             ordered_ports = [component.ports[i] for i in connected_port_names]
 
         for io_gratings in io_gratings_lines:
-            for i in range(min(N, len(connected_port_names))):
+            for i in range(
+                min(N, len(connected_port_names)) if connected_port_names else N
+            ):
                 p0 = io_gratings[i].ports[gc_port_name]
                 p1 = ordered_ports[i]
                 waypoints = generate_manhattan_waypoints(

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -336,7 +336,7 @@ def route_fiber_array(
             ordered_ports = [component.ports[i] for i in connected_port_names]
 
         for io_gratings in io_gratings_lines:
-            for i in range(N):
+            for i in range(min(N, len(connected_port_names))):
                 p0 = io_gratings[i].ports[gc_port_name]
                 p1 = ordered_ports[i]
                 waypoints = generate_manhattan_waypoints(


### PR DESCRIPTION
With the current code, we get the following behavior:

```
 c = gf.Component("demo")
    s = gf.c.straight()
    pt = c << s
    pb = c << s
    pb.rotate(90)
    pt.move((400, 50))

    pb.movex(300)
    pb.movey(-10)
    route = route_manhattan(
        pb.ports["o2"],
        pt.ports["o1"],
        cross_section="xs_sc_auto_widen",
    )
    c.add(route.references)
    c.show(show_ports=True)
```

Produces this:

![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/96ca963b-9c8f-46c9-9d50-04ab55d36ebd)


But this: 
```
c = gf.Component("demo")
    s = gf.c.straight()
    pt = c << s
    pb = c << s
    pb.rotate(90)
    pt.move((400, 50))

    pb.movex(400)
    pb.movey(-10)
    route = route_manhattan(
        pb.ports["o2"],
        pt.ports["o1"],
        cross_section="xs_sc_auto_widen",
    )
    c.add(route.references)
    c.show(show_ports=True)
```

Produces this:

![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/544af517-bb02-437b-b00b-53cf6c7bfb5f)

Which is of course not correct. 

Changing the logic slightly can make it so that the code above behaves as I would expect:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/a73d7407-048d-4763-98b3-bc62a9c63b9b)
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/66ac4211-5278-4be4-ae6b-4392676fd171)

