### PR TITLE
consitent cutback_bend

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -1085,7 +1085,7 @@ cutback_bend
 
   import gdsfactory as gf
 
-  c = gf.components.cutback_bend(straight_length=5.0, rows=6, columns=5)
+  c = gf.components.cutback_bend(straight_length=5.0, rows=6, cols=5)
   c.plot()
 
 
@@ -1100,7 +1100,7 @@ cutback_bend180
 
   import gdsfactory as gf
 
-  c = gf.components.cutback_bend180(straight_length=5.0, rows=6, columns=6, spacing=3)
+  c = gf.components.cutback_bend180(straight_length=5.0, rows=6, cols=6, spacing=3)
   c.plot()
 
 
@@ -1115,7 +1115,7 @@ cutback_bend180circular
 
   import gdsfactory as gf
 
-  c = gf.components.cutback_bend180circular(straight_length=5.0, rows=6, columns=6, spacing=3)
+  c = gf.components.cutback_bend180circular(straight_length=5.0, rows=6, cols=6, spacing=3)
   c.plot()
 
 
@@ -1130,7 +1130,7 @@ cutback_bend90
 
   import gdsfactory as gf
 
-  c = gf.components.cutback_bend90(straight_length=5.0, rows=6, columns=6, spacing=5)
+  c = gf.components.cutback_bend90(straight_length=5.0, rows=6, cols=6, spacing=5)
   c.plot()
 
 
@@ -1145,7 +1145,7 @@ cutback_bend90circular
 
   import gdsfactory as gf
 
-  c = gf.components.cutback_bend90circular(straight_length=5.0, rows=6, columns=6, spacing=5)
+  c = gf.components.cutback_bend90circular(straight_length=5.0, rows=6, cols=6, spacing=5)
   c.plot()
 
 
@@ -2899,7 +2899,7 @@ ring_single
 
   import gdsfactory as gf
 
-  c = gf.components.ring_single(gap=0.2, radius=10.0, length_x=4.0, length_y=0.6, cross_section='xs_sc')
+  c = gf.components.ring_single(gap=0.2, radius=10.0, length_x=4.0, length_y=0.6, cross_section='xs_sc', pass_cross_section_to_bend=True)
   c.plot()
 
 

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -95,6 +95,8 @@ from gdsfactory.components.cutback_component import (
 )
 from gdsfactory.components.cutback_loss import (
     cutback_loss,
+    cutback_loss_bend90,
+    cutback_loss_bend180,
     cutback_loss_mmi1x2,
     cutback_loss_spirals,
 )
