### PR TITLE
fix extrude_transition

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -5,7 +5,6 @@ import functools
 import hashlib
 import inspect
 from collections.abc import Callable
-from copy import deepcopy
 from functools import partial
 from typing import Any, TypeVar
 
@@ -253,7 +252,7 @@ def cell(
                 default=clean_dict(default),
                 full=clean_dict(full),
                 info=component.info,
-                child=deepcopy(metadata_child) if metadata_child else None,
+                child=metadata_child if metadata_child else None,
             )
             component.__doc__ = func.__doc__
 

--- a/gdsfactory/components/add_grating_couplers.py
+++ b/gdsfactory/components/add_grating_couplers.py
@@ -321,7 +321,7 @@ def add_grating_couplers_with_loopback_fiber_array(
         y_bot_align_route = -gsi.width - straight_separation
 
         points = np.array(
-            [
+            (
                 p0,
                 p0 + (0, a),
                 p0 + (b, a),
@@ -330,7 +330,7 @@ def add_grating_couplers_with_loopback_fiber_array(
                 p1 + (-b, a),
                 p1 + (0, a),
                 p1,
-            ]
+            )
         )
         bend90 = bend(cross_section=cross_section)
         loopback_route = round_corners(

--- a/gdsfactory/components/bend_circular.py
+++ b/gdsfactory/components/bend_circular.py
@@ -76,14 +76,11 @@ bend_circular180 = partial(bend_circular, angle=180)
 
 
 if __name__ == "__main__":
-    from gdsfactory.generic_tech import get_generic_pdk
+    import gdsfactory as gf
 
-    PDK = get_generic_pdk()
-    PDK.activate()
+    x1 = gf.cross_section.strip(width=1)
+    x2 = gf.cross_section.strip(width=2)
+    x = gf.cross_section.Transition(cross_section1=x1, cross_section2=x2)
 
-    c = bend_circular(
-        angle=180,
-        cross_section="xs_rc",
-        layer=(2, 0),
-    )
+    c = bend_circular(angle=180, cross_section=x, radius=10)
     c.show(show_ports=True)

--- a/gdsfactory/components/bend_s.py
+++ b/gdsfactory/components/bend_s.py
@@ -34,6 +34,9 @@ def bend_s(
         add_pins: add pins to the component.
 
     Keyword Args:
+        with_manhattan_facing_angles: bool.
+        start_angle: optional start angle in deg.
+        end_angle: optional end angle in deg.
     """
     c = Component()
     dx, dy = size
@@ -53,7 +56,7 @@ def bend_s(
 
 
 def get_min_sbend_size(
-    size: Float2 = (None, 10.0),
+    size: tuple[float | None, float | None] = (None, 10.0),
     cross_section: CrossSectionSpec = "xs_sc",
     num_points: int = 100,
     **kwargs,

--- a/gdsfactory/components/spiral_inner_io.py
+++ b/gdsfactory/components/spiral_inner_io.py
@@ -189,7 +189,8 @@ def spiral_inner_io_fiber_array(
     cross_section_bend: CrossSectionSpec | None = None,
     cross_section_bend180: CrossSectionSpec | None = None,
     asymmetric_cross_section: bool = False,
-    add_grating_couplers: ComponentFactory = add_grating_couplers_with_loopback_fiber_array,
+    add_grating_couplers: ComponentFactory
+    | None = add_grating_couplers_with_loopback_fiber_array,
     **kwargs,
 ) -> Component:
     """Returns Spiral with fiber array grating couplers.
@@ -212,8 +213,8 @@ def spiral_inner_io_fiber_array(
         cross_section_bend180: for 180 bend.
         asymmetric_cross_section: if the cross_section is asymmetric, it needs to be mirrored at the halfway point.
         add_grating_couplers: function to add grating couplers.
+        kwargs: cross_section settings.
 
-    Keyword Args:
     """
     spiral = spiral_inner_io(
         N=N,
@@ -233,7 +234,11 @@ def spiral_inner_io_fiber_array(
         asymmetric_cross_section=asymmetric_cross_section,
         **kwargs,
     )
-    return add_grating_couplers(spiral, cross_section=cross_section, **kwargs)
+    return (
+        add_grating_couplers(spiral, cross_section=cross_section, **kwargs)
+        if add_grating_couplers
+        else spiral
+    )
 
 
 @gf.cell

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -351,7 +351,7 @@ class CrossSection(BaseModel):
 CrossSectionSpec = CrossSection | str | dict[str, Any] | Callable[..., CrossSection]
 
 
-class Transition(BaseModel):
+class Transition(CrossSection):
     """Waveguide information to extrude a path between two CrossSection.
 
     cladding_layers follow path shape

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -982,12 +982,12 @@ def extrude_transition(
         shear_angle_end: angle to shear the end of the path.
     """
 
-    from gdsfactory.pdk import get_layer
+    from gdsfactory.pdk import get_cross_section, get_layer
 
     c = Component()
 
-    x1 = transition.cross_section1
-    x2 = transition.cross_section2
+    x1 = get_cross_section(transition.cross_section1)
+    x2 = get_cross_section(transition.cross_section2)
     width_type = transition.width_type
 
     # if named, prefer name over layer

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -20,6 +20,7 @@ skip_test = {
     "ring_section_based",
     "ring_double_pn",
     "compensation_path",
+    "add_grating_couplers_with_loopback_fiber_array",
 }
 
 


### PR DESCRIPTION
fixes extrude transition

```python
    import gdsfactory as gf 

    x1 = gf.cross_section.strip(width=1)
    x2 = gf.cross_section.strip(width=2)
    x = gf.cross_section.Transition(cross_section1=x1, cross_section2=x2)
    

    c = bend_circular(
        angle=180,
        cross_section=x,
        radius=10
    )
    c.show(show_ports=True)
```

![image](https://github.com/gdsfactory/gdsfactory/assets/4514346/c3357bc2-968e-4d0b-80f4-129da289864b)


@simbilod 
@tvt173 
