### PR TITLE
get_bundle_sbend for vertical ports

### DIFF
--- a/gdsfactory/routing/get_bundle.py
+++ b/gdsfactory/routing/get_bundle.py
@@ -275,6 +275,7 @@ def get_bundle(
                 ports2,
                 sort_ports=sort_ports,
                 cross_section=cross_section,
+                axis=start_axis,
             )
         return get_bundle_same_axis(**params)
 

--- a/gdsfactory/routing/get_bundle_sbend.py
+++ b/gdsfactory/routing/get_bundle_sbend.py
@@ -11,7 +11,8 @@ def get_bundle_sbend(
     ports2: Port,
     sort_ports: bool = True,
     enforce_port_ordering: bool = True,
-    axis="X" ** kwargs,
+    axis: str = "X",
+    **kwargs,
 ) -> list[Route]:
     """Returns a list of routes from ports1 to ports2.
 
@@ -20,6 +21,7 @@ def get_bundle_sbend(
         ports2: end ports.
         sort_ports: sort ports.
         enforce_port_ordering: enforces port ordering.
+        axis: axis to bend. X or Y.
         kwargs: cross_section settings.
 
     Returns:
@@ -38,8 +40,10 @@ def get_bundle_sbend(
         xsize = p2.center[0] - p1.center[0]
         if axis == "X":
             bend = bend_s(size=(xsize, ysize), **kwargs)
-        else:
+        elif axis == "Y":
             bend = bend_s(size=(ysize, -xsize), **kwargs)
+        else:
+            raise ValueError("axis must be 'X' or 'Y'")
         sbend = bend.ref()
         sbend.connect("o1", p1)
         routes.append(

--- a/gdsfactory/routing/get_bundle_sbend.py
+++ b/gdsfactory/routing/get_bundle_sbend.py
@@ -11,6 +11,7 @@ def get_bundle_sbend(
     ports2: Port,
     sort_ports: bool = True,
     enforce_port_ordering: bool = True,
+    axis='X'
     **kwargs,
 ) -> list[Route]:
     """Returns a list of routes from ports1 to ports2.
@@ -36,7 +37,10 @@ def get_bundle_sbend(
     for p1, p2 in zip(ports1, ports2):
         ysize = p2.center[1] - p1.center[1]
         xsize = p2.center[0] - p1.center[0]
-        bend = bend_s(size=(xsize, ysize), **kwargs)
+        if axis=='X':
+            bend = bend_s(size=(xsize, ysize), **kwargs)
+        else:
+            bend = bend_s(size=(ysize, -xsize), **kwargs)
         sbend = bend.ref()
         sbend.connect("o1", p1)
         routes.append(

--- a/gdsfactory/routing/get_bundle_sbend.py
+++ b/gdsfactory/routing/get_bundle_sbend.py
@@ -11,8 +11,7 @@ def get_bundle_sbend(
     ports2: Port,
     sort_ports: bool = True,
     enforce_port_ordering: bool = True,
-    axis='X'
-    **kwargs,
+    axis="X" ** kwargs,
 ) -> list[Route]:
     """Returns a list of routes from ports1 to ports2.
 
@@ -37,7 +36,7 @@ def get_bundle_sbend(
     for p1, p2 in zip(ports1, ports2):
         ysize = p2.center[1] - p1.center[1]
         xsize = p2.center[0] - p1.center[0]
-        if axis=='X':
+        if axis == "X":
             bend = bend_s(size=(xsize, ysize), **kwargs)
         else:
             bend = bend_s(size=(ysize, -xsize), **kwargs)


### PR DESCRIPTION
get_bundle(with_sbend=True) swapped the x and y arguments when I tried to use vertically oriented ports, so I'm passing start_axis to get_bundle_sbend and swapping the coordinates. Still doesn't work for arbitrary angles because the function uses the x and y coordinates directly instead of rotating the coordinate system.