### PR TITLE
Remove taper from electrical routing

### DIFF
--- a/gdsfactory/routing/route_single_from_steps.py
+++ b/gdsfactory/routing/route_single_from_steps.py
@@ -131,7 +131,7 @@ def route_single_from_steps(
 
 
 route_single_from_steps_electrical = partial(
-    route_single_from_steps, bend="wire_corner", taper=None, cross_section="metal3"
+    route_single_from_steps, bend="wire_corner", cross_section="metal3" # taper=None, 
 )
 
 

--- a/gdsfactory/routing/route_single_from_steps.py
+++ b/gdsfactory/routing/route_single_from_steps.py
@@ -131,7 +131,9 @@ def route_single_from_steps(
 
 
 route_single_from_steps_electrical = partial(
-    route_single_from_steps, bend="wire_corner", cross_section="metal3" # taper=None, 
+    route_single_from_steps,
+    bend="wire_corner",
+    cross_section="metal3",  # taper=None,
 )
 
 


### PR DESCRIPTION
`route_single_from_steps` does not take `taper` as a keyword anymore. 