### PR TITLE
Add actionlint to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,8 @@ repos:
   #   rev: v1.1.333
   #   hooks:
   #   - id: pyright
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
This would check GitHub Action workflows for blatant mistakes.

@joamatab 
