### PR TITLE
Handling top and bottom GC routing

### DIFF
--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -341,13 +341,30 @@ def route_fiber_array(
             ):
                 p0 = io_gratings[i].ports[gc_port_name]
                 p1 = ordered_ports[i]
-                waypoints = generate_manhattan_waypoints(
-                    input_port=p0,
-                    output_port=p1,
-                    bend=bend90,
-                    straight=straight,
-                    cross_section=cross_section,
-                )
+
+                # Differentiate between the situation where the structure ports are above or
+                # below the GC ports
+                if p0.y > p1.y:
+                    # GC is above the structure - rotuing is a bit more involved as we need to clear
+                    # the rest of GCs
+                    waypoints = generate_manhattan_waypoints(
+                        input_port=p0,
+                        output_port=p1,
+                        bend=bend90,
+                        straight=straight,
+                        cross_section=cross_section,
+                        start_straight_length=20,
+                    )
+
+                else:
+                    # GC is below structure
+                    waypoints = generate_manhattan_waypoints(
+                        input_port=p0,
+                        output_port=p1,
+                        bend=bend90,
+                        straight=straight,
+                        cross_section=cross_section,
+                    )
                 route = route_filter(
                     waypoints=waypoints,
                     bend=bend90,


### PR DESCRIPTION
Modifies `route_fiber_array` to be able to handle simple situations were there are ports at the top and bottom.

Before this PR, we would have situations like this:
![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/0c03ab9a-8a37-488d-9f94-4ab05162ef97)


With the PR, such a situation is solved (when using `optical_routing_type=0`:

![image](https://github.com/gdsfactory/gdsfactory/assets/48526366/b50d9b44-526b-4731-aa8b-33ebfa28dc52)
