### PR TITLE
Add __contains__ method to Info

### DIFF
--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -82,6 +82,9 @@ class Info(BaseModel, extra="allow", validate_assignment=True):
         if __val is not None:
             setattr(self, __key, __val)
 
+    def __contains__(self, __key: str) -> bool:
+        return hasattr(self, __key)
+
     def get(self, __key: str, default: Any | None = None) -> Any:
         return getattr(self, __key) if hasattr(self, __key) else default
 


### PR DESCRIPTION
This enables checking for entries in `Info` via `"entry" in c.info`, which used to work when `component.info` was still a `dict`. There is a bunch of old code that relies on this behavior, so we should continue to support it.