### PR TITLE
Add additional reasonable default lumerical mappings

### DIFF
--- a/gdsfactory/generic_tech/simulation_settings.py
+++ b/gdsfactory/generic_tech/simulation_settings.py
@@ -14,6 +14,9 @@ material_name_to_lumerical_default = {
     "si": "Si (Silicon) - Palik",
     "sio2": "SiO2 (Glass) - Palik",
     "sin": "Si3N4 (Silicon Nitride) - Phillip",
+    "tungsten": "W (tungsten) - Palik",
+    "cu": "Cu (copper) - CRC",
+    "air": "Air",
 }
 
 


### PR DESCRIPTION
These are used for metals/vias in gf45 (and I assume other processes), and seem like reasonable defaults. Upstreaming because it's kind of weird to have to manually set these