### PR TITLE
fix to the output of the from_updk function

### DIFF
--- a/gdsfactory/read/__init__.py
+++ b/gdsfactory/read/__init__.py
@@ -4,10 +4,10 @@ from gdsfactory.read.from_dphox import from_dphox
 from gdsfactory.read.from_gdspaths import from_gdsdir, from_gdspaths
 from gdsfactory.read.from_np import from_image, from_np
 from gdsfactory.read.from_phidl import from_gdstk, from_phidl
+from gdsfactory.read.from_updk import from_updk
 from gdsfactory.read.from_yaml import cell_from_yaml, from_yaml
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
 from gdsfactory.read.import_gds import import_gds, import_gds_raw
-from gdsfactory.read.from_updk import from_updk
 
 __all__ = [
     "from_dphox",
@@ -22,5 +22,5 @@ __all__ = [
     "cell_from_yaml_template",
     "import_gds",
     "import_gds_raw",
-    "from_updk"
+    "from_updk",
 ]

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -139,9 +139,8 @@ add_pins = gf.partial(add_pins_inside2um, layer_label=layer_label, layer=layer_p
             if layer_label and parameters_colon
             else ""
         )
-        list_parameters="\\n".join(f"{p_name}" for p_name in parameters_equal)
-        parameters_labels=f"    c.add_label(text=f'Parameters:\\n{list_parameters}', position=(0,0), layer=layer_label)\n"
-
+        list_parameters = "\\n".join(f"{p_name}" for p_name in parameters_equal)
+        parameters_labels = f"    c.add_label(text=f'Parameters:\\n{list_parameters}', position=(0,0), layer=layer_label)\n"
 
         if parameters:
             doc = f'"""{block.doc}\n\n    Args:\n    {parameters_doc}\n    """'


### PR DESCRIPTION
The result of creating a PDK using the from_pdk function is not compatible with the cell-replacement function of Nazca.
This is due to the requirement of such function of having the parameres listed in a specific format of.

Parameters:
name1=value1
name2=value2


on top of that the resulting file was missing a couple of references and I have adde the  gf. 