### PR TITLE
fix cicd docker flow

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,5 +1,5 @@
-FROM jupyter/base-notebook:python-3.10
-# FROM jupyter/base-notebook
+FROM python:3.11-slim
+# FROM jupyter/base-notebook:python-3.10
 # FROM continuumio/miniconda3
 
 # expose klive and Jupyter Notebook ports

--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -38,6 +38,6 @@ RUN mamba install gdspy gdstk pymeep=*=mpi_mpich_* -y && \
     mamba install -c conda-forge slepc4py=*=complex* -y
 
 
-RUN pip install gdsfactory[cad,full]
+RUN pip install gdsfactory[cad,full]==7.9.2
 WORKDIR /home/jovyan
 # VOLUME /home/jovyan/work

--- a/.devcontainer/Dockerfile.dev_minimal
+++ b/.devcontainer/Dockerfile.dev_minimal
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 RUN apt update
 RUN pip install gdsfactory==7.9.2 klayout

--- a/.devcontainer/Dockerfile.dev_minimal
+++ b/.devcontainer/Dockerfile.dev_minimal
@@ -1,4 +1,4 @@
 FROM python:3.10-slim
 
 RUN apt update
-RUN pip install gdsfactory klayout
+RUN pip install gdsfactory==7.9.2 klayout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
 
   release_docker:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: release_pypi
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,12 @@ cmd = "grep -q -F {new_version} CHANGELOG.md"
 name = "create & check changelog"
 
 [[tool.tbump.file]]
+src = ".devcontainer/Dockerfile.dev"
+
+[[tool.tbump.file]]
+src = ".devcontainer/Dockerfile.dev_minimal"
+
+[[tool.tbump.file]]
 src = "README.md"
 
 [[tool.tbump.file]]


### PR DESCRIPTION
towards a reproduceable docker container environment

- pin version of gdsfactory for each docker release
- ensure docker build starts after PyPi 
- switch from jupyterhub image to python-slim

@jan-david-fischbach 
@HelgeGehring 
@yaugenst 
@nikosavola 
@tvt173 
@sebastian-goeldi 