### PR TITLE
Support different s-bend factories in `get_route_sbend`

### DIFF
--- a/gdsfactory/routing/get_route_sbend.py
+++ b/gdsfactory/routing/get_route_sbend.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 from gdsfactory.components.bend_s import bend_s
 from gdsfactory.port import Port
-from gdsfactory.typings import Route
+from gdsfactory.typings import ComponentFactory, Route
 
 
-def get_route_sbend(port1: Port, port2: Port, **kwargs) -> Route:
+def get_route_sbend(
+    port1: Port, port2: Port, *, bend_s: ComponentFactory = bend_s, **kwargs
+) -> Route:
     """Returns an Sbend Route to connect two ports.
 
     Args:
         port1: start port.
         port2: end port.
+        bend_s: S-bend component factory.
 
-    keyword Args:
+    Keyword Args:
         npoints: number of points.
         with_cladding_box: square bounding box to avoid DRC errors.
         cross_section: function.

--- a/tests/routing/test_routing_get_route_sbend.py
+++ b/tests/routing/test_routing_get_route_sbend.py
@@ -1,0 +1,37 @@
+from functools import partial
+
+import gdsfactory as gf
+
+
+def test_get_route_sbend():
+    c = gf.Component()
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.move((100, 50))
+    route = gf.routing.get_route_sbend(mmi1.ports["o3"], mmi2.ports["o1"])
+    c.add(route.references)
+    c.show()
+    assert len(route.references) == 1
+    assert route.length > 0
+    assert route.ports == (mmi1.ports["o3"], mmi2.ports["o1"])
+
+
+def test_get_route_sbend_custom_factory():
+    c = gf.Component()
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.move((100, 50))
+    # does not make sense physically but gdsfactory should still generate this
+    route = gf.routing.get_route_sbend(
+        mmi1.ports["o3"],
+        mmi2.ports["o1"],
+        bend_s=partial(
+            gf.components.bend_s, cross_section="xs_heater_metal", npoints=10
+        ),
+    )
+    c.add(route.references)
+    c.show()
+    assert len(route.references) == 1
+    assert route.length > 0
+    assert route.ports == (mmi1.ports["o3"], mmi2.ports["o1"])
+    assert gf.generic_tech.LAYER.HEATER in c.layers


### PR DESCRIPTION
Support different s-bend factories in `get_route_sbend` and add basic testing for the function.

This may be used to for example provide an s-bend factory with decorators applied