### PR TITLE
acess ports by index

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -371,8 +371,11 @@ class Component(_GeometryHelper):
             else {"component": self.name, "settings": {}}
         )
 
-    def __getitem__(self, key) -> Port:
+    def __getitem__(self, key: str | int) -> Port:
         """Access reference ports."""
+        if isinstance(key, int):
+            key = list(self.ports.keys())[key]
+
         if key not in self.ports:
             ports = list(self.ports.keys())
             raise ValueError(f"{key!r} not in {ports}")

--- a/gdsfactory/component_reference.py
+++ b/gdsfactory/component_reference.py
@@ -475,8 +475,11 @@ class ComponentReference(_GeometryHelper):
         ), f"TypeError, Got {type(v)}, expecting ComponentReference"
         return v
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str | int):
         """Access reference ports."""
+        if isinstance(key, int):
+            key = list(self.ports.keys())[key]
+
         if key not in self.ports:
             ports = list(self.ports.keys())
             raise ValueError(f"{key!r} not in {ports}")

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -30,5 +30,16 @@ def test_ports_add() -> None:
     assert p1.orientation == p2.orientation
 
 
+def test_port_get_item():
+    wg = gf.components.straight()
+
+    assert wg["o1"] == wg[0]
+    assert wg["o2"] == wg[1]
+
+    wg_ref = wg.ref()
+    assert wg_ref["o1"] == wg_ref[0]
+    assert wg_ref["o2"] == wg_ref[1]
+
+
 if __name__ == "__main__":
     test_ports_add()


### PR DESCRIPTION

Allows you to access ports by index

```

    assert wg["o1"] == wg[0]
    assert wg["o2"] == wg[1]

    wg_ref = wg.ref()
    assert wg_ref["o1"] == wg_ref[0]
    assert wg_ref["o2"] == wg_ref[1]
```


based on https://github.com/gdsfactory/gdsfactory/pull/789

@sequoiap 