### PR TITLE
Add flake8-debugger checks to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ select = [
   "I",  # isort
   "C",  # flake8-comprehensions
   "B",  # flake8-bugbear
+  "T10",  # flake8-debugger
   "UP"
 ]
 


### PR DESCRIPTION
Add flake8-debugger checks to ruff to avoid committing debug statements such as `breakpoint()`

Closes #2232