### PR TITLE
Add xsection decorator to pdk

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -27,7 +27,7 @@ from gdsfactory.component import (
 from gdsfactory.config import CONF, PATH
 from gdsfactory.port import Port
 from gdsfactory.read.import_gds import import_gds
-from gdsfactory.cross_section import CrossSection, Section
+from gdsfactory.cross_section import CrossSection, Section, xsection
 from gdsfactory.difftest import difftest, diff
 from gdsfactory.boolean import boolean
 
@@ -139,4 +139,5 @@ __all__ = (
     "typings",
     "vcell",
     "write_cells",
+    "xsection",
 )

--- a/gdsfactory/components/cavity.py
+++ b/gdsfactory/components/cavity.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec
 
 @cell
 def cavity(
-    component: ComponentSpec = dbr,
+    component: ComponentSpec = "dbr",
     coupler: ComponentSpec = "coupler",
     length: float = 0.1,
     gap: float = 0.2,
@@ -42,7 +42,6 @@ def cavity(
     coupler = gf.get_component(coupler, length=length, gap=gap, **kwargs)
 
     c = gf.Component()
-    c.component = mirror
     cr = c << coupler
     ml = c << mirror
     mr = c << mirror

--- a/gdsfactory/components/dbr.py
+++ b/gdsfactory/components/dbr.py
@@ -31,7 +31,6 @@ def dbr_cell(
     l1: float = period / 2,
     l2: float = period / 2,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs,
 ) -> Component:
     """Distributed Bragg Reflector unit cell.
 
@@ -42,7 +41,6 @@ def dbr_cell(
         l2: thick length in um.
         n: number of periods.
         cross_section: cross_section spec.
-        kwargs: cross_section settings.
 
     .. code::
 
@@ -59,9 +57,8 @@ def dbr_cell(
     l2 = snap_to_grid(l2)
     w1 = snap_to_grid(w1, 2)
     w2 = snap_to_grid(w2, 2)
-    xs = gf.get_cross_section(cross_section, **kwargs)
-    xs1 = xs.copy(width=w1)
-    xs2 = xs.copy(width=w2)
+    xs1 = gf.get_cross_section(cross_section, width=w1)
+    xs2 = gf.get_cross_section(cross_section, width=w2)
 
     c = Component()
     c1 = c << straight(length=l1, cross_section=xs1)
@@ -81,7 +78,6 @@ def dbr(
     n: int = 10,
     cross_section: CrossSectionSpec = "strip",
     straight_length: float = 10e-3,
-    **kwargs,
 ) -> Component:
     """Distributed Bragg Reflector.
 
@@ -93,7 +89,6 @@ def dbr(
         n: number of periods.
         cross_section: cross_section spec.
         straight_length: length of the straight section between cutbacks.
-        kwargs: cross_section settings.
 
     .. code::
 
@@ -107,11 +102,11 @@ def dbr(
                |_________
     """
     c = Component()
-    xs = gf.get_cross_section(cross_section, **kwargs)
+    xs = gf.get_cross_section(cross_section)
     s1 = c << straight(cross_section=xs, length=straight_length)
     s2 = c << straight(cross_section=xs, length=straight_length)
 
-    cell = dbr_cell(w1=w1, w2=w2, l1=l1, l2=l2, cross_sectIon=cross_section)
+    cell = dbr_cell(w1=w1, w2=w2, l1=l1, l2=l2, cross_section=cross_section)
     ref = c.add_ref(cell, columns=n, rows=1, spacing=(l1 + l2, 100))
 
     s1.connect(port="o1", other=cell.ports["o1"], allow_width_mismatch=True)

--- a/gdsfactory/components/dbr.py
+++ b/gdsfactory/components/dbr.py
@@ -111,7 +111,7 @@ def dbr(
     s1 = c << straight(cross_section=xs, length=straight_length)
     s2 = c << straight(cross_section=xs, length=straight_length)
 
-    cell = dbr_cell(w1=w1, w2=w2, l1=l1, l2=l2, cross_section=cross_section)
+    cell = dbr_cell(w1=w1, w2=w2, l1=l1, l2=l2, cross_sectIon=cross_section)
     ref = c.add_ref(cell, columns=n, rows=1, spacing=(l1 + l2, 100))
 
     s1.connect(port="o1", other=cell.ports["o1"], allow_width_mismatch=True)

--- a/gdsfactory/components/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_coupler_tree.py
@@ -43,7 +43,6 @@ def grating_coupler_tree(
         with_loopback=with_loopback,
         grating_coupler=grating_coupler,
         fanout_length=fanout_length,
-        component_name=c.name,
         bend=bend,
         taper=None,
         **kwargs,

--- a/gdsfactory/containers.py
+++ b/gdsfactory/containers.py
@@ -26,6 +26,7 @@ from gdsfactory.components.cutback_loss import (
     cutback_loss_spirals,
 )
 from gdsfactory.components.cutback_splitter import cutback_splitter
+from gdsfactory.components.extension import extend_ports
 from gdsfactory.components.pack_doe import pack_doe, pack_doe_grid
 from gdsfactory.routing.add_electrical_pads_shortest import add_electrical_pads_shortest
 from gdsfactory.routing.add_electrical_pads_top import add_electrical_pads_top
@@ -72,4 +73,5 @@ __all__ = [
     "cutback_loss_mmi1x2",
     "cutback_loss_spirals",
     "cutback_splitter",
+    "extend_ports",
 ]

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -751,25 +751,6 @@ def strip_nitride_tip(
     )
 
 
-strip_nitride_silicon_tip = partial(
-    strip,
-    sections=(
-        Section(width=0.1, layer="WGN", name="tip_nitride"),
-        Section(width=0.2, layer="WG", name="tip_silicon"),
-    ),
-)
-strip_sc_tip = partial(
-    nitride,
-    sections=(Section(width=0.2, layer="WG", name="tip"),),
-)
-
-# L shaped waveguide (slab only on one side of the core)
-l_wg = partial(
-    strip,
-    sections=(Section(width=4, layer="SLAB90", name="slab", offset=-2 - 0.25),),
-)
-
-
 @xsection
 def slot(
     width: float = 0.5,

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -688,17 +688,54 @@ def nitride(
     )
 
 
-strip_rib_tip = partial(
-    strip,
-    sections=(Section(width=0.2, layer="SLAB90", name="slab"),),
-)
-strip_nitride_tip = partial(
-    nitride,
-    sections=(
-        Section(width=0.2, layer="WGN", name="tip_nitride"),
-        Section(width=0.1, layer="WG", name="tip_silicon"),
-    ),
-)
+@xsection
+def strip_rib_tip(
+    width: float = 0.5,
+    width_tip: float = 0.2,
+    layer: LayerSpec = "WG",
+    layer_slab: LayerSpec = "SLAB90",
+    radius: float = 10.0,
+    radius_min: float = 5,
+    **kwargs,
+) -> CrossSection:
+    """Return Strip cross_section."""
+    sections = (Section(width=width_tip, layer=layer_slab, name="slab"),)
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        sections=sections,
+        **kwargs,
+    )
+
+
+@xsection
+def strip_nitride_tip(
+    width: float = 1.0,
+    layer: LayerSpec = "WGN",
+    layer_silicon: LayerSpec = "WG",
+    width_tip_nitride: float = 0.2,
+    width_tip_silicon: float = 0.1,
+    radius: float = radius_nitride,
+    radius_min: float = radius_nitride,
+    **kwargs,
+) -> CrossSection:
+    """Return Strip cross_section."""
+    sections = (
+        Section(width=width_tip_nitride, layer=layer, name="tip_nitride"),
+        Section(width=width_tip_silicon, layer=layer_silicon, name="tip_silicon"),
+    )
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        sections=sections,
+        **kwargs,
+    )
+
+
 strip_nitride_silicon_tip = partial(
     strip,
     sections=(

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -241,11 +241,10 @@ class CrossSection(BaseModel):
 
     @property
     def name(self) -> str:
-        if not self._name:
-            h = hashlib.md5(str(self).encode()).hexdigest()[:8]
-            return f"xs_{h}"
-        else:
+        if self._name:
             return self._name
+        h = hashlib.md5(str(self).encode()).hexdigest()[:8]
+        return f"xs_{h}"
 
     @property
     def width(self) -> float:

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -7,10 +7,9 @@ To create a component you need to extrude the path with a cross-section.
 from __future__ import annotations
 
 import hashlib
-import sys
 import warnings
 from collections.abc import Callable, Iterable
-from functools import partial
+from functools import partial, wraps
 from inspect import getmembers, signature
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal
@@ -434,6 +433,35 @@ class Transition(CrossSection):
         return self.cross_section1.sections[0].layer
 
 
+cross_sections = {}
+_cross_section_default_names = {}
+
+
+def xsection(func):
+    """Decorator to register a cross section function.
+
+    Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
+
+    .. code-block:: python
+
+        @xsection
+        def xs_sc(width=TECH.width_sc, radius=TECH.radius_sc):
+            return gf.cross_section.cross_section(width=width, radius=radius)
+    """
+    default_xs = func()
+    _cross_section_default_names[default_xs.name] = func.__name__
+
+    @wraps(func)
+    def newfunc(**kwargs):
+        xs = func(**kwargs)
+        if xs.name in _cross_section_default_names:
+            xs._name = _cross_section_default_names[xs.name]
+        return xs
+
+    cross_sections[func.__name__] = newfunc
+    return newfunc
+
+
 def cross_section(
     width: float = 0.5,
     offset: float = 0,
@@ -554,35 +582,113 @@ def cross_section(
 radius_nitride = 20
 radius_rib = 20
 
-strip = strip = partial(cross_section, radius=10, radius_min=5)
-rib2 = partial(
-    strip,
-    sections=(Section(width=6, layer="SLAB90", name="slab", simplify=50 * nm),),
-    radius=radius_rib,
-    radius_min=radius_rib,
-)
-rib = partial(
-    strip,
-    cladding_layers=("SLAB90",),
-    cladding_offsets=(3,),
-    cladding_simplify=(50 * nm,),
-    radius=radius_rib,
-    radius_min=radius_rib,
-)
-rib_bbox = partial(
-    strip,
-    bbox_layers=("SLAB90",),
-    bbox_offsets=(3,),
-    radius=radius_rib,
-    radius_min=radius_rib,
-)
-nitride = partial(
-    strip,
-    layer="WGN",
-    width=1.0,
-    radius=radius_nitride,
-    radius_min=radius_nitride,
-)
+
+@xsection
+def strip(
+    width: float = 0.5,
+    layer: LayerSpec = "WG",
+    radius: float = 10.0,
+    radius_min: float = 5,
+    **kwargs,
+) -> CrossSection:
+    """Return Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        **kwargs,
+    )
+
+
+@xsection
+def rib(
+    width: float = 0.5,
+    layer: LayerSpec = "WG",
+    radius: float = radius_rib,
+    radius_min: float = radius_rib,
+    cladding_layers: LayerSpecs = ("SLAB90",),
+    cladding_offsets: Floats = (3,),
+    cladding_simplify: Floats = (50 * nm,),
+    **kwargs,
+) -> CrossSection:
+    """Return Rib cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        cladding_layers=cladding_layers,
+        cladding_offsets=cladding_offsets,
+        cladding_simplify=cladding_simplify,
+        **kwargs,
+    )
+
+
+@xsection
+def rib_bbox(
+    width: float = 0.5,
+    layer: LayerSpec = "WG",
+    radius: float = radius_rib,
+    radius_min: float = radius_rib,
+    bbox_layers: LayerSpecs = ("SLAB90",),
+    bbox_offsets: Floats = (3,),
+    **kwargs,
+) -> CrossSection:
+    """Return Rib cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        bbox_layers=bbox_layers,
+        bbox_offsets=bbox_offsets,
+        **kwargs,
+    )
+
+
+@xsection
+def rib2(
+    width: float = 0.5,
+    layer: LayerSpec = "WG",
+    layer_slab: LayerSpec = "SLAB90",
+    radius: float = radius_rib,
+    radius_min: float = radius_rib,
+    width_slab: float = 6,
+    **kwargs,
+) -> CrossSection:
+    """Return Rib cross_section."""
+    sections = (
+        Section(width=width_slab, layer=layer_slab, name="slab", simplify=50 * nm),
+    )
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        sections=sections,
+        **kwargs,
+    )
+
+
+@xsection
+def nitride(
+    width: float = 1.0,
+    layer: LayerSpec = "WGN",
+    radius: float = radius_nitride,
+    radius_min: float = radius_nitride,
+    **kwargs,
+) -> CrossSection:
+    """Return Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        **kwargs,
+    )
+
+
 strip_rib_tip = partial(
     strip,
     sections=(Section(width=0.2, layer="SLAB90", name="slab"),),
@@ -605,6 +711,7 @@ strip_sc_tip = partial(
     nitride,
     sections=(Section(width=0.2, layer="WG", name="tip"),),
 )
+
 # L shaped waveguide (slab only on one side of the core)
 l_wg = partial(
     strip,
@@ -612,6 +719,7 @@ l_wg = partial(
 )
 
 
+@xsection
 def slot(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -654,6 +762,7 @@ def slot(
     )
 
 
+@xsection
 def rib_with_trenches(
     width: float = 0.5,
     width_trench: float = 2.0,
@@ -752,6 +861,7 @@ def rib_with_trenches(
     )
 
 
+@xsection
 def l_with_trenches(
     width: float = 0.5,
     width_trench: float = 2.0,
@@ -828,43 +938,127 @@ def l_with_trenches(
     )
 
 
-metal1 = partial(
-    cross_section,
-    layer="M1",
-    width=10.0,
+@xsection
+def metal1(
+    width: float = 10,
+    layer: LayerSpec = "M1",
+    radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    radius=None,
-)
-metal2 = partial(
-    metal1,
-    layer="M2",
-)
-metal3 = partial(
-    metal1,
-    layer="M3",
-)
-heater_metal = partial(
-    metal1,
-    width=2.5,
-    layer="HEATER",
-)
-
-metal_routing = metal3
-npp = partial(metal1, layer="NPP", width=0.5)
-
-metal_slotted = partial(
-    cross_section,
-    width=10,
-    offset=0,
-    layer="M3",
-    sections=(
-        Section(width=10, layer="M3", offset=11),
-        Section(width=10, layer="M3", offset=-11),
-    ),
-)
+    **kwargs,
+) -> CrossSection:
+    """Return Metal Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
 
 
+@xsection
+def metal2(
+    width: float = 10,
+    layer: LayerSpec = "M2",
+    radius: float | None = None,
+    port_names=port_names_electrical,
+    port_types=port_types_electrical,
+    **kwargs,
+) -> CrossSection:
+    """Return Metal Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
+
+
+@xsection
+def metal3(
+    width: float = 10,
+    layer: LayerSpec = "M3",
+    radius: float | None = None,
+    port_names=port_names_electrical,
+    port_types=port_types_electrical,
+    **kwargs,
+) -> CrossSection:
+    """Return Metal Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
+
+
+@xsection
+def metal_routing(
+    width: float = 10,
+    layer: LayerSpec = "M3",
+    radius: float | None = None,
+    port_names=port_names_electrical,
+    port_types=port_types_electrical,
+    **kwargs,
+) -> CrossSection:
+    """Return Metal Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
+
+
+@xsection
+def heater_metal(
+    width: float = 2.5,
+    layer: LayerSpec = "HEATER",
+    radius: float | None = None,
+    port_names=port_names_electrical,
+    port_types=port_types_electrical,
+    **kwargs,
+) -> CrossSection:
+    """Return Metal Strip cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
+
+
+@xsection
+def npp(
+    width: float = 0.5,
+    layer: LayerSpec = "NPP",
+    radius: float | None = None,
+    port_names=port_names_electrical,
+    port_types=port_types_electrical,
+    **kwargs,
+) -> CrossSection:
+    """Return Doped NPP cross_section."""
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        port_names=port_names,
+        port_types=port_types,
+        **kwargs,
+    )
+
+
+@xsection
 def pin(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -968,6 +1162,7 @@ def pin(
     )
 
 
+@xsection
 def pn(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -1155,6 +1350,7 @@ def pn(
     )
 
 
+@xsection
 def pn_with_trenches(
     width: float = 0.5,
     layer: LayerSpec | None = None,
@@ -1363,6 +1559,7 @@ def pn_with_trenches(
     )
 
 
+@xsection
 def pn_with_trenches_asymmetric(
     width: float = 0.5,
     layer: LayerSpec | None = None,
@@ -1585,6 +1782,7 @@ def pn_with_trenches_asymmetric(
     )
 
 
+@xsection
 def l_wg_doped_with_trenches(
     width: float = 0.5,
     layer: LayerSpec | None = None,
@@ -1752,6 +1950,7 @@ def l_wg_doped_with_trenches(
     )
 
 
+@xsection
 def strip_heater_metal_undercut(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -1829,6 +2028,7 @@ def strip_heater_metal_undercut(
     )
 
 
+@xsection
 def strip_heater_metal(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -1877,6 +2077,7 @@ def strip_heater_metal(
     )
 
 
+@xsection
 def strip_heater_doped(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -1950,13 +2151,7 @@ def strip_heater_doped(
     )
 
 
-strip_heater_doped_via_stack = partial(
-    strip_heater_doped,
-    layers_heater=("WG", "NPP", "VIAC"),
-    bbox_offsets_heater=(0, 0.1, -0.2),
-)
-
-
+@xsection
 def rib_heater_doped(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -2041,6 +2236,7 @@ def rib_heater_doped(
     )
 
 
+@xsection
 def rib_heater_doped_via_stack(
     width: float = 0.5,
     layer: LayerSpec = "WG",
@@ -2168,6 +2364,7 @@ def rib_heater_doped_via_stack(
     )
 
 
+@xsection
 def pn_ge_detector_si_contacts(
     width_si: float = 6.0,
     layer_si: LayerSpec = "WG",
@@ -2373,7 +2570,7 @@ def get_cross_sections(
     return xs
 
 
-cross_sections = get_cross_sections(sys.modules[__name__])
+# cross_sections = get_cross_sections(sys.modules[__name__])
 
 
 if __name__ == "__main__":
@@ -2393,5 +2590,9 @@ if __name__ == "__main__":
     # xs = pn(slab_inset=0.2)
     # xs = metal1()
     # s0 = Section(width=2, layer=(1, 0))
-    xs = strip(radius=5)
-    # print(s0.name)
+    # xs = strip()
+    # print(xs.name)
+    import gdsfactory as gf
+
+    xs = gf.get_cross_section("metal_routing")
+    print(xs.name)

--- a/gdsfactory/generic_tech/cells.py
+++ b/gdsfactory/generic_tech/cells.py
@@ -19,7 +19,9 @@ straight_heater_metal = partial(
     cross_section=xs.strip,
 )
 terminator = partial(gf.c.taper, width2=1)
-grating_coupler_te = partial(gf.c.grating_coupler_te, cross_section=xs.strip)
+
+grating_coupler_te = partial(gf.c.grating_coupler_te, cross_section="strip")
+# grating_coupler_te = partial(gf.c.grating_coupler_te, cross_section=xs.strip)
 pad = partial(gf.c.pad, size=pad_size, layer=LAYER.MTOP)
 
 mmi1x2 = partial(
@@ -40,7 +42,7 @@ add_fiber_array_optical_south_electrical_north = partial(
     component=straight_heater_metal,
     pad=pad,
     grating_coupler=grating_coupler_te,
-    cross_section_metal=xs.metal_routing,
+    cross_section_metal="metal_routing",
     pad_spacing=pad_spacing,
 )
 add_termination = partial(gf.c.add_termination, terminator=terminator)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -12,8 +12,8 @@ from typing import Any
 import kfactory as kf
 import numpy as np
 import yaml
-from kfactory import KCLayout, LayerEnum
-from pydantic import ConfigDict, Field
+from kfactory import LayerEnum
+from pydantic import BaseModel, ConfigDict, Field
 
 from gdsfactory import logger
 from gdsfactory.config import CONF
@@ -109,7 +109,7 @@ def extract_args_from_docstring(docstring: str) -> dict[str, Any] | None:
     return args_dict
 
 
-class Pdk(KCLayout):
+class Pdk(BaseModel):
     """Store layers, cross_sections, cell functions, simulation_settings ...
 
     only one Pdk can be active at a given time.
@@ -142,6 +142,7 @@ class Pdk(KCLayout):
 
     """
 
+    name: str
     cross_sections: dict[str, CrossSectionOrFactory] = Field(
         default_factory=dict, exclude=True
     )

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -19,7 +19,6 @@ def add_fiber_array(
     component: ComponentSpec = straight_function,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     gc_port_name: str = "o1",
-    component_name: str | None = None,
     select_ports: Callable = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
     taper: ComponentSpec | None = None,
@@ -33,7 +32,6 @@ def add_fiber_array(
         component: component spec to connect to grating couplers.
         grating_coupler: spec for route terminations.
         gc_port_name: grating coupler input port name.
-        component_name: optional for the label.
         select_ports: function to select ports.
         cross_section: cross_section function.
         taper: taper spec.
@@ -108,7 +106,6 @@ def add_fiber_array(
     if gc_port_name not in gc.ports:
         raise ValueError(f"gc_port_name={gc_port_name!r} not in {gc.ports.keys()}")
 
-    component_name = component_name or component.name
     component_new = Component()
 
     optical_ports = select_ports(component.ports)
@@ -121,7 +118,6 @@ def add_fiber_array(
         ref,
         grating_coupler=grating_coupler,
         gc_port_name=gc_port_name,
-        component_name=component_name,
         cross_section=cross_section,
         select_ports=select_ports,
         taper=taper,
@@ -135,8 +131,8 @@ def add_fiber_array(
 if __name__ == "__main__":
     from gdsfactory.samples.big_device import big_device
 
-    component = big_device(nports=10)
     component = gf.c.mmi2x2()
+    component = big_device(nports=10)
     radius = 5.0
     c = add_fiber_array(component=component)
     # test_type0()

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -19,7 +19,6 @@ def add_fiber_single(
     component: ComponentSpec = straight_function,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     gc_port_name: str = "o1",
-    component_name: str | None = None,
     select_ports: Callable = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
     taper: ComponentSpec | None = None,
@@ -38,7 +37,6 @@ def add_fiber_single(
         component: component spec to connect to grating couplers.
         grating_coupler: spec for route terminations.
         gc_port_name: grating coupler input port name.
-        component_name: optional for the label.
         select_ports: function to select ports.
         cross_section: cross_section function.
         taper: taper spec.
@@ -113,8 +111,7 @@ def add_fiber_single(
         else gf.get_component(grating_coupler)
     )
 
-    component_name = component_name or component.name
-    c1 = Component(f"{component_name}_fiber_single")
+    c1 = Component()
     ref = c1.add_ref(component)
 
     input_port_names = input_port_names or [
@@ -130,7 +127,6 @@ def add_fiber_single(
         ref,
         grating_coupler=grating_coupler,
         gc_port_name=gc_port_name,
-        component_name=component_name,
         cross_section=cross_section,
         select_ports=select_ports,
         taper=taper,
@@ -148,7 +144,6 @@ def add_fiber_single(
         ref,
         grating_coupler=grating_coupler,
         gc_port_name=gc_port_name,
-        component_name=component_name,
         cross_section=cross_section,
         select_ports=select_ports,
         taper=taper,

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -19,7 +19,6 @@ def add_pads_bot(
     component: ComponentSpec = straight_heater_metal,
     select_ports: Callable = select_ports_electrical,
     port_names: Strs | None = None,
-    component_name: str | None = None,
     cross_section: CrossSectionSpec = "metal_routing",
     pad_port_name: str = "e1",
     pad: ComponentSpec = pad_rectangular,
@@ -40,7 +39,6 @@ def add_pads_bot(
         component: component spec to connect to.
         select_ports: function to select_ports.
         port_names: optional port names. Overrides select_ports.
-        component_name: optional for the label.
         cross_section: cross_section spec.
         get_input_labels_function: function to get input labels. None skips labels.
         layer_label: optional layer for grating coupler label.
@@ -95,7 +93,6 @@ def add_pads_bot(
     """
     component_new = Component()
     component = gf.get_component(component)
-    component_name = component_name or component.name
 
     pad_spacing = gf.get_constant(pad_spacing)
     cref = component_new << component
@@ -125,7 +122,6 @@ def add_pads_bot(
         component,
         grating_coupler=pad,
         gc_port_name=pad_port_name,
-        component_name=component_name,
         cross_section=cross_section,
         select_ports=select_ports,
         with_loopback=False,
@@ -159,7 +155,6 @@ def add_pads_top(
     Keyword Args:
         select_ports: function to select_ports.
         port_names: optional port names. Overrides select_ports.
-        component_name: optional for the label.
         cross_section: cross_section function.
         get_input_labels_function: function to get input labels. None skips labels.
         layer_label: optional layer for grating coupler label.

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -153,7 +153,10 @@ def route_fiber_array(
     # - grating_couplers is a list of grating couplers
     # Define the route filter to apply to connection methods
 
-    bend90 = gf.get_component(bend, cross_section=cross_section, radius=radius)
+    if radius:
+        bend90 = gf.get_component(bend, cross_section=cross_section, radius=radius)
+    else:
+        bend90 = gf.get_component(bend, cross_section=cross_section)
 
     # `delta_gr_min` Used to avoid crossing between straights in special cases
     # This could happen when abs(x_port - x_grating) <= 2 * radius

--- a/gdsfactory/samples/21_add_fiber_array.py
+++ b/gdsfactory/samples/21_add_fiber_array.py
@@ -11,7 +11,7 @@ def big_device_with_gratings() -> gf.Component:
     component = big_device(nports=10)
     radius = 5.0
     return gf.routing.add_fiber_array(
-        component=component, radius=radius, fanout_length=50.0
+        component=component, radius=radius, fanout_length=50.0, radius_loopback=10
     )
 
 

--- a/gdsfactory/samples/sample_reticle.py
+++ b/gdsfactory/samples/sample_reticle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import gdsfactory as gf
 
 
-@gf.cell(check_ports=False)
+@gf.cell
 def spiral_gc(**kwargs):
     c = gf.c.spiral(**kwargs)
     c = gf.routing.add_fiber_array(c)
@@ -13,7 +13,7 @@ def spiral_gc(**kwargs):
     return c
 
 
-@gf.cell(check_ports=False)
+@gf.cell
 def mzi_gc(length_x=10, **kwargs):
     c = gf.components.mzi2x2_2x2_phase_shifter(
         length_x=length_x, auto_rename_ports=False, **kwargs
@@ -26,7 +26,7 @@ def mzi_gc(length_x=10, **kwargs):
     return c
 
 
-@gf.cell(check_ports=False)
+@gf.cell
 def sample_reticle(grid: bool = False) -> gf.Component:
     """Returns MZI with TE grating couplers."""
     from gdsfactory.generic_tech.cells import (
@@ -34,9 +34,7 @@ def sample_reticle(grid: bool = False) -> gf.Component:
     )
 
     mzis = [mzi_gc(length_x=lengths) for lengths in [100, 200, 300]]
-
     spirals = [spiral_gc(length=length) for length in [0, 100, 200]]
-
     rings = []
     for length_x in [10, 20, 30]:
         ring = gf.components.ring_single_heater(length_x=length_x)
@@ -47,9 +45,8 @@ def sample_reticle(grid: bool = False) -> gf.Component:
         ring_te.name = f"ring_{length_x}"
         rings.append(ring_te)
 
-    copies = 3
+    copies = 3  # number of copies of each component
     components = mzis * copies + rings * copies + spirals * copies
-
     if grid:
         return gf.grid(components)
     c = gf.pack(components)

--- a/test-data-regression/test_import_gds_ports.yml
+++ b/test-data-regression/test_import_gds_ports.yml
@@ -1,9 +1,9 @@
 info:
   length: 10
   route_info_length: 10
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 10
+  route_info_type: strip
   route_info_weight: 10
-  route_info_xs_34e31a19_length: 10
   width: 0.5
 name: straight_L10_N2_CSstrip
 settings:

--- a/test-data-regression/test_netlists_add_termination_.yml
+++ b/test-data-regression/test_netlists_add_termination_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_awg_.yml
+++ b/test-data-regression/test_netlists_awg_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -49,9 +49,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -69,9 +69,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -89,9 +89,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -109,9 +109,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -129,9 +129,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -149,9 +149,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -169,9 +169,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -189,9 +189,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -209,9 +209,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -229,9 +229,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -249,9 +249,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -269,9 +269,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -289,9 +289,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -309,9 +309,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -329,9 +329,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -349,9 +349,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -369,9 +369,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -389,9 +389,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -432,9 +432,9 @@ instances:
     info:
       length: 10.5
       route_info_length: 10.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10.5
+      route_info_type: strip
       route_info_weight: 10.5
-      route_info_xs_34e31a19_length: 10.5
       width: 0.5
     settings:
       cross_section: strip
@@ -446,9 +446,9 @@ instances:
     info:
       length: 10.5
       route_info_length: 10.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10.5
+      route_info_type: strip
       route_info_weight: 10.5
-      route_info_xs_34e31a19_length: 10.5
       width: 0.5
     settings:
       cross_section: strip
@@ -460,9 +460,9 @@ instances:
     info:
       length: 10.5
       route_info_length: 10.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10.5
+      route_info_type: strip
       route_info_weight: 10.5
-      route_info_xs_34e31a19_length: 10.5
       width: 0.5
     settings:
       cross_section: strip
@@ -474,9 +474,9 @@ instances:
     info:
       length: 12
       route_info_length: 12
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 12
+      route_info_type: strip
       route_info_weight: 12
-      route_info_xs_34e31a19_length: 12
       width: 0.5
     settings:
       cross_section: strip
@@ -488,9 +488,9 @@ instances:
     info:
       length: 12
       route_info_length: 12
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 12
+      route_info_type: strip
       route_info_weight: 12
-      route_info_xs_34e31a19_length: 12
       width: 0.5
     settings:
       cross_section: strip
@@ -502,9 +502,9 @@ instances:
     info:
       length: 13.5
       route_info_length: 13.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 13.5
+      route_info_type: strip
       route_info_weight: 13.5
-      route_info_xs_34e31a19_length: 13.5
       width: 0.5
     settings:
       cross_section: strip
@@ -516,9 +516,9 @@ instances:
     info:
       length: 13.5
       route_info_length: 13.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 13.5
+      route_info_type: strip
       route_info_weight: 13.5
-      route_info_xs_34e31a19_length: 13.5
       width: 0.5
     settings:
       cross_section: strip
@@ -530,9 +530,9 @@ instances:
     info:
       length: 14.834
       route_info_length: 14.834
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 14.834
+      route_info_type: strip
       route_info_weight: 14.834
-      route_info_xs_34e31a19_length: 14.834
       width: 0.5
     settings:
       cross_section: strip
@@ -544,9 +544,9 @@ instances:
     info:
       length: 19.166
       route_info_length: 19.166
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 19.166
+      route_info_type: strip
       route_info_weight: 19.166
-      route_info_xs_34e31a19_length: 19.166
       width: 0.5
     settings:
       cross_section: strip
@@ -558,9 +558,9 @@ instances:
     info:
       length: 1.5
       route_info_length: 1.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 1.5
+      route_info_type: strip
       route_info_weight: 1.5
-      route_info_xs_34e31a19_length: 1.5
       width: 0.5
     settings:
       cross_section: strip
@@ -572,9 +572,9 @@ instances:
     info:
       length: 1.5
       route_info_length: 1.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 1.5
+      route_info_type: strip
       route_info_weight: 1.5
-      route_info_xs_34e31a19_length: 1.5
       width: 0.5
     settings:
       cross_section: strip
@@ -586,9 +586,9 @@ instances:
     info:
       length: 23.5
       route_info_length: 23.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 23.5
+      route_info_type: strip
       route_info_weight: 23.5
-      route_info_xs_34e31a19_length: 23.5
       width: 0.5
     settings:
       cross_section: strip
@@ -600,9 +600,9 @@ instances:
     info:
       length: 27.834
       route_info_length: 27.834
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 27.834
+      route_info_type: strip
       route_info_weight: 27.834
-      route_info_xs_34e31a19_length: 27.834
       width: 0.5
     settings:
       cross_section: strip
@@ -614,9 +614,9 @@ instances:
     info:
       length: 32.166
       route_info_length: 32.166
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 32.166
+      route_info_type: strip
       route_info_weight: 32.166
-      route_info_xs_34e31a19_length: 32.166
       width: 0.5
     settings:
       cross_section: strip
@@ -628,9 +628,9 @@ instances:
     info:
       length: 36.5
       route_info_length: 36.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 36.5
+      route_info_type: strip
       route_info_weight: 36.5
-      route_info_xs_34e31a19_length: 36.5
       width: 0.5
     settings:
       cross_section: strip
@@ -642,9 +642,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3
+      route_info_type: strip
       route_info_weight: 3
-      route_info_xs_34e31a19_length: 3
       width: 0.5
     settings:
       cross_section: strip
@@ -656,9 +656,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3
+      route_info_type: strip
       route_info_weight: 3
-      route_info_xs_34e31a19_length: 3
       width: 0.5
     settings:
       cross_section: strip
@@ -670,9 +670,9 @@ instances:
     info:
       length: 40.834
       route_info_length: 40.834
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.834
+      route_info_type: strip
       route_info_weight: 40.834
-      route_info_xs_34e31a19_length: 40.834
       width: 0.5
     settings:
       cross_section: strip
@@ -684,9 +684,9 @@ instances:
     info:
       length: 45.166
       route_info_length: 45.166
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 45.166
+      route_info_type: strip
       route_info_weight: 45.166
-      route_info_xs_34e31a19_length: 45.166
       width: 0.5
     settings:
       cross_section: strip
@@ -698,9 +698,9 @@ instances:
     info:
       length: 49.5
       route_info_length: 49.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 49.5
+      route_info_type: strip
       route_info_weight: 49.5
-      route_info_xs_34e31a19_length: 49.5
       width: 0.5
     settings:
       cross_section: strip
@@ -712,9 +712,9 @@ instances:
     info:
       length: 4.5
       route_info_length: 4.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4.5
+      route_info_type: strip
       route_info_weight: 4.5
-      route_info_xs_34e31a19_length: 4.5
       width: 0.5
     settings:
       cross_section: strip
@@ -726,9 +726,9 @@ instances:
     info:
       length: 4.5
       route_info_length: 4.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4.5
+      route_info_type: strip
       route_info_weight: 4.5
-      route_info_xs_34e31a19_length: 4.5
       width: 0.5
     settings:
       cross_section: strip
@@ -740,9 +740,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 6
+      route_info_type: strip
       route_info_weight: 6
-      route_info_xs_34e31a19_length: 6
       width: 0.5
     settings:
       cross_section: strip
@@ -754,9 +754,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 6
+      route_info_type: strip
       route_info_weight: 6
-      route_info_xs_34e31a19_length: 6
       width: 0.5
     settings:
       cross_section: strip
@@ -768,9 +768,9 @@ instances:
     info:
       length: 7.5
       route_info_length: 7.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.5
+      route_info_type: strip
       route_info_weight: 7.5
-      route_info_xs_34e31a19_length: 7.5
       width: 0.5
     settings:
       cross_section: strip
@@ -782,9 +782,9 @@ instances:
     info:
       length: 7.5
       route_info_length: 7.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.5
+      route_info_type: strip
       route_info_weight: 7.5
-      route_info_xs_34e31a19_length: 7.5
       width: 0.5
     settings:
       cross_section: strip
@@ -796,9 +796,9 @@ instances:
     info:
       length: 9
       route_info_length: 9
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 9
+      route_info_type: strip
       route_info_weight: 9
-      route_info_xs_34e31a19_length: 9
       width: 0.5
     settings:
       cross_section: strip
@@ -810,9 +810,9 @@ instances:
     info:
       length: 9
       route_info_length: 9
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 9
+      route_info_type: strip
       route_info_weight: 9
-      route_info_xs_34e31a19_length: 9
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_bend_euler_s_.yml
+++ b/test-data-regression/test_netlists_bend_euler_s_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90

--- a/test-data-regression/test_netlists_cdsem_coupler_.yml
+++ b/test-data-regression/test_netlists_cdsem_coupler_.yml
@@ -1,24 +1,24 @@
 instances:
-  coupler_straight_L420_G_16dd3191_210000_7600:
+  coupler_straight_L420_G_5a603e4c_210000_14625:
     component: coupler_straight
     info: {}
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
+      gap: 0.25
+      length: 420
+  coupler_straight_L420_G_ae24e604_210000_7600:
+    component: coupler_straight
+    info: {}
+    settings:
+      cross_section: strip
       gap: 0.2
       length: 420
-  coupler_straight_L420_G_1a01aeec_210000_575:
+  coupler_straight_L420_G_c3c00a0e_210000_575:
     component: coupler_straight
     info: {}
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       gap: 0.15
-      length: 420
-  coupler_straight_L420_G_dd437795_210000_14625:
-    component: coupler_straight
-    info: {}
-    settings:
-      cross_section: xs_34e31a19
-      gap: 0.25
       length: 420
   text_rectangular_T150_S_009a275c_433000_2500:
     component: text_rectangular
@@ -56,21 +56,21 @@ instances:
 name: cdsem_coupler_L420_G0p1_0fa6dd27
 nets: []
 placements:
-  coupler_straight_L420_G_16dd3191_210000_7600:
-    mirror: false
-    rotation: 0
-    x: 0
-    y: 7.25
-  coupler_straight_L420_G_1a01aeec_210000_575:
-    mirror: false
-    rotation: 0
-    x: 0
-    y: 0.25
-  coupler_straight_L420_G_dd437795_210000_14625:
+  coupler_straight_L420_G_5a603e4c_210000_14625:
     mirror: false
     rotation: 0
     x: 0
     y: 14.25
+  coupler_straight_L420_G_ae24e604_210000_7600:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 7.25
+  coupler_straight_L420_G_c3c00a0e_210000_575:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0.25
   text_rectangular_T150_S_009a275c_433000_2500:
     mirror: false
     rotation: 0
@@ -92,18 +92,18 @@ warnings:
     unconnected_ports:
     - message: 12 unconnected optical ports!
       ports:
-      - coupler_straight_L420_G_1a01aeec_210000_575,o1
-      - coupler_straight_L420_G_1a01aeec_210000_575,o2
-      - coupler_straight_L420_G_1a01aeec_210000_575,o4
-      - coupler_straight_L420_G_1a01aeec_210000_575,o3
-      - coupler_straight_L420_G_16dd3191_210000_7600,o1
-      - coupler_straight_L420_G_16dd3191_210000_7600,o2
-      - coupler_straight_L420_G_16dd3191_210000_7600,o4
-      - coupler_straight_L420_G_16dd3191_210000_7600,o3
-      - coupler_straight_L420_G_dd437795_210000_14625,o1
-      - coupler_straight_L420_G_dd437795_210000_14625,o2
-      - coupler_straight_L420_G_dd437795_210000_14625,o4
-      - coupler_straight_L420_G_dd437795_210000_14625,o3
+      - coupler_straight_L420_G_c3c00a0e_210000_575,o1
+      - coupler_straight_L420_G_c3c00a0e_210000_575,o2
+      - coupler_straight_L420_G_c3c00a0e_210000_575,o4
+      - coupler_straight_L420_G_c3c00a0e_210000_575,o3
+      - coupler_straight_L420_G_ae24e604_210000_7600,o1
+      - coupler_straight_L420_G_ae24e604_210000_7600,o2
+      - coupler_straight_L420_G_ae24e604_210000_7600,o4
+      - coupler_straight_L420_G_ae24e604_210000_7600,o3
+      - coupler_straight_L420_G_5a603e4c_210000_14625,o1
+      - coupler_straight_L420_G_5a603e4c_210000_14625,o2
+      - coupler_straight_L420_G_5a603e4c_210000_14625,o4
+      - coupler_straight_L420_G_5a603e4c_210000_14625,o3
       values:
       - - 0
         - 250

--- a/test-data-regression/test_netlists_cdsem_straight_.yml
+++ b/test-data-regression/test_netlists_cdsem_straight_.yml
@@ -32,9 +32,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 420
+      route_info_type: strip
       route_info_weight: 420
-      route_info_xs_34e31a19_length: 420
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coh_rx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_rx_single_pol_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -49,9 +49,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -69,9 +69,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -89,9 +89,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -109,9 +109,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -129,9 +129,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -149,9 +149,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -228,9 +228,9 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
       cross_section: strip
@@ -241,9 +241,9 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
       cross_section: strip
@@ -254,9 +254,9 @@ instances:
     info:
       length: 36.5
       route_info_length: 36.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 36.5
+      route_info_type: strip
       route_info_weight: 36.5
-      route_info_xs_34e31a19_length: 36.5
       width: 0.5
     settings:
       cross_section: strip
@@ -268,9 +268,9 @@ instances:
     info:
       length: 36.5
       route_info_length: 36.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 36.5
+      route_info_type: strip
       route_info_weight: 36.5
-      route_info_xs_34e31a19_length: 36.5
       width: 0.5
     settings:
       cross_section: strip
@@ -282,9 +282,9 @@ instances:
     info:
       length: 3.5
       route_info_length: 3.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3.5
+      route_info_type: strip
       route_info_weight: 3.5
-      route_info_xs_34e31a19_length: 3.5
       width: 0.5
     settings:
       cross_section: strip
@@ -296,9 +296,9 @@ instances:
     info:
       length: 3.5
       route_info_length: 3.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3.5
+      route_info_type: strip
       route_info_weight: 3.5
-      route_info_xs_34e31a19_length: 3.5
       width: 0.5
     settings:
       cross_section: strip
@@ -310,9 +310,9 @@ instances:
     info:
       length: 3.75
       route_info_length: 3.75
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3.75
+      route_info_type: strip
       route_info_weight: 3.75
-      route_info_xs_34e31a19_length: 3.75
       width: 0.5
     settings:
       cross_section: strip
@@ -324,9 +324,9 @@ instances:
     info:
       length: 3.75
       route_info_length: 3.75
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3.75
+      route_info_type: strip
       route_info_weight: 3.75
-      route_info_xs_34e31a19_length: 3.75
       width: 0.5
     settings:
       cross_section: strip
@@ -338,9 +338,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -352,9 +352,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -366,9 +366,9 @@ instances:
     info:
       length: 51.25
       route_info_length: 51.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 51.25
+      route_info_type: strip
       route_info_weight: 51.25
-      route_info_xs_34e31a19_length: 51.25
       width: 0.5
     settings:
       cross_section: strip
@@ -380,9 +380,9 @@ instances:
     info:
       length: 51.25
       route_info_length: 51.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 51.25
+      route_info_type: strip
       route_info_weight: 51.25
-      route_info_xs_34e31a19_length: 51.25
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -130,9 +130,9 @@ instances:
     info:
       length: 65.875
       route_info_length: 65.875
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 65.875
+      route_info_type: strip
       route_info_weight: 65.875
-      route_info_xs_34e31a19_length: 65.875
       width: 0.5
     settings:
       cross_section: strip
@@ -144,9 +144,9 @@ instances:
     info:
       length: 65.875
       route_info_length: 65.875
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 65.875
+      route_info_type: strip
       route_info_weight: 65.875
-      route_info_xs_34e31a19_length: 65.875
       width: 0.5
     settings:
       cross_section: strip
@@ -158,9 +158,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip
@@ -172,9 +172,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coh_tx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_single_pol_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -93,9 +93,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -114,9 +114,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -135,9 +135,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -156,9 +156,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -246,9 +246,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 100
+      route_info_type: strip
       route_info_weight: 100
-      route_info_xs_34e31a19_length: 100
       width: 0.5
     settings:
       cross_section: strip
@@ -259,9 +259,9 @@ instances:
     info:
       length: 32.625
       route_info_length: 32.625
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 32.625
+      route_info_type: strip
       route_info_weight: 32.625
-      route_info_xs_34e31a19_length: 32.625
       width: 0.5
     settings:
       cross_section: strip
@@ -273,9 +273,9 @@ instances:
     info:
       length: 32.625
       route_info_length: 32.625
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 32.625
+      route_info_type: strip
       route_info_weight: 32.625
-      route_info_xs_34e31a19_length: 32.625
       width: 0.5
     settings:
       cross_section: strip
@@ -287,9 +287,9 @@ instances:
     info:
       length: 32.625
       route_info_length: 32.625
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 32.625
+      route_info_type: strip
       route_info_weight: 32.625
-      route_info_xs_34e31a19_length: 32.625
       width: 0.5
     settings:
       cross_section: strip
@@ -301,9 +301,9 @@ instances:
     info:
       length: 32.625
       route_info_length: 32.625
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 32.625
+      route_info_type: strip
       route_info_weight: 32.625
-      route_info_xs_34e31a19_length: 32.625
       width: 0.5
     settings:
       cross_section: strip
@@ -315,9 +315,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -328,9 +328,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -341,9 +341,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip
@@ -355,9 +355,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip
@@ -369,9 +369,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip
@@ -383,9 +383,9 @@ instances:
     info:
       length: 7.25
       route_info_length: 7.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.25
+      route_info_type: strip
       route_info_weight: 7.25
-      route_info_xs_34e31a19_length: 7.25
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coupler90_.yml
+++ b/test-data-regression/test_netlists_coupler90_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -24,9 +24,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coupler90circular_.yml
+++ b/test-data-regression/test_netlists_coupler90circular_.yml
@@ -8,9 +8,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -21,9 +21,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coupler_adiabatic_.yml
+++ b/test-data-regression/test_netlists_coupler_adiabatic_.yml
@@ -1,5 +1,5 @@
 instances:
-  bezier_CP0_0_10_0_10_m1_4767eb94_m20000_1270:
+  bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270:
     component: bezier
     info:
       end_angle: 0
@@ -8,9 +8,9 @@ instances:
       route_info_length: 20.036
       route_info_min_bend_radius: 72.935
       route_info_n_bend_s: 1
-      route_info_type: xs_4ec6b2c0
+      route_info_strip_length: 20.036
+      route_info_type: strip
       route_info_weight: 20.036
-      route_info_xs_4ec6b2c0_length: 20.036
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -23,10 +23,10 @@ instances:
         - -1
       - - 20
         - -1
-      cross_section: xs_4ec6b2c0
+      cross_section: strip
       npoints: 201
       with_manhattan_facing_angles: true
-  bezier_CP0_m3_10_m3_10__07235f68_m20000_m500:
+  bezier_CP0_m3_10_m3_10__494670bd_m20000_m500:
     component: bezier
     info:
       end_angle: 0
@@ -35,9 +35,9 @@ instances:
       route_info_length: 20.036
       route_info_min_bend_radius: 72.935
       route_info_n_bend_s: 1
-      route_info_type: xs_d9e914be
+      route_info_strip_length: 20.036
+      route_info_type: strip
       route_info_weight: 20.036
-      route_info_xs_d9e914be_length: 20.036
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -50,10 +50,10 @@ instances:
         - -2
       - - 20
         - -2
-      cross_section: xs_d9e914be
+      cross_section: strip
       npoints: 201
       with_manhattan_facing_angles: true
-  bezier_CP70_m1_85_m1_85_5940811d_65000_1270:
+  bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270:
     component: bezier
     info:
       end_angle: 0
@@ -62,9 +62,9 @@ instances:
       route_info_length: 30.024
       route_info_min_bend_radius: 163.506
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30.024
+      route_info_type: strip
       route_info_weight: 30.024
-      route_info_xs_34e31a19_length: 30.024
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -77,10 +77,10 @@ instances:
         - 0
       - - 100
         - 0
-      cross_section: xs_34e31a19
+      cross_section: strip
       npoints: 201
       with_manhattan_facing_angles: true
-  bezier_CP70_m1_85_m1_85_5940811d_65000_m500:
+  bezier_CP70_m1_85_m1_85_c9a8926c_65000_m500:
     component: bezier
     info:
       end_angle: 0
@@ -89,9 +89,9 @@ instances:
       route_info_length: 30.024
       route_info_min_bend_radius: 163.506
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30.024
+      route_info_type: strip
       route_info_weight: 30.024
-      route_info_xs_34e31a19_length: 30.024
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -104,14 +104,14 @@ instances:
         - 0
       - - 100
         - 0
-      cross_section: xs_34e31a19
+      cross_section: strip
       npoints: 201
       with_manhattan_facing_angles: true
-  coupler_straight_L50_G0_a8f21bfb_25000_385:
+  coupler_straight_L50_G0_e5e3337b_25000_385:
     component: coupler_straight
     info: {}
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       gap: 0.27
       length: 50
   taper_L10_W0p5_W0p4_PNo_a87d0813_m5000_0:
@@ -154,40 +154,40 @@ instances:
       with_two_ports: true
 name: coupler_adiabatic_L20_L_6807e123
 nets:
-- p1: bezier_CP0_0_10_0_10_m1_4767eb94_m20000_1270,o2
+- p1: bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270,o2
   p2: taper_L10_W0p5_W0p6_PNo_23934efe_m5000_770,o2
-- p1: bezier_CP0_m3_10_m3_10__07235f68_m20000_m500,o2
+- p1: bezier_CP0_m3_10_m3_10__494670bd_m20000_m500,o2
   p2: taper_L10_W0p5_W0p4_PNo_a87d0813_m5000_0,o2
-- p1: bezier_CP70_m1_85_m1_85_5940811d_65000_1270,o1
-  p2: coupler_straight_L50_G0_a8f21bfb_25000_385,o3
-- p1: bezier_CP70_m1_85_m1_85_5940811d_65000_m500,o1
-  p2: coupler_straight_L50_G0_a8f21bfb_25000_385,o4
-- p1: coupler_straight_L50_G0_a8f21bfb_25000_385,o1
+- p1: bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270,o1
+  p2: coupler_straight_L50_G0_e5e3337b_25000_385,o3
+- p1: bezier_CP70_m1_85_m1_85_c9a8926c_65000_m500,o1
+  p2: coupler_straight_L50_G0_e5e3337b_25000_385,o4
+- p1: coupler_straight_L50_G0_e5e3337b_25000_385,o1
   p2: taper_L10_W0p5_W0p4_PNo_a87d0813_m5000_0,o1
-- p1: coupler_straight_L50_G0_a8f21bfb_25000_385,o2
+- p1: coupler_straight_L50_G0_e5e3337b_25000_385,o2
   p2: taper_L10_W0p5_W0p6_PNo_23934efe_m5000_770,o1
 placements:
-  bezier_CP0_0_10_0_10_m1_4767eb94_m20000_1270:
+  bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270:
     mirror: false
     rotation: 0
     x: -30
     y: 1.77
-  bezier_CP0_m3_10_m3_10__07235f68_m20000_m500:
+  bezier_CP0_m3_10_m3_10__494670bd_m20000_m500:
     mirror: false
     rotation: 0
     x: -30
     y: 2
-  bezier_CP70_m1_85_m1_85_5940811d_65000_1270:
+  bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270:
     mirror: false
     rotation: 0
     x: -20
     y: 1.77
-  bezier_CP70_m1_85_m1_85_5940811d_65000_m500:
+  bezier_CP70_m1_85_m1_85_c9a8926c_65000_m500:
     mirror: true
     rotation: 0
     x: -20
     y: -1
-  coupler_straight_L50_G0_a8f21bfb_25000_385:
+  coupler_straight_L50_G0_e5e3337b_25000_385:
     mirror: false
     rotation: 0
     x: 0
@@ -203,7 +203,7 @@ placements:
     x: 0
     y: 0.77
 ports:
-  o1: bezier_CP0_m3_10_m3_10__07235f68_m20000_m500,o1
-  o2: bezier_CP0_0_10_0_10_m1_4767eb94_m20000_1270,o1
-  o3: bezier_CP70_m1_85_m1_85_5940811d_65000_1270,o2
-  o4: bezier_CP70_m1_85_m1_85_5940811d_65000_m500,o2
+  o1: bezier_CP0_m3_10_m3_10__494670bd_m20000_m500,o1
+  o2: bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270,o1
+  o3: bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270,o2
+  o4: bezier_CP70_m1_85_m1_85_c9a8926c_65000_m500,o2

--- a/test-data-regression/test_netlists_coupler_adiabatic_.yml
+++ b/test-data-regression/test_netlists_coupler_adiabatic_.yml
@@ -1,5 +1,5 @@
 instances:
-  bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270:
+  bezier_CP0_0_10_0_10_m1_8e7e82ff_m20000_1270:
     component: bezier
     info:
       end_angle: 0
@@ -8,9 +8,9 @@ instances:
       route_info_length: 20.036
       route_info_min_bend_radius: 72.935
       route_info_n_bend_s: 1
-      route_info_strip_length: 20.036
-      route_info_type: strip
+      route_info_type: xs_4ec6b2c079041542924e7b0404e097d0
       route_info_weight: 20.036
+      route_info_xs_4ec6b2c079041542924e7b0404e097d0_length: 20.036
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -23,10 +23,10 @@ instances:
         - -1
       - - 20
         - -1
-      cross_section: strip
+      cross_section: xs_4ec6b2c079041542924e7b0404e097d0
       npoints: 201
       with_manhattan_facing_angles: true
-  bezier_CP0_m3_10_m3_10__494670bd_m20000_m500:
+  bezier_CP0_m3_10_m3_10__aaf3b4a4_m20000_m500:
     component: bezier
     info:
       end_angle: 0
@@ -35,9 +35,9 @@ instances:
       route_info_length: 20.036
       route_info_min_bend_radius: 72.935
       route_info_n_bend_s: 1
-      route_info_strip_length: 20.036
-      route_info_type: strip
+      route_info_type: xs_d9e914bef592fc3aa9c59d7e523240d9
       route_info_weight: 20.036
+      route_info_xs_d9e914bef592fc3aa9c59d7e523240d9_length: 20.036
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -50,7 +50,7 @@ instances:
         - -2
       - - 20
         - -2
-      cross_section: strip
+      cross_section: xs_d9e914bef592fc3aa9c59d7e523240d9
       npoints: 201
       with_manhattan_facing_angles: true
   bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270:
@@ -154,9 +154,9 @@ instances:
       with_two_ports: true
 name: coupler_adiabatic_L20_L_6807e123
 nets:
-- p1: bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270,o2
+- p1: bezier_CP0_0_10_0_10_m1_8e7e82ff_m20000_1270,o2
   p2: taper_L10_W0p5_W0p6_PNo_23934efe_m5000_770,o2
-- p1: bezier_CP0_m3_10_m3_10__494670bd_m20000_m500,o2
+- p1: bezier_CP0_m3_10_m3_10__aaf3b4a4_m20000_m500,o2
   p2: taper_L10_W0p5_W0p4_PNo_a87d0813_m5000_0,o2
 - p1: bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270,o1
   p2: coupler_straight_L50_G0_e5e3337b_25000_385,o3
@@ -167,12 +167,12 @@ nets:
 - p1: coupler_straight_L50_G0_e5e3337b_25000_385,o2
   p2: taper_L10_W0p5_W0p6_PNo_23934efe_m5000_770,o1
 placements:
-  bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270:
+  bezier_CP0_0_10_0_10_m1_8e7e82ff_m20000_1270:
     mirror: false
     rotation: 0
     x: -30
     y: 1.77
-  bezier_CP0_m3_10_m3_10__494670bd_m20000_m500:
+  bezier_CP0_m3_10_m3_10__aaf3b4a4_m20000_m500:
     mirror: false
     rotation: 0
     x: -30
@@ -203,7 +203,7 @@ placements:
     x: 0
     y: 0.77
 ports:
-  o1: bezier_CP0_m3_10_m3_10__494670bd_m20000_m500,o1
-  o2: bezier_CP0_0_10_0_10_m1_a7b61973_m20000_1270,o1
+  o1: bezier_CP0_m3_10_m3_10__aaf3b4a4_m20000_m500,o1
+  o2: bezier_CP0_0_10_0_10_m1_8e7e82ff_m20000_1270,o1
   o3: bezier_CP70_m1_85_m1_85_c9a8926c_65000_1270,o2
   o4: bezier_CP70_m1_85_m1_85_c9a8926c_65000_m500,o2

--- a/test-data-regression/test_netlists_coupler_broadband_.yml
+++ b/test-data-regression/test_netlists_coupler_broadband_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -49,9 +49,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -69,9 +69,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90

--- a/test-data-regression/test_netlists_coupler_straight_.yml
+++ b/test-data-regression/test_netlists_coupler_straight_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_coupler_symmetric_.yml
+++ b/test-data-regression/test_netlists_coupler_symmetric_.yml
@@ -8,9 +8,9 @@ instances:
       route_info_length: 10.187
       route_info_min_bend_radius: 11.851
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10.187
+      route_info_type: strip
       route_info_weight: 10.187
-      route_info_xs_34e31a19_length: 10.187
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -28,9 +28,9 @@ instances:
       route_info_length: 10.187
       route_info_min_bend_radius: 11.851
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10.187
+      route_info_type: strip
       route_info_weight: 10.187
-      route_info_xs_34e31a19_length: 10.187
       start_angle: 0
     settings:
       allow_min_radius_violation: false

--- a/test-data-regression/test_netlists_cutback_bend180_.yml
+++ b/test-data-regression/test_netlists_cutback_bend180_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 40.656
       route_info_length: 40.656
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.656
+      route_info_type: strip
       route_info_weight: 40.656
-      route_info_xs_34e31a19_length: 40.656
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 40.656
       route_info_length: 40.656
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.656
+      route_info_type: strip
       route_info_weight: 40.656
-      route_info_xs_34e31a19_length: 40.656
       width: 0.5
     settings:
       cross_section: strip
@@ -30,9 +30,9 @@ instances:
     info:
       length: 40.656
       route_info_length: 40.656
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.656
+      route_info_type: strip
       route_info_weight: 40.656
-      route_info_xs_34e31a19_length: 40.656
       width: 0.5
     settings:
       cross_section: strip
@@ -43,9 +43,9 @@ instances:
     info:
       length: 40.656
       route_info_length: 40.656
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.656
+      route_info_type: strip
       route_info_weight: 40.656
-      route_info_xs_34e31a19_length: 40.656
       width: 0.5
     settings:
       cross_section: strip
@@ -56,9 +56,9 @@ instances:
     info:
       length: 40.656
       route_info_length: 40.656
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40.656
+      route_info_type: strip
       route_info_weight: 40.656
-      route_info_xs_34e31a19_length: 40.656
       width: 0.5
     settings:
       cross_section: strip
@@ -74,9 +74,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -93,9 +93,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -112,9 +112,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -131,9 +131,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -150,9 +150,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -169,9 +169,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -188,9 +188,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -207,9 +207,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -226,9 +226,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -245,9 +245,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -264,9 +264,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -283,9 +283,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -302,9 +302,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -321,9 +321,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -340,9 +340,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -359,9 +359,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -378,9 +378,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -397,9 +397,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -416,9 +416,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -435,9 +435,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -454,9 +454,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -473,9 +473,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -492,9 +492,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -511,9 +511,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -530,9 +530,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -549,9 +549,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -568,9 +568,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -587,9 +587,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -606,9 +606,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -625,9 +625,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -644,9 +644,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -663,9 +663,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -682,9 +682,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -701,9 +701,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -720,9 +720,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -739,9 +739,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -758,9 +758,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -777,9 +777,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -796,9 +796,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -815,9 +815,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -834,9 +834,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -853,9 +853,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -872,9 +872,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -891,9 +891,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -910,9 +910,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -929,9 +929,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -948,9 +948,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -967,9 +967,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -986,9 +986,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1005,9 +1005,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1024,9 +1024,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1043,9 +1043,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1062,9 +1062,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1081,9 +1081,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1100,9 +1100,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1119,9 +1119,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1138,9 +1138,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1157,9 +1157,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1176,9 +1176,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1195,9 +1195,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1214,9 +1214,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1233,9 +1233,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1252,9 +1252,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1271,9 +1271,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1290,9 +1290,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1309,9 +1309,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1328,9 +1328,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1347,9 +1347,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1366,9 +1366,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1385,9 +1385,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1404,9 +1404,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1423,9 +1423,9 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -1437,9 +1437,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1450,9 +1450,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1463,9 +1463,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1476,9 +1476,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1489,9 +1489,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1502,9 +1502,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1515,9 +1515,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1528,9 +1528,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1541,9 +1541,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1554,9 +1554,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1567,9 +1567,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1580,9 +1580,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1593,9 +1593,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1606,9 +1606,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1619,9 +1619,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1632,9 +1632,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1645,9 +1645,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1658,9 +1658,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1671,9 +1671,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1684,9 +1684,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1697,9 +1697,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1710,9 +1710,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1723,9 +1723,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1736,9 +1736,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1749,9 +1749,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1762,9 +1762,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1775,9 +1775,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1788,9 +1788,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1801,9 +1801,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1814,9 +1814,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1827,9 +1827,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1840,9 +1840,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1853,9 +1853,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1866,9 +1866,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1879,9 +1879,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1892,9 +1892,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1905,9 +1905,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1918,9 +1918,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1931,9 +1931,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1944,9 +1944,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1957,9 +1957,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1970,9 +1970,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1983,9 +1983,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1996,9 +1996,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2009,9 +2009,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2022,9 +2022,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2035,9 +2035,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2048,9 +2048,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2061,9 +2061,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2074,9 +2074,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2087,9 +2087,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2100,9 +2100,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2113,9 +2113,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2126,9 +2126,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2139,9 +2139,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2152,9 +2152,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2165,9 +2165,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2178,9 +2178,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2191,9 +2191,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2204,9 +2204,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2217,9 +2217,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2230,9 +2230,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2243,9 +2243,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2256,9 +2256,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2269,9 +2269,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2282,9 +2282,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2295,9 +2295,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2308,9 +2308,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2321,9 +2321,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2334,9 +2334,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2347,9 +2347,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2360,9 +2360,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_cutback_bend90_.yml
+++ b/test-data-regression/test_netlists_cutback_bend90_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -30,9 +30,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -43,9 +43,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -56,9 +56,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -74,9 +74,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -93,9 +93,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -112,9 +112,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -131,9 +131,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -150,9 +150,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -169,9 +169,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -188,9 +188,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -207,9 +207,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -226,9 +226,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -245,9 +245,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -264,9 +264,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -283,9 +283,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -302,9 +302,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -321,9 +321,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -340,9 +340,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -359,9 +359,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -378,9 +378,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -397,9 +397,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -416,9 +416,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -435,9 +435,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -454,9 +454,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -473,9 +473,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -492,9 +492,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -511,9 +511,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -530,9 +530,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -549,9 +549,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -568,9 +568,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -587,9 +587,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -606,9 +606,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -625,9 +625,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -644,9 +644,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -663,9 +663,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -682,9 +682,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -701,9 +701,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -720,9 +720,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -739,9 +739,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -758,9 +758,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -777,9 +777,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -796,9 +796,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -815,9 +815,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -834,9 +834,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -853,9 +853,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -872,9 +872,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -891,9 +891,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -910,9 +910,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -929,9 +929,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -948,9 +948,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -967,9 +967,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -986,9 +986,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1005,9 +1005,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1024,9 +1024,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1043,9 +1043,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1062,9 +1062,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1081,9 +1081,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1100,9 +1100,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1119,9 +1119,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1138,9 +1138,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1157,9 +1157,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1176,9 +1176,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1195,9 +1195,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1214,9 +1214,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1233,9 +1233,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1252,9 +1252,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1271,9 +1271,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1290,9 +1290,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1309,9 +1309,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1328,9 +1328,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1347,9 +1347,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1366,9 +1366,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1385,9 +1385,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1404,9 +1404,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1423,9 +1423,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1442,9 +1442,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1461,9 +1461,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1480,9 +1480,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1499,9 +1499,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1518,9 +1518,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1537,9 +1537,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1556,9 +1556,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1575,9 +1575,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1594,9 +1594,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1613,9 +1613,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1632,9 +1632,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1651,9 +1651,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1670,9 +1670,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1689,9 +1689,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1708,9 +1708,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1727,9 +1727,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1746,9 +1746,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1765,9 +1765,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1784,9 +1784,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1803,9 +1803,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1822,9 +1822,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1841,9 +1841,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1860,9 +1860,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1879,9 +1879,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1898,9 +1898,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1917,9 +1917,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1936,9 +1936,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1955,9 +1955,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1974,9 +1974,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1993,9 +1993,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2012,9 +2012,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2031,9 +2031,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2050,9 +2050,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2069,9 +2069,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2088,9 +2088,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2107,9 +2107,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2126,9 +2126,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2145,9 +2145,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2164,9 +2164,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2183,9 +2183,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2202,9 +2202,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2221,9 +2221,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2240,9 +2240,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2259,9 +2259,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2278,9 +2278,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2297,9 +2297,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2316,9 +2316,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2335,9 +2335,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2354,9 +2354,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2373,9 +2373,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2392,9 +2392,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2411,9 +2411,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2430,9 +2430,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2449,9 +2449,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2468,9 +2468,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2487,9 +2487,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2506,9 +2506,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2525,9 +2525,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2544,9 +2544,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2563,9 +2563,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2582,9 +2582,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2601,9 +2601,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2620,9 +2620,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2639,9 +2639,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2658,9 +2658,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2677,9 +2677,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2696,9 +2696,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2715,9 +2715,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2734,9 +2734,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2753,9 +2753,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2772,9 +2772,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2791,9 +2791,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2805,9 +2805,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2818,9 +2818,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2831,9 +2831,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2844,9 +2844,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2857,9 +2857,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2870,9 +2870,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2883,9 +2883,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2896,9 +2896,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2909,9 +2909,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2922,9 +2922,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2935,9 +2935,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2948,9 +2948,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2961,9 +2961,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2974,9 +2974,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2987,9 +2987,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3000,9 +3000,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3013,9 +3013,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3026,9 +3026,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3039,9 +3039,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3052,9 +3052,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3065,9 +3065,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3078,9 +3078,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3091,9 +3091,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3104,9 +3104,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3117,9 +3117,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3130,9 +3130,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3143,9 +3143,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3156,9 +3156,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3169,9 +3169,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3182,9 +3182,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3195,9 +3195,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3208,9 +3208,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3221,9 +3221,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3234,9 +3234,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3247,9 +3247,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3260,9 +3260,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3273,9 +3273,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3286,9 +3286,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3299,9 +3299,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3312,9 +3312,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3325,9 +3325,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3338,9 +3338,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3351,9 +3351,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3364,9 +3364,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3377,9 +3377,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3390,9 +3390,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3403,9 +3403,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3416,9 +3416,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3429,9 +3429,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3442,9 +3442,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3455,9 +3455,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3468,9 +3468,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3481,9 +3481,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3494,9 +3494,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3507,9 +3507,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3520,9 +3520,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3533,9 +3533,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3546,9 +3546,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3559,9 +3559,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3572,9 +3572,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3585,9 +3585,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3598,9 +3598,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3611,9 +3611,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3624,9 +3624,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3637,9 +3637,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3650,9 +3650,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3663,9 +3663,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3676,9 +3676,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3689,9 +3689,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3702,9 +3702,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3715,9 +3715,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3728,9 +3728,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3741,9 +3741,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3754,9 +3754,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3767,9 +3767,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3780,9 +3780,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3793,9 +3793,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3806,9 +3806,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3819,9 +3819,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3832,9 +3832,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3845,9 +3845,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3858,9 +3858,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3871,9 +3871,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3884,9 +3884,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3897,9 +3897,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3910,9 +3910,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3923,9 +3923,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3936,9 +3936,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3949,9 +3949,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3962,9 +3962,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3975,9 +3975,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3988,9 +3988,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4001,9 +4001,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4014,9 +4014,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4027,9 +4027,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4040,9 +4040,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4053,9 +4053,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4066,9 +4066,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4079,9 +4079,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4092,9 +4092,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4105,9 +4105,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4118,9 +4118,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4131,9 +4131,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4144,9 +4144,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4157,9 +4157,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4170,9 +4170,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4183,9 +4183,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4196,9 +4196,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4209,9 +4209,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4222,9 +4222,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4235,9 +4235,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4248,9 +4248,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4261,9 +4261,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4274,9 +4274,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4287,9 +4287,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4300,9 +4300,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4313,9 +4313,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4326,9 +4326,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4339,9 +4339,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4352,9 +4352,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4365,9 +4365,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4378,9 +4378,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4391,9 +4391,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4404,9 +4404,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4417,9 +4417,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4430,9 +4430,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4443,9 +4443,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4456,9 +4456,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4469,9 +4469,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4482,9 +4482,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4495,9 +4495,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4508,9 +4508,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4521,9 +4521,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4534,9 +4534,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4547,9 +4547,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4560,9 +4560,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4573,9 +4573,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4586,9 +4586,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4599,9 +4599,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4612,9 +4612,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4625,9 +4625,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4638,9 +4638,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4651,9 +4651,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4664,9 +4664,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_cutback_bend90circular_.yml
+++ b/test-data-regression/test_netlists_cutback_bend90circular_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -30,9 +30,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -43,9 +43,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -56,9 +56,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -73,9 +73,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -89,9 +89,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -105,9 +105,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -121,9 +121,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -137,9 +137,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -153,9 +153,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -169,9 +169,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -185,9 +185,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -201,9 +201,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -217,9 +217,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -233,9 +233,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -249,9 +249,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -265,9 +265,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -281,9 +281,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -297,9 +297,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -313,9 +313,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -329,9 +329,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -345,9 +345,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -361,9 +361,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -377,9 +377,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -393,9 +393,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -409,9 +409,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -425,9 +425,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -441,9 +441,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -457,9 +457,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -473,9 +473,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -489,9 +489,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -505,9 +505,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -521,9 +521,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -537,9 +537,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -553,9 +553,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -569,9 +569,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -585,9 +585,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -601,9 +601,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -617,9 +617,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -633,9 +633,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -649,9 +649,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -665,9 +665,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -681,9 +681,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -697,9 +697,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -713,9 +713,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -729,9 +729,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -745,9 +745,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -761,9 +761,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -777,9 +777,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -793,9 +793,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -809,9 +809,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -825,9 +825,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -841,9 +841,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -857,9 +857,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -873,9 +873,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -889,9 +889,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -905,9 +905,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -921,9 +921,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -937,9 +937,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -953,9 +953,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -969,9 +969,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -985,9 +985,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1001,9 +1001,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1017,9 +1017,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1033,9 +1033,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1049,9 +1049,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1065,9 +1065,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1081,9 +1081,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1097,9 +1097,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1113,9 +1113,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1129,9 +1129,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1145,9 +1145,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1161,9 +1161,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1177,9 +1177,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1193,9 +1193,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1209,9 +1209,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1225,9 +1225,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1241,9 +1241,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1257,9 +1257,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1273,9 +1273,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1289,9 +1289,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1305,9 +1305,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1321,9 +1321,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1337,9 +1337,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1353,9 +1353,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1369,9 +1369,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1385,9 +1385,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1401,9 +1401,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1417,9 +1417,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1433,9 +1433,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1449,9 +1449,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1465,9 +1465,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1481,9 +1481,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1497,9 +1497,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1513,9 +1513,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1529,9 +1529,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1545,9 +1545,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1561,9 +1561,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1577,9 +1577,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1593,9 +1593,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1609,9 +1609,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1625,9 +1625,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1641,9 +1641,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1657,9 +1657,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1673,9 +1673,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1689,9 +1689,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1705,9 +1705,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1721,9 +1721,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1737,9 +1737,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1753,9 +1753,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1769,9 +1769,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1785,9 +1785,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1801,9 +1801,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1817,9 +1817,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1833,9 +1833,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1849,9 +1849,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1865,9 +1865,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1881,9 +1881,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1897,9 +1897,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1913,9 +1913,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1929,9 +1929,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1945,9 +1945,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1961,9 +1961,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1977,9 +1977,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1993,9 +1993,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2009,9 +2009,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2025,9 +2025,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2041,9 +2041,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2057,9 +2057,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2073,9 +2073,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2089,9 +2089,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2105,9 +2105,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2121,9 +2121,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2137,9 +2137,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2153,9 +2153,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2169,9 +2169,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2185,9 +2185,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2201,9 +2201,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2217,9 +2217,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2233,9 +2233,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2249,9 +2249,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2265,9 +2265,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2281,9 +2281,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2297,9 +2297,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2313,9 +2313,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2329,9 +2329,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2345,9 +2345,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2361,9 +2361,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -2373,9 +2373,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2386,9 +2386,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2399,9 +2399,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2412,9 +2412,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2425,9 +2425,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2438,9 +2438,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2451,9 +2451,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2464,9 +2464,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2477,9 +2477,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2490,9 +2490,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2503,9 +2503,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2516,9 +2516,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2529,9 +2529,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2542,9 +2542,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2555,9 +2555,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2568,9 +2568,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2581,9 +2581,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2594,9 +2594,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2607,9 +2607,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2620,9 +2620,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2633,9 +2633,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2646,9 +2646,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2659,9 +2659,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2672,9 +2672,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2685,9 +2685,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2698,9 +2698,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2711,9 +2711,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2724,9 +2724,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2737,9 +2737,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2750,9 +2750,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2763,9 +2763,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2776,9 +2776,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2789,9 +2789,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2802,9 +2802,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2815,9 +2815,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2828,9 +2828,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2841,9 +2841,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2854,9 +2854,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2867,9 +2867,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2880,9 +2880,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2893,9 +2893,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2906,9 +2906,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2919,9 +2919,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2932,9 +2932,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2945,9 +2945,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2958,9 +2958,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2971,9 +2971,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2984,9 +2984,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2997,9 +2997,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3010,9 +3010,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3023,9 +3023,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3036,9 +3036,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3049,9 +3049,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3062,9 +3062,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3075,9 +3075,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3088,9 +3088,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3101,9 +3101,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3114,9 +3114,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3127,9 +3127,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3140,9 +3140,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3153,9 +3153,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3166,9 +3166,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3179,9 +3179,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3192,9 +3192,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3205,9 +3205,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3218,9 +3218,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3231,9 +3231,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3244,9 +3244,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3257,9 +3257,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3270,9 +3270,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3283,9 +3283,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3296,9 +3296,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3309,9 +3309,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3322,9 +3322,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3335,9 +3335,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3348,9 +3348,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3361,9 +3361,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3374,9 +3374,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3387,9 +3387,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3400,9 +3400,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3413,9 +3413,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3426,9 +3426,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3439,9 +3439,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3452,9 +3452,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3465,9 +3465,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3478,9 +3478,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3491,9 +3491,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3504,9 +3504,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3517,9 +3517,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3530,9 +3530,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3543,9 +3543,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3556,9 +3556,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3569,9 +3569,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3582,9 +3582,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3595,9 +3595,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3608,9 +3608,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3621,9 +3621,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3634,9 +3634,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3647,9 +3647,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3660,9 +3660,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3673,9 +3673,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3686,9 +3686,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3699,9 +3699,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3712,9 +3712,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3725,9 +3725,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3738,9 +3738,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3751,9 +3751,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3764,9 +3764,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3777,9 +3777,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3790,9 +3790,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3803,9 +3803,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3816,9 +3816,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3829,9 +3829,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3842,9 +3842,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3855,9 +3855,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3868,9 +3868,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3881,9 +3881,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3894,9 +3894,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3907,9 +3907,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3920,9 +3920,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3933,9 +3933,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3946,9 +3946,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3959,9 +3959,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3972,9 +3972,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3985,9 +3985,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -3998,9 +3998,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4011,9 +4011,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4024,9 +4024,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4037,9 +4037,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4050,9 +4050,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4063,9 +4063,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4076,9 +4076,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4089,9 +4089,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4102,9 +4102,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4115,9 +4115,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4128,9 +4128,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4141,9 +4141,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4154,9 +4154,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4167,9 +4167,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4180,9 +4180,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4193,9 +4193,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4206,9 +4206,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4219,9 +4219,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -4232,9 +4232,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_cutback_bend_.yml
+++ b/test-data-regression/test_netlists_cutback_bend_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -161,9 +161,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -199,9 +199,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -218,9 +218,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -237,9 +237,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -256,9 +256,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -275,9 +275,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -294,9 +294,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -313,9 +313,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -332,9 +332,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -351,9 +351,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -370,9 +370,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -389,9 +389,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -408,9 +408,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -427,9 +427,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -446,9 +446,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -465,9 +465,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -484,9 +484,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -503,9 +503,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -522,9 +522,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -541,9 +541,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -560,9 +560,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -579,9 +579,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -598,9 +598,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -617,9 +617,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -636,9 +636,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -655,9 +655,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -674,9 +674,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -693,9 +693,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -712,9 +712,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -731,9 +731,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -750,9 +750,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -769,9 +769,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -788,9 +788,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -807,9 +807,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -826,9 +826,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -845,9 +845,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -864,9 +864,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -883,9 +883,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -902,9 +902,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -921,9 +921,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -940,9 +940,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -959,9 +959,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -978,9 +978,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -997,9 +997,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1016,9 +1016,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1035,9 +1035,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1054,9 +1054,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1073,9 +1073,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1092,9 +1092,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1111,9 +1111,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1130,9 +1130,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1149,9 +1149,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1168,9 +1168,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1187,9 +1187,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1206,9 +1206,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1225,9 +1225,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1244,9 +1244,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1263,9 +1263,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1282,9 +1282,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -1296,9 +1296,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1309,9 +1309,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1322,9 +1322,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1335,9 +1335,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1348,9 +1348,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1361,9 +1361,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1374,9 +1374,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1387,9 +1387,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1400,9 +1400,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1413,9 +1413,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1426,9 +1426,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1439,9 +1439,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1452,9 +1452,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1465,9 +1465,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1478,9 +1478,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1491,9 +1491,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1504,9 +1504,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1517,9 +1517,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1530,9 +1530,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1543,9 +1543,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1556,9 +1556,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1569,9 +1569,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1582,9 +1582,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1595,9 +1595,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1608,9 +1608,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1621,9 +1621,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1634,9 +1634,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1647,9 +1647,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1660,9 +1660,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1673,9 +1673,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1686,9 +1686,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1699,9 +1699,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1712,9 +1712,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1725,9 +1725,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1738,9 +1738,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1751,9 +1751,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1764,9 +1764,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1777,9 +1777,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1790,9 +1790,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1803,9 +1803,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1816,9 +1816,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1829,9 +1829,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1842,9 +1842,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1855,9 +1855,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1868,9 +1868,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1881,9 +1881,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1894,9 +1894,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1907,9 +1907,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1920,9 +1920,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1933,9 +1933,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1946,9 +1946,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1959,9 +1959,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1972,9 +1972,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1985,9 +1985,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -1998,9 +1998,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2011,9 +2011,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2024,9 +2024,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2037,9 +2037,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2050,9 +2050,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2063,9 +2063,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2076,9 +2076,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2089,9 +2089,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2102,9 +2102,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2115,9 +2115,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2128,9 +2128,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2141,9 +2141,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2154,9 +2154,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -2167,9 +2167,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_cutback_component_mirror_.yml
+++ b/test-data-regression/test_netlists_cutback_component_mirror_.yml
@@ -489,13 +489,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C2:
@@ -508,13 +508,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C3:
@@ -527,13 +527,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C4:
@@ -546,13 +546,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D1:
@@ -565,13 +565,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D2:
@@ -584,13 +584,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D3:
@@ -603,13 +603,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D4:
@@ -622,13 +622,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   _1:
@@ -636,12 +636,12 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 20
       npoints: 2
   m1:
@@ -649,12 +649,12 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 20
       npoints: 2
 name: cutback_component_CFtap_64ce8722

--- a/test-data-regression/test_netlists_cutback_splitter_.yml
+++ b/test-data-regression/test_netlists_cutback_splitter_.yml
@@ -969,13 +969,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C2:
@@ -988,13 +988,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C3:
@@ -1007,13 +1007,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   C4:
@@ -1026,13 +1026,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D1:
@@ -1045,13 +1045,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D2:
@@ -1064,13 +1064,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D3:
@@ -1083,13 +1083,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   D4:
@@ -1102,13 +1102,13 @@ instances:
       route_info_length: 42.817
       route_info_min_bend_radius: 9.086
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 42.817
+      route_info_type: strip
       route_info_weight: 42.817
-      route_info_xs_34e31a19_length: 42.817
     settings:
       allow_min_radius_violation: false
       angle: 180
-      cross_section: xs_34e31a19
+      cross_section: strip
       p: 0.5
       with_arc_floorplan: true
   _1:
@@ -1116,12 +1116,12 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 20
       npoints: 2
   m1:
@@ -1129,12 +1129,12 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 20
       npoints: 2
 name: cutback_splitter_Cmmi1x_5fd4c12d

--- a/test-data-regression/test_netlists_dbr_.yml
+++ b/test-data-regression/test_netlists_dbr_.yml
@@ -14,36 +14,36 @@ instances:
       l2: 0.159
       w1: 0.45
       w2: 0.55
-  straight_L0p01_N2_CSxs_34e31a19_3185_0:
+  straight_L0p01_N2_CSstrip_3185_0:
     component: straight
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.01
+      route_info_type: strip
       route_info_weight: 0.01
-      route_info_xs_34e31a19_length: 0.01
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 0.01
       npoints: 2
-  straight_L0p01_N2_CSxs_34e31a19_m5_0:
+  straight_L0p01_N2_CSstrip_m5_0:
     component: straight
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.01
+      route_info_type: strip
       route_info_weight: 0.01
-      route_info_xs_34e31a19_length: 0.01
       width: 0.5
     settings:
-      cross_section: xs_34e31a19
+      cross_section: strip
       length: 0.01
       npoints: 2
 name: dbr_W0p45_W0p55_L0p159__efcfb70c
 nets:
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<0.0>,o1
-  p2: straight_L0p01_N2_CSxs_34e31a19_m5_0,o1
+  p2: straight_L0p01_N2_CSstrip_m5_0,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<0.0>,o2
   p2: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<1.0>,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<1.0>,o2
@@ -63,47 +63,47 @@ nets:
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<8.0>,o2
   p2: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<9.0>,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<9.0>,o2
-  p2: straight_L0p01_N2_CSxs_34e31a19_3185_0,o1
+  p2: straight_L0p01_N2_CSstrip_3185_0,o1
 placements:
   dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_L0p01_N2_CSxs_34e31a19_3185_0:
+  straight_L0p01_N2_CSstrip_3185_0:
     mirror: false
     rotation: 0
     x: 3.18
     y: 0
-  straight_L0p01_N2_CSxs_34e31a19_m5_0:
+  straight_L0p01_N2_CSstrip_m5_0:
     mirror: false
     rotation: 180
     x: 0
     y: 0
 ports:
-  o1: straight_L0p01_N2_CSxs_34e31a19_m5_0,o2
+  o1: straight_L0p01_N2_CSstrip_m5_0,o2
 warnings:
   optical:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - straight_L0p01_N2_CSxs_34e31a19_3185_0,o2
+      - straight_L0p01_N2_CSstrip_3185_0,o2
       values:
       - - 3190
         - 0
     width_mismatch:
-    - message: Widths of ports straight_L0p01_N2_CSxs_34e31a19_m5_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<0.0>,o1
+    - message: Widths of ports straight_L0p01_N2_CSstrip_m5_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<0.0>,o1
         not equal. Difference of 50 um
       ports:
-      - straight_L0p01_N2_CSxs_34e31a19_m5_0,o1
+      - straight_L0p01_N2_CSstrip_m5_0,o1
       - dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<0.0>,o1
       values:
       - 500
       - 450
-    - message: Widths of ports straight_L0p01_N2_CSxs_34e31a19_3185_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<9.0>,o2
+    - message: Widths of ports straight_L0p01_N2_CSstrip_3185_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<9.0>,o2
         not equal. Difference of 50 um
       ports:
-      - straight_L0p01_N2_CSxs_34e31a19_3185_0,o1
+      - straight_L0p01_N2_CSstrip_3185_0,o1
       - dbr_cell_W0p45_W0p55_L0_81fd17cb_1590_0<9.0>,o2
       values:
       - 500

--- a/test-data-regression/test_netlists_delay_snake_sbend_.yml
+++ b/test-data-regression/test_netlists_delay_snake_sbend_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 21.408
       route_info_min_bend_radius: 4.543
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 21.408
+      route_info_type: strip
       route_info_weight: 21.408
-      route_info_xs_34e31a19_length: 21.408
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -29,9 +29,9 @@ instances:
       route_info_length: 21.408
       route_info_min_bend_radius: 4.543
       route_info_n_bend_90: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 21.408
+      route_info_type: strip
       route_info_weight: 21.408
-      route_info_xs_34e31a19_length: 21.408
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -48,9 +48,9 @@ instances:
       route_info_length: 100.178
       route_info_min_bend_radius: 364.774
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 100.178
+      route_info_type: strip
       route_info_weight: 100.178
-      route_info_xs_34e31a19_length: 100.178
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -64,9 +64,9 @@ instances:
     info:
       length: 78.681
       route_info_length: 78.681
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 78.681
+      route_info_type: strip
       route_info_weight: 78.681
-      route_info_xs_34e31a19_length: 78.681
       width: 0.5
     settings:
       cross_section: strip
@@ -77,9 +77,9 @@ instances:
     info:
       length: 78.681
       route_info_length: 78.681
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 78.681
+      route_info_type: strip
       route_info_weight: 78.681
-      route_info_xs_34e31a19_length: 78.681
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 49.911
       route_info_min_bend_radius: 21.183
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 49.911
+      route_info_type: strip
       route_info_weight: 49.911
-      route_info_xs_34e31a19_length: 49.911
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 49.911
       route_info_min_bend_radius: 21.183
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 49.911
+      route_info_type: strip
       route_info_weight: 49.911
-      route_info_xs_34e31a19_length: 49.911
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 49.911
       route_info_min_bend_radius: 21.183
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 49.911
+      route_info_type: strip
       route_info_weight: 49.911
-      route_info_xs_34e31a19_length: 49.911
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 49.911
       route_info_min_bend_radius: 21.183
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 49.911
+      route_info_type: strip
       route_info_weight: 49.911
-      route_info_xs_34e31a19_length: 49.911
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -101,9 +101,9 @@ instances:
     info:
       length: 67
       route_info_length: 67
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 67
+      route_info_type: strip
       route_info_weight: 67
-      route_info_xs_34e31a19_length: 67
       width: 0.5
     settings:
       cross_section: strip
@@ -115,9 +115,9 @@ instances:
     info:
       length: 67
       route_info_length: 67
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 67
+      route_info_type: strip
       route_info_weight: 67
-      route_info_xs_34e31a19_length: 67
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ge_detector_straight_si_contacts_.yml
+++ b/test-data-regression/test_netlists_ge_detector_straight_si_contacts_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_e02d6bc5
+      route_info_pn_ge_detector_si_contacts_length: 40
+      route_info_type: pn_ge_detector_si_contacts
       route_info_weight: 40
-      route_info_xs_e02d6bc5_length: 40
       width: 6
     settings:
       cross_section: pn_ge_detector_si_contacts

--- a/test-data-regression/test_netlists_greek_cross_with_pads_.yml
+++ b/test-data-regression/test_netlists_greek_cross_with_pads_.yml
@@ -151,7 +151,7 @@ instances:
       - via1
       - via2
       - null
-name: greek_cross_with_pads_P_fa616bf3
+name: greek_cross_with_pads_P_d48c0f08
 nets:
 - p1: pad_S100_100_LMTOP_BLNo_fdaf576b_200000_0,e4
   p2: via_stack_S11_11_LM1_M2_e6789b8f_200000_m55500,e2

--- a/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/test-data-regression/test_netlists_loop_mirror_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -92,9 +92,9 @@ instances:
     info:
       length: 1.25
       route_info_length: 1.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 1.25
+      route_info_type: strip
       route_info_weight: 1.25
-      route_info_xs_34e31a19_length: 1.25
       width: 0.5
     settings:
       cross_section: strip
@@ -106,9 +106,9 @@ instances:
     info:
       length: 20
       route_info_length: 20
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20
+      route_info_type: strip
       route_info_weight: 20
-      route_info_xs_34e31a19_length: 20
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -172,9 +172,9 @@ instances:
     info:
       length: 107
       route_info_length: 107
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 107
+      route_info_type: strip
       route_info_weight: 107
-      route_info_xs_34e31a19_length: 107
       width: 0.5
     settings:
       cross_section: strip
@@ -186,9 +186,9 @@ instances:
     info:
       length: 107
       route_info_length: 107
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 107
+      route_info_type: strip
       route_info_weight: 107
-      route_info_xs_34e31a19_length: 107
       width: 0.5
     settings:
       cross_section: strip
@@ -200,9 +200,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -214,9 +214,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -228,9 +228,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -242,9 +242,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -70,9 +70,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -89,9 +89,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -108,9 +108,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -127,9 +127,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -146,9 +146,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -244,9 +244,9 @@ instances:
     info:
       length: 234
       route_info_length: 234
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 234
+      route_info_type: strip
       route_info_weight: 234
-      route_info_xs_34e31a19_length: 234
       width: 0.5
     settings:
       cross_section: strip
@@ -258,9 +258,9 @@ instances:
     info:
       length: 274
       route_info_length: 274
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 274
+      route_info_type: strip
       route_info_weight: 274
-      route_info_xs_34e31a19_length: 274
       width: 0.5
     settings:
       cross_section: strip
@@ -272,9 +272,9 @@ instances:
     info:
       length: 35.946
       route_info_length: 35.946
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 35.946
+      route_info_type: strip
       route_info_weight: 35.946
-      route_info_xs_34e31a19_length: 35.946
       width: 0.5
     settings:
       cross_section: strip
@@ -286,9 +286,9 @@ instances:
     info:
       length: 35.946
       route_info_length: 35.946
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 35.946
+      route_info_type: strip
       route_info_weight: 35.946
-      route_info_xs_34e31a19_length: 35.946
       width: 0.5
     settings:
       cross_section: strip
@@ -300,9 +300,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -314,9 +314,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -172,9 +172,9 @@ instances:
     info:
       length: 107
       route_info_length: 107
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 107
+      route_info_type: strip
       route_info_weight: 107
-      route_info_xs_34e31a19_length: 107
       width: 0.5
     settings:
       cross_section: strip
@@ -186,9 +186,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -200,9 +200,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 30
+      route_info_type: strip
       route_info_weight: 30
-      route_info_xs_34e31a19_length: 30
       width: 0.5
     settings:
       cross_section: strip
@@ -214,9 +214,9 @@ instances:
     info:
       length: 361
       route_info_length: 361
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 361
+      route_info_type: strip
       route_info_weight: 361
-      route_info_xs_34e31a19_length: 361
       width: 0.5
     settings:
       cross_section: strip
@@ -228,9 +228,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip
@@ -242,9 +242,9 @@ instances:
     info:
       length: 40
       route_info_length: 40
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 40
+      route_info_type: strip
       route_info_weight: 40
-      route_info_xs_34e31a19_length: 40
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mode_converter_.yml
+++ b/test-data-regression/test_netlists_mode_converter_.yml
@@ -8,9 +8,9 @@ instances:
       route_info_length: 25.254
       route_info_min_bend_radius: 39.163
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 25.254
+      route_info_type: strip
       route_info_weight: 25.254
-      route_info_xs_34e31a19_length: 25.254
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -28,9 +28,9 @@ instances:
       route_info_length: 25.254
       route_info_min_bend_radius: 39.163
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 25.254
+      route_info_type: strip
       route_info_weight: 25.254
-      route_info_xs_34e31a19_length: 25.254
       start_angle: 0
     settings:
       allow_min_radius_violation: false

--- a/test-data-regression/test_netlists_mzi1x2_2x2_.yml
+++ b/test-data-regression/test_netlists_mzi1x2_2x2_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -219,9 +219,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -232,9 +232,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -245,9 +245,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi2x2_2x2_.yml
+++ b/test-data-regression/test_netlists_mzi2x2_2x2_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -219,9 +219,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -232,9 +232,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -245,9 +245,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 200
       route_info_length: 200
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 200
+      route_info_type: strip
       route_info_weight: 200
-      route_info_xs_34e31a19_length: 200
       width: 0.5
     settings:
       cross_section: strip
@@ -236,9 +236,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -249,9 +249,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_.yml
+++ b/test-data-regression/test_netlists_mzi_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -219,9 +219,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -232,9 +232,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -245,9 +245,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_arm_.yml
+++ b/test-data-regression/test_netlists_mzi_arm_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -42,9 +42,9 @@ instances:
     info:
       length: 0.8
       route_info_length: 0.8
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.8
+      route_info_type: strip
       route_info_weight: 0.8
-      route_info_xs_34e31a19_length: 0.8
       width: 0.5
     settings:
       cross_section: strip
@@ -55,9 +55,9 @@ instances:
     info:
       length: 0.8
       route_info_length: 0.8
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.8
+      route_info_type: strip
       route_info_weight: 0.8
-      route_info_xs_34e31a19_length: 0.8
       width: 0.5
     settings:
       cross_section: strip
@@ -73,9 +73,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -92,9 +92,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -106,9 +106,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_coupler_.yml
+++ b/test-data-regression/test_netlists_mzi_coupler_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -178,9 +178,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -191,9 +191,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -204,9 +204,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -217,9 +217,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -230,9 +230,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -243,9 +243,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 200
       route_info_length: 200
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 200
+      route_info_type: strip
       route_info_weight: 200
-      route_info_xs_34e31a19_length: 200
       width: 0.5
     settings:
       cross_section: strip
@@ -236,9 +236,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -249,9 +249,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 200
       route_info_length: 200
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 200
+      route_info_type: strip
       route_info_weight: 200
-      route_info_xs_34e31a19_length: 200
       width: 0.5
     settings:
       cross_section: strip
@@ -236,9 +236,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -249,9 +249,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_pin_.yml
+++ b/test-data-regression/test_netlists_mzi_pin_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -206,9 +206,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 100
+      route_info_type: strip
       route_info_weight: 100
-      route_info_xs_34e31a19_length: 100
       width: 0.5
     settings:
       cross_section: strip
@@ -229,9 +229,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -242,9 +242,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_a202615a
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_a202615a_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_a202615a
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_a202615a_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -49,9 +49,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_1954d54a
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_1954d54a_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -69,9 +69,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_1954d54a
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_1954d54a_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 16.637
-      route_info_type: strip
+      route_info_type: xs_a202615a695f07de817bf8f1b5e4da79
       route_info_weight: 16.637
+      route_info_xs_a202615a695f07de817bf8f1b5e4da79_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 16.637
-      route_info_type: strip
+      route_info_type: xs_a202615a695f07de817bf8f1b5e4da79
       route_info_weight: 16.637
+      route_info_xs_a202615a695f07de817bf8f1b5e4da79_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -49,9 +49,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 16.637
-      route_info_type: strip
+      route_info_type: xs_1954d54ad7e8050b48d3d0ba956bb703
       route_info_weight: 16.637
+      route_info_xs_1954d54ad7e8050b48d3d0ba956bb703_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -69,9 +69,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 16.637
-      route_info_type: strip
+      route_info_type: xs_1954d54ad7e8050b48d3d0ba956bb703
       route_info_weight: 16.637
+      route_info_xs_1954d54ad7e8050b48d3d0ba956bb703_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90

--- a/test-data-regression/test_netlists_mzm_.yml
+++ b/test-data-regression/test_netlists_mzm_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -193,9 +193,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -226,9 +226,9 @@ instances:
     info:
       length: 7
       route_info_length: 7
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7
+      route_info_type: strip
       route_info_weight: 7
-      route_info_xs_34e31a19_length: 7
       width: 0.5
     settings:
       cross_section: strip
@@ -239,9 +239,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ring_crow_couplers_.yml
+++ b/test-data-regression/test_netlists_ring_crow_couplers_.yml
@@ -8,9 +8,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -25,9 +25,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -42,9 +42,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -59,9 +59,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -76,9 +76,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -93,9 +93,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -154,9 +154,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -171,9 +171,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -188,9 +188,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -205,9 +205,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -222,9 +222,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -239,9 +239,9 @@ instances:
       route_info_length: 15.708
       route_info_min_bend_radius: 10
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15.708
+      route_info_type: strip
       route_info_weight: 15.708
-      route_info_xs_34e31a19_length: 15.708
     settings:
       allow_min_radius_violation: false
       angle: 90

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -26,9 +26,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.01
+      route_info_type: strip
       route_info_weight: 0.01
-      route_info_xs_34e31a19_length: 0.01
       width: 0.5
     settings:
       cross_section: strip
@@ -39,9 +39,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.01
+      route_info_type: strip
       route_info_weight: 0.01
-      route_info_xs_34e31a19_length: 0.01
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ring_double_heater_.yml
+++ b/test-data-regression/test_netlists_ring_double_heater_.yml
@@ -28,9 +28,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 0.01
+      route_info_type: strip_heater_metal
       route_info_weight: 0.01
-      route_info_xs_18860153_length: 0.01
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -41,9 +41,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 0.01
+      route_info_type: strip_heater_metal
       route_info_weight: 0.01
-      route_info_xs_18860153_length: 0.01
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -53,10 +53,10 @@ instances:
     component: straight
     info:
       length: 1
+      route_info_heater_metal_length: 1
       route_info_length: 1
-      route_info_type: xs_c500a645
+      route_info_type: heater_metal
       route_info_weight: 1
-      route_info_xs_c500a645_length: 1
       width: 2.5
     settings:
       cross_section: heater_metal

--- a/test-data-regression/test_netlists_ring_double_pn_.yml
+++ b/test-data-regression/test_netlists_ring_double_pn_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_pn_AG0p3_DG_9230a1cc
+name: ring_double_pn_AG0p3_DG_f0c63fb7
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -55,9 +55,9 @@ instances:
     info:
       length: 0.6
       route_info_length: 0.6
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.6
+      route_info_type: strip
       route_info_weight: 0.6
-      route_info_xs_34e31a19_length: 0.6
       width: 0.5
     settings:
       cross_section: strip
@@ -68,9 +68,9 @@ instances:
     info:
       length: 0.6
       route_info_length: 0.6
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.6
+      route_info_type: strip
       route_info_weight: 0.6
-      route_info_xs_34e31a19_length: 0.6
       width: 0.5
     settings:
       cross_section: strip
@@ -81,9 +81,9 @@ instances:
     info:
       length: 4
       route_info_length: 4
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4
+      route_info_type: strip
       route_info_weight: 4
-      route_info_xs_34e31a19_length: 4
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ring_single_array_.yml
+++ b/test-data-regression/test_netlists_ring_single_array_.yml
@@ -28,9 +28,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ring_single_dut_.yml
+++ b/test-data-regression/test_netlists_ring_single_dut_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -55,9 +55,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -68,9 +68,9 @@ instances:
     info:
       length: 4
       route_info_length: 4
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4
+      route_info_type: strip
       route_info_weight: 4
-      route_info_xs_34e31a19_length: 4
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_ring_single_heater_.yml
+++ b/test-data-regression/test_netlists_ring_single_heater_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 16.637
+      route_info_type: strip_heater_metal
       route_info_weight: 16.637
-      route_info_xs_18860153_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -29,9 +29,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 16.637
+      route_info_type: strip_heater_metal
       route_info_weight: 16.637
-      route_info_xs_18860153_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -56,9 +56,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 0.01
+      route_info_type: strip_heater_metal
       route_info_weight: 0.01
-      route_info_xs_18860153_length: 0.01
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -69,9 +69,9 @@ instances:
     info:
       length: 0.01
       route_info_length: 0.01
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 0.01
+      route_info_type: strip_heater_metal
       route_info_weight: 0.01
-      route_info_xs_18860153_length: 0.01
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -82,9 +82,9 @@ instances:
     info:
       length: 1
       route_info_length: 1
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 1
+      route_info_type: strip_heater_metal
       route_info_weight: 1
-      route_info_xs_18860153_length: 1
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_ring_single_pn_.yml
+++ b/test-data-regression/test_netlists_ring_single_pn_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_single_pn_G0p3_R5__b0270650
+name: ring_single_pn_G0p3_R5__9a9277c3
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_spiral_.yml
+++ b/test-data-regression/test_netlists_spiral_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -28,9 +28,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -47,9 +47,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -66,9 +66,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -85,9 +85,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -104,9 +104,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -123,9 +123,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -142,9 +142,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -161,9 +161,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -180,9 +180,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -199,9 +199,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -218,9 +218,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -237,9 +237,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -256,9 +256,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -275,9 +275,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -294,9 +294,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -313,9 +313,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -332,9 +332,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -351,9 +351,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -370,9 +370,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -389,9 +389,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -408,9 +408,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -427,9 +427,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -446,9 +446,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -465,9 +465,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -484,9 +484,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -503,9 +503,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -522,9 +522,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -536,9 +536,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 100
+      route_info_type: strip
       route_info_weight: 100
-      route_info_xs_34e31a19_length: 100
       width: 0.5
     settings:
       cross_section: strip
@@ -549,9 +549,9 @@ instances:
     info:
       length: 123
       route_info_length: 123
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 123
+      route_info_type: strip
       route_info_weight: 123
-      route_info_xs_34e31a19_length: 123
       width: 0.5
     settings:
       cross_section: strip
@@ -562,9 +562,9 @@ instances:
     info:
       length: 123
       route_info_length: 123
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 123
+      route_info_type: strip
       route_info_weight: 123
-      route_info_xs_34e31a19_length: 123
       width: 0.5
     settings:
       cross_section: strip
@@ -575,9 +575,9 @@ instances:
     info:
       length: 129
       route_info_length: 129
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 129
+      route_info_type: strip
       route_info_weight: 129
-      route_info_xs_34e31a19_length: 129
       width: 0.5
     settings:
       cross_section: strip
@@ -588,9 +588,9 @@ instances:
     info:
       length: 129
       route_info_length: 129
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 129
+      route_info_type: strip
       route_info_weight: 129
-      route_info_xs_34e31a19_length: 129
       width: 0.5
     settings:
       cross_section: strip
@@ -601,9 +601,9 @@ instances:
     info:
       length: 135
       route_info_length: 135
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 135
+      route_info_type: strip
       route_info_weight: 135
-      route_info_xs_34e31a19_length: 135
       width: 0.5
     settings:
       cross_section: strip
@@ -614,9 +614,9 @@ instances:
     info:
       length: 135
       route_info_length: 135
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 135
+      route_info_type: strip
       route_info_weight: 135
-      route_info_xs_34e31a19_length: 135
       width: 0.5
     settings:
       cross_section: strip
@@ -627,9 +627,9 @@ instances:
     info:
       length: 141
       route_info_length: 141
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 141
+      route_info_type: strip
       route_info_weight: 141
-      route_info_xs_34e31a19_length: 141
       width: 0.5
     settings:
       cross_section: strip
@@ -640,9 +640,9 @@ instances:
     info:
       length: 141
       route_info_length: 141
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 141
+      route_info_type: strip
       route_info_weight: 141
-      route_info_xs_34e31a19_length: 141
       width: 0.5
     settings:
       cross_section: strip
@@ -653,9 +653,9 @@ instances:
     info:
       length: 147
       route_info_length: 147
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 147
+      route_info_type: strip
       route_info_weight: 147
-      route_info_xs_34e31a19_length: 147
       width: 0.5
     settings:
       cross_section: strip
@@ -666,9 +666,9 @@ instances:
     info:
       length: 147
       route_info_length: 147
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 147
+      route_info_type: strip
       route_info_weight: 147
-      route_info_xs_34e31a19_length: 147
       width: 0.5
     settings:
       cross_section: strip
@@ -679,9 +679,9 @@ instances:
     info:
       length: 153
       route_info_length: 153
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 153
+      route_info_type: strip
       route_info_weight: 153
-      route_info_xs_34e31a19_length: 153
       width: 0.5
     settings:
       cross_section: strip
@@ -692,9 +692,9 @@ instances:
     info:
       length: 153
       route_info_length: 153
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 153
+      route_info_type: strip
       route_info_weight: 153
-      route_info_xs_34e31a19_length: 153
       width: 0.5
     settings:
       cross_section: strip
@@ -705,9 +705,9 @@ instances:
     info:
       length: 159
       route_info_length: 159
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 159
+      route_info_type: strip
       route_info_weight: 159
-      route_info_xs_34e31a19_length: 159
       width: 0.5
     settings:
       cross_section: strip
@@ -718,9 +718,9 @@ instances:
     info:
       length: 15
       route_info_length: 15
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15
+      route_info_type: strip
       route_info_weight: 15
-      route_info_xs_34e31a19_length: 15
       width: 0.5
     settings:
       cross_section: strip
@@ -731,9 +731,9 @@ instances:
     info:
       length: 15
       route_info_length: 15
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15
+      route_info_type: strip
       route_info_weight: 15
-      route_info_xs_34e31a19_length: 15
       width: 0.5
     settings:
       cross_section: strip
@@ -744,9 +744,9 @@ instances:
     info:
       length: 21
       route_info_length: 21
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 21
+      route_info_type: strip
       route_info_weight: 21
-      route_info_xs_34e31a19_length: 21
       width: 0.5
     settings:
       cross_section: strip
@@ -757,9 +757,9 @@ instances:
     info:
       length: 21
       route_info_length: 21
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 21
+      route_info_type: strip
       route_info_weight: 21
-      route_info_xs_34e31a19_length: 21
       width: 0.5
     settings:
       cross_section: strip
@@ -770,9 +770,9 @@ instances:
     info:
       length: 27
       route_info_length: 27
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 27
+      route_info_type: strip
       route_info_weight: 27
-      route_info_xs_34e31a19_length: 27
       width: 0.5
     settings:
       cross_section: strip
@@ -783,9 +783,9 @@ instances:
     info:
       length: 27
       route_info_length: 27
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 27
+      route_info_type: strip
       route_info_weight: 27
-      route_info_xs_34e31a19_length: 27
       width: 0.5
     settings:
       cross_section: strip
@@ -796,9 +796,9 @@ instances:
     info:
       length: 33
       route_info_length: 33
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 33
+      route_info_type: strip
       route_info_weight: 33
-      route_info_xs_34e31a19_length: 33
       width: 0.5
     settings:
       cross_section: strip
@@ -809,9 +809,9 @@ instances:
     info:
       length: 33
       route_info_length: 33
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 33
+      route_info_type: strip
       route_info_weight: 33
-      route_info_xs_34e31a19_length: 33
       width: 0.5
     settings:
       cross_section: strip
@@ -822,9 +822,9 @@ instances:
     info:
       length: 39
       route_info_length: 39
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 39
+      route_info_type: strip
       route_info_weight: 39
-      route_info_xs_34e31a19_length: 39
       width: 0.5
     settings:
       cross_section: strip
@@ -835,9 +835,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3
+      route_info_type: strip
       route_info_weight: 3
-      route_info_xs_34e31a19_length: 3
       width: 0.5
     settings:
       cross_section: strip
@@ -848,9 +848,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 3
+      route_info_type: strip
       route_info_weight: 3
-      route_info_xs_34e31a19_length: 3
       width: 0.5
     settings:
       cross_section: strip
@@ -861,9 +861,9 @@ instances:
     info:
       length: 9
       route_info_length: 9
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 9
+      route_info_type: strip
       route_info_weight: 9
-      route_info_xs_34e31a19_length: 9
       width: 0.5
     settings:
       cross_section: strip
@@ -874,9 +874,9 @@ instances:
     info:
       length: 9
       route_info_length: 9
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 9
+      route_info_type: strip
       route_info_weight: 9
-      route_info_xs_34e31a19_length: 9
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_spiral_racetrack_fixed_length_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_fixed_length_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -44,9 +44,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -58,9 +58,9 @@ instances:
     info:
       length: 20.25
       route_info_length: 20.25
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 20.25
+      route_info_type: strip
       route_info_weight: 20.25
-      route_info_xs_34e31a19_length: 20.25
       width: 0.5
     settings:
       cross_section: strip
@@ -71,9 +71,9 @@ instances:
     info:
       length: 47.457
       route_info_length: 47.457
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 47.457
+      route_info_type: strip
       route_info_weight: 47.457
-      route_info_xs_34e31a19_length: 47.457
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
@@ -27,9 +27,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_93476d9a
+      route_info_npp_length: 30
+      route_info_type: npp
       route_info_weight: 30
-      route_info_xs_93476d9a_length: 30
       width: 0.5
     settings:
       cross_section: npp
@@ -40,9 +40,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_93476d9a
+      route_info_npp_length: 30
+      route_info_type: npp
       route_info_weight: 30
-      route_info_xs_93476d9a_length: 30
       width: 0.5
     settings:
       cross_section: npp

--- a/test-data-regression/test_netlists_spiral_racetrack_heater_metal_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_heater_metal_.yml
@@ -5,12 +5,12 @@ instances:
       dy: 0
       length: 62.831
       radius: 20
+      route_info_heater_metal_length: 62.831
       route_info_length: 62.831
       route_info_min_bend_radius: 20
       route_info_n_bend_90: 2
-      route_info_type: xs_c500a645
+      route_info_type: heater_metal
       route_info_weight: 62.831
-      route_info_xs_c500a645_length: 62.831
     settings:
       allow_min_radius_violation: false
       angle: 180
@@ -43,10 +43,10 @@ instances:
     component: straight
     info:
       length: 30
+      route_info_heater_metal_length: 30
       route_info_length: 30
-      route_info_type: xs_c500a645
+      route_info_type: heater_metal
       route_info_weight: 30
-      route_info_xs_c500a645_length: 30
       width: 2.5
     settings:
       cross_section: heater_metal
@@ -56,10 +56,10 @@ instances:
     component: straight
     info:
       length: 30
+      route_info_heater_metal_length: 30
       route_info_length: 30
-      route_info_type: xs_c500a645
+      route_info_type: heater_metal
       route_info_weight: 30
-      route_info_xs_c500a645_length: 30
       width: 2.5
     settings:
       cross_section: heater_metal

--- a/test-data-regression/test_netlists_splitter_chain_.yml
+++ b/test-data-regression/test_netlists_splitter_chain_.yml
@@ -8,9 +8,9 @@ instances:
       route_info_length: 11.206
       route_info_min_bend_radius: 13.012
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 11.206
+      route_info_type: strip
       route_info_weight: 11.206
-      route_info_xs_34e31a19_length: 11.206
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -28,9 +28,9 @@ instances:
       route_info_length: 11.206
       route_info_min_bend_radius: 13.012
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 11.206
+      route_info_type: strip
       route_info_weight: 11.206
-      route_info_xs_34e31a19_length: 11.206
       start_angle: 0
     settings:
       allow_min_radius_violation: false

--- a/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/test-data-regression/test_netlists_splitter_tree_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -92,9 +92,9 @@ instances:
       route_info_length: 91.103
       route_info_min_bend_radius: 129.147
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 91.103
+      route_info_type: strip
       route_info_weight: 91.103
-      route_info_xs_34e31a19_length: 91.103
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -112,9 +112,9 @@ instances:
       route_info_length: 91.103
       route_info_min_bend_radius: 129.147
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 91.103
+      route_info_type: strip
       route_info_weight: 91.103
-      route_info_xs_34e31a19_length: 91.103
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -132,9 +132,9 @@ instances:
       route_info_length: 91.103
       route_info_min_bend_radius: 129.147
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 91.103
+      route_info_type: strip
       route_info_weight: 91.103
-      route_info_xs_34e31a19_length: 91.103
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -152,9 +152,9 @@ instances:
       route_info_length: 91.103
       route_info_min_bend_radius: 129.147
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 91.103
+      route_info_type: strip
       route_info_weight: 91.103
-      route_info_xs_34e31a19_length: 91.103
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -204,9 +204,9 @@ instances:
     info:
       length: 44.5
       route_info_length: 44.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 44.5
+      route_info_type: strip
       route_info_weight: 44.5
-      route_info_xs_34e31a19_length: 44.5
       width: 0.5
     settings:
       cross_section: strip
@@ -218,9 +218,9 @@ instances:
     info:
       length: 44.5
       route_info_length: 44.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 44.5
+      route_info_type: strip
       route_info_weight: 44.5
-      route_info_xs_34e31a19_length: 44.5
       width: 0.5
     settings:
       cross_section: strip
@@ -232,9 +232,9 @@ instances:
     info:
       length: 4.375
       route_info_length: 4.375
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4.375
+      route_info_type: strip
       route_info_weight: 4.375
-      route_info_xs_34e31a19_length: 4.375
       width: 0.5
     settings:
       cross_section: strip
@@ -246,9 +246,9 @@ instances:
     info:
       length: 4.375
       route_info_length: 4.375
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4.375
+      route_info_type: strip
       route_info_weight: 4.375
-      route_info_xs_34e31a19_length: 4.375
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_staircase_.yml
+++ b/test-data-regression/test_netlists_staircase_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -30,9 +30,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -43,9 +43,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -61,9 +61,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -80,9 +80,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -99,9 +99,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -118,9 +118,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -137,9 +137,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -156,9 +156,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -175,9 +175,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -194,9 +194,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -208,9 +208,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -221,9 +221,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -234,9 +234,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -247,9 +247,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip
@@ -260,9 +260,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 5
+      route_info_type: strip
       route_info_weight: 5
-      route_info_xs_34e31a19_length: 5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_straight_array_.yml
+++ b/test-data-regression/test_netlists_straight_array_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -17,9 +17,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -30,9 +30,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -43,9 +43,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_straight_heater_meander_doped_.yml
+++ b/test-data-regression/test_netlists_straight_heater_meander_doped_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -93,9 +93,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -114,9 +114,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -135,9 +135,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -156,9 +156,9 @@ instances:
       route_info_length: 8.318
       route_info_min_bend_radius: 3.53
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 8.318
+      route_info_type: strip
       route_info_weight: 8.318
-      route_info_xs_34e31a19_length: 8.318
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -220,9 +220,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -234,9 +234,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 10
+      route_info_type: strip
       route_info_weight: 10
-      route_info_xs_34e31a19_length: 10
       width: 0.5
     settings:
       cross_section: strip
@@ -248,9 +248,9 @@ instances:
     info:
       length: 15
       route_info_length: 15
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15
+      route_info_type: strip
       route_info_weight: 15
-      route_info_xs_34e31a19_length: 15
       width: 0.5
     settings:
       cross_section: strip
@@ -261,9 +261,9 @@ instances:
     info:
       length: 15
       route_info_length: 15
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 15
+      route_info_type: strip
       route_info_weight: 15
-      route_info_xs_34e31a19_length: 15
       width: 0.5
     settings:
       cross_section: strip
@@ -274,9 +274,9 @@ instances:
     info:
       length: 2
       route_info_length: 2
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 2
+      route_info_type: strip
       route_info_weight: 2
-      route_info_xs_34e31a19_length: 2
       width: 0.5
     settings:
       cross_section: strip
@@ -288,9 +288,9 @@ instances:
     info:
       length: 4
       route_info_length: 4
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 4
+      route_info_type: strip
       route_info_weight: 4
-      route_info_xs_34e31a19_length: 4
       width: 0.5
     settings:
       cross_section: strip
@@ -302,9 +302,9 @@ instances:
     info:
       length: 7.5
       route_info_length: 7.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.5
+      route_info_type: strip
       route_info_weight: 7.5
-      route_info_xs_34e31a19_length: 7.5
       width: 0.5
     settings:
       cross_section: strip
@@ -315,9 +315,9 @@ instances:
     info:
       length: 7.5
       route_info_length: 7.5
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 7.5
+      route_info_type: strip
       route_info_weight: 7.5
-      route_info_xs_34e31a19_length: 7.5
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_straight_heater_metal_.yml
+++ b/test-data-regression/test_netlists_straight_heater_metal_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -17,9 +17,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -30,9 +30,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -43,9 +43,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -56,9 +56,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -69,9 +69,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -82,9 +82,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -95,9 +95,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -108,9 +108,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -121,9 +121,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -134,9 +134,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -147,9 +147,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -160,9 +160,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -173,9 +173,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -186,9 +186,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -199,9 +199,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -212,9 +212,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -225,9 +225,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -238,9 +238,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -251,9 +251,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -264,9 +264,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -277,9 +277,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -290,9 +290,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -303,9 +303,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -316,9 +316,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -329,9 +329,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -342,9 +342,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -355,9 +355,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -368,9 +368,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -381,9 +381,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -394,9 +394,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -407,9 +407,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -420,9 +420,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -433,9 +433,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -446,9 +446,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -459,9 +459,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -472,9 +472,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -485,9 +485,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -498,9 +498,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -511,9 +511,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -524,9 +524,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -537,9 +537,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -550,9 +550,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -563,9 +563,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -576,9 +576,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -589,9 +589,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -602,9 +602,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -615,9 +615,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -628,9 +628,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -641,9 +641,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -654,9 +654,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -667,9 +667,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -680,9 +680,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -693,9 +693,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -706,9 +706,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -719,9 +719,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -732,9 +732,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -745,9 +745,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -758,9 +758,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -771,9 +771,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -784,9 +784,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -797,9 +797,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -810,9 +810,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -823,9 +823,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -836,9 +836,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -849,9 +849,9 @@ instances:
     info:
       length: 2.4
       route_info_length: 2.4
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 2.4
+      route_info_type: strip_heater_metal
       route_info_weight: 2.4
-      route_info_xs_18860153_length: 2.4
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -862,9 +862,9 @@ instances:
     info:
       length: 2.4
       route_info_length: 2.4
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 2.4
+      route_info_type: strip_heater_metal
       route_info_weight: 2.4
-      route_info_xs_18860153_length: 2.4
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_straight_heater_metal_90_90_.yml
+++ b/test-data-regression/test_netlists_straight_heater_metal_90_90_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -17,9 +17,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -30,9 +30,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -43,9 +43,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -56,9 +56,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -69,9 +69,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -82,9 +82,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -95,9 +95,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -108,9 +108,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -121,9 +121,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -134,9 +134,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -147,9 +147,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -160,9 +160,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -173,9 +173,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -186,9 +186,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -199,9 +199,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -212,9 +212,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -225,9 +225,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -238,9 +238,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -251,9 +251,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -264,9 +264,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -277,9 +277,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -290,9 +290,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -303,9 +303,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -316,9 +316,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -329,9 +329,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -342,9 +342,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -355,9 +355,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -368,9 +368,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -381,9 +381,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -394,9 +394,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -407,9 +407,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -420,9 +420,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -433,9 +433,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -446,9 +446,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -459,9 +459,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -472,9 +472,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -485,9 +485,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -498,9 +498,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -511,9 +511,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -524,9 +524,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -537,9 +537,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -550,9 +550,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -563,9 +563,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -576,9 +576,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -589,9 +589,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -602,9 +602,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -615,9 +615,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -628,9 +628,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -641,9 +641,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -654,9 +654,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -667,9 +667,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -680,9 +680,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -693,9 +693,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -706,9 +706,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -719,9 +719,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -732,9 +732,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -745,9 +745,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -758,9 +758,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -771,9 +771,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -784,9 +784,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -797,9 +797,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -810,9 +810,9 @@ instances:
     info:
       length: 5
       route_info_length: 5
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 5
+      route_info_type: strip_heater_metal
       route_info_weight: 5
-      route_info_xs_18860153_length: 5
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -823,9 +823,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -836,9 +836,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -849,9 +849,9 @@ instances:
     info:
       length: 2.4
       route_info_length: 2.4
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 2.4
+      route_info_type: strip_heater_metal
       route_info_weight: 2.4
-      route_info_xs_18860153_length: 2.4
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -862,9 +862,9 @@ instances:
     info:
       length: 2.4
       route_info_length: 2.4
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 2.4
+      route_info_type: strip_heater_metal
       route_info_weight: 2.4
-      route_info_xs_18860153_length: 2.4
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_straight_heater_metal_simple_.yml
+++ b/test-data-regression/test_netlists_straight_heater_metal_simple_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 320
       route_info_length: 320
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 320
+      route_info_type: strip_heater_metal
       route_info_weight: 320
-      route_info_xs_18860153_length: 320
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_straight_heater_metal_undercut_.yml
+++ b/test-data-regression/test_netlists_straight_heater_metal_undercut_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -17,9 +17,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -30,9 +30,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -43,9 +43,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -56,9 +56,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -69,9 +69,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -82,9 +82,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -95,9 +95,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -108,9 +108,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -121,9 +121,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -134,9 +134,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -147,9 +147,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -160,9 +160,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -173,9 +173,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -186,9 +186,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -199,9 +199,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -212,9 +212,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -225,9 +225,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -238,9 +238,9 @@ instances:
     info:
       length: 15.9
       route_info_length: 15.9
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 15.9
+      route_info_type: strip_heater_metal
       route_info_weight: 15.9
-      route_info_xs_18860153_length: 15.9
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -251,9 +251,9 @@ instances:
     info:
       length: 15.9
       route_info_length: 15.9
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 15.9
+      route_info_type: strip_heater_metal
       route_info_weight: 15.9
-      route_info_xs_18860153_length: 15.9
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_straight_heater_metal_undercut_90_90_.yml
+++ b/test-data-regression/test_netlists_straight_heater_metal_undercut_90_90_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -17,9 +17,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -30,9 +30,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -43,9 +43,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -56,9 +56,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -69,9 +69,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -82,9 +82,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -95,9 +95,9 @@ instances:
     info:
       length: 6
       route_info_length: 6
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 6
+      route_info_type: strip_heater_metal
       route_info_weight: 6
-      route_info_xs_18860153_length: 6
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -108,9 +108,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -121,9 +121,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -134,9 +134,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -147,9 +147,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -160,9 +160,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -173,9 +173,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -186,9 +186,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -199,9 +199,9 @@ instances:
     info:
       length: 30
       route_info_length: 30
-      route_info_type: xs_e5b34941
+      route_info_strip_heater_metal_undercut_length: 30
+      route_info_type: strip_heater_metal_undercut
       route_info_weight: 30
-      route_info_xs_e5b34941_length: 30
       width: 0.5
     settings:
       cross_section: strip_heater_metal_undercut
@@ -212,9 +212,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -225,9 +225,9 @@ instances:
     info:
       length: 0.1
       route_info_length: 0.1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 0.1
+      route_info_type: strip
       route_info_weight: 0.1
-      route_info_xs_34e31a19_length: 0.1
       width: 0.5
     settings:
       cross_section: strip
@@ -238,9 +238,9 @@ instances:
     info:
       length: 15.9
       route_info_length: 15.9
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 15.9
+      route_info_type: strip_heater_metal
       route_info_weight: 15.9
-      route_info_xs_18860153_length: 15.9
       width: 0.5
     settings:
       cross_section: strip_heater_metal
@@ -251,9 +251,9 @@ instances:
     info:
       length: 15.9
       route_info_length: 15.9
-      route_info_type: xs_18860153
+      route_info_strip_heater_metal_length: 15.9
+      route_info_type: strip_heater_metal
       route_info_weight: 15.9
-      route_info_xs_18860153_length: 15.9
       width: 0.5
     settings:
       cross_section: strip_heater_metal

--- a/test-data-regression/test_netlists_straight_pin_.yml
+++ b/test-data-regression/test_netlists_straight_pin_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 480
       route_info_length: 480
-      route_info_type: xs_ee002e1f
+      route_info_pin_length: 480
+      route_info_type: pin
       route_info_weight: 480
-      route_info_xs_ee002e1f_length: 480
       width: 0.5
     settings:
       cross_section: pin

--- a/test-data-regression/test_netlists_straight_pin_slot_.yml
+++ b/test-data-regression/test_netlists_straight_pin_slot_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 480
       route_info_length: 480
-      route_info_type: xs_ee002e1f
+      route_info_pin_length: 480
+      route_info_type: pin
       route_info_weight: 480
-      route_info_xs_ee002e1f_length: 480
       width: 0.5
     settings:
       cross_section: pin

--- a/test-data-regression/test_netlists_straight_pn_.yml
+++ b/test-data-regression/test_netlists_straight_pn_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 1980
       route_info_length: 1980
-      route_info_type: xs_ef495afa
+      route_info_pn_length: 1980
+      route_info_type: pn
       route_info_weight: 1980
-      route_info_xs_ef495afa_length: 1980
       width: 0.5
     settings:
       cross_section: pn

--- a/test-data-regression/test_netlists_switch_tree_.yml
+++ b/test-data-regression/test_netlists_switch_tree_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -30,9 +30,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -51,9 +51,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -72,9 +72,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 16.637
+      route_info_type: strip
       route_info_weight: 16.637
-      route_info_xs_34e31a19_length: 16.637
     settings:
       allow_min_radius_violation: false
       angle: 90
@@ -92,9 +92,9 @@ instances:
       route_info_length: 500.845
       route_info_min_bend_radius: 1870.03
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 500.845
+      route_info_type: strip
       route_info_weight: 500.845
-      route_info_xs_34e31a19_length: 500.845
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -112,9 +112,9 @@ instances:
       route_info_length: 500.845
       route_info_min_bend_radius: 1870.03
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 500.845
+      route_info_type: strip
       route_info_weight: 500.845
-      route_info_xs_34e31a19_length: 500.845
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -132,9 +132,9 @@ instances:
       route_info_length: 500.845
       route_info_min_bend_radius: 1870.03
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 500.845
+      route_info_type: strip
       route_info_weight: 500.845
-      route_info_xs_34e31a19_length: 500.845
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -152,9 +152,9 @@ instances:
       route_info_length: 500.845
       route_info_min_bend_radius: 1870.03
       route_info_n_bend_s: 1
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 500.845
+      route_info_type: strip
       route_info_weight: 500.845
-      route_info_xs_34e31a19_length: 500.845
       start_angle: 0
     settings:
       allow_min_radius_violation: false
@@ -240,9 +240,9 @@ instances:
     info:
       length: 29.375
       route_info_length: 29.375
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 29.375
+      route_info_type: strip
       route_info_weight: 29.375
-      route_info_xs_34e31a19_length: 29.375
       width: 0.5
     settings:
       cross_section: strip
@@ -254,9 +254,9 @@ instances:
     info:
       length: 29.375
       route_info_length: 29.375
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 29.375
+      route_info_type: strip
       route_info_weight: 29.375
-      route_info_xs_34e31a19_length: 29.375
       width: 0.5
     settings:
       cross_section: strip
@@ -268,9 +268,9 @@ instances:
     info:
       length: 69
       route_info_length: 69
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 69
+      route_info_type: strip
       route_info_weight: 69
-      route_info_xs_34e31a19_length: 69
       width: 0.5
     settings:
       cross_section: strip
@@ -282,9 +282,9 @@ instances:
     info:
       length: 69
       route_info_length: 69
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 69
+      route_info_type: strip
       route_info_weight: 69
-      route_info_xs_34e31a19_length: 69
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_terminator_.yml
+++ b/test-data-regression/test_netlists_terminator_.yml
@@ -1,35 +1,35 @@
 instances:
-  taper_cross_section_CSF_10cc8ed5_25000_0:
+  taper_cross_section_CSs_d7986ffc_25000_0:
     component: taper_cross_section
     info:
       route_info_length: 50
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 50
+      route_info_strip_taper_length: 50
+      route_info_type: strip
       route_info_weight: 50
-      route_info_xs_34e31a19_length: 50
-      route_info_xs_34e31a19_taper_length: 50
     settings:
-      cross_section1: Fcross_section_Mgdsfactorypcross_section_SR10_RM5
+      cross_section1: strip
       cross_section2: xs_960aa7b6
       length: 50
       linear: false
       npoints: 100
       width_type: sine
-name: terminator_L50_CSIFcros_2d525ef0
+name: terminator_L50_CSIstrip_a7ffecd8
 nets: []
 placements:
-  taper_cross_section_CSF_10cc8ed5_25000_0:
+  taper_cross_section_CSs_d7986ffc_25000_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: taper_cross_section_CSF_10cc8ed5_25000_0,o1
+  o1: taper_cross_section_CSs_d7986ffc_25000_0,o1
 warnings:
   optical:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - taper_cross_section_CSF_10cc8ed5_25000_0,o2
+      - taper_cross_section_CSs_d7986ffc_25000_0,o2
       values:
       - - 50000
         - 0

--- a/test-data-regression/test_netlists_verniers_.yml
+++ b/test-data-regression/test_netlists_verniers_.yml
@@ -60,9 +60,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_34e31a19
+      route_info_strip_length: 100
+      route_info_type: strip
       route_info_weight: 100
-      route_info_xs_34e31a19_length: 100
       width: 0.5
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_via_corner_.yml
+++ b/test-data-regression/test_netlists_via_corner_.yml
@@ -53,7 +53,7 @@ instances:
       spacing:
       - 2
       - 2
-name: via_corner_CSFcross_sec_da01ea22
+name: via_corner_CSmetal2_0_1_37803ae7
 nets:
 - p1: compass_S10_10_LM2_PTel_76f0ee1a_0_0,e1
   p2: compass_S10_10_LM3_PTel_907be21f_0_0,e1

--- a/test-data-regression/test_settings_add_termination_.yml
+++ b/test-data-regression/test_settings_add_termination_.yml
@@ -1,9 +1,9 @@
 info:
   length: 10
   route_info_length: 10
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 10
+  route_info_type: strip
   route_info_weight: 10
-  route_info_xs_34e31a19_length: 10
   width: 0.5
 name: add_termination_Cstraig_a456518a
 settings:

--- a/test-data-regression/test_settings_add_trenches90_.yml
+++ b/test-data-regression/test_settings_add_trenches90_.yml
@@ -6,9 +6,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 16.637
+  route_info_type: strip
   route_info_weight: 16.637
-  route_info_xs_34e31a19_length: 16.637
 name: add_trenches_Cbend_eule_0a7a1008
 settings:
   component: bend_euler

--- a/test-data-regression/test_settings_bend_circular180_.yml
+++ b/test-data-regression/test_settings_bend_circular180_.yml
@@ -5,9 +5,9 @@ info:
   route_info_length: 31.415
   route_info_min_bend_radius: 10
   route_info_n_bend_90: 2
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 31.415
+  route_info_type: strip
   route_info_weight: 31.415
-  route_info_xs_34e31a19_length: 31.415
 name: bend_circular_RNone_A18_72bb12de
 settings:
   allow_min_radius_violation: false

--- a/test-data-regression/test_settings_bend_circular_.yml
+++ b/test-data-regression/test_settings_bend_circular_.yml
@@ -5,9 +5,9 @@ info:
   route_info_length: 15.708
   route_info_min_bend_radius: 10
   route_info_n_bend_90: 1
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 15.708
+  route_info_type: strip
   route_info_weight: 15.708
-  route_info_xs_34e31a19_length: 15.708
 name: bend_circular_RNone_A90_35590aa7
 settings:
   allow_min_radius_violation: false

--- a/test-data-regression/test_settings_bend_euler180_.yml
+++ b/test-data-regression/test_settings_bend_euler180_.yml
@@ -6,9 +6,9 @@ info:
   route_info_length: 42.817
   route_info_min_bend_radius: 9.086
   route_info_n_bend_90: 2
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 42.817
+  route_info_type: strip
   route_info_weight: 42.817
-  route_info_xs_34e31a19_length: 42.817
 name: bend_euler_RNone_A180_P_a75aec30
 settings:
   allow_min_radius_violation: false

--- a/test-data-regression/test_settings_bend_euler_.yml
+++ b/test-data-regression/test_settings_bend_euler_.yml
@@ -6,9 +6,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 16.637
+  route_info_type: strip
   route_info_weight: 16.637
-  route_info_xs_34e31a19_length: 16.637
 name: bend_euler_RNone_A90_P0_d7c3a5a9
 settings:
   allow_min_radius_violation: false

--- a/test-data-regression/test_settings_bend_s_.yml
+++ b/test-data-regression/test_settings_bend_s_.yml
@@ -5,9 +5,9 @@ info:
   route_info_length: 11.206
   route_info_min_bend_radius: 13.012
   route_info_n_bend_s: 1
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 11.206
+  route_info_type: strip
   route_info_weight: 11.206
-  route_info_xs_34e31a19_length: 11.206
   start_angle: 0
 name: bend_s_S11_1p8_N99_CSst_71d8cbbd
 settings:

--- a/test-data-regression/test_settings_bezier_.yml
+++ b/test-data-regression/test_settings_bezier_.yml
@@ -5,9 +5,9 @@ info:
   route_info_length: 10.226
   route_info_min_bend_radius: 10.885
   route_info_n_bend_s: 1
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 10.226
+  route_info_type: strip
   route_info_weight: 10.226
-  route_info_xs_34e31a19_length: 10.226
   start_angle: 0
 name: bezier_CP0_0_5_0_5_1p8__9eb21687
 settings:

--- a/test-data-regression/test_settings_greek_cross_with_pads_.yml
+++ b/test-data-regression/test_settings_greek_cross_with_pads_.yml
@@ -1,7 +1,7 @@
 info: {}
-name: greek_cross_with_pads_P_fa616bf3
+name: greek_cross_with_pads_P_d48c0f08
 settings:
-  cross_section: Fcross_section_Mgdsfactorypcross_section_SLM1_W10_PNe1_e2_PTelectrical_electrical_RNone
+  cross_section: metal1
   greek_cross_component: greek_cross
   pad: pad
   pad_spacing: 150

--- a/test-data-regression/test_settings_ring_single_pn_.yml
+++ b/test-data-regression/test_settings_ring_single_pn_.yml
@@ -1,7 +1,7 @@
 info: {}
-name: ring_single_pn_G0p3_R5__b0270650
+name: ring_single_pn_G0p3_R5__9a9277c3
 settings:
-  cross_section: Fcross_section_Mgdsfactorypcross_section_SR10_RM5_Sslab
+  cross_section: Fstrip_Mgdsfactorypcross_section_SSslab
   doped_heater: true
   doped_heater_angle_buffer: 10
   doped_heater_layer: NPP

--- a/test-data-regression/test_settings_straight_.yml
+++ b/test-data-regression/test_settings_straight_.yml
@@ -1,9 +1,9 @@
 info:
   length: 10
   route_info_length: 10
-  route_info_type: xs_34e31a19
+  route_info_strip_length: 10
+  route_info_type: strip
   route_info_weight: 10
-  route_info_xs_34e31a19_length: 10
   width: 0.5
 name: straight_L10_N2_CSstrip
 settings:

--- a/test-data-regression/test_settings_taper_cross_section_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_.yml
@@ -1,9 +1,9 @@
 info:
   route_info_length: 10
-  route_info_type: xs_87fc063d
+  route_info_strip_rib_tip_length: 10
+  route_info_strip_rib_tip_taper_length: 10
+  route_info_type: strip_rib_tip
   route_info_weight: 10
-  route_info_xs_87fc063d_length: 10
-  route_info_xs_87fc063d_taper_length: 10
 name: taper_cross_section_CSs_83462faa
 settings:
   cross_section1: strip_rib_tip

--- a/test-data-regression/test_settings_taper_cross_section_linear_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_linear_.yml
@@ -1,9 +1,9 @@
 info:
   route_info_length: 10
-  route_info_type: xs_87fc063d
+  route_info_strip_rib_tip_length: 10
+  route_info_strip_rib_tip_taper_length: 10
+  route_info_type: strip_rib_tip
   route_info_weight: 10
-  route_info_xs_87fc063d_length: 10
-  route_info_xs_87fc063d_taper_length: 10
 name: taper_cross_section_CSs_58b2cba3
 settings:
   cross_section1: strip_rib_tip

--- a/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
@@ -1,9 +1,9 @@
 info:
   route_info_length: 10
-  route_info_type: xs_87fc063d
+  route_info_strip_rib_tip_length: 10
+  route_info_strip_rib_tip_taper_length: 10
+  route_info_type: strip_rib_tip
   route_info_weight: 10
-  route_info_xs_87fc063d_length: 10
-  route_info_xs_87fc063d_taper_length: 10
 name: taper_cross_section_CSs_9478a791
 settings:
   cross_section1: strip_rib_tip

--- a/test-data-regression/test_settings_taper_cross_section_sine_.yml
+++ b/test-data-regression/test_settings_taper_cross_section_sine_.yml
@@ -1,9 +1,9 @@
 info:
   route_info_length: 10
-  route_info_type: xs_87fc063d
+  route_info_strip_rib_tip_length: 10
+  route_info_strip_rib_tip_taper_length: 10
+  route_info_type: strip_rib_tip
   route_info_weight: 10
-  route_info_xs_87fc063d_length: 10
-  route_info_xs_87fc063d_taper_length: 10
 name: taper_cross_section_CSs_6aa7fce8
 settings:
   cross_section1: strip_rib_tip

--- a/test-data-regression/test_settings_terminator_.yml
+++ b/test-data-regression/test_settings_terminator_.yml
@@ -1,7 +1,7 @@
 info: {}
-name: terminator_L50_CSIFcros_2d525ef0
+name: terminator_L50_CSIstrip_a7ffecd8
 settings:
-  cross_section_input: Fcross_section_Mgdsfactorypcross_section_SR10_RM5
+  cross_section_input: strip
   doping_layers:
   - NPP
   doping_offset: 1

--- a/test-data-regression/test_settings_via_corner_.yml
+++ b/test-data-regression/test_settings_via_corner_.yml
@@ -3,13 +3,13 @@ info:
   size:
   - 10
   - 10
-name: via_corner_CSFcross_sec_da01ea22
+name: via_corner_CSmetal2_0_1_37803ae7
 settings:
   cross_section:
-  - - Fcross_section_Mgdsfactorypcross_section_SLM2_W10_PNe1_e2_PTelectrical_electrical_RNone
+  - - metal2
     - - 0
       - 180
-  - - Fcross_section_Mgdsfactorypcross_section_SLM3_W10_PNe1_e2_PTelectrical_electrical_RNone
+  - - metal3
     - - 90
       - 270
   layers_labels:

--- a/test-data-regression/test_settings_wire_straight_.yml
+++ b/test-data-regression/test_settings_wire_straight_.yml
@@ -1,9 +1,9 @@
 info:
   length: 10
   route_info_length: 10
-  route_info_type: xs_0efa6a61
+  route_info_metal_routing_length: 10
+  route_info_type: metal_routing
   route_info_weight: 10
-  route_info_xs_0efa6a61_length: 10
   width: 10
 name: straight_L10_N2_CSmetal_routing
 settings:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -47,6 +47,19 @@ def test_copy() -> None:
     d = jsondiff.diff(x1.model_dump(), x2.model_dump())
     assert len(d) == 0, d
 
+    xs1 = gf.get_cross_section("metal_routing")
+    xs2 = xs1.copy(width=2)
+    assert xs2.name != xs1.name, f"{xs2.name} == {xs1.name}"
+
+    xs1 = gf.get_cross_section("metal_routing")
+    xs2 = xs1.copy(width=10)
+    assert xs2.name == xs1.name, f"{xs2.name} != {xs1.name}"
+
+
+def test_name() -> None:
+    s = gf.cross_section.strip()
+    assert s.name == "strip"
+
 
 xc_sin = partial(
     gf.cross_section.cross_section,


### PR DESCRIPTION
- Creating a decorator for xsection
- registers cross_section in a global namespace


gf.get_cross_section('strip').name == gf.cross_section.strip.name 


Next steps:

- [ ] deprecate get_cross_sections?
- [ ] fix tests
- [ ] update docs