### PR TITLE
Update `gf install` command for KLayout integration

### DIFF
--- a/docs/notebooks/_2_klayout.py
+++ b/docs/notebooks/_2_klayout.py
@@ -12,7 +12,7 @@
 
 # You can install the klayout generic pdk (layermap and DRC) in 2 ways:
 #
-# 1. from the terminal by typing `gf install klayout-genericpdk` after installing gdsfactory `pip install gdsfactory`
+# 1. from the terminal by typing `gf install-klayout-genericpdk` after installing gdsfactory `pip install gdsfactory`
 # 2. using KLayout package manager (see image below), Tools --> Manage Packages
 #
 # ![KLayout package](https://i.imgur.com/AkfcCms.png)


### PR DESCRIPTION
The gf install in the tutorial is currently wrong, this fixes it

![image](https://github.com/gdsfactory/gdsfactory/assets/7860886/d2f31ba1-b8ba-440a-80a9-4206157a4f50)
