### PR TITLE
Fix for boolean example in Geometry notebook

### DIFF
--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "E = gf.components.ellipse(radii=(10, 5), layer=(1, 0))\n",
     "R = gf.components.rectangle(size=(15, 5), layer=(2, 0))\n",
-    "C = gf.boolean(A=E, B=R, operation=\"not\", layer=(3, 0))\n",
+    "C = gf.boolean(A=E, B=R, operation=\"not\", layer1=(1, 0), layer2=(2, 0), layer=(3, 0))\n",
     "# Other operations include 'and', 'or', 'xor', or equivalently 'A-B', 'B-A', 'A+B'\n",
     "\n",
     "# Plot the originals and the result\n",

--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -45,7 +45,7 @@
     "# Plot the originals and the result\n",
     "D = gf.Component()\n",
     "D.add_ref(E)\n",
-    "D.add_ref(R).dmovey(-1.5)\n",
+    "D.add_ref(R)\n",
     "D.add_ref(C).dmovex(30)\n",
     "D.plot()"
    ]


### PR DESCRIPTION
Fix for `gf.boolean(...)` outputting empty component in geometry docs notebook

also removed code moving the rectangle down by 1.5um to make the image rendered in the docs a clearer before and after comparison