### PR TITLE
prevent validating schematic subdictionary of info

### DIFF
--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -65,6 +65,8 @@ class Info(BaseModel, extra="allow", validate_assignment=True):
         cls, data: dict[str, int | float | Sequence | str]
     ) -> dict[str, int | float | Sequence | str]:
         for name, value in data.items():
+            if name == "schematic":
+                continue  # prevent validation of schematic sub-dictionary
             if not isinstance(value, str | int | float | Sequence):
                 raise ValueError(
                     "Values of the info dict only support int, float, string or tuple."


### PR DESCRIPTION
This allows the schematic editor to work as expected.