### PR TITLE
Sizing layers

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -691,6 +691,11 @@ if __name__ == "__main__":
     layer1_sized = LogicalLayer(layer=(1, 0)).sized(10000)
     layer1_sized_asymmetric = LogicalLayer(layer=(1, 0)).sized(0, 50000)
 
+    layer3 = LogicalLayer(layer=(3, 0))
+    layer3_sequence = LogicalLayer(layer=(3, 0)).sized(2000,2000).sized(-1000,-1000)
+    layer3_sequence_list = LogicalLayer(layer=(3, 0)).sized((2000, 2000))
+    layer3_sequence_lists = LogicalLayer(layer=(3, 0)).sized((0, 0), (5000, 1000))
+
     ls = LayerStack(
         layers={
             "layerlevel_layer1": LayerLevel(layer=layer1, thickness=10, zmin=0),
@@ -703,6 +708,16 @@ if __name__ == "__main__":
             "layerlevel_layer1_to_layer2_derived": LayerLevel(
                 layer=layer1_sized, thickness=10, zmin=0, derived_layer=layer2
             ),
+            "layerlevel_layer3": LayerLevel(layer=layer3, thickness=10, zmin=0),
+            "layer3_sequence": LayerLevel(
+                layer=layer3_sequence, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(4,0))
+            ),
+            "layer3_sequence_list": LayerLevel(
+                layer=layer3_sequence_list, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(5,0))
+            ),
+            "layer3_sequence_lists": LayerLevel(
+                layer=layer3_sequence_lists, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(6,0))
+            ),
         }
     )
 
@@ -712,8 +727,8 @@ if __name__ == "__main__":
     c = gf.Component()
 
     rect1 = c << gf.components.rectangle(size=(10, 10), layer=(1, 0))
-    rect2 = c << gf.components.rectangle(size=(10, 10), layer=(2, 0))
-    rect2.dmove((5, 5))
+    rect2 = c << gf.components.rectangle(size=(10, 10), layer=(3, 0))
+    rect2.dmove((30, 30))
     # c.show()
 
     # import gdsfactory as gf

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -131,9 +131,9 @@ class AbstractLayer(BaseModel):
             mode = [mode] * len(xoffset)
 
         # Accumulate
-        sizings_xoffsets = [x for x in self.sizings_xoffsets] + xoffset
-        sizings_yoffsets = [x for x in self.sizings_yoffsets] + yoffset
-        sizings_modes = [x for x in self.sizings_modes] + mode
+        sizings_xoffsets = list(self.sizings_xoffsets) + xoffset
+        sizings_yoffsets = list(self.sizings_yoffsets) + yoffset
+        sizings_modes = list(self.sizings_modes) + mode
 
         # Return a copy of the layer with updated sizings
         current_layer_attributes = self.__dict__.copy()
@@ -664,7 +664,7 @@ def get_component_with_derived_layers(component, layer_stack: LayerStack) -> Com
 
     component_derived = Component()
 
-    for layer_name, level in layer_stack.layers.items():
+    for level in layer_stack.layers.values():
         if level.derived_layer is None:
             if isinstance(level.layer, LogicalLayer):
                 derived_layer_index = get_layer(level.layer.layer)
@@ -692,7 +692,7 @@ if __name__ == "__main__":
     layer1_sized_asymmetric = LogicalLayer(layer=(1, 0)).sized(0, 50000)
 
     layer3 = LogicalLayer(layer=(3, 0))
-    layer3_sequence = LogicalLayer(layer=(3, 0)).sized(2000,2000).sized(-1000,-1000)
+    layer3_sequence = LogicalLayer(layer=(3, 0)).sized(2000, 2000).sized(-1000, -1000)
     layer3_sequence_list = LogicalLayer(layer=(3, 0)).sized((2000, 2000))
     layer3_sequence_lists = LogicalLayer(layer=(3, 0)).sized((0, 0), (5000, 1000))
 
@@ -710,13 +710,22 @@ if __name__ == "__main__":
             ),
             "layerlevel_layer3": LayerLevel(layer=layer3, thickness=10, zmin=0),
             "layer3_sequence": LayerLevel(
-                layer=layer3_sequence, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(4,0))
+                layer=layer3_sequence,
+                thickness=10,
+                zmin=0,
+                derived_layer=LogicalLayer(layer=(4, 0)),
             ),
             "layer3_sequence_list": LayerLevel(
-                layer=layer3_sequence_list, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(5,0))
+                layer=layer3_sequence_list,
+                thickness=10,
+                zmin=0,
+                derived_layer=LogicalLayer(layer=(5, 0)),
             ),
             "layer3_sequence_lists": LayerLevel(
-                layer=layer3_sequence_lists, thickness=10, zmin=0, derived_layer=LogicalLayer(layer=(6,0))
+                layer=layer3_sequence_lists,
+                thickness=10,
+                zmin=0,
+                derived_layer=LogicalLayer(layer=(6, 0)),
             ),
         }
     )

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -686,47 +686,35 @@ if __name__ == "__main__":
     # For now, make regular layers trivial DerivedLayers
     # This might be automatable during LayerStack instantiation, or we could modify the Layer object in LayerMap too
 
