### PR TITLE
 avoid zero length polygons

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1127,7 +1127,8 @@ class Component(_GeometryHelper):
             if hasattr(points, "properties"):
                 polygon.properties = deepcopy(points.properties)
 
-            self._add_polygons(polygon)
+            if polygon.area() > 0:
+                self._add_polygons(polygon)
             return polygon
 
         elif hasattr(points, "geoms"):
@@ -1151,11 +1152,18 @@ class Component(_GeometryHelper):
             points = snap.snap_to_grid(points) if snap_to_grid else points
             layer, datatype = _parse_layer(layer)
             polygon = Polygon(points, (layer, datatype))
-            self._add_polygons(polygon)
+            if polygon.area() > 0:
+                self._add_polygons(polygon)
             return polygon
         elif points.ndim == 3:
             layer, datatype = _parse_layer(layer)
-            polygons = [Polygon(ppoints, (layer, datatype)) for ppoints in points]
+
+            polygons = []
+            for polygon_points in points:
+                polygon = Polygon(polygon_points, (layer, datatype))
+                if polygon.area() > 0:
+                    polygons.append(polygon)
+
             self._add_polygons(*polygons)
             return polygons
         else:
@@ -1186,7 +1194,8 @@ class Component(_GeometryHelper):
             datatype=datatype,
         )
         for polygon in polygons:
-            self._add_polygons(polygon)
+            if polygon.area() > 0:
+                self._add_polygons(polygon)
         return polygon
 
     def _add_polygons(self, *polygons: list[Polygon]) -> None:

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -2423,6 +2423,6 @@ if __name__ == "__main__":
     # c = p.extrude(xs)
     # c = gf.c.straight(cross_section=xs)
     # xs = pn(slab_inset=0.2)
-    xs = xs_sc.copy(width=1)
+    xs = pn(width_slab=0)
     c = gf.c.straight(cross_section=xs)
     c.show()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -89,5 +89,13 @@ def test_import_gds_settings() -> None:
     assert c3
 
 
+def test_avoid_zero_area_polygons() -> None:
+    c = gf.Component("pads")
+    xs = gf.cross_section.pn(width_slab=0)
+    c = gf.c.straight(cross_section=xs)
+    assert c.get_polygons(by_spec=True)[(3, 0)] == []
+
+
 if __name__ == "__main__":
-    test_extract()
+    # test_extract()
+    test_avoid_zero_area_polygons()


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/2355

Component.add_polygon does not create zero area boundaries

