### PR TITLE
Update snspd.py

### DIFF
--- a/gdsfactory/components/snspd.py
+++ b/gdsfactory/components/snspd.py
@@ -93,7 +93,10 @@ def snspd(
             hp.connect("o2", hp_prev.ports["o2"])
         else:
             hp.connect("o1", hp_prev.ports["o1"])
-        last_port = hp.ports["o1"]
+        if terminals_same_side:
+            last_port = hp.ports["o2"]
+        else:
+            last_port = hp.ports["o1"]
         hp_prev = hp
         alternate = not alternate
 


### PR DESCRIPTION
Using the snspd component with default parameters, but changing 'terminals_same_side' param to True was incorrectly placing the terminal connection - incorrectly connecting the port of 'finish_se' reference to the last hairpin.