### PR TITLE
Fix for `get_pin_triangle_polygon_tip` function

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -108,8 +108,8 @@ def get_pin_triangle_polygon_tip(
     if orientation is None:
         raise ValueError("Port {port.name!r} needs to have an orientation.")
 
-    ca = np.cos(orientation * np.pi / 180)
-    sa = np.sin(orientation * np.pi / 180)
+    ca = np.round(np.cos(orientation * np.pi / 180), 12)
+    sa = np.round(np.sin(orientation * np.pi / 180), 12)
     rot_mat = np.array([[ca, -sa], [sa, ca]])
     d = p.width / 2
 

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -111,7 +111,7 @@ def get_pin_triangle_polygon_tip(
     ca = np.round(np.cos(orientation * np.pi / 180), 12)
     sa = np.round(np.sin(orientation * np.pi / 180), 12)
     rot_mat = np.array([[ca, -sa], [sa, ca]])
-    d = p.width / 2
+    d = p.dwidth / 2
 
     dtip = np.array([d, 0])
 


### PR DESCRIPTION
Fix for pin size issue referenced in #2783 and shown below. Additionally fixes issue where invalid locations were being returned for pin labels due to unhandled floating point error

![image](https://github.com/gdsfactory/gdsfactory/assets/169110167/672a7598-c442-474f-9dd6-92e2c19377a5)

