### PR TITLE
Match `post_process` in `import_gds` to `@gf.cell`

### DIFF
--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 from functools import cache
 from pathlib import Path
 
@@ -15,7 +15,7 @@ from gdsfactory.component import Component
 def import_gds(
     gdspath: str | Path,
     cellname: str | None = None,
-    post_process: Iterable[Callable[[Component], None]] | None = None,
+    post_process: Hashable[Iterable[Callable[[Component], None]]] | None = None,
     **kwargs,
 ) -> Component:
     """Reads a GDS file and returns a Component.

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from functools import cache
 from pathlib import Path
 
@@ -15,7 +15,7 @@ from gdsfactory.component import Component
 def import_gds(
     gdspath: str | Path,
     cellname: str | None = None,
-    post_process: Callable[[Component], Component] | None = None,
+    post_process: Iterable[Callable[[Component], None]] | None = None,
     **kwargs,
 ) -> Component:
     """Reads a GDS file and returns a Component.
@@ -37,8 +37,8 @@ def import_gds(
     cellname = cellname or temp_kcl.top_cell().name
     kcell = temp_kcl[cellname]
     c = kcell_to_component(kcell)
-    if post_process:
-        post_process(c)
+    for pp in post_process or []:
+        pp(c)
 
     temp_kcl.library.delete()
     del kf.kcell.kcls[temp_kcl.name]

--- a/tests/test_add_ports.py
+++ b/tests/test_add_ports.py
@@ -28,7 +28,7 @@ def test_add_ports_from_pins() -> None:
         add_ports_from_markers_inside, pin_layer=LAYER.PORT, inside=True
     )
 
-    c2 = gf.import_gds(gdspath, post_process=[add_ports])
+    c2 = gf.import_gds(gdspath, post_process=(add_ports,))
     assert c2.ports["o1"].dcenter[0] == 0, c2.ports["o1"].dcenter[0]
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 
@@ -40,7 +40,7 @@ def test_add_ports_from_pins_path() -> None:
     assert c.ports["o1"].dcenter[0] == 0
     assert c.ports["o2"].dcenter[0] == x, c.ports["o2"].dcenter[0]
     gdspath = c.write_gds(with_metadata=False)
-    c2 = gf.import_gds(gdspath, post_process=[add_ports_from_siepic_pins])
+    c2 = gf.import_gds(gdspath, post_process=(add_ports_from_siepic_pins,))
     assert c2.ports["o1"].dcenter[0] == 0, c2.ports["o1"].dcenter[0]
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 
@@ -55,7 +55,7 @@ def test_add_ports_from_labels() -> None:
         add_ports_from_labels, port_layer=LAYER.TEXT, port_width=port_width
     )
 
-    c2 = gf.import_gds(gdspath, post_process=[add_ports])
+    c2 = gf.import_gds(gdspath, post_process=(add_ports,))
     assert c2.ports["o1"].dcenter[0] == 0
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 

--- a/tests/test_add_ports.py
+++ b/tests/test_add_ports.py
@@ -28,7 +28,7 @@ def test_add_ports_from_pins() -> None:
         add_ports_from_markers_inside, pin_layer=LAYER.PORT, inside=True
     )
 
-    c2 = gf.import_gds(gdspath, post_process=add_ports)
+    c2 = gf.import_gds(gdspath, post_process=[add_ports])
     assert c2.ports["o1"].dcenter[0] == 0, c2.ports["o1"].dcenter[0]
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 
@@ -40,7 +40,7 @@ def test_add_ports_from_pins_path() -> None:
     assert c.ports["o1"].dcenter[0] == 0
     assert c.ports["o2"].dcenter[0] == x, c.ports["o2"].dcenter[0]
     gdspath = c.write_gds(with_metadata=False)
-    c2 = gf.import_gds(gdspath, post_process=add_ports_from_siepic_pins)
+    c2 = gf.import_gds(gdspath, post_process=[add_ports_from_siepic_pins])
     assert c2.ports["o1"].dcenter[0] == 0, c2.ports["o1"].dcenter[0]
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 
@@ -55,7 +55,7 @@ def test_add_ports_from_labels() -> None:
         add_ports_from_labels, port_layer=LAYER.TEXT, port_width=port_width
     )
 
-    c2 = gf.import_gds(gdspath, post_process=add_ports)
+    c2 = gf.import_gds(gdspath, post_process=[add_ports])
     assert c2.ports["o1"].dcenter[0] == 0
     assert c2.ports["o2"].dcenter[0] == x, c2.ports["o2"].dcenter[0]
 


### PR DESCRIPTION
The `post_process` in `import_gds` currently accepts a function but the `post_process` in `@gf.cell` accepts an iterable of functions. Makes sense to unify the two.