### PR TITLE
Recommend pip instead of conda for installation

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -2,14 +2,13 @@
 
 We support Python 3.10 or 3.11, and recommend [VSCode](https://code.visualstudio.com/) IDE. If you do not have Python installed, you can [download Anaconda](https://www.anaconda.com/download/).
 
-Upon Python installation, open Anaconda Prompt as Administrator and install the latest gdsfactory (from the conda-forge channel) and Optional `cad` visualization extras using pip.
+Upon Python installation, open Anaconda Prompt as Administrator and install the latest gdsfactory
 
 ![anaconda prompt](https://i.imgur.com/eKk2bbs.png)
 
 
 ```
-conda install -c conda-forge gdstk -y
-pip install "gdsfactory[cad]"--upgrade
+pip install gdsfactory --upgrade
 ```
 
 ## Update gdsfactory
@@ -17,7 +16,7 @@ pip install "gdsfactory[cad]"--upgrade
 You can upgrade gdsfactory using the following command:
 
 ```
-pip install gdsfactory[cad] --upgrade
+pip install gdsfactory --upgrade
 ```
 
 Please note that some PDKs may only work for a specific version of gdsfactory. Ensure you install the correct gdsfactory version specified in the pyproject.toml file. This will automatically happen when you install gdsfactory as one of the PDK dependencies. For example, pip install gf180 will install the latest gdsfactory version tested for the GlobalFoundries180 PDK.
@@ -61,7 +60,6 @@ The following lines will:
 git clone git@github.com:YourUserName/gdsfactory.git
 cd gdsfactory
 git clone https://github.com/gdsfactory/gdsfactory-test-data.git -b test-data test-data
-conda install -c conda-forge gdstk -y
 pip install -e .[cad,dev]
 pre-commit install
 ```

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1619,13 +1619,14 @@ class Component(_GeometryHelper):
             return fig
 
         except ImportError:
-            print(
-                "You can install `pip install 'gdsfactory[cad]'` for better visualization"
-            )
             component.plot(plotter="matplotlib")
 
     def plot_kweb(self):
         """Shows current gds in kweb."""
+        warnings.warn(
+            "Component.plot_kweb() is deprecated and will be removed in future versions of gdsfactory. "
+            "Use Component.plot() instead"
+        )
 
         try:
             import kweb.server_jupyter as kj
@@ -1693,6 +1694,11 @@ class Component(_GeometryHelper):
             min_aspect: minimum aspect ratio.
         """
         from gdsfactory.quickplotter import quickplot
+
+        warnings.warn(
+            "Component.plot_matplotlib() is deprecated and will be removed in future versions of gdsfactory. "
+            "Use Component.plot() instead"
+        )
 
         quickplot(self, **kwargs)
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1620,7 +1620,7 @@ class Component(_GeometryHelper):
 
         except ImportError:
             print(
-                "You can install `pip install gdsfactory[cad]` for better visualization"
+                "You can install `pip install 'gdsfactory[cad]'` for better visualization"
             )
             component.plot(plotter="matplotlib")
 
@@ -1630,7 +1630,7 @@ class Component(_GeometryHelper):
         try:
             import kweb.server_jupyter as kj
         except Exception:
-            print("You need to install kweb with `pip install gdsfactory[cad]`")
+            print("You need to install kweb with `pip install 'gdsfactory[cad]'`")
             return self.plot_klayout()
 
         from html import escape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 dependencies = [
   "flatdict",
-  "gdstk<0.10",
+  "gdstk>=0.9.49,<0.10",
   "jinja2<4",
   "loguru<1",
   "matplotlib<4",
@@ -33,7 +33,20 @@ dependencies = [
   "toolz<1",
   "types-PyYAML",
   "typer<1",
-  "watchdog<4"
+  "watchdog<4",
+  "kfactory[git,ipy]>=0.9.1,<0.11",
+  "freetype-py",
+  "mapbox_earcut",
+  "networkx",
+  "pyglet<2",
+  "scikit-image",
+  "trimesh>=4,<4.1",
+  "ipycytoscape",
+  "ipyevents",
+  "ipykernel",
+  "ipympl",
+  "ipytree",
+  "ipywidgets"
 ]
 description = "python library to generate GDS layouts"
 keywords = ["eda", "photonics", "python"]
@@ -45,21 +58,7 @@ version = "7.10.0"
 
 [project.optional-dependencies]
 cad = [
-  "freetype-py",
-  "ipycytoscape",
-  "ipyevents",
-  "ipykernel",
-  "ipympl",
-  "ipytree",
-  "ipywidgets",
-  "jupytext",
-  "kweb>=1.1.9,<1.3",
-  "kfactory[git,ipy]>=0.9.1,<0.11",
-  "mapbox_earcut",
-  "networkx",
-  "pyglet<2",
-  "scikit-image",
-  "trimesh"
+  "kweb>=1.1.9,<1.3"
 ]
 dev = [
   "ipykernel",


### PR DESCRIPTION
- Recommend pip instead of conda for installation
- deprecate plot_kweb and plot_matplotlib
- move most dependencies from `pip install gdsfactory[cad]` into `pip install gdsfactory`