### PR TITLE
Fix annotation of gf.cell for syntax highlighting

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -81,7 +81,7 @@ def cell(
 
 @overload
 def cell(
-    func: Callable[..., Component],
+    func: _F,
     /,
     *,
     autoname: bool = True,
@@ -99,11 +99,11 @@ def cell(
     get_child_name: bool = False,
     post_process: Sequence[Callable] | None = None,
     info: dict[str, int | float | str] | None = None,
-) -> Callable[..., Component]: ...
+) -> _F: ...
 
 
 def cell(
-    func: Callable[..., Component] | None = None,
+    func=None,
     /,
     *,
     autoname: bool = True,

--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -81,7 +81,15 @@ def cell(
 
 @overload
 def cell(
+from typing import Callable, TypeVar
+
+Component = TypeVar('Component')  # Define what Component is expected to be if needed
+_F = TypeVar('_F', bound=Callable[..., Component])
+
+def cell(
     func: _F,
+    /,
+    *,
     /,
     *,
     autoname: bool = True,


### PR DESCRIPTION
This reverts some of the changes in #2620 . I am not sure why the _F return annotation was not used. It broke my syntax highlighting in VSCode (I lost the list of arguments). @flaport Please drop your thoughts if you have a chance.