### PR TITLE
replace multiple invalid transformations warnings by a single one

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1958,6 +1958,7 @@ class Component(_GeometryHelper):
         self,
         gdspath: PathType | None = None,
         gdsdir: PathType | None = None,
+        check_invalid_transformations: bool = True,
         **kwargs,
     ) -> Path:
         """Write component to GDS and returns gdspath.
@@ -1982,6 +1983,13 @@ class Component(_GeometryHelper):
             with_netlist: writes a netlist in JSON format.
             netlist_function: function to generate the netlist.
         """
+        from gdsfactory.decorators import has_valid_transformations
+
+        if check_invalid_transformations and not has_valid_transformations(self):
+            warnings.warn(
+                f"Component {self.name} has invalid transformations. "
+                "Try component.flatten_invalid_refs() first."
+            )
 
         return self._write_library(
             gdspath=gdspath, gdsdir=gdsdir, with_oasis=False, **kwargs

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -245,10 +245,10 @@ class Settings(BaseSettings):
     difftest_ignore_label_differences: bool = False
     layer_error_path: tuple[int, int] = (1000, 0)
     ports_off_grid: Literal["warn", "error", "ignore"] = Field(
-        default="warn", description="Ensures ports are on grid."
+        default="ignore", description="Ensures ports are on grid."
     )
     ports_not_manhattan: Literal["warn", "error", "ignore"] = Field(
-        default="warn", description="Ensures ports are manhattan."
+        default="ignore", description="Ensures ports are manhattan."
     )
     enforce_ports_on_grid: bool = True
     bend_radius_error_type: ErrorType = ErrorType.WARNING

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -50,8 +50,8 @@ def clean_value_json(
     if isinstance(value, pydantic.BaseModel):
         return clean_dict(value.model_dump())
 
-    elif fast_serialization and hasattr(value, "name"):
-        return value.name
+    elif fast_serialization and hasattr(value, "hash_geometry"):
+        return value.hash_geometry()
 
     elif hasattr(value, "get_component_spec"):
         return value.get_component_spec()

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -50,8 +50,8 @@ def clean_value_json(
     if isinstance(value, pydantic.BaseModel):
         return clean_dict(value.model_dump())
 
-    elif fast_serialization and hasattr(value, "hash_geometry"):
-        return value.hash_geometry()
+    elif fast_serialization and hasattr(value, "name"):
+        return value.name
 
     elif hasattr(value, "get_component_spec"):
         return value.get_component_spec()

--- a/tests/test_cell_warnings.py
+++ b/tests/test_cell_warnings.py
@@ -15,9 +15,9 @@ def non_manhattan_component() -> gf.Component:
     return gf.path.extrude(p, xs)
 
 
-def test_non_manhattan_warn() -> None:
-    with pytest.warns(UserWarning):
-        assert non_manhattan_component()
+# def test_non_manhattan_warn() -> None:
+#     with pytest.warns(UserWarning):
+#         assert non_manhattan_component()
 
 
 @pytest.mark.skip("TODO: fix this test")


### PR DESCRIPTION
Avoids being overwhelmed by many off-grid or non manhattan ports that can bury other messages

Instead issues a single warning on `write_gds` and suggest a fix for it. [See](https://gdsfactory.github.io/gdsfactory/notebooks/04_routing_non_manhattan.html)

- ignore non manhattan port warnings
- issue one warning when saving a component that has invalid transformations and suggest a fix for it


@nikosavola 
@yaugenst 
@mdecea 
@HelgeGehring 
@tvt173 