### PR TITLE
Support custom labeler when adding pins

### DIFF
--- a/gdsfactory/add_labels.py
+++ b/gdsfactory/add_labels.py
@@ -176,10 +176,10 @@ def add_labels(
     Args:
         component: to add labels to.
         get_label_function: function to get label.
-        layer_label: layer_label.
+        layer_label: LayerSpec for the label.
         gc: Optional grating coupler.
 
-    keyword Args:
+    Keyword Args:
         layer: port GDS layer.
         prefix: with in port name.
         suffix: select ports with port name suffix.

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -152,6 +152,7 @@ def add_pin_rectangle_inside(
     pin_length: float = 0.1,
     layer: LayerSpec = "PORT",
     layer_label: LayerSpec = "TEXT",
+    label_function: Callable[[Component, Port], str] | None = None,
 ) -> None:
     """Add square pin towards the inside of the port.
 
@@ -161,6 +162,7 @@ def add_pin_rectangle_inside(
         pin_length: length of the pin marker for the port.
         layer: for the pin marker.
         layer_label: for the label.
+        label_function: function to return label text according to the ``component`` and ``port``.
 
     .. code::
 
@@ -174,29 +176,28 @@ def add_pin_rectangle_inside(
           |      __       |
           |_______________|
     """
-    p = port
-    a = p.orientation
+    a = port.orientation
     ca = np.cos(a * np.pi / 180)
     sa = np.sin(a * np.pi / 180)
     rot_mat = np.array([[ca, -sa], [sa, ca]])
 
-    d = p.width / 2
+    d = port.width / 2
 
     dbot = np.array([0, -d])
     dtop = np.array([0, +d])
     dbotin = np.array([-pin_length, -d])
     dtopin = np.array([-pin_length, +d])
 
-    p0 = p.center + _rotate(dbot, rot_mat)
-    p1 = p.center + _rotate(dtop, rot_mat)
-    ptopin = p.center + _rotate(dtopin, rot_mat)
-    pbotin = p.center + _rotate(dbotin, rot_mat)
+    p0 = port.center + _rotate(dbot, rot_mat)
+    p1 = port.center + _rotate(dtop, rot_mat)
+    ptopin = port.center + _rotate(dtopin, rot_mat)
+    pbotin = port.center + _rotate(dbotin, rot_mat)
     polygon = [p0, p1, ptopin, pbotin]
     component.add_polygon(polygon, layer=layer)
     if layer_label:
         component.add_label(
-            text=str(p.name),
-            position=p.center,
+            text=label_function(component, port) if label_function else str(port.name),
+            position=port.center,
             layer=layer_label,
         )
 
@@ -480,6 +481,7 @@ def add_pins(
         pin_length: length of the pin marker for the port.
         layer: layer for the pin marker.
         layer_label: add label for the pin marker.
+        label_function: function to return label text according to the ``component`` and ``port``.
     """
     reference = reference or component
     ports = (

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -5,8 +5,14 @@ from functools import partial
 import pytest
 
 import gdsfactory as gf
-from gdsfactory.add_pins import add_bbox_siepic, add_pins_siepic
+from gdsfactory.add_pins import (
+    add_bbox_siepic,
+    add_pin_rectangle_inside,
+    add_pins_siepic,
+)
+from gdsfactory.component import Component
 from gdsfactory.generic_tech import LAYER
+from gdsfactory.port import Port
 
 cladding_layers_optical_siepic = ("DEVREC",)  # for SiEPIC verification
 cladding_offsets_optical_siepic = (0,)  # for SiEPIC verification
@@ -46,6 +52,72 @@ def test_add_pins() -> None:
     assert len(pins_component.polygons) == 2, len(pins_component.polygons)
 
 
+def test_add_pin_rectangle_inside() -> None:
+    """Test that a square pin is added towards the inside of the port."""
+    c = Component()
+    w = 1.0
+    port = Port(
+        name="test_port",
+        center=(0, 0),
+        width=w,
+        orientation=0,
+        layer=(1, 0),
+    )
+    c.add_port(port)
+    add_pin_rectangle_inside(
+        component=c,
+        port=port,
+        pin_length=0.1,
+        layer=(2, 0),
+        layer_label=(3, 0),
+        label_function=None,
+    )
+    assert len(c.polygons) == 1, len(c.polygons)
+    assert len(c.labels) == 1, len(c.labels)
+    assert c.labels[0].text == "test_port", c.labels[0].text
+    assert c.labels[0].origin == (0, 0), c.labels[0].origin
+    assert (c.labels[0].layer, c.labels[0].texttype) == (3, 0), (
+        c.labels[0].layer,
+        c.labels[0].texttype,
+    )
+
+
+def test_add_pin_rectangle_inside_with_label_function() -> None:
+    """Test that a square pin is added towards the inside of the port with a custom label."""
+    c = Component(name="test_add_pins")
+    w = 1.0
+    port = Port(
+        name="test_port",
+        center=(0, 0),
+        width=w,
+        orientation=0,
+        layer=(1, 0),
+    )
+    c.add_port(port)
+
+    def label_function(component: Component, port: Port) -> str:
+        return f"{component.name}_{port.name}_test"
+
+    add_pin_rectangle_inside(
+        component=c,
+        port=port,
+        pin_length=0.1,
+        layer=(2, 0),
+        layer_label=(3, 0),
+        label_function=label_function,
+    )
+    assert len(c.polygons) == 1, len(c.polygons)
+    assert len(c.labels) == 1, len(c.labels)
+    assert c.labels[0].text == "test_add_pins_test_port_test", c.labels[0].text
+    assert c.labels[0].origin == (0, 0), c.labels[0].origin
+    assert (c.labels[0].layer, c.labels[0].texttype) == (3, 0), (
+        c.labels[0].layer,
+        c.labels[0].texttype,
+    )
+
+
 if __name__ == "__main__":
     # test_add_pins()
     test_add_pins_with_routes(0)
+    test_add_pin_rectangle_inside()
+    test_add_pin_rectangle_inside_with_label_function()


### PR DESCRIPTION
This PR adds support for a custom `label_function` in `add_pin_rectangle_inside`. This allows labels differing from the port names according to given Component and Port combinations.

A simple test is also added.

Closes #2251