### PR TITLE
Section ports

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -914,7 +914,7 @@ def extrude(
         if port_names[0] is not None:
             port_width = width if np.isscalar(width) else width[0]
             port_orientation = (p_sec.start_angle + 180) % 360
-            center = points[0]
+            center = np.average([points1[0], points2[0]], axis=0)
             face = [points1[0], points2[0]]
             face = [_rotated_delta(point, center, port_orientation) for point in face]
 
@@ -935,7 +935,7 @@ def extrude(
         if port_names[1] is not None:
             port_width = width if np.isscalar(width) else width[-1]
             port_orientation = (p_sec.end_angle) % 360
-            center = points[-1]
+            center = np.average([points1[-1], points2[-1]], axis=0)
             face = [points1[-1], points2[-1]]
             face = [_rotated_delta(point, center, port_orientation) for point in face]
 

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -123,6 +123,21 @@ def test_diagonal_extrude_consistent_naming() -> None:
     assert c.name == expected_name, c.name
 
 
+def test_extrude_port_centers() -> None:
+    """Tests whether the ports created from CrossSections with multiple Sections are offset properly. Does not test the shear angle case."""
+    s1_offset = 1
+    s0 = gf.Section(layer="WG", width=0.5, offset=0, port_names=("o1", "o2"))
+    s1 = gf.Section(layer="M1", width=0.5, offset=s1_offset, port_names=("e1", "e2"))
+    xs = gf.CrossSection(sections=(s0, s1))
+    s = gf.components.straight(cross_section=xs)
+
+    assert s.ports["e1"].center[0] == s.ports["o1"].center[0]
+    assert s.ports["e1"].center[1] == s.ports["o1"].center[1] - s1_offset
+
+    assert s.ports["e2"].center[0] == s.ports["o2"].center[0]
+    assert s.ports["e2"].center[1] == s.ports["o2"].center[1] - s1_offset
+
+
 if __name__ == "__main__":
     test_diagonal_extrude_consistent_naming()
     # test_transition_cross_section()


### PR DESCRIPTION
When extruding a `CrossSection` which has `Ports` defined on more than just the central `Section`, the `Section`'s offset is not taken into account and all of the `Ports` end up in the same location. This PR fixes this and properly accounts for the `Section` offset when creating a `Port` for it.

Example code:
```
import gdsfactory as gf

s1_offset = 1
s0 = gf.Section(
    layer="WG",
    width=0.5,
    offset=0,
    port_names=("o1", "o2")
)
s1 = gf.Section(
    layer="M1",
    width=0.5,
    offset=s1_offset,
    port_names=("e1", "e2"),
)
xs = gf.CrossSection(sections=(s0, s1))
s = gf.components.bend_s(cross_section=xs)
s.show(show_ports=True)
```
Here, the ports are all placed in the same location:
<img width="1543" alt="image" src="https://github.com/gdsfactory/gdsfactory/assets/53101766/ac67adae-ff50-497d-ab0f-98c0f13fb5df">
And here is the result of running the same code with this fix:
<img width="1541" alt="image" src="https://github.com/gdsfactory/gdsfactory/assets/53101766/300c84f0-77ee-43a2-8e64-aa2e8ec04842">
