### PR TITLE
Add context manager methods to Pdk

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -719,6 +719,16 @@ class Pdk(BaseModel):
                 "Check the error for missing property"
             ) from e
 
+    def __enter__(self) -> Pdk:
+        """Called when entering the Pdk context manager."""
+        self.activate()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Called when exiting the Pdk context manager."""
+        global _ACTIVE_PDK
+        _ACTIVE_PDK = None
+
 
 _ACTIVE_PDK = None
 


### PR DESCRIPTION
First pass at making the `Pdk` class work as a context manager so we can write code like this:
```
from pdk_source import PDK
with PDK as pdk:
   ...
```
This will add another way to manage the activation/deactivation of the PDK.