### PR TITLE
No straight factory to metal heater meander

### DIFF
--- a/gdsfactory/components/straight_heater_meander.py
+++ b/gdsfactory/components/straight_heater_meander.py
@@ -172,7 +172,7 @@ def straight_heater_meander(
             gf.cross_section.cross_section, width=heater_width, layer=layer_heater
         )
 
-        heater = c << straight(
+        heater = c << gf.c.straight(
             length=straight_length,
             cross_section=heater_cross_section,
         )


### PR DESCRIPTION
Fixes an oversight in https://github.com/gdsfactory/gdsfactory/pull/2378 where a layer heater used the same straight factory as the photonic part.