-    from gdsfactory.generic_tech import LAYER
-
-    layer1 = LogicalLayer(layer=(2, 0))
-    layer2 = LogicalLayer(layer=LAYER.WG)
+    layer1 = LogicalLayer(layer=(1, 0))
+    layer2 = LogicalLayer(layer=(2, 0))
+    layer1_sized = LogicalLayer(layer=(1, 0)).sized(10000)
+    layer1_sized_asymmetric = LogicalLayer(layer=(1, 0)).sized(0, 50000)
 
     ls = LayerStack(
         layers={
             "layerlevel_layer1": LayerLevel(layer=layer1, thickness=10, zmin=0),
-            "layerlevel_layer2": LayerLevel(layer=layer2, thickness=10, zmin=10),
-            "layerlevel_and_layer": LayerLevel(
-                layer=layer1 & layer2,
-                thickness=10,
-                zmin=0,
-                derived_layer=LogicalLayer(layer=(3, 0)),
+            "layerlevel_layer1_sized": LayerLevel(
+                layer=layer1_sized, thickness=10, zmin=0
             ),
-            "layerlevel_xor_layer": LayerLevel(
-                layer=layer1 ^ layer2,
-                thickness=10,
-                zmin=0,
-                derived_layer=LogicalLayer(layer=(4, 0)),
+            "layerlevel_layer1_asymmetric": LayerLevel(
+                layer=layer1_sized_asymmetric, thickness=10, zmin=0
             ),
-            "layerlevel_not_layer": LayerLevel(
-                layer=layer1 - layer2,
-                thickness=10,
-                zmin=0,
-                derived_layer=LogicalLayer(layer=(5, 0)),
-            ),
-            "layerlevel_or_layer": LayerLevel(
-                layer=layer1 | layer2,
-                thickness=10,
-                zmin=0,
-                derived_layer=LogicalLayer(layer=(6, 0)),
-            ),
-            "layerlevel_composed_layer": LayerLevel(
-                layer=layer1 - (layer1 & layer2),
-                thickness=10,
-                zmin=0,
-                derived_layer=LogicalLayer(layer=(7, 0)),
+            "layerlevel_layer1_to_layer2_derived": LayerLevel(
+                layer=layer1_sized, thickness=10, zmin=0, derived_layer=layer2
             ),
         }
     )
+
+    # Test with simple component
+    import gdsfactory as gf
+
+    c = gf.Component()
+
+    rect1 = c << gf.components.rectangle(size=(10, 10), layer=(1, 0))
+    rect2 = c << gf.components.rectangle(size=(10, 10), layer=(2, 0))
+    rect2.dmove((5, 5))
+    # c.show()
 
     # import gdsfactory as gf
 
@@ -737,8 +725,8 @@ if __name__ == "__main__":
     # rect2.dmove((5, 5))
     # c.show()
 
-    # c = get_component_with_derived_layers(c, ls)
-    # c.show()
+    c = get_component_with_derived_layers(c, ls)
+    c.show()
 
-    s = ls.get_klayout_3d_script()
-    print(s)
+    # s = ls.get_klayout_3d_script()
+    # print(s)

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -665,17 +665,15 @@ def get_component_with_derived_layers(component, layer_stack: LayerStack) -> Com
     component_derived = Component()
 
     for layer_name, level in layer_stack.layers.items():
-        if isinstance(level.layer, LogicalLayer):
-            derived_layer_index = get_layer(level.layer.layer)
-        elif isinstance(level.layer, DerivedLayer):
-            if level.derived_layer is not None:
-                derived_layer_index = get_layer(level.derived_layer.layer)
+        if level.derived_layer is None:
+            if isinstance(level.layer, LogicalLayer):
+                derived_layer_index = get_layer(level.layer.layer)
             else:
                 raise ValueError(
-                    f"Error at LayerLevel {layer_name}: derived_layer must be provided if the level's layer is a DerivedLayer"
+                    "If derived_layer is not provided, the LayerLevel layer must be a LogicalLayer"
                 )
         else:
-            raise ValueError("layer must be one of LogicalLayer or DerivedLayer")
+            derived_layer_index = get_layer(level.derived_layer.layer)
 
         shapes = level.layer.get_shapes(component=component)
         component_derived.shapes(derived_layer_index).insert(shapes)


### PR DESCRIPTION
Partially addresses #2841

- Adds a .sized method (as suggested by @sebastian-goeldi ) to modify LogicalLayers and DerivedLayers in components with derived layers.
- Also allows LogicalLayers to be placed onto DerivedLayers (say, if you want a new GDS layer after sizing).

Works as expected:

![image](https://github.com/user-attachments/assets/79ac4287-8c23-4961-a9f2-cadf1c9b071a)
