### PR TITLE
deprecate python3.10

### DIFF
--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -6,6 +6,7 @@ import importlib
 import pathlib
 import sys
 import tempfile
+import warnings
 from enum import Enum, auto
 from typing import TYPE_CHECKING
 
@@ -44,6 +45,8 @@ plugins = [
     "lumapi",
     "sax",
 ]
+
+warnings.warn("GDSFactory requires python 3.11 or higher", DeprecationWarning)
 
 
 class ErrorType(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<1",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]==0.20.1",
+  "kfactory[ipy]==0.19.2",
   "watchdog<6",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
add deprecation warning when installing python 3.10 and install latest kfactory version compatible with python3.10