### PR TITLE
Rename fiber ports

### DIFF
--- a/gdsfactory/components/edge_coupler_array.py
+++ b/gdsfactory/components/edge_coupler_array.py
@@ -18,8 +18,20 @@ from gdsfactory.typings import (
     Float2,
 )
 
-edge_coupler_silicon = partial(taper, width2=0.2, length=100, with_two_ports=True)
-edge_coupler_silicon_2 = partial(taper, width2=0.2, length=130, with_two_ports=True)
+edge_coupler_silicon = partial(
+    taper,
+    width2=0.2,
+    length=100,
+    with_two_ports=True,
+    port_order_types=("optical", "edge_te"),
+)
+edge_coupler_silicon_2 = partial(
+    taper,
+    width2=0.2,
+    length=130,
+    with_two_ports=True,
+    port_order_types=("optical", "edge_te"),
+)
 
 
 @gf.cell

--- a/gdsfactory/components/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_coupler_elliptical.py
@@ -100,7 +100,6 @@ def grating_taper_points(
 
 @gf.cell
 def grating_coupler_elliptical(
-    polarization: str = "te",
     taper_length: float = 16.6,
     taper_angle: float = 40.0,
     wavelength: float = 1.554,
@@ -115,12 +114,12 @@ def grating_coupler_elliptical(
     slab_offset: float = 2.0,
     spiked: bool = True,
     cross_section: CrossSectionSpec = "xs_sc",
+    polarization: str = "te",
     **kwargs,
 ) -> Component:
     r"""Grating coupler with parametrization based on Lumerical FDTD simulation.
 
     Args:
-        polarization: te or tm.
         taper_length: taper length from input.
         taper_angle: grating flare angle.
         wavelength: grating transmission central wavelength (um).
@@ -135,6 +134,7 @@ def grating_coupler_elliptical(
         slab_offset: in um.
         spiked: grating teeth have sharp spikes to avoid non-manhattan drc errors.
         cross_section: specification (CrossSection, string or dict).
+        polarization: te or tm.
         kwargs: cross_section settings.
 
     .. code::
@@ -259,7 +259,7 @@ def grating_coupler_elliptical(
         width=10,
         orientation=0,
         layer=layer,
-        port_type="optical",
+        port_type=f"optical_{polarization}",
     )
 
     xs.add_bbox(c)

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -164,7 +164,7 @@ def grating_coupler_elliptical_arbitrary(
         width=10,
         orientation=0,
         layer=xs.layer,
-        port_type="optical",
+        port_type=f"vertical_{polarization}",
     )
     xs.add_bbox(c)
     return c

--- a/gdsfactory/components/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_coupler_elliptical_trenches.py
@@ -133,7 +133,7 @@ def grating_coupler_elliptical_trenches(
         width=10,
         orientation=0,
         layer=layer,
-        port_type="optical",
+        port_type=f"optical_{polarization}",
     )
     return c
 

--- a/gdsfactory/components/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_coupler_rectangular.py
@@ -141,7 +141,7 @@ def grating_coupler_rectangular(
     xport = np.round((x0 + cgrating.x) / 2, 3)
     c.add_port(
         name="o2",
-        port_type="optical",
+        port_type=f"vertical_{polarization}",
         center=(xport, 0),
         orientation=0,
         width=width_grating,

--- a/gdsfactory/components/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_rectangular_arbitrary.py
@@ -159,7 +159,7 @@ def grating_coupler_rectangular_arbitrary(
     xport = np.round((xi + length_taper) / 2, 3)
     c.add_port(
         name="o2",
-        port_type="optical",
+        port_type=f"vertical_{polarization}",
         center=(xport, 0),
         orientation=0,
         width=width_grating,

--- a/gdsfactory/components/grating_coupler_rectangular_arbitrary_slab.py
+++ b/gdsfactory/components/grating_coupler_rectangular_arbitrary_slab.py
@@ -128,7 +128,7 @@ def grating_coupler_rectangular_arbitrary_slab(
 
     c.add_port(
         name="o2",
-        port_type="optical",
+        port_type=f"vertical_{polarization}",
         center=(xport, 0),
         orientation=0,
         width=width_grating,

--- a/test-data-regression/test_settings_edge_coupler_array_.yml
+++ b/test-data-regression/test_settings_edge_coupler_array_.yml
@@ -12,6 +12,9 @@ settings:
     module: gdsfactory.components.taper
     settings:
       length: 100
+      port_order_types:
+      - optical
+      - edge_te
       width2: 0.2
       with_two_ports: true
   n: 5

--- a/test-data-regression/test_settings_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_settings_edge_coupler_array_with_loopback_.yml
@@ -13,6 +13,9 @@ settings:
     module: gdsfactory.components.taper
     settings:
       length: 100
+      port_order_types:
+      - optical
+      - edge_te
       width2: 0.2
       with_two_ports: true
   extension_length: 1.0

--- a/test-data-regression/test_settings_edge_coupler_silicon_.yml
+++ b/test-data-regression/test_settings_edge_coupler_silicon_.yml
@@ -4,7 +4,7 @@ info:
   width1: 0.5
   width2: 0.2
 module: gdsfactory.components.taper
-name: taper_length100_width20p2
+name: taper_680c9faf
 settings:
   cross_section: xs_sc
   length: 100
@@ -14,7 +14,7 @@ settings:
   - o2
   port_order_types:
   - optical
-  - optical
+  - edge_te
   width1: 0.5
   width2: 0.2
   with_two_ports: true


### PR DESCRIPTION
edge and vertical ports should be called differently than `optical`


this PR changes them to `vertical_{polarization}`

@tvt173 