### PR TITLE
Adding length_x and lengths_y arguments in ring_crow() component

### DIFF
--- a/gdsfactory/components/ring_crow.py
+++ b/gdsfactory/components/ring_crow.py
@@ -17,7 +17,7 @@ def ring_crow(
     bends: list[ComponentSpec] = [bend_circular] * 3,
     ring_cross_sections: list[CrossSectionSpec] = [strip] * 3,
     length_x: float = 0, 
-    lengths_y: float = [0] * 3,
+    lengths_y: list[float] = [0] * 3,
 ) -> Component:
     """Coupled ring resonators.
 

--- a/gdsfactory/components/ring_crow.py
+++ b/gdsfactory/components/ring_crow.py
@@ -16,7 +16,7 @@ def ring_crow(
     output_straight_cross_section: CrossSectionSpec = strip,
     bends: list[ComponentSpec] = [bend_circular] * 3,
     ring_cross_sections: list[CrossSectionSpec] = [strip] * 3,
-    length_x: float = 0, 
+    length_x: float = 0,
     lengths_y: list[float] = [0] * 3,
 ) -> Component:
     """Coupled ring resonators.

--- a/gdsfactory/components/ring_crow.py
+++ b/gdsfactory/components/ring_crow.py
@@ -16,6 +16,8 @@ def ring_crow(
     output_straight_cross_section: CrossSectionSpec = strip,
     bends: list[ComponentSpec] = [bend_circular] * 3,
     ring_cross_sections: list[CrossSectionSpec] = [strip] * 3,
+    length_x: float = 0, 
+    lengths_y: float = [0] * 3,
 ) -> Component:
     """Coupled ring resonators.
 
@@ -60,7 +62,7 @@ def ring_crow(
 
     # Input bus
     input_straight = gf.get_component(
-        straight, length=2 * radius[0], cross_section=input_straight_cross_section
+        straight, length=2 * radius[0] + length_x, cross_section=input_straight_cross_section
     )
     input_straight_cross_section = gf.get_cross_section(input_straight_cross_section)
     input_straight_width = input_straight_cross_section.width
@@ -72,8 +74,8 @@ def ring_crow(
     # Cascade rings
     cum_y_dist = input_straight_width / 2
 
-    for index, (gap, r, bend, cross_section) in enumerate(
-        zip(gaps, radius, bends, ring_cross_sections)
+    for index, (gap, r, bend, cross_section, length_y) in enumerate(
+        zip(gaps, radius, bends, ring_cross_sections, lengths_y)
     ):
         gap = gf.snap.snap_to_grid(gap, grid_factor=2)
         ring = Component(f"ring{index}")
@@ -86,19 +88,30 @@ def ring_crow(
         bend3 = ring.add_ref(bend_c, alias=f"top_left_bend_ring_{index}")
         bend4 = ring.add_ref(bend_c, alias=f"bot_left_bend_ring_{index}")
 
-        bend2.connect("o1", bend1.ports["o2"])
-        bend3.connect("o1", bend2.ports["o2"])
-        bend4.connect("o1", bend3.ports["o2"])
+        straight_hor_c = gf.get_component(straight, length=length_x, cross_section=cross_section)
+        straight_ver_c = gf.get_component(straight, length=length_y, cross_section=cross_section)
+        straight_hor1 = ring.add_ref(straight_hor_c, alias=f"bot_hor_waveguide_ring_{index}")
+        straight_hor2 = ring.add_ref(straight_hor_c, alias=f"top_hor_waveguide_ring_{index}")
+        straight_ver1 = ring.add_ref(straight_ver_c, alias=f"right_ver_waveguide_ring_{index}")
+        straight_ver2 = ring.add_ref(straight_ver_c, alias=f"left_ver_waveguide_ring_{index}")
+
+        bend1.connect("o1",straight_hor1.ports["o2"])
+        straight_ver1.connect("o1", bend1.ports["o2"])
+        bend2.connect("o1", straight_ver1.ports["o2"])
+        straight_hor2.connect("o1",bend2.ports["o2"])
+        bend3.connect("o1", straight_hor2.ports["o2"])
+        straight_ver2.connect("o1", bend3.ports["o2"])
+        bend4.connect("o1", straight_ver2.ports["o2"])
 
         ring_ref = c.add_ref(ring)
         ring_ref.movey(cum_y_dist + gap + bend_width / 2)
         c.absorb(ring_ref)
-        cum_y_dist += gap + bend_width + 2 * r
+        cum_y_dist += gap + bend_width + 2 * r + length_y
 
     # Output bus
     output_straight = gf.get_component(
         straight,
-        length=2 * radius[-1],
+        length=2 * radius[-1] + length_x,
         cross_section=output_straight_cross_section,
     )
     output_straight_width = output_straight_cross_section().width


### PR DESCRIPTION
Hi,

I have added two arguments **"length_x"** and **"lengths_y"** in the component **ring_crow()**, which were missing earlier. It allows designers to set a particular coupler length and different vertical straight lengths for all the rings. 

Here is an output sample:
![image](https://github.com/gdsfactory/gdsfactory/assets/102401390/20eff5c6-e258-41e7-9c65-795138d6331c)
