### PR TITLE
Cell can do partials

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -336,6 +336,7 @@ def cell(
             get_child_name=get_child_name,
             post_process=post_process,
             info=info,
+            basename=basename,
         )
     )
 

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -31,7 +31,6 @@ from gdsfactory.components.bbox import bbox
 from gdsfactory.components.bend_circular import bend_circular, bend_circular180
 from gdsfactory.components.bend_circular_heater import bend_circular_heater
 from gdsfactory.components.bend_euler import (
-    BendEuler,
     bend_euler,
     bend_euler180,
     bend_euler_s,
@@ -265,7 +264,7 @@ from gdsfactory.components.spiral_inner_io import (
 )
 from gdsfactory.components.splitter_chain import splitter_chain
 from gdsfactory.components.splitter_tree import splitter_tree
-from gdsfactory.components.straight import Straight, straight, straight_array
+from gdsfactory.components.straight import straight, straight_array
 from gdsfactory.components.straight_heater_doped_rib import straight_heater_doped_rib
 from gdsfactory.components.straight_heater_doped_strip import (
     straight_heater_doped_strip,
@@ -624,8 +623,6 @@ __all__ = [
     "wire_straight",
     "hexagon",
     "octagon",
-    "Straight",
-    "BendEuler",
 ]
 
 cells = get_cells(sys.modules[__name__])

--- a/gdsfactory/components/bend_euler.py
+++ b/gdsfactory/components/bend_euler.py
@@ -10,17 +10,7 @@ from gdsfactory.components.straight import straight
 from gdsfactory.components.wire import wire_corner
 from gdsfactory.cross_section import strip
 from gdsfactory.path import euler
-from gdsfactory.typings import CrossSectionSpec, TypedDict
-
-
-class BendEuler(TypedDict):
-    radius: float | None
-    angle: float
-    p: float
-    with_arc_floorplan: bool
-    npoints: int | None
-    direction: str
-    cross_section: CrossSectionSpec
+from gdsfactory.typings import CrossSectionSpec
 
 
 @gf.cell

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -2,17 +2,10 @@
 from __future__ import annotations
 
 import warnings
-from typing import TypedDict
 
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.cross_section import CrossSectionSpec
-
-
-class Straight(TypedDict):
-    length: float
-    npoints: int
-    cross_section: CrossSectionSpec
 
 
 @gf.cell

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -246,8 +246,8 @@ def place(
             if mirror is True and port:
                 ref.mirror_x(x0=_get_anchor_value_from_name(ref, port, "x"))
             elif mirror is True:
-                if x:
-                    ref.mirror_x(x0=x)
+                if x is not None:
+                    ref.mirror_x(x0=_get_anchor_value_from_name(ref, x, "x"))
                 else:
                     ref.mirror_x()
             elif mirror is False:

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -33,7 +33,7 @@ import dataclasses
 import json
 import pathlib
 from collections.abc import Callable
-from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union, Unpack
 
 import gdstk
 import numpy as np
@@ -343,6 +343,7 @@ __all__ = (
     "Tuple",
     "Dict",
     "TypedDict",
+    "Unpack",
 )
 
 

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -350,7 +350,7 @@ __all__ = (
 def write_schema(model: BaseModel = NetlistModel) -> None:
     from gdsfactory.config import PATH
 
-    s = model.schema_json()
+    s = model.model_json_schema()
     d = OmegaConf.create(s)
 
     schema_path_json = PATH.schema_netlist

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -33,7 +33,7 @@ import dataclasses
 import json
 import pathlib
 from collections.abc import Callable
-from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union, Unpack
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import gdstk
 import numpy as np
@@ -342,8 +342,6 @@ __all__ = (
     "List",
     "Tuple",
     "Dict",
-    "TypedDict",
-    "Unpack",
 )
 
 

--- a/test-data-regression/test_component_from_yaml_ports.yml
+++ b/test-data-regression/test_component_from_yaml_ports.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: component_yaml_ports
 info: {}
 module: gdsfactory.read.from_yaml
 name: component_yaml_ports_d68fa3aa

--- a/test-data-regression/test_components_0_.yml
+++ b/test-data-regression/test_components_0_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: mirror_port
 info: {}
 module: gdsfactory.read.from_yaml
 name: mirror_port_f610a6e9

--- a/test-data-regression/test_components_1_.yml
+++ b/test-data-regression/test_components_1_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: mirror_x
 info: {}
 module: gdsfactory.read.from_yaml
 name: mirror_x_c0f7d032

--- a/test-data-regression/test_components_2_.yml
+++ b/test-data-regression/test_components_2_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: rotation
 info: {}
 module: gdsfactory.read.from_yaml
 name: rotation_99ea4645

--- a/test-data-regression/test_components_3_.yml
+++ b/test-data-regression/test_components_3_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: dxdy
 info: {}
 module: gdsfactory.read.from_yaml
 name: dxdy_d4ff57bc

--- a/test-data-regression/test_settings_sample_connections_.yml
+++ b/test-data-regression/test_settings_sample_connections_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_connections
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_connections_23ad5c38

--- a/test-data-regression/test_settings_sample_different_link_factory_.yml
+++ b/test-data-regression/test_settings_sample_different_link_factory_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_path_length_matching
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_path_length_matching_215cd1fb

--- a/test-data-regression/test_settings_sample_docstring_.yml
+++ b/test-data-regression/test_settings_sample_docstring_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_docstring
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_docstring_e2d59879

--- a/test-data-regression/test_settings_sample_doe_.yml
+++ b/test-data-regression/test_settings_sample_doe_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: mask
 info: {}
 module: gdsfactory.read.from_yaml
 name: mask_a0e3547b

--- a/test-data-regression/test_settings_sample_mirror_simple_.yml
+++ b/test-data-regression/test_settings_sample_mirror_simple_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_mirror_simple
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_mirror_simple_a2dbfa91

--- a/test-data-regression/test_settings_sample_mmis_.yml
+++ b/test-data-regression/test_settings_sample_mmis_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_mmis
 info:
   description: just a demo on adding metadata
   polarization: te

--- a/test-data-regression/test_settings_sample_rotation_.yml
+++ b/test-data-regression/test_settings_sample_rotation_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_rotation
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_rotation_d458f45b

--- a/test-data-regression/test_settings_sample_waypoints_.yml
+++ b/test-data-regression/test_settings_sample_waypoints_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: sample_waypoints
 info: {}
 module: gdsfactory.read.from_yaml
 name: sample_waypoints_f04e1be3

--- a/test-data-regression/test_settings_yaml_anchor_.yml
+++ b/test-data-regression/test_settings_yaml_anchor_.yml
@@ -1,4 +1,4 @@
-function: _from_yaml
+function: yaml_anchor
 info: {}
 module: gdsfactory.read.from_yaml
 name: yaml_anchor_8731fb27


### PR DESCRIPTION
allows you to use cell to create partials, and create new function signatures while maintaining IDE autocompletion


```python
straight = gf.components.straight
straight_sc = cell(straight, cross_section="xs_sc", basename="straight_sc")
straight_so = cell(straight, cross_section="xs_so", basename="straight_so")
straight_rc = cell(straight, cross_section="xs_rc", basename="straight_rc")
straight_ro = cell(straight, cross_section="xs_ro", basename="straight_ro")
straight_nc = cell(straight, cross_section="xs_nc", basename="straight_nc")
straight_no = cell(straight, cross_section="xs_no", basename="straight_no")
```

fixes https://github.com/gdsfactory/gdsfactory/issues/2609 in a more elegant way