### PR TITLE
Add arg for constant pad value in read.from_np

### DIFF
--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -43,7 +43,7 @@ def from_np(
         layer: layer tuple to output gds.
         threshold: value along which to find contours in the array.
         invert: invert the mask.
-        outer_pad_value: set outer padding used by np.pad to this constant value (optional).
+        outer_pad_value: set the value of the 2 pixels of padding added to the image border by np.pad (optional).
 
     """
     from skimage import measure

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -31,7 +31,8 @@ def from_np(
     layer: tuple[int, int] = (1, 0),
     threshold: float = 0.99,
     invert: bool = True,
-    outer_pad_value: float | None = None,
+    border_pad_num_pixels: int = 2,
+    border_pad_pixel_value: float | None = None,
 ) -> Component:
     """Returns Component from a np.ndarray.
 
@@ -43,7 +44,8 @@ def from_np(
         layer: layer tuple to output gds.
         threshold: value along which to find contours in the array.
         invert: invert the mask.
-        outer_pad_value: set the value of the 2 pixels of padding added to the image border by np.pad (optional).
+        border_pad_num_pixels: number of pixels to pad image border with. A value of 2 is usually sufficient to capture contours along the image border.
+        border_pad_pixel_value: set value of padding pixels (optional). This is passed to np.pad through the 'constant_values' argument.
 
     """
     from skimage import measure
@@ -52,10 +54,10 @@ def from_np(
     d = Component()
 
     pad_kwargs = {}
-    if outer_pad_value is not None:
-        pad_kwargs = {"constant_values": outer_pad_value}
+    if border_pad_pixel_value is not None:
+        pad_kwargs = {"constant_values": border_pad_pixel_value}
 
-    ndarray = np.pad(ndarray, 2, **pad_kwargs)
+    ndarray = np.pad(ndarray, border_pad_num_pixels, **pad_kwargs)
     contours = measure.find_contours(ndarray, threshold)
     assert len(contours) > 0, (
         f"no contours found for threshold = {threshold}, maybe you can reduce the"

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -31,6 +31,7 @@ def from_np(
     layer: tuple[int, int] = (1, 0),
     threshold: float = 0.99,
     invert: bool = True,
+    outer_pad_value: float | None = None,
 ) -> Component:
     """Returns Component from a np.ndarray.
 
@@ -42,13 +43,19 @@ def from_np(
         layer: layer tuple to output gds.
         threshold: value along which to find contours in the array.
         invert: invert the mask.
+        outer_pad_value: set outer padding used by np.pad to this constant value (optional).
 
     """
     from skimage import measure
 
     c = Component()
     d = Component()
-    ndarray = np.pad(ndarray, 2)
+
+    pad_kwargs = {}
+    if outer_pad_value is not None:
+        pad_kwargs = {"constant_values": outer_pad_value}
+
+    ndarray = np.pad(ndarray, 2, **pad_kwargs)
     contours = measure.find_contours(ndarray, threshold)
     assert len(contours) > 0, (
         f"no contours found for threshold = {threshold}, maybe you can reduce the"
@@ -73,6 +80,7 @@ def from_image(
     layer: tuple[int, int] = (1, 0),
     threshold: float = 0.99,
     invert: bool = True,
+    outer_pad_value: float | None = None,
 ) -> Component:
     """Returns Component from a png image.
 
@@ -82,6 +90,7 @@ def from_image(
         layer: layer tuple to output gds.
         threshold: value along which to find contours in the array.
         invert: invert the mask. True by default.
+        outer_pad_value: set outer padding used by np.pad to this constant value (optional).
     """
     import matplotlib.pyplot as plt
 
@@ -100,6 +109,7 @@ def from_image(
         layer=layer,
         threshold=threshold,
         invert=invert,
+        outer_pad_value=outer_pad_value,
     )
 
 


### PR DESCRIPTION
Added an optional argument to `read.from_np` to allow user to specify a value to pad the image array with.