### PR TITLE
save_options should be None by default

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -739,7 +739,7 @@ class ComponentBase:
         self,
         gdspath: PathType | None = None,
         gdsdir: PathType | None = None,
-        save_options: kdb.SaveLayoutOptions = save_layout_options(),
+        save_options: kdb.SaveLayoutOptions | None = None,
         **kwargs,
     ) -> pathlib.Path:
         """Write component to GDS and returns gdspath.
@@ -764,6 +764,9 @@ class ComponentBase:
 
         if not gdspath.parent.is_dir():
             gdspath.parent.mkdir(parents=True, exist_ok=True)
+
+        if save_options is None:
+            save_options = save_layout_options()
 
         if kwargs:
             for k in kwargs:


### PR DESCRIPTION
Currently the default value of `save_options` in `write_gds` is fetched from the config at the time of declaration. Of course, this means that no subsequent changes to the config will be listened to at runtime. This PR fixes that issue.

fixes #2905 