### PR TITLE
Make CrossSection hashable

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -239,6 +239,12 @@ class CrossSection(BaseModel):
         else:
             raise KeyError(f"{key} not in {list(key_to_section.keys())}")
 
+    def __hash__(self) -> int:
+        # self.info is not hashable. Converting to hashable here.
+        _model_attributes = self.model_dump()
+        _model_attributes["info"] = frozenset(_model_attributes.pop("info"))
+        return hash(self.__class__) + hash(frozenset(_model_attributes))
+
     def copy(
         self,
         width: float | None = None,


### PR DESCRIPTION
I needed to use a `CrossSection` object as the key of a dictionary, but it wasn't hashable. This solved it for me.