### PR TITLE
Fix: Correct Boolean Operation for Stacked Geometries

### DIFF
--- a/gdsfactory/boolean.py
+++ b/gdsfactory/boolean.py
@@ -86,6 +86,7 @@ def boolean(
         f = boolean_operations[operation]
         r = f(r1, r2)
         r = c.shapes(layer_index).insert(r)
+        break
 
     return c
 


### PR DESCRIPTION
Hi, this is a pull request for fixing [#2997 ](https://github.com/gdsfactory/gdsfactory/issues/2997)
The solution involves breaking the shape recursion after the first iteration, rather than applying the 'or' operation to all geometries before 'not'. This approach prevents the issue observed in the subtraction operation.
The problem was not due to subtraction in KLayout. Manually extracting and reforming polygons into different `gf.kdb.Region`s resolves the issue:
```python
# previous codes please check #2997
A_polygons = c1.get_polygons()[1]
B_polygons = c2.get_polygons()[3]
A_region = gf.kdb.Region(A_polygons)
B_region = gf.kdb.Region(B_polygons)
res = gf.Component()
res.add_polygon(A_region - B_region, layer=(1, 0))
res
```
![image](https://github.com/user-attachments/assets/f9aac543-1ae7-4999-b82f-b4c209cd5b88)
The first result yielded by `KCell.begin_shapes_rec()` provides the top-level polygons required for the operation. So I don't see any need to run the whole loop.
Thank you!