### PR TITLE
Obey stacklevel in `warnings.warn` for loguru output

### DIFF
--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -292,16 +292,13 @@ class Settings(BaseSettings):
 
         def showwarning(message, category, filename, lineno, *args, **kwargs):
             try:
-                inferred_stack_depth = (
-                    len(traceback.format_stack())
-                    - next(
-                        (
-                            i
-                            for i, stack in enumerate(traceback.format_stack())
-                            if f'File "{filename}", line {lineno}' in stack
-                        )
-                    )
-                    - 1
+                inferred_stack_depth = next(
+                    i
+                    for (
+                        i,
+                        stack,
+                    ) in enumerate(reversed(traceback.extract_stack()))
+                    if stack.lineno == lineno and stack.filename == filename
                 )
             except StopIteration:
                 # depth 2 would show the same line as warnings.warn with default stacklevel

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -290,8 +290,6 @@ class Settings(BaseSettings):
         self.logger.add(sys.stdout, format=tracing_formatter, filter=self.logfilter)
         self.logger.debug("LogLevel: {}", self.logfilter.level)
 
-        showwarning_ = warnings.showwarning
-
         def showwarning(message, category, filename, lineno, *args, **kwargs):
             try:
                 inferred_stack_depth = (
@@ -311,7 +309,6 @@ class Settings(BaseSettings):
             self.logger.opt(depth=inferred_stack_depth).warning(
                 f"{category.__name__}: {message}"
             )
-            showwarning_(message, category, filename, lineno, *args, **kwargs)
 
         warnings.showwarning = showwarning
 


### PR DESCRIPTION
As an example, these two statements are now both printed with the same linenumber in the same file
### Loguru
```
2024-04-05 12:15:41.127 | WARNING  | gdsfactory.pdk:get_cross_section:532 - UserWarning: CrossSection.copy() only modifies the attributes of the first section.
```
### Warnings
```
/home/niko/dev/gdsfactory/gdsfactory/pdk.py:532: UserWarning: CrossSection.copy() only modifies the attributes of the first section.
  return cross_section.copy(**kwargs)
```

Additionally, disables using warnings.showwarnings and makes the gdsfactory defaults only print using loguru, closes #2588