### PR TITLE
Fixes show_subports not showing top-level Component ports

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1767,7 +1767,7 @@ class Component(_GeometryHelper):
         )
 
         if show_subports:
-            component = self.copy()
+            component = component.copy()
             for reference in component.references:
                 if isinstance(component, ComponentReference):
                     add_pins_triangle(


### PR DESCRIPTION
When calling `Component.show(show_ports=True, show_subports=True)`, top-level ports are not drawn. This is because we're adding the top-level port markers to `component` but are ignoring that for the `show_subports=True` case and making a new copy of the `Component`.