### PR TITLE
bugfix: assert_on_grid failing for large values

### DIFF
--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -317,7 +317,7 @@ class Port:
         return new_port
 
     def get_extended_center(self, length: float = 1.0) -> ndarray:
-        """Returns an extended port center."""
+        """Returns the position of port center extended by length in its orientation."""
         angle = np.deg2rad(self.orientation)
         c = np.cos(angle)
         s = np.sin(angle)
@@ -331,7 +331,7 @@ class Port:
         """Ensures ports edges are on grid to avoid snap_to_grid errors."""
         center = np.array(self.center)
         center_snapped = snap_to_grid(center, grid_factor=grid_factor)
-        if not np.isclose(center, center_snapped).all():
+        if not np.isclose(center, center_snapped, rtol=0).all():
             message = (
                 f"port = {self.name!r}, center = {self.center} is not on grid.\n"
                 "You can use Component.flatten_offgrid_references() to snap to grid."

--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -31,7 +31,7 @@ def assert_on_grid(
     grid_factor: int = 1,
 ) -> None:
     x_grid = snap_to_grid(x, nm=nm, grid_factor=grid_factor)
-    if not np.isclose(x_grid, x):
+    if not np.isclose(x_grid, x, rtol=0).all():
         raise ValueError(f"{x} needs to be on 1nm grid and should be {x_grid}")
 
 
@@ -41,7 +41,7 @@ assert_on_2nm_grid = partial(assert_on_grid, nm=2)
 
 def assert_on_2x_grid(x: float) -> None:
     x_grid = snap_to_grid(x, grid_factor=2)
-    if not np.isclose(x_grid, x):
+    if not np.isclose(x_grid, x, rtol=0).all():
         raise ValueError(f"{x} needs to be on 2x grid and should be {x_grid}")
 
 


### PR DESCRIPTION
`np.isclose` is not appropriate to compare large values because the default relative tolerance is `1e-5`. So any dimension beyond 100um will fail the `assert_on_grid` test. There are two solutions for this:
1. use `np.isclose(x1-x2, 0)`; or
2. use `np.isclose(x1, x2, rtol=0)`

I chose the second solution for more clarity of intent. I replaced instances wherever I could find, but please check if there are more.

Warning: This may cause breaking changes in people's layouts if they have been relying on assert_on_grid.