### PR TITLE
Allow for different cross sections in cdsem

### DIFF
--- a/gdsfactory/components/cdsem_straight_density.py
+++ b/gdsfactory/components/cdsem_straight_density.py
@@ -8,7 +8,13 @@ from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight
 from gdsfactory.components.text_rectangular import text_rectangular
-from gdsfactory.typings import ComponentFactory, CrossSectionSpec, Floats
+from gdsfactory.typings import (
+    ComponentFactory,
+    CrossSectionSpec,
+    CrossSectionSpecs,
+    Floats,
+    Tuple,
+)
 
 text_rectangular_mini = partial(text_rectangular, size=1)
 
@@ -22,7 +28,7 @@ def cdsem_straight_density(
     gaps: Floats = gaps,
     length: float = 420.0,
     label: str = "",
-    cross_section: CrossSectionSpec = "xs_sc",
+    cross_section: CrossSectionSpec | CrossSectionSpecs = "xs_sc",
     text: ComponentFactory | None = text_rectangular_mini,
 ) -> Component:
     """Returns sweep of dense straight lines.
@@ -32,17 +38,23 @@ def cdsem_straight_density(
         gaps: list of gaps.
         length: of the lines.
         label: defaults to widths[0] gaps[0].
-        cross_section: spec.
+        cross_section: spec. Can be a list and then each line has a corresponding cross_section.
         text: optional function for text.
     """
     c = Component()
     label = label or f"{int(widths[0]*1e3)} {int(gaps[0]*1e3)}"
 
+    if isinstance(cross_section, Tuple):
+        if len(cross_section) != len(widths):
+            raise ValueError(
+                "The number of specified cross sections does not correspond to the number of widths"
+            )
+    else:
+        cross_section = [cross_section] * len(widths)
+
     ymin = 0
-    for width, gap in zip(widths, gaps):
-        tooth_ref = c << straight(
-            length=length, cross_section=cross_section, width=width
-        )
+    for width, gap, xs in zip(widths, gaps, cross_section):
+        tooth_ref = c << straight(length=length, cross_section=xs, width=width)
         tooth_ref.ymin = ymin
         ymin += width + gap
 
@@ -53,5 +65,7 @@ def cdsem_straight_density(
 
 
 if __name__ == "__main__":
-    c = cdsem_straight_density()
+    c = cdsem_straight_density(
+        widths=(0.2, 0.3), gaps=(0.1, 0.2), cross_section="xs_sc"
+    )
     c.show(show_ports=True)


### PR DESCRIPTION
Allows different cross sections in `cdsem_straight_density`

Now we can specify different cross sections for each line in the dense array