### PR TITLE
Small tweaks in `add_pins`

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -212,7 +212,7 @@ def add_pin_rectangle_inside(
 
     if layer_label:
         component.add_label(
-            text=str(p.name),
+            text=p.name,
             position=p.dcenter,
             layer=layer_label,
         )

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 import kfactory as kf
 import numpy as np
 import yaml
-from numpy import ndarray
+from typing_extensions import TypeVar
 
 import gdsfactory as gf
 from gdsfactory.component import container
@@ -36,9 +36,14 @@ LayerSpec = Layer | str | int | None
 LayerSpecs = tuple[LayerSpec, ...]
 nm = 1e-3
 
+T = TypeVar("T")
 
-def _rotate(v: ndarray, m: ndarray) -> ndarray:
-    return np.dot(m, v)
+
+def _rotate(
+    vector: np.typing.NDArray[T], rotation_matrix: np.typing.NDArray[T]
+) -> np.typing.NDArray[T]:
+    """Rotate a vector by a rotation matrix."""
+    return rotation_matrix @ vector
 
 
 def add_bbox(

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -175,8 +175,8 @@ def add_pin_rectangle_inside(
         component: to add pins.
         port: Port.
         pin_length: length of the pin marker for the port.
-        layer: for the pin marker.
-        layer_label: for the label.
+        layer: layer to place the pin rectangle on.
+        layer_label: layer to place the text label on.
 
     .. code::
 


### PR DESCRIPTION
I was planning to reintroduce some missing features of [`add_pin_rectangle_inside` from gdsfactory 7](https://github.com/gdsfactory/gdsfactory7/blob/65aaeac6f5350000a0fd9de8b9f0b5e56dd58367/gdsfactory/add_pins.py#L154) but decided against it in the end. Maybe it is better to keep this function simple enough and implement the `label_function` from before in my own code.

I noticed some related things that could be polished a bit and gathered those in this PR.

### Commits
- **Update `add_pin_rectangle_inside` docstrings for clearer layers**
- **No unnecessary `str` casting in `add_pin_rectangle_inside`**
- **Clearer rotation helper function in add_pins**
