### PR TITLE
bugfix for rectangle instantiation

### DIFF
--- a/gdsfactory/components/rectangle.py
+++ b/gdsfactory/components/rectangle.py
@@ -69,7 +69,7 @@ def rectangle(
         cb.y = ref.ymin
         ct.y = ref.ymax
 
-    c.info["area"] = xsize * ysize
+    c.info["area"] = float(xsize * ysize)
     return c
 
 


### PR DESCRIPTION
This fixes a validation error when rectangles are called.

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Info
  Value error, Values of the info dict only support int, float, string or tuple.area: 760000, <class 'numpy.int64'> [type=value_error, input_value={'area': 760000}, input_type=dict]
```