### PR TITLE
Use layer tuple instead of section name for _default sections

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -973,7 +973,9 @@ def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
 
     named_sections = {}
     for section in sections:
-        name = section.name or get_layer(section.layer)
+        name = section.name
+        if name is None or name == "_default":
+            name = get_layer(section.layer)
         if name in named_sections:
             raise ValueError(
                 f"Duplicate name or layer '{name}' of section used for cross-section in transition. Cross-sections with multiple Sections for a single layer must have unique names for each section"


### PR DESCRIPTION
When extruding a transition, the `_get_named_sections` function will return `name="_default"` for default sections. This PR ignores the name if it's `"_default"`