### PR TITLE
[minor bugs] Port.info: shallow copy -> deep copy

### DIFF
--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -312,7 +312,7 @@ class Port:
             port_type=self.port_type,
             cross_section=self.cross_section,
             shear_angle=self.shear_angle,
-            info=self.info.model_copy(),
+            info=self.info.model_copy(deep=True),
         )
         return new_port
 


### PR DESCRIPTION
## Problem Statement
In `gdsfactory/port.py` [line 315](https://github.com/gdsfactory/gdsfactory/blob/main/gdsfactory/port.py#L315), the `info` was set to `info.model_copy()`. This setting results in a **shallow copy** according to the [pydantic official documentation](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_copy).

It will trigger a bug that one `info` attribute will <ins>still share among different port copies</ins>. 
How I find it: I used `info` to track back the port owner and found `port.copy()` did work except for `info`. And finally I realized that a **deep copy** should add argument `deep=True`.


## Merging Conflict
It seems that NO conflict with other patches at the current branch, and can be merged automatically.