@@ -420,6 +422,8 @@ __all__ = [
     "cutback_loss",
     "cutback_loss_mmi1x2",
     "cutback_loss_spirals",
+    "cutback_loss_bend90",
+    "cutback_loss_bend180",
     "cutback_splitter",
     "dbr",
     "dbr_tapered",

--- a/gdsfactory/components/cutback_bend.py
+++ b/gdsfactory/components/cutback_bend.py
@@ -22,11 +22,11 @@ def _get_bend_size(bend90: Component) -> float64:
 
 @cell
 def cutback_bend(
-    bend90: ComponentSpec = bend_euler,
+    component: ComponentSpec = bend_euler,
     straight: ComponentSpec = straight,
     straight_length: float = 5.0,
     rows: int = 6,
-    columns: int = 5,
+    cols: int = 5,
     **kwargs,
 ) -> Component:
     """Deprecated.
@@ -38,7 +38,7 @@ def cutback_bend(
         straight: straight spec.
         straight_length: in um.
         rows: number of rows.
-        columns: number of columns.
+        cols: number of cols.
         kwargs: cross_section settings.
 
     .. code::
@@ -52,7 +52,7 @@ def cutback_bend(
     """
     from gdsfactory.pdk import get_component
 
-    bend90 = get_component(bend90, **kwargs)
+    bend90 = get_component(component, **kwargs)
     straightx = straight(length=straight_length, **kwargs)
 
     # Define a map between symbols and (component, input port, output port)
@@ -64,7 +64,7 @@ def cutback_bend(
 
     # Generate the sequence of staircases
     s = ""
-    for i in range(columns):
+    for i in range(cols):
         s += "ASBS" * rows
         s += "ASAS" if i % 2 == 0 else "BSBS"
     s = s[:-4]
@@ -72,28 +72,28 @@ def cutback_bend(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=90
     )
-    c.info["n_bends"] = rows * columns * 2 + columns * 2 - 2
+    c.info["n_bends"] = rows * cols * 2 + cols * 2 - 2
     return c
 
 
 @cell
 def cutback_bend90(
-    bend90: ComponentSpec = bend_euler,
+    component: ComponentSpec = bend_euler,
     straight: ComponentSpec = straight,
     straight_length: float = 5.0,
     rows: int = 6,
-    columns: int = 6,
+    cols: int = 6,
     spacing: int = 5,
     **kwargs,
 ) -> Component:
     """Returns bend90 cutback.
 
     Args:
-        bend90: bend spec.
+        component: bend spec.
         straight: straight spec.
         straight_length: in um.
         rows: number of rows.
-        columns: number of columns.
+        cols: number of cols.
         kwargs: cross_section settings.
 
     .. code::
@@ -103,7 +103,7 @@ def cutback_bend90(
     """
     from gdsfactory.pdk import get_component
 
-    bend90 = get_component(bend90, **kwargs)
+    bend90 = get_component(component, **kwargs)
     straightx = straight(length=straight_length, **kwargs)
     straight_length = 2 * _get_bend_size(bend90) + spacing + straight_length
     straighty = straight(length=straight_length, **kwargs)
@@ -119,7 +119,7 @@ def cutback_bend90(
     # Generate the sequence of staircases
     s = "".join(
         "A-A-B-B-" * rows + "|" if i % 2 == 0 else "B-B-A-A-" * rows + "|"
-        for i in range(columns)
+        for i in range(cols)
     )
     s = s[:-1]
 
@@ -127,13 +127,13 @@ def cutback_bend90(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=0
     )
-    c.info["n_bends"] = rows * columns * 4
+    c.info["n_bends"] = rows * cols * 4
     return c
 
 
 @cell
 def staircase(
-    bend90: ComponentSpec = bend_euler,
+    component: ComponentSpec = bend_euler,
     straight: ComponentSpec = straight,
     length_v: float = 5.0,
     length_h: float = 5.0,
@@ -148,10 +148,10 @@ def staircase(
         length_v: vertical length.
         length_h: vertical length.
         rows: number of rows.
-        columns: number of columns.
+        cols: number of cols.
         kwargs: cross_section settings.
     """
-    bend90 = bend90(**kwargs) if callable(bend90) else bend90
+    bend90 = component(**kwargs) if callable(component) else component
 
     wgh = straight(length=length_h, **kwargs)
     wgv = straight(length=length_v, **kwargs)
@@ -176,11 +176,11 @@ def staircase(
 
 @cell
 def cutback_bend180(
-    bend180: ComponentSpec = bend_euler180,
+    component: ComponentSpec = bend_euler180,
     straight: ComponentSpec = straight,
     straight_length: float = 5.0,
     rows: int = 6,
-    columns: int = 6,
+    cols: int = 6,
     spacing: int = 3,
     **kwargs,
 ) -> Component:
@@ -191,7 +191,7 @@ def cutback_bend180(
         straight: straight spec.
         straight_length: in um.
         rows: number of rows.
-        columns: number of columns.
+        cols: number of cols.
         spacing: in um.
         kwargs: cross_section settings.
 
@@ -204,7 +204,7 @@ def cutback_bend180(
     """
     from gdsfactory.pdk import get_component
 
-    bend180 = get_component(bend180, **kwargs)
+    bend180 = get_component(component, **kwargs)
     straightx = straight(length=straight_length, **kwargs)
     wg_vertical = straight(
         length=2 * bend180.size_info.width + straight_length + spacing,
@@ -221,8 +221,7 @@ def cutback_bend180(
 
     # Generate the sequence of staircases
     s = "".join(
-        "D-C-" * rows + "|" if i % 2 == 0 else "C-D-" * rows + "|"
-        for i in range(columns)
+        "D-C-" * rows + "|" if i % 2 == 0 else "C-D-" * rows + "|" for i in range(cols)
     )
 
     s = s[:-1]
@@ -230,22 +229,22 @@ def cutback_bend180(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=0
     )
-    c.info["n_bends"] = rows * columns * 2 + columns * 2 - 2
+    c.info["n_bends"] = rows * cols * 2 + cols * 2 - 2
     return c
 
 
-cutback_bend180circular = partial(cutback_bend180, bend180=bend_circular180)
-cutback_bend90circular = partial(cutback_bend90, bend90=bend_circular)
+cutback_bend180circular = partial(cutback_bend180, component=bend_circular180)
+cutback_bend90circular = partial(cutback_bend90, component=bend_circular)
 
 if __name__ == "__main__":
     # c = cutback_bend()
     # c = cutback_bend90()
-    # c = cutback_bend_circular(rows=7, columns=4, radius=5) #62
-    # c = cutback_bend_circular(rows=14, columns=4) #118
+    # c = cutback_bend_circular(rows=7, cols=4, radius=5) #62
+    # c = cutback_bend_circular(rows=14, cols=4) #118
     # c = cutback_bend90()
-    # c = cutback_bend180(rows=3, columns=1)
-    # c = cutback_bend(rows=3, columns=2)
-    # c = cutback_bend90(rows=3, columns=2)
-    c = cutback_bend180(rows=2, columns=2)
-    # c = cutback_bend(rows=3, columns=2)
+    # c = cutback_bend180(rows=3, cols=1)
+    # c = cutback_bend(rows=3, cols=2)
+    # c = cutback_bend90(rows=3, cols=2)
+    c = cutback_bend180(rows=2, cols=2)
+    # c = cutback_bend(rows=3, cols=2)
     c.show(show_ports=True)

--- a/gdsfactory/components/cutback_loss.py
+++ b/gdsfactory/components/cutback_loss.py
@@ -3,6 +3,7 @@ from functools import partial
 import numpy as np
 
 import gdsfactory as gf
+from gdsfactory.components.cutback_bend import cutback_bend90, cutback_bend180
 from gdsfactory.components.cutback_component import cutback_component
 from gdsfactory.components.mmi1x2 import mmi1x2
 from gdsfactory.components.spiral_inner_io import spiral_inner_io
@@ -86,6 +87,12 @@ def cutback_loss_spirals(
 
 
 cutback_loss_mmi1x2 = partial(cutback_loss, component=mmi1x2, port2="o3", mirror2=True)
+cutback_loss_bend90 = partial(
+    cutback_loss, component="bend_euler", cutback=cutback_bend90, cols=12
+)
+cutback_loss_bend180 = partial(
+    cutback_loss, component="bend_euler180", cutback=cutback_bend180, cols=12
+)
 
 
 if __name__ == "__main__":
@@ -97,6 +104,7 @@ if __name__ == "__main__":
     # components = cutback_loss(
     #     component=gf.c.mmi2x2, decorator=gf.routing.add_fiber_array
     # )
-    components = cutback_loss_mmi1x2(decorator=gf.routing.add_fiber_array)
+    # components = cutback_loss_mmi1x2(decorator=gf.routing.add_fiber_array)
+    components = cutback_loss_bend180(decorator=gf.routing.add_fiber_array)
     c = gf.pack(components)[0]
     c.show()

--- a/test-data-regression/test_settings_cutback_bend180_.yml
+++ b/test-data-regression/test_settings_cutback_bend180_.yml
@@ -28,22 +28,22 @@ settings:
   changed: {}
   child: null
   default:
-    bend180:
+    cols: 6
+    component:
       function: bend_euler
       settings:
         angle: 180
-    columns: 6
     rows: 6
     spacing: 3
     straight:
       function: straight
     straight_length: 5.0
   full:
-    bend180:
+    cols: 6
+    component:
       function: bend_euler
       settings:
         angle: 180
-    columns: 6
     rows: 6
     spacing: 3
     straight:

--- a/test-data-regression/test_settings_cutback_bend180circular_.yml
+++ b/test-data-regression/test_settings_cutback_bend180circular_.yml
@@ -1,4 +1,4 @@
-name: cutback_bend180_13911d77
+name: cutback_bend180_4bdd1d43
 ports:
   o1:
     center:
@@ -26,28 +26,28 @@ ports:
     width: 0.5
 settings:
   changed:
-    bend180:
+    component:
       function: bend_circular
       settings:
         angle: 180
   child: null
   default:
-    bend180:
+    cols: 6
+    component:
       function: bend_euler
       settings:
         angle: 180
-    columns: 6
     rows: 6
     spacing: 3
     straight:
       function: straight
     straight_length: 5.0
   full:
-    bend180:
+    cols: 6
+    component:
       function: bend_circular
       settings:
         angle: 180
-    columns: 6
     rows: 6
     spacing: 3
     straight:
@@ -58,4 +58,4 @@ settings:
     n_bends: 82
   info_version: 2
   module: gdsfactory.components.cutback_bend
-  name: cutback_bend180_13911d77
+  name: cutback_bend180_4bdd1d43

--- a/test-data-regression/test_settings_cutback_bend90_.yml
+++ b/test-data-regression/test_settings_cutback_bend90_.yml
@@ -28,18 +28,18 @@ settings:
   changed: {}
   child: null
   default:
-    bend90:
+    cols: 6
+    component:
       function: bend_euler
-    columns: 6
     rows: 6
     spacing: 5
     straight:
       function: straight
     straight_length: 5.0
   full:
-    bend90:
+    cols: 6
+    component:
       function: bend_euler
-    columns: 6
     rows: 6
     spacing: 5
     straight:

--- a/test-data-regression/test_settings_cutback_bend90circular_.yml
+++ b/test-data-regression/test_settings_cutback_bend90circular_.yml
@@ -1,4 +1,4 @@
-name: cutback_bend90_d1ad1beb
+name: cutback_bend90_d89ef24e
 ports:
   o1:
     center:
@@ -26,22 +26,22 @@ ports:
     width: 0.5
 settings:
   changed:
-    bend90:
+    component:
       function: bend_circular
   child: null
   default:
-    bend90:
+    cols: 6
+    component:
       function: bend_euler
-    columns: 6
     rows: 6
     spacing: 5
     straight:
       function: straight
     straight_length: 5.0
   full:
-    bend90:
+    cols: 6
+    component:
       function: bend_circular
-    columns: 6
     rows: 6
     spacing: 5
     straight:
@@ -52,4 +52,4 @@ settings:
     n_bends: 144
   info_version: 2
   module: gdsfactory.components.cutback_bend
-  name: cutback_bend90_d1ad1beb
+  name: cutback_bend90_d89ef24e

--- a/test-data-regression/test_settings_cutback_bend_.yml
+++ b/test-data-regression/test_settings_cutback_bend_.yml
@@ -28,17 +28,17 @@ settings:
   changed: {}
   child: null
   default:
-    bend90:
+    cols: 5
+    component:
       function: bend_euler
-    columns: 5
     rows: 6
     straight:
       function: straight
     straight_length: 5.0
   full:
-    bend90:
+    cols: 5
+    component:
       function: bend_euler
-    columns: 5
     rows: 6
     straight:
       function: straight

--- a/test-data-regression/test_settings_staircase_.yml
+++ b/test-data-regression/test_settings_staircase_.yml
@@ -28,7 +28,7 @@ settings:
   changed: {}
   child: null
   default:
-    bend90:
+    component:
       function: bend_euler
     length_h: 5.0
     length_v: 5.0
@@ -36,7 +36,7 @@ settings:
     straight:
       function: straight
   full:
-    bend90:
+    component:
       function: bend_euler
     length_h: 5.0
     length_v: 5.0


### PR DESCRIPTION
- use component as first argument for bend cutbacks
- replace `columns` by `cols` to be consistent with `cutback_component` 