### PR TITLE
Fix 1nm gaps in manhattan routes due to snapping issues

### DIFF
--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -203,6 +203,7 @@ def transformed(ref: ComponentReference):
     c.add(copy_reference(ref))
     c = c.flatten()
     c.copy_child_info(ref.ref_cell)
+    c.add_ports(ref.ports)
     c.info["transformed_cell"] = ref.ref_cell.name
     return c
 

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -203,7 +203,6 @@ def transformed(ref: ComponentReference):
     c.add(copy_reference(ref))
     c = c.flatten()
     c.copy_child_info(ref.ref_cell)
-    c.add_ports(ref.ports)
     c.info["transformed_cell"] = ref.ref_cell.name
     return c
 

--- a/gdsfactory/routing/manhattan.py
+++ b/gdsfactory/routing/manhattan.py
@@ -699,6 +699,7 @@ def round_corners(
     # Remove any flat angle, otherwise the algorithm won't work
     points = remove_flat_angles(points)
     points = np.array(points)
+    points = np.round(points, 3)
 
     straight_sections = []  # (p0, angle, length)
     p0_straight = points[0]

--- a/test-data-regression/test_settings_add_grating_couplers_fiber_array_.yml
+++ b/test-data-regression/test_settings_add_grating_couplers_fiber_array_.yml
@@ -78,7 +78,7 @@ settings:
     with_loopback: false
   function_name: add_grating_couplers_with_loopback_fiber_array
   info:
-    length: 19999.999
+    length: 20000.009
     polarization: te
     wavelength: 1.53
   info_version: 2

--- a/test-data-regression/test_settings_spiral_inner_io_fiber_array_.yml
+++ b/test-data-regression/test_settings_spiral_inner_io_fiber_array_.yml
@@ -101,7 +101,7 @@ settings:
     y_straight_inner_top: 50.0
   function_name: spiral_inner_io_fiber_array
   info:
-    length: 19999.999
+    length: 20000.009
     polarization: te
     wavelength: 1.53
   info_version: 2

--- a/tests/test_get_netlist.py
+++ b/tests/test_get_netlist.py
@@ -269,8 +269,7 @@ def test_get_netlist_electrical_different_widths() -> None:
 
 def test_get_netlist_transformed() -> None:
     rotation_value = 35
-    cname = "test_get_netlist_transformed"
-    c = gf.Component(cname)
+    c = gf.Component()
     i1 = c.add_ref(gf.components.straight(), "i1")
     i2 = c.add_ref(gf.components.straight(), "i2")
     i1.rotate(rotation_value)
@@ -282,12 +281,13 @@ def test_get_netlist_transformed() -> None:
     # perform the initial sanity checks on the netlist
     netlist = c.get_netlist()
     connections = netlist["connections"]
-    assert len(connections) == 1
+    assert len(connections) == 1, len(connections)
     cpairs = list(connections.items())
     extracted_port_pair = set(cpairs[0])
     expected_port_pair = {"i2,o2", "i1,o1"}
     assert extracted_port_pair == expected_port_pair
 
+    cname = c.name
     recursive_netlist = get_netlist_recursive(c)
     top_netlist = recursive_netlist[cname]
     # the recursive netlist should have 3 entries, for the top level and two rotated straights
@@ -306,21 +306,4 @@ def test_get_netlist_transformed() -> None:
 
 
 if __name__ == "__main__":
-    # c = gf.c.array()
-    # n = c.get_netlist()
-    # print(len(n.keys()))
-    # c = test_get_netlist_cell_array()
-    # c = test_get_netlist_cell_array_connecting()
-    # c = test_get_netlist_simple()
-    # c = test_get_netlist_promoted()
-    # c = test_get_netlist_close_enough()
-    # c = test_get_netlist_close_enough_orthogonal()
-    # c = test_get_netlist_close_enough_fails()
-    # c = test_get_netlist_close_enough_orthogonal_fails()
-    # c = test_get_netlist_close_enough_both()
-    # c = test_get_netlist_close_enough_rotated()
-    # c = test_get_netlist_throws_error_bad_rotation()
-    # c = test_get_netlist_tiny()
-    # c = test_get_netlist_metal()
-    c = test_get_netlist_electrical_different_widths()
-    c.show()
+    test_get_netlist_transformed()


### PR DESCRIPTION
snap manhattan routes to 1nm to avoid 1nm gaps


@mdecea
@HelgeGehring  
@sebastian-goeldi 
@tvt173 