### PR TITLE
remove_zero_length_tapers_and_pins

### DIFF
--- a/gdsfactory/components/bend_circular.py
+++ b/gdsfactory/components/bend_circular.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.path import arc
 from gdsfactory.snap import snap_to_grid
-from gdsfactory.typings import CrossSectionSpec
+from gdsfactory.typings import Callable, CrossSectionSpec
 
 
 @gf.cell
@@ -18,7 +18,7 @@ def bend_circular(
     width: float | None = None,
     cross_section: CrossSectionSpec = "xs_sc",
     add_pins: bool = True,
-    add_bbox: callable | None = None,
+    add_bbox: Callable | None = None,
 ) -> Component:
     """Returns a radial arc.
 

--- a/gdsfactory/components/bend_euler.py
+++ b/gdsfactory/components/bend_euler.py
@@ -10,7 +10,7 @@ from gdsfactory.components.straight import straight
 from gdsfactory.components.wire import wire_corner
 from gdsfactory.cross_section import strip
 from gdsfactory.path import euler
-from gdsfactory.typings import CrossSectionSpec
+from gdsfactory.typings import Callable, CrossSectionSpec
 
 
 @gf.cell
@@ -25,7 +25,7 @@ def bend_euler(
     direction: str = "ccw",
     cross_section: CrossSectionSpec = "xs_sc",
     add_pins: bool = True,
-    add_bbox: callable | None = None,
+    add_bbox: Callable | None = None,
 ) -> Component:
     """Euler bend with changing bend radius.
 

