### PR TITLE
Improve type annotations for gf.cell

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -70,7 +70,8 @@ class Settings(BaseModel):
 
 # Type signature when calling as a decorator on a function
 @overload
-def cell(func: _F) -> _F: ...
+def cell(func: _F) -> _F:
+    ...
 
 
 # Type signature when calling the decorator itself (i.e., decorator factory)
@@ -89,8 +90,9 @@ def cell(
     default_decorator: Callable[[Component], Component] | None = None,
     add_settings: bool = True,
     validate: bool = False,
-    get_child_name: bool = False
-) -> Callable[[_F], _F]: ...
+    get_child_name: bool = False,
+) -> Callable[[_F], _F]:
+    ...
 
 
 def cell(


### PR DESCRIPTION
The recent changes to `gf.cell` included nailing down the return type of `cell` to be `Callable[[_F], _F]`, which isn't correct, since it can return either that or a `Component`. To fix this, I've added 2 new functions with the `@overload` decorator to specify the behavior when `cell` is used as a decorator factory separately from when it's used as just a decorator. 

I also wonder whether it would be useful to lock in the return type like so:
```
_F = TypeVar("_F", bound=Callable[..., Component])
```

@joamatab 