### PR TITLE
fix bend coupler output cross section

### DIFF
--- a/gdsfactory/components/ring_single_bend_coupler.py
+++ b/gdsfactory/components/ring_single_bend_coupler.py
@@ -63,7 +63,9 @@ def coupler_bend(
     bend_inner_ref = c.create_vinst(bend90_inner_right)
     bend_output_ref = c.create_vinst(bend_output_right)
 
-    output = gf.get_component(bend_output, angle=angle_outer, cross_section=cross_section_outer)
+    output = gf.get_component(
+        bend_output, angle=angle_outer, cross_section=cross_section_outer
+    )
     output_ref = c.create_vinst(output)
     output_ref.connect("o1", bend_output_ref.ports["o2"], mirror=True)
 

--- a/gdsfactory/components/ring_single_bend_coupler.py
+++ b/gdsfactory/components/ring_single_bend_coupler.py
@@ -63,7 +63,7 @@ def coupler_bend(
     bend_inner_ref = c.create_vinst(bend90_inner_right)
     bend_output_ref = c.create_vinst(bend_output_right)
 
-    output = gf.get_component(bend_output, angle=angle_outer)
+    output = gf.get_component(bend_output, angle=angle_outer, cross_section=cross_section_outer)
     output_ref = c.create_vinst(output)
     output_ref.connect("o1", bend_output_ref.ports["o2"], mirror=True)
 

--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -17,6 +17,7 @@ skip_test = {
     "ring_double_pn",
     "pack_doe",
     "pack_doe_grid",
+    "text_freetype",
 }
 cells_to_test = set(cells.keys()) - skip_test
 


### PR DESCRIPTION
previously the output cross section of this component was not being explicitly set. in that case, if you set it to anything other than default, the component breaks with a PortMismatchError