### PR TITLE
Fix all-angle routing and off-grid placements

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1131,7 +1131,7 @@ class Component(_GeometryHelper):
         self,
         points,
         layer: str | int | tuple[int, int] | np.nan = np.nan,
-        snap_to_grid: bool = True,
+        snap_to_grid: bool = False,
     ) -> Polygon:
         """Adds a Polygon to the Component.
 

--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -19,7 +19,6 @@ from rich.console import Console
 from rich.table import Table
 
 from gdsfactory.serialization import clean_value_json
-from gdsfactory.snap import snap_to_grid
 
 if TYPE_CHECKING:
     from gdsfactory.port import Port
@@ -528,7 +527,7 @@ class Group(_GeometryHelper):
             axis : {'x', 'y'}
                 Direction of the move.
         """
-        destination = snap_to_grid(destination)
+        # destination = snap_to_grid(destination)
         for e in self.elements:
             e.move(origin=origin, destination=destination, axis=axis)
         return self

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -900,7 +900,7 @@ def extrude(
 
         # Join points together
         points_poly = np.concatenate([points1, points2[::-1, :]])
-        points_poly = np.round(points_poly, 3)
+        # points_poly = np.round(points_poly, 3)
 
         layers = layer if hidden else [layer, layer]
         if not hidden and p_sec.length() > 1e-3:


### PR DESCRIPTION
In recent commits, snapping to points and polygons was added which breaks all-angle routing and off-grid placements. These three edits must be made in order for it to work again. However, I recognize that these changes were probably added for a reason. Maybe the behavior should be toggled based on a setting in the config?  We already have an `enforce_ports_on_grid` setting, but maybe that should be generalized to something like `allow_offgrid`? 