### PR TITLE
Raise warning on empty add marker layer instead of failing

### DIFF
--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -20,6 +20,7 @@ from gdsfactory import ComponentReference
 from gdsfactory.cell import cell_with_child
 from gdsfactory.components.straight import straight
 from gdsfactory.components.text_rectangular import text_rectangular_multi_layer
+from gdsfactory.config import logger
 from gdsfactory.port import auto_rename_ports
 from gdsfactory.typings import (
     Anchor,
@@ -290,15 +291,21 @@ def add_marker_layer(
         c = component
     polygon = c.get_polygons(as_shapely_merged=True)
 
-    component.add_polygon(polygon, layer=marker_layer)
-    if marker_label:
-        component.add_label(
-            marker_label,
-            position=(
-                (point := polygon.representative_point()).x,
-                point.y,
-            ),
-            layer=marker_layer,
+    if not polygon.is_empty:
+        component.add_polygon(polygon, layer=marker_layer)
+        if marker_label:
+            component.add_label(
+                marker_label,
+                position=(
+                    (point := polygon.representative_point()).x,
+                    point.y,
+                ),
+                layer=marker_layer,
+            )
+    else:
+        logger.warning(
+            f"Could not add marker layer {marker_layer} to {component.name} because it is empty."
+            f"Supplied {layers_to_mark=!r}."
         )
     return component.flatten() if flatten else component
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from gdsfactory.config import PATH
+from gdsfactory.config import PATH, logger
 
 
 @pytest.fixture(scope="session")
@@ -13,3 +13,11 @@ def datadir() -> pathlib.Path:
 @pytest.fixture(scope="session")
 def original_datadir() -> pathlib.Path:
     return PATH.repo / "test-data-regression"
+
+
+@pytest.fixture
+def caplog(caplog):
+    """Support `loguru` logger in pytest caplog fixture. See https://github.com/Delgan/loguru/issues/59."""
+    handler_id = logger.add(caplog.handler, format="{message}")
+    yield caplog
+    logger.remove(handler_id)

--- a/tests/test_add_marker_layer.py
+++ b/tests/test_add_marker_layer.py
@@ -9,11 +9,20 @@ from gdsfactory.typings import Component
 RANDOM_MARKER_LAYER = (111, 111)
 RANDOM_MARKER_LABEL = "TEST_LABEL"
 
+TEST_COMPONENT_LAYER_A = (1, 0)
+TEST_COMPONENT_LAYER_B = (2, 0)
+
 
 @gf.cell
 def component(width=10, height=20) -> Component:
     c = gf.Component()
-    c.add_polygon([(0, 0), (width, 0), (width, height), (0, height)], layer=(1, 0))
+    c.add_polygon(
+        [(0, 0), (width, 0), (width, height), (0, height)], layer=TEST_COMPONENT_LAYER_A
+    )
+    c.add_polygon(
+        [(0, 0), (width, 0), (width, height / 2), (0, height / 2)],
+        layer=TEST_COMPONENT_LAYER_B,
+    )
     return c
 
 
@@ -50,6 +59,38 @@ def test_add_marker_layer_kwargs_passed() -> None:
     c = my_component(height=50)
     assert RANDOM_MARKER_LAYER in c.layers
     assert c.size[1] == 50
+
+
+def test_add_marker_layer_layers_to_mark_passed() -> None:
+    my_component = partial(
+        component,
+        decorator=partial(
+            add_marker_layer,
+            marker_layer=RANDOM_MARKER_LAYER,
+            layers_to_mark=[TEST_COMPONENT_LAYER_B],
+        ),
+    )
+
+    c = my_component()
+    assert RANDOM_MARKER_LAYER in c.layers
+    assert c.get_polygons(
+        by_spec=TEST_COMPONENT_LAYER_B, as_shapely=True
+    ) == c.get_polygons(by_spec=RANDOM_MARKER_LAYER, as_shapely=True)
+
+
+def test_add_marker_layer_layers_to_mark_does_not_exist(caplog) -> None:
+    my_component = partial(
+        component,
+        decorator=partial(
+            add_marker_layer,
+            marker_layer=RANDOM_MARKER_LAYER,
+            layers_to_mark=[(999, 999)],
+        ),
+    )
+
+    c = my_component()
+    assert "Could not add marker layer" in caplog.text
+    assert RANDOM_MARKER_LAYER not in c.layers
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Allow selecting empty layers in `add_marker_layer` but log warning.
* Support capturing loguru output in pytests

Closes #2405