### PR TITLE
Infer rough component name for labeling from stack

### DIFF
--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -95,7 +95,12 @@ def test_add_pin_rectangle_inside_with_label_function() -> None:
     )
     c.add_port(port)
 
-    def label_function(component: Component, port: Port) -> str:
+    def label_function(
+        component: Component, rough_component_name: str, port: Port
+    ) -> str:
+        assert (
+            rough_component_name == "test_add_pin_rectangle_inside_with_label_function"
+        ), rough_component_name
         return f"{component.name}_{port.name}_test"
 
     add_pin_rectangle_inside(


### PR DESCRIPTION
Infer rough component name for labeling from stack.

I hope this is not too hacky or cause too much performance hit (called only if label_function specified). In any case, pins are not always added and the Component is still given to the labeler to use if it has a name.

Closes #2266