### PR TITLE
Add possibility of adding label when adding fiber array

### DIFF
--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -124,6 +124,12 @@ Anchor = Literal[
     "center",
     "cc",
 ]
+AnchorSubset = Literal[
+    "center",
+    "l",
+    "r",
+    "s",
+]
 Axis = Literal["x", "y"]
 NSEW = Literal["N", "S", "E", "W"]
 


### PR DESCRIPTION
I added the possibility of adding a text to a structure when adding a fiber array. I believe this functionality is useful, since this way one can add an identifier to a test structure when adding fiber arrays. Doing it this way allows to place the labels with respect to the grating couplers, which is likely the safest placement so as to not interact with the component itself.

You can choose to place the label in different positions:

`add_fiber_array(c, dev_id='abc', text=text_m3, id_placement="l")` will place the label at the left of the grating coupler array:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/4f017974-991e-43f5-9cce-e38c3a61151f)

`add_fiber_array(c, dev_id='abc', text=text_m3, id_placement="r")` will place the label at the right of the grating coupler array:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/8fa219f3-1754-4d33-bc1b-c328ad4cf482)

`add_fiber_array(c, dev_id='abc', text=text_m3, id_placement="center")` will place the label at the center of the grating coupler array:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/6b0b82c5-8bc9-4022-8d96-aef1c15a3389)

`add_fiber_array(c, dev_id='abc', text=text_m3, id_placement="s")` will place the label at the center of the grating coupler array but below the array:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/9b9a5a66-c90b-424e-82f7-821343523ce7)

By default no text is added.
