### PR TITLE
expose mirror_straight in spiral_external_io

### DIFF
--- a/gdsfactory/components/spiral_external_io.py
+++ b/gdsfactory/components/spiral_external_io.py
@@ -34,6 +34,7 @@ def spiral_external_io(
     with_inner_ports: bool = False,
     y_straight_outer_offset: float = 0.0,
     inner_loop_spacing_offset: float = 0.0,
+    mirror_straight: bool = False,
     **kwargs,
 ) -> Component:
     """Returns spiral with input and output ports outside the spiral.
@@ -51,6 +52,7 @@ def spiral_external_io(
         with_inner_ports: if True, removes the internal S-bend and exposes new ports
         y_straight_outer_offset: amount to add/remove to the last points at the outer output of the spiral
         inner_loop_spacing_offset: extra difference between the inner ports
+        mirror_straight: if True, mirrors the straight cross section in round_corners (can help when xs is asymmetric)
         kwargs: cross_section settings.
     """
     if length:
@@ -142,12 +144,14 @@ def spiral_external_io(
             pts_w[1:],
             bend=bend,
             cross_section=cross_section,
+            mirror_straight=mirror_straight,
             **kwargs,
         )
         route_east = round_corners(
             pts_e[1:],
             bend=bend,
             cross_section=cross_section,
+            mirror_straight=mirror_straight,
             **kwargs,
         )
         component.add(route_west.references)

--- a/test-data-regression/test_settings_spiral_external_io_.yml
+++ b/test-data-regression/test_settings_spiral_external_io_.yml
@@ -34,6 +34,7 @@ settings:
     cross_section: xs_sc
     inner_loop_spacing_offset: 0.0
     length: null
+    mirror_straight: false
     with_inner_ports: false
     x_inner_length_cutback: 300.0
     x_inner_offset: 0.0
@@ -48,6 +49,7 @@ settings:
     cross_section: xs_sc
     inner_loop_spacing_offset: 0.0
     length: null
+    mirror_straight: false
     with_inner_ports: false
     x_inner_length_cutback: 300.0
     x_inner_offset: 0.0


### PR DESCRIPTION
cannot use kwargs because they are also passed to bend, which does not have mirror_straight as an argument, causing errors