### PR TITLE
Fix access to references in component_sequence

### DIFF
--- a/gdsfactory/components/component_sequence.py
+++ b/gdsfactory/components/component_sequence.py
@@ -188,7 +188,9 @@ def component_sequence(
 
     # Add any extra port specified in ports_map
     for name, (alias, alias_port_name) in ports_map.items():
-        component.add_port(name=name, port=component[alias].ports[alias_port_name])
+        component.add_port(
+            name=name, port=component.named_references[alias].ports[alias_port_name]
+        )
 
     return component
 


### PR DESCRIPTION
Correctly access the component references in `component_sequence`. 

As it is written before the PR, with `component.add_port(name=name, port=component[alias].ports[alias_port_name])` instead of accessing the subcomponent we are trying to find a port with the name `alias` which does not make sense.