### PR TITLE
adding a 'stagger' option to diff

### DIFF
--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -28,6 +28,7 @@ def diff(
     ignore_cell_name_differences: bool | None = None,
     ignore_label_differences: bool | None = None,
     show: bool = False,
+    stagger: bool = True,
 ) -> bool:
     """Returns True if files are different, prints differences and shows them in klayout.
 
@@ -40,6 +41,7 @@ def diff(
         ignore_cell_name_differences: if True, ignores any cell name differences. If None (default), defers to the value set in CONF.difftest_ignore_cell_name_differences
         ignore_label_differences: if True, ignores any label differences when run in XOR mode. If None (default) defers to the value set in CONF.difftest_ignore_label_differences
         show: shows diff in klayout.
+        stagger: if True, staggers the old/new/xor views. If False, all three are overlaid.
     """
     old = read_top_cell(ref_file)
     new = read_top_cell(run_file)
@@ -148,8 +150,9 @@ def diff(
         new_ref = c << new
 
         dy = 10
-        old_ref.dmovey(+old.dysize + dy)
-        new_ref.dmovey(-old.dysize - dy)
+        if stagger:
+            old_ref.dmovey(+old.dysize + dy)
+            new_ref.dmovey(-old.dysize - dy)
 
         layer_label = (1, 0)
         layer_label = kf.kcl.layer(*layer_label)


### PR DESCRIPTION
sometimes the current "stagger" behavior of the `diff` function is nice, to see the changes at a glance. but sometimes you just want to see all three views (old/new/xor) perfectly overlaid. this PR gives the user the option