### PR TITLE
Component reduce

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -51,7 +51,6 @@ from gdsfactory.port import (
     map_ports_to_orientation_cw,
     select_ports,
 )
-from gdsfactory.read import import_gds
 from gdsfactory.serialization import clean_dict
 from gdsfactory.snap import snap_to_grid
 
@@ -2613,6 +2612,8 @@ def serialize_gds(component):
 
 def deserialize_gds(gds_filepath):
     """Loads Component as GDS + YAML metadata from temporary files, and deletes them."""
+    from gdsfactory.read import import_gds
+
     c = import_gds(gds_filepath, read_metadata=True)
     metadata_filepath = gds_filepath.with_suffix(".yml")
     metadata_filepath.unlink()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
         Layers,
         LayerSpec,
         PathType,
+        Tuple,
     )
 
 valid_plotters = ["matplotlib", "klayout", "kweb"]
@@ -2602,7 +2603,7 @@ class Component(_GeometryHelper):
 
 
 # Component functions
-def serialize_gds(component):
+def serialize_gds(component: Component) -> Tuple[PathType]:
     """Saves Component as GDS + YAML metadata in temporary files with unique name."""
     gds_filepath = GDSDIR_TEMP / component.name
     gds_filepath = gds_filepath.with_suffix(".gds")
@@ -2610,7 +2611,7 @@ def serialize_gds(component):
     return (gds_filepath,)
 
 
-def deserialize_gds(gds_filepath):
+def deserialize_gds(gds_filepath: PathType) -> Component:
     """Loads Component as GDS + YAML metadata from temporary files, and deletes them."""
     from gdsfactory.read import import_gds
 

--- a/tests/test_component_pickle.py
+++ b/tests/test_component_pickle.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import pickle
+
+import gdsfactory as gf
+
+
+def ports_are_equal(port1, port2) -> bool:
+    return (
+        port1.x == port2.x
+        and port1.y == port2.y
+        and port1.width == port2.width
+        and port1.orientation == port2.orientation
+        and port1.layer == port2.layer
+    )
+
+
+def components_are_equal(component1, component2) -> bool:
+    # Compare the basic metadata
+    if component1.name != component2.name or component1.settings != component2.settings:
+        return False
+
+    # Compare the ports
+    if set(component1.ports.keys()) != set(component2.ports.keys()):
+        return False
+    for port_name in component1.ports:
+        if not ports_are_equal(
+            component1.ports[port_name], component2.ports[port_name]
+        ):
+            return False
+
+    # Compare the polygons
+    polygons1 = component1.get_polygons(by_spec=True)
+    polygons2 = component2.get_polygons(by_spec=True)
+    if set(polygons1.keys()) != set(polygons2.keys()):
+        return False
+    for spec in polygons1.keys():
+        if not all(
+            (p1 == p2).all() for p1, p2 in zip(polygons1[spec], polygons2[spec])
+        ):
+            return False
+
+    # If all checks passed, the components are considered equal
+    return True
+
+
+# Usage in your test
+def test_component_pickle() -> None:
+    c1 = gf.components.straight()
+    with open("test.pkl", "wb") as f:
+        pickle.dump(c1, f)
+    with open("test.pkl", "rb") as f:
+        c2 = pickle.load(f)
+    os.remove("test.pkl")
+
+    assert components_are_equal(
+        c1, c2
+    ), "The components are not equal after pickling and unpickling."
+
+
+if __name__ == "__main__":
+    test_component_pickle()


### PR DESCRIPTION
Override the "reduce" built-in method in Component to allow pickling. This is useful when integrating gdsfactory/gplugins with libraries that use pickling to move data around

@joamatab I'm not sure about this one because there's a lot going with the caching/serialization in gdsfactory. I tried using json and yaml serialization, but it didn't work as well as gds + metadata like I do now.

I don't really care how it's done, I just want to fix the "gdstk.Cell not serializable" errors we get when we try to pickle Components, and I just want a component similar in structure to be returned (I don't really care about unique IDs and such since this is for simulation, not layout)