--- a/gdsfactory/components/cross.py
+++ b/gdsfactory/components/cross.py
@@ -55,7 +55,7 @@ def cross(
                 width=width,
                 layer=layer,
                 orientation=90,
-                center=(0, length / 2),
+                center=(0, +length / 2),
                 port_type=port_type,
             )
             c.add_port(

--- a/gdsfactory/components/cross.py
+++ b/gdsfactory/components/cross.py
@@ -55,7 +55,7 @@ def cross(
                 width=width,
                 layer=layer,
                 orientation=90,
-                center=(0, +length / 2),
+                center=(0, length / 2),
                 port_type=port_type,
             )
             c.add_port(

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -27,7 +27,7 @@ def straight(
         width: width to use. Defaults to cross_section.width.
         add_pins: add pins to the component.
         cross_section: specification (CrossSection, string or dict).
-        add_bbox: add bounding box to the component.
+        add_bbox: function to add bounding box to the component.
 
     .. code::
 

--- a/gdsfactory/components/taper.py
+++ b/gdsfactory/components/taper.py
@@ -60,20 +60,22 @@ def taper(
     y2 = width2 / 2
     x1 = x.model_copy(update=dict(width=width1))
     x2 = x.model_copy(update=dict(width=width2))
-    xpts = [0, length, length, 0]
-    ypts = [y1, y2, -y2, -y1]
-    c.add_polygon((xpts, ypts), layer=layer)
 
-    x1 = x.copy(width=width1)
-    x2 = x.copy(width=width2)
-
-    xpts = [0, length, length, 0]
-    for section in x.sections[1:]:
-        layer = section.layer
-        y1 = section.width / 2
-        y2 = y1 + (width2 - width1)
+    if length:
+        xpts = [0, length, length, 0]
         ypts = [y1, y2, -y2, -y1]
         c.add_polygon((xpts, ypts), layer=layer)
+
+        x1 = x.copy(width=width1)
+        x2 = x.copy(width=width2)
+
+        xpts = [0, length, length, 0]
+        for section in x.sections[1:]:
+            layer = section.layer
+            y1 = section.width / 2
+            y2 = y1 + (width2 - width1)
+            ypts = [y1, y2, -y2, -y1]
+            c.add_polygon((xpts, ypts), layer=layer)
 
     c.add_port(
         name=port_order_name[0],
@@ -208,18 +210,19 @@ def taper_strip_to_ridge_trenches(
     # straight
     x = [0, length, length, 0]
     yw = [y0, yL, -yL, -y0]
-    c.add_polygon((x, yw), layer=layer_wg)
+    if length:
+        c.add_polygon((x, yw), layer=layer_wg)
 
-    # top trench
-    ymin0 = width / 2
-    yminL = width / 2
-    ymax0 = width / 2 + trench_width
-    ymaxL = width / 2 + trench_width + slab_offset
-    x = [0, length, length, 0]
-    ytt = [ymin0, yminL, ymaxL, ymax0]
-    ytb = [-ymin0, -yminL, -ymaxL, -ymax0]
-    c.add_polygon((x, ytt), layer=trench_layer)
-    c.add_polygon((x, ytb), layer=trench_layer)
+        # top trench
+        ymin0 = width / 2
+        yminL = width / 2
+        ymax0 = width / 2 + trench_width
+        ymaxL = width / 2 + trench_width + slab_offset
+        x = [0, length, length, 0]
+        ytt = [ymin0, yminL, ymaxL, ymax0]
+        ytb = [-ymin0, -yminL, -ymaxL, -ymax0]
+        c.add_polygon((x, ytt), layer=trench_layer)
+        c.add_polygon((x, ytb), layer=trench_layer)
 
     c.add_port(name="o1", center=(0, 0), width=width, orientation=180, layer=layer_wg)
     c.add_port(
@@ -244,8 +247,9 @@ taper_sc_nc = partial(
 
 
 if __name__ == "__main__":
+    c = taper(length=0)
     # c = taper_strip_to_ridge_trenches()
     # c = taper_strip_to_ridge()
     # c = taper(width1=1.5, width2=1, cross_section="xs_rc")
-    c = taper_sc_nc()
-    c.show(show_ports=True)
+    # c = taper_sc_nc()
+    c.show(show_ports=False)

--- a/gdsfactory/components/taper_parabolic.py
+++ b/gdsfactory/components/taper_parabolic.py
@@ -26,16 +26,17 @@ def taper_parabolic(
         npoints: number of points.
         layer: layer spec.
     """
-    x = np.linspace(0, 1, npoints)
-    y = transition_exponential(y1=width1, y2=width2, exp=exp)(x) / 2
-
-    x = length * x
-    points1 = np.array([x, y]).T
-    points2 = np.flipud(np.array([x, -y]).T)
-    points = np.concatenate([points1, points2])
-
     c = gf.Component()
-    c.add_polygon(points, layer=layer)
+
+    if length:
+        x = np.linspace(0, 1, npoints)
+        y = transition_exponential(y1=width1, y2=width2, exp=exp)(x) / 2
+        x = length * x
+        points1 = np.array([x, y]).T
+        points2 = np.flipud(np.array([x, -y]).T)
+        points = np.concatenate([points1, points2])
+        c.add_polygon(points, layer=layer)
+
     c.add_port(name="o1", center=(0, 0), width=width1, orientation=180, layer=layer)
     c.add_port(name="o2", center=(length, 0), width=width2, orientation=0, layer=layer)
     return c
@@ -43,6 +44,6 @@ def taper_parabolic(
 
 if __name__ == "__main__":
     # c = taper_parabolic(width2=6, length=40, exp=0.6)
-    c = taper_parabolic()
+    c = taper_parabolic(length=0)
     print(c.name)
     c.show(show_ports=True)

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -519,7 +519,8 @@ def cross_section(
 radius_nitride = 20
 radius_rib = 20
 
-strip = partial(cross_section, add_pins_function_name="add_pins_inside1nm")
+strip = partial(cross_section, add_pins_function_name=None)
+strip_pins = partial(cross_section, add_pins_function_name="add_pins_inside1nm")
 strip_auto_widen = partial(strip, auto_widen=True)
 strip_no_pins = cross_section
 
@@ -2324,6 +2325,7 @@ def get_cross_sections(
 xs_sc = strip()
 xs_sc_auto_widen = strip_auto_widen()
 xs_sc_no_pins = strip_no_pins()
+xs_sc_pins = strip_pins()
 
 xs_rc = rib(bbox_layers=["DEVREC"], bbox_offsets=[0.0])
 xs_rc2 = rib2()

--- a/test-data-regression/test_import_json_label.yml
+++ b/test-data-regression/test_import_json_label.yml
@@ -24,9 +24,9 @@ cell_settings:
   recenter: false
   route_info:
     length: 10.0
-    type: xs_sc_no_pins
+    type: xs_sc
     weight: 10.0
-    xs_sc_no_pins_length: 10.0
+    xs_sc_length: 10.0
   width: 0.5
 doe: null
 measurement: null

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -27,14 +27,14 @@ instances:
       route_info:
         length: 16.637
         n_bend_90: 1.0
-        type: xs_5d28b726
+        type: xs_2b1b1ae4
         weight: 16.637
-        xs_5d28b726_length: 16.637
+        xs_2b1b1ae4_length: 16.637
       width: 0.45
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -74,14 +74,14 @@ instances:
       route_info:
         length: 16.637
         n_bend_90: 1.0
-        type: xs_5d28b726
+        type: xs_2b1b1ae4
         weight: 16.637
-        xs_5d28b726_length: 16.637
+        xs_2b1b1ae4_length: 16.637
       width: 0.45
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -121,14 +121,14 @@ instances:
       route_info:
         length: 16.637
         n_bend_90: 1.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 16.637
-        xs_c75e0198_length: 16.637
+        xs_87d90acd_length: 16.637
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -168,14 +168,14 @@ instances:
       route_info:
         length: 16.637
         n_bend_90: 1.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 16.637
-        xs_c75e0198_length: 16.637
+        xs_87d90acd_length: 16.637
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -228,7 +228,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -261,14 +261,14 @@ instances:
       length: 1.0
       route_info:
         length: 1.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 1.0
-        xs_c75e0198_length: 1.0
+        xs_87d90acd_length: 1.0
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -304,7 +304,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -337,14 +337,14 @@ instances:
       length: 3.0
       route_info:
         length: 3.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 3.0
-        xs_c75e0198_length: 3.0
+        xs_87d90acd_length: 3.0
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -380,7 +380,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -413,14 +413,14 @@ instances:
       length: 4.0
       route_info:
         length: 4.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 4.0
-        xs_c75e0198_length: 4.0
+        xs_87d90acd_length: 4.0
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -456,7 +456,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -489,14 +489,14 @@ instances:
       length: 3.0
       route_info:
         length: 3.0
-        type: xs_c75e0198
+        type: xs_87d90acd
         weight: 3.0
-        xs_c75e0198_length: 3.0
+        xs_87d90acd_length: 3.0
       width: 0.55
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -532,7 +532,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -565,14 +565,14 @@ instances:
       length: 1.0
       route_info:
         length: 1.0
-        type: xs_5d28b726
+        type: xs_2b1b1ae4
         weight: 1.0
-        xs_5d28b726_length: 1.0
+        xs_2b1b1ae4_length: 1.0
       width: 0.45
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -9,7 +9,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -46,7 +46,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -83,7 +83,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -123,7 +123,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -159,7 +159,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -199,7 +199,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -23,7 +23,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -70,7 +70,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -105,7 +105,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -141,7 +141,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -181,7 +181,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -217,7 +217,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -257,7 +257,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -293,7 +293,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -333,7 +333,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_sample_different_link_factory_.yml
+++ b/test-data-regression/test_netlists_sample_different_link_factory_.yml
@@ -37,7 +37,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -84,7 +84,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -131,7 +131,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -178,7 +178,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -225,7 +225,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -272,7 +272,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -319,7 +319,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -366,7 +366,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -413,7 +413,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -460,7 +460,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -507,7 +507,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -554,7 +554,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -609,7 +609,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -649,7 +649,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -685,7 +685,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -725,7 +725,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -761,7 +761,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -801,7 +801,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -837,7 +837,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -877,7 +877,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -913,7 +913,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -953,7 +953,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -989,7 +989,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1029,7 +1029,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1065,7 +1065,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1105,7 +1105,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1141,7 +1141,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1181,7 +1181,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1217,7 +1217,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1257,7 +1257,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1293,7 +1293,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1333,7 +1333,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_sample_docstring_.yml
+++ b/test-data-regression/test_netlists_sample_docstring_.yml
@@ -23,7 +23,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -70,7 +70,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -115,7 +115,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -155,7 +155,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -191,7 +191,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -231,7 +231,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -267,7 +267,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -307,7 +307,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_sample_mmis_.yml
+++ b/test-data-regression/test_netlists_sample_mmis_.yml
@@ -23,7 +23,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -70,7 +70,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -115,7 +115,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -155,7 +155,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -191,7 +191,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -231,7 +231,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -267,7 +267,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -307,7 +307,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_netlists_sample_waypoints_.yml
+++ b/test-data-regression/test_netlists_sample_waypoints_.yml
@@ -41,7 +41,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -88,7 +88,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -135,7 +135,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -182,7 +182,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -229,7 +229,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -276,7 +276,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -323,7 +323,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -370,7 +370,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -405,7 +405,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -445,7 +445,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -481,7 +481,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -521,7 +521,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -557,7 +557,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -597,7 +597,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -633,7 +633,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -673,7 +673,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -709,7 +709,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -749,7 +749,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -785,7 +785,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -825,7 +825,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -861,7 +861,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -901,7 +901,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -937,7 +937,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -977,7 +977,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1013,7 +1013,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1053,7 +1053,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1089,7 +1089,7 @@ instances:
     info:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null
@@ -1129,7 +1129,7 @@ instances:
     settings:
       cross_section:
         add_pins_function_module: gdsfactory.add_pins
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         auto_widen: false
         auto_widen_minimum_length: 200.0
         bbox_layers: null

--- a/test-data-regression/test_settings.yml
+++ b/test-data-regression/test_settings.yml
@@ -31,18 +31,18 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   full:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   function_name: demo_cross_section_setting
   info:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     length: 10.0
     route_info:
       length: 10.0

--- a/test-data-regression/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
+++ b/test-data-regression/test_settings_add_grating_couplers_with_loopback_fiber_single_.yml
@@ -56,7 +56,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     gc_port_name: o1
     grating_coupler:
       function: grating_coupler_elliptical_trenches
@@ -75,7 +75,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     gc_port_name: o1
     grating_coupler:
       function: grating_coupler_elliptical_trenches

--- a/test-data-regression/test_settings_bend_straight_bend_.yml
+++ b/test-data-regression/test_settings_bend_straight_bend_.yml
@@ -32,7 +32,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     direction: ccw
     npoints: 720
     p: 0.5
@@ -43,7 +43,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     direction: ccw
     npoints: 720
     p: 0.5

--- a/test-data-regression/test_settings_cdc_.yml
+++ b/test-data-regression/test_settings_cdc_.yml
@@ -55,7 +55,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     dc: 0.5
     dx: 10.0
     dy: 1.8
@@ -72,7 +72,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     dc: 0.5
     dx: 10.0
     dy: 1.8

--- a/test-data-regression/test_settings_disk_heater_.yml
+++ b/test-data-regression/test_settings_disk_heater_.yml
@@ -2,7 +2,7 @@ name: disk_heater
 ports:
   e1:
     center:
-    - -22.551
+    - -22.55
     - 0.251
     layer:
     - 49
@@ -14,7 +14,7 @@ ports:
     width: 10.0
   e2:
     center:
-    - 33.251
+    - 33.25
     - 0.251
     layer:
     - 49

--- a/test-data-regression/test_settings_ring_crow_.yml
+++ b/test-data-regression/test_settings_ring_crow_.yml
@@ -64,11 +64,11 @@ settings:
     input_straight_cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     output_straight_cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     radius:
     - 10.0
     - 10.0
@@ -76,13 +76,13 @@ settings:
     ring_cross_sections:
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   full:
     bends:
     - function: bend_circular
@@ -96,11 +96,11 @@ settings:
     input_straight_cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     output_straight_cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     radius:
     - 10.0
     - 10.0
@@ -108,13 +108,13 @@ settings:
     ring_cross_sections:
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   function_name: ring_crow
   info: {}
   info_version: 2

--- a/test-data-regression/test_settings_ring_crow_couplers_.yml
+++ b/test-data-regression/test_settings_ring_crow_couplers_.yml
@@ -68,13 +68,13 @@ settings:
     ring_cross_sections:
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   full:
     bends:
     - function: bend_circular
@@ -92,13 +92,13 @@ settings:
     ring_cross_sections:
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     - function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
   function_name: ring_crow_couplers
   info: {}
   info_version: 2

--- a/test-data-regression/test_settings_ring_single_pn_.yml
+++ b/test-data-regression/test_settings_ring_single_pn_.yml
@@ -31,7 +31,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -99,7 +99,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_straight_heater_doped_rib_.yml
+++ b/test-data-regression/test_settings_straight_heater_doped_rib_.yml
@@ -127,7 +127,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -195,7 +195,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_straight_heater_doped_strip_.yml
+++ b/test-data-regression/test_settings_straight_heater_doped_strip_.yml
@@ -142,7 +142,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -210,7 +210,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_straight_heater_meander_.yml
+++ b/test-data-regression/test_settings_straight_heater_meander_.yml
@@ -127,7 +127,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     extension_length: 15.0
     heater_taper_length: 10.0
     heater_width: 2.5
@@ -147,7 +147,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     extension_length: 15.0
     heater_taper_length: 10.0
     heater_width: 2.5

--- a/test-data-regression/test_settings_straight_rib_.yml
+++ b/test-data-regression/test_settings_straight_rib_.yml
@@ -1,4 +1,4 @@
-name: straight_0dd74e54
+name: straight_7d7b8106
 ports:
   o1:
     center:
@@ -29,7 +29,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -61,7 +61,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -87,7 +87,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -107,10 +107,10 @@ settings:
     length: 10.0
     route_info:
       length: 10.0
-      type: xs_f0722844
+      type: xs_6e41a64d
       weight: 10.0
-      xs_f0722844_length: 10.0
+      xs_6e41a64d_length: 10.0
     width: 0.5
   info_version: 2
   module: gdsfactory.components.straight
-  name: straight_0dd74e54
+  name: straight_7d7b8106

--- a/test-data-regression/test_settings_straight_rib_tapered_.yml
+++ b/test-data-regression/test_settings_straight_rib_tapered_.yml
@@ -1,4 +1,4 @@
-name: straight_0dd74e54_extend_ports_90a9fa88
+name: straight_7d7b8106_extend_ports_2f59897c
 ports:
   o1:
     center:
@@ -32,7 +32,7 @@ settings:
         cross_section:
           function: cross_section
           settings:
-            add_pins_function_name: add_pins_inside1nm
+            add_pins_function_name: null
             sections:
             - hidden: false
               insets: null
@@ -74,7 +74,7 @@ settings:
         cross_section:
           function: cross_section
           settings:
-            add_pins_function_name: add_pins_inside1nm
+            add_pins_function_name: null
             sections:
             - hidden: false
               insets: null
@@ -105,7 +105,7 @@ settings:
     cross_section:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -125,10 +125,10 @@ settings:
     length: 10.0
     route_info:
       length: 10.0
-      type: xs_f0722844
+      type: xs_6e41a64d
       weight: 10.0
-      xs_f0722844_length: 10.0
+      xs_6e41a64d_length: 10.0
     width: 0.5
   info_version: 2
   module: gdsfactory.components.extension
-  name: straight_0dd74e54_extend_ports_90a9fa88
+  name: straight_7d7b8106_extend_ports_2f59897c

--- a/test-data-regression/test_settings_taper_cross_section_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_.yml
@@ -31,7 +31,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -57,7 +57,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_taper_cross_section_linear_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_linear_.yml
@@ -33,7 +33,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -59,7 +59,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
@@ -33,7 +33,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -59,7 +59,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_taper_cross_section_sine_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_sine_.yml
@@ -32,7 +32,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null
@@ -58,7 +58,7 @@ settings:
     cross_section1:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
         sections:
         - hidden: false
           insets: null

--- a/test-data-regression/test_settings_tapers_.yml
+++ b/test-data-regression/test_settings_tapers_.yml
@@ -121,9 +121,9 @@ settings:
     length: 20
     route_info:
       length: 20
-      type: xs_2df11454
+      type: xs_b26ea532
       weight: 20
-      xs_2df11454_length: 20
+      xs_b26ea532_length: 20
     width: 2
   info_version: 2
   module: gdsfactory.routing.add_fiber_array

--- a/test-data-regression/test_settings_terminator_.yml
+++ b/test-data-regression/test_settings_terminator_.yml
@@ -19,7 +19,7 @@ settings:
     cross_section_input:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     cross_section_tip: null
     doping_layers:
     - NPP
@@ -30,7 +30,7 @@ settings:
     cross_section_input:
       function: cross_section
       settings:
-        add_pins_function_name: add_pins_inside1nm
+        add_pins_function_name: null
     cross_section_tip: null
     doping_layers:
     - NPP

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -31,7 +31,7 @@ strip_siepic100nm = partial(
 @pytest.mark.parametrize("optical_routing_type", [0, 1])
 def test_add_pins_with_routes(optical_routing_type) -> None:
     """Add pins to a straight ensure that all the routes have pins."""
-    cross_section = "xs_sc"
+    cross_section = "xs_sc_pins"
     c = gf.components.straight(length=1.0, cross_section=cross_section)
     gc = gf.components.grating_coupler_elliptical_te(cross_section=cross_section)
     cc = gf.routing.add_fiber_single(
@@ -46,7 +46,7 @@ def test_add_pins_with_routes(optical_routing_type) -> None:
 
 def test_add_pins() -> None:
     """Ensure that all the waveguide has 2 pins."""
-    cross_section = "xs_sc"
+    cross_section = "xs_sc_pins"
     c = gf.components.straight(length=1.0, cross_section=cross_section)
     pins_component = c.extract(layers=(LAYER.PORT,))
     assert len(pins_component.polygons) == 2, len(pins_component.polygons)
@@ -123,6 +123,6 @@ def test_add_pin_rectangle_inside_with_label_function() -> None:
 
 if __name__ == "__main__":
     # test_add_pins()
-    test_add_pins_with_routes(0)
-    test_add_pin_rectangle_inside()
+    # test_add_pins_with_routes(0)
+    # test_add_pin_rectangle_inside()
     test_add_pin_rectangle_inside_with_label_function()


### PR DESCRIPTION
fixes #2311 

- remove zero length polygons in tapers
- remove pins from default cross_section `xs_sc` to avoid early users confusion

@nikosavola
@mdecea 