### PR TITLE
Use shutil.copytree to install KLayout tech on Windows

### DIFF
--- a/gdsfactory/install.py
+++ b/gdsfactory/install.py
@@ -36,7 +36,7 @@ def make_link(src, dest, overwrite: bool = True) -> None:
         print("     Error: ", err)
         if sys.platform == "win32":
             # https://stackoverflow.com/questions/32877260/privlege-error-trying-to-create-symlink-using-python-on-windows-10
-            shutil.copy(src, dest)
+            shutil.copytree(src, dest)
     print("Symlink made:")
     print(f"From: {src}")
     print(f"To:   {dest}")


### PR DESCRIPTION
`shutil.copy` only works for single files so we need to use `shutil.copytree` for the technology install to work