### PR TITLE
[gdsfactory7] component.move uses functions.move

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -2196,9 +2196,11 @@ class Component(_GeometryHelper):
         """
         auto_rename_ports_orientation(self, **kwargs)
 
-    def move(self, origin=(0, 0), destination=None, axis: Axis | None = None, **kwargs) -> Component:
+    def move(
+        self, origin=(0, 0), destination=None, axis: Axis | None = None, **kwargs
+    ) -> Component:
         """Returns new Component with a mirrored reference.
-        
+
         Args:
             origin: of component.
             destination: Optional x, y.
@@ -2206,7 +2208,9 @@ class Component(_GeometryHelper):
         """
         from gdsfactory.functions import move
 
-        return move(component=self, origin=origin, destination=destination, axis=axis, **kwargs)
+        return move(
+            component=self, origin=origin, destination=destination, axis=axis, **kwargs
+        )
 
     def mirror(self, p1: Float2 = (0, 1), p2: Float2 = (0, 0), **kwargs) -> Component:
         """Returns new Component with a mirrored reference.

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -2196,9 +2196,17 @@ class Component(_GeometryHelper):
         """
         auto_rename_ports_orientation(self, **kwargs)
 
-    def move(self, *args, **kwargs) -> Component:
-        """Make a reference instead"""
-        raise ValueError(move_error_message)
+    def move(self, origin=(0, 0), destination=None, axis: Axis | None = None, **kwargs) -> Component:
+        """Returns new Component with a mirrored reference.
+        
+        Args:
+            origin: of component.
+            destination: Optional x, y.
+            axis: x or y axis.
+        """
+        from gdsfactory.functions import move
+
+        return move(component=self, origin=origin, destination=destination, axis=axis, **kwargs)
 
     def mirror(self, p1: Float2 = (0, 1), p2: Float2 = (0, 0), **kwargs) -> Component:
         """Returns new Component with a mirrored reference.


### PR DESCRIPTION
with this move function now also creates new component instead of giving `ValueError` same as `mirror` methods:

https://github.com/gdsfactory/gdsfactory/blob/8678a18527b2e19484e8f6603386863c92f35d71/gdsfactory/component.py#L2203-L2212