### PR TITLE
add missing layers

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1148,6 +1148,8 @@ class ComponentBase:
 
         layout_view.max_hier()
         layout_view.load_layer_props(str(lyp_path))
+
+        layout_view.add_missing_layers()
         layout_view.zoom_fit()
 
         layout_view.set_config("text-visible", "true" if show_labels else "false")


### PR DESCRIPTION
Fixes https://github.com/gdsfactory/gdsfactory/discussions/3237

when plotting components if there are layers not defined in the LayerViews of the PDK they don't show up when doing plot
![image](https://github.com/user-attachments/assets/b491d4e4-1384-46db-a460-8b4a6672c0ad)


After this fix all layers will show up
![image](https://github.com/user-attachments/assets/58b33a16-4aa4-442d-8799-3e384ddf7980)




@tgustafson-ntnu
@luomeng007
