### PR TITLE
c.info requires native types

### DIFF
--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -37,8 +37,8 @@ def straight(
     ref = c << path
     c.add_ports(ref.ports)
 
-    c.info["length"] = length
-    c.info["width"] = x.width
+    c.info["length"] = float(length)
+    c.info["width"] = float(x.width)
     c.add_route_info(cross_section=x, length=length)
     c.absorb(ref)
     return c


### PR DESCRIPTION
I caught an untested bug on the straight component: `c.info["length"] = length`. Pydantic complained that length was not int or float (and it did not coerce it). Instead it was a numpy int which was returned by a rounding function. I fixed with `c.info["length"] = float(length)`.

I assumed this was the right solution as I saw it somewhere else in the codebase. Hope others find this error here. I am pasting the error in case someone might google:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Info
  Value error, Values of the info dict only support int, float, string or tuple.length: 960, <class 'numpy.int64'> [type=value_error, input_value={'length': 960}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/value_error
```