### PR TITLE
Support adding partialed cross_sections in taper cross section again

### DIFF
--- a/gdsfactory/add_tapers_cross_section.py
+++ b/gdsfactory/add_tapers_cross_section.py
@@ -51,16 +51,26 @@ def add_tapers(
 
     for port_name, port in component.ports.items():
         if port.name in ports_to_taper_names:
-            _taper = (
-                taper
-                if isinstance(taper, Component)
-                else gf.get_component(
+            if (
+                isinstance(taper, gf.partial)
+                and "cross_section2" in taper.keywords
+                and cross_section2 is None
+            ):
+                _taper = gf.get_component(
+                    taper,
+                    cross_section2=gf.partial(
+                        taper.keywords["cross_section2"], width=port.width
+                    ),
+                )
+            elif isinstance(taper, Component):
+                _taper = taper
+            else:
+                _taper = gf.get_component(
                     taper,
                     cross_section1=cross_section1 or port.cross_section,
                     cross_section2=cross_section2,
                     **kwargs,
                 )
-            )
             taper_ref = c << _taper
             taper_ref.connect(taper_ref.ports[taper_port_name1].name, port)
             c.add_port(name=port_name, port=taper_ref.ports[taper_port_name2])

--- a/gdsfactory/components/taper_cross_section.py
+++ b/gdsfactory/components/taper_cross_section.py
@@ -90,7 +90,7 @@ taper_sc_nc_sine = partial(
     npoints=101,
     cross_section1="xs_nc_sc_tip",
     cross_section2="xs_sc_nc_tip",
-)  # FIXME
+)
 
 if __name__ == "__main__":
     # x1 = partial(strip, width=0.5)

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -565,13 +565,20 @@ strip_rib_tip = partial(
     strip,
     sections=(Section(width=0.2, layer="SLAB90", name="slab"),),
 )
+# fix under hre
 strip_nitride_tip = partial(
     nitride,
-    sections=(Section(width=0.2, layer="WGN", name="tip_nitride"),),
+    sections=(
+        Section(width=0.2, layer="WGN", name="tip_nitride"),
+        Section(width=0.1, layer="WG", name="tip_silicon"),
+    ),
 )
 strip_nitride_silicon_tip = partial(
     strip,
-    sections=(Section(width=0.2, layer="WG", name="tip_silicon"),),
+    sections=(
+        Section(width=0.1, layer="WGN", name="tip_nitride"),
+        Section(width=0.2, layer="WG", name="tip_silicon"),
+    ),
 )
 strip_sc_tip = partial(
     nitride,

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -610,7 +610,7 @@ def transition(
     """Returns a smoothly-transitioning between two CrossSections.
 
     Only cross-sectional elements that have the `name` (as in X.add(..., name = 'wg') )
-    parameter specified in both input CrosSections will be created.
+    parameter specified in both input CrossSections will be created.
     Port names will be cloned from the input CrossSections in reverse.
 
     Args:


### PR DESCRIPTION
Also fixes a `fixme` example in the file. The example CrossSections did not share any Sections.

Closes #2329 