### PR TITLE
faster Component.extract()

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -850,21 +850,27 @@ class ComponentBase:
 
         Args:
             layers: list of layers to extract.
-            recursive: if True, extracts layers recursively.
+            recursive: if True, extracts layers recursively and returns a flattened Component.
         """
         from gdsfactory.pdk import get_layer_tuple
 
         c = self.dup()
+        if recursive:
+            c.flatten()
 
         layer_tuples = [get_layer_tuple(layer) for layer in layers]
+        component_layers = c.layers
 
-        for layer_tuple in self.layers:
+        for layer_tuple in layer_tuples:
+            if layer_tuple not in component_layers:
+                warnings.warn(
+                    f"Layer {layer_tuple} not found in component {self.name!r} layers."
+                )
+
+        for layer_tuple in component_layers:
             if layer_tuple not in layer_tuples:
                 layer_index = self.kcl.layer(*layer_tuple)
-                if recursive:
-                    self.kcl.clear_layer(layer_index)
-                else:
-                    self.shapes(layer_index).clear()
+                c.shapes(layer_index).clear()
 
         return c
 


### PR DESCRIPTION
fixes slowness in `Component.extract()` reported in https://github.com/gdsfactory/gdsfactory/issues/3086

Before
Layer 0 Time: 0.121232 s
Layer 4 Time: 31.529844 s
Layer 0 and 4 Time: 34.504553 s


After
Layer 0 Time: 0.060577 s
Layer 4 Time: 0.001984 s
Layer 0 and 4 Time: 0.002031 s

thanks @octavephotonics for reporting this!


