### PR TITLE
Fix boolean_or operations

### DIFF
--- a/gdsfactory/boolean.py
+++ b/gdsfactory/boolean.py
@@ -84,7 +84,7 @@ def boolean(
         if isinstance(A, kf.Instance):
             r1.transform(A.cplx_trans)
         if isinstance(B, kf.Instance):
-            r1.transform(B.cplx_trans)
+            r2.transform(B.cplx_trans)
         f = boolean_operations[operation]
         r = f(r1, r2)
         r = c.shapes(layer_index).insert(r)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -52,7 +52,10 @@ def size(region: kdb.Region, offset: float, dbu=1e3) -> kdb.Region:
 
 
 def boolean_or(region1: kdb.Region, region2: kdb.Region) -> kdb.Region:
-    return region1.__or__(region2)
+    if kdb.Region.interacting(region1, region2):
+        return kdb.Region.merge(region1.__or__(region2))
+    else:
+        return region1.__or__(region2)
 
 
 def boolean_not(region1: kdb.Region, region2: kdb.Region) -> kdb.Region:


### PR DESCRIPTION
When trying to merge two component references using the `or` operator with `gf.boolean(...)`, as the docs suggest, the output doesn't merge `A` and `B` unless they explicitly overlap. Even if the references share an edge, the output is not merged. Additionally, the output is currently dependent on the order in which the references are given (e.g. `A=ref1, B=ref2` vs. `A=ref2, B=ref1`), and in one of the cases, the output appears mirrored (though it is actually just mistranslated, as shown later).

![image](https://github.com/gdsfactory/gdsfactory/assets/169110167/70caaec7-a5ca-461c-a92f-b5a1a6857625)


Issues: 
- `A | B`: 
    - Output is effectively mirrored 
    - Isn't merged even though the edges of the two polygons coincide
   
-  `B | A`: 
    - Polygons were not properly translated relative to each other, though the output is a single merged polygon

-     -     -

**Expected behavior**
I would expect a boolean `or` to maintain the relative positions of the input polygons and also merge everything into a singular output polygon (in the case that the inputs share at least an edge).

The mistranslation issue was being caused by this bit of code here:

```
    for r1, r2 in zip(
        a.begin_shapes_rec(layer_index1),
        b.begin_shapes_rec(layer_index2),
    ):
        r1 = kf.kdb.Region(r1)
        r2 = kf.kdb.Region(r2)
        if isinstance(A, kf.Instance):
            r1.transform(A.cplx_trans)
        if isinstance(B, kf.Instance):
            r1.transform(B.cplx_trans)        # <---
        f = boolean_operations[operation]
        r = f(r1, r2)
        r = c.shapes(layer_index).insert(r)

    return c
```

This was applying both transformations from `A` and `B` to `r1`.

From what I can tell, however, the issue with the output not merging seems like it might be due to how the `or` operation is performed in the backend (maybe within KLayout itself?) rather than an issue with GDSFactory/KFactory, but I don't think I'm familiar enough with any of the backend stuff to really say with any degree of certainty.

Regardless, especially since the docs suggest using `gf.boolean(...)` to merge components/references, I would expect `boolean_or` to merge any regions that are touching.

The solution I've found is to use the `interacting(...)` function in KLayout's `Region` class to detect the cases where two non-overlapping polygons share an edge so that they can be merged.

I am not sure how this change effects performance, however, or if a more elegant solution exists, so any suggestions/edits are welcome.