### PR TITLE
Remove default cross section

### DIFF
--- a/gdsfactory/components/awg.py
+++ b/gdsfactory/components/awg.py
@@ -108,6 +108,7 @@ def awg(
     free_propagation_region_output_function=free_propagation_region_output,
     fpr_spacing: float = 50.0,
     arm_spacing: float = 1.0,
+    cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Returns a basic Arrayed Waveguide grating.
 
@@ -121,15 +122,18 @@ def awg(
         free_propagation_region_output_function: for output.
         fpr_spacing: x separation between input/output free propagation region.
         arm_spacing: y separation between arms.
+        cross_section: cross_section function.
     """
     c = Component()
     fpr_in = free_propagation_region_input_function(
         inputs=1,
         outputs=arms,
+        cross_section=cross_section,
     )
     fpr_out = free_propagation_region_output_function(
         inputs=outputs,
         outputs=arms,
+        cross_section=cross_section,
     )
 
     fpr_in_ref = c.add_ref(fpr_in)
@@ -145,6 +149,7 @@ def awg(
         gf.port.get_ports_list(fpr_in_ref, prefix="E"),
         sort_ports=True,
         separation=arm_spacing,
+        cross_section=cross_section,
     )
 
     c.add_port("o1", port=fpr_in_ref.ports["o1"])

--- a/gdsfactory/components/coh_rx_single_pol.py
+++ b/gdsfactory/components/coh_rx_single_pol.py
@@ -39,6 +39,7 @@ def coh_rx_single_pol(
         signal_input_coupler: Optional coupler for the signal.
         cross_section_metal_top: cross_section for the top metal layer.
         cross_section_metal: cross_section for the metal layer.
+        cross_section: cross_section for the waveguides.
 
     .. code::
 
@@ -133,7 +134,7 @@ def coh_rx_single_pol(
         det_ports.append(det.ports["o1"])
         ports_hybrid.append(hybrid.ports[port_name])
 
-    gf.routing.route_bundle(c, ports_hybrid, det_ports)
+    gf.routing.route_bundle(c, ports_hybrid, det_ports, cross_section=cross_section)
 
     # --- Draw metal connections ----
     gf.routing.route_single_electrical(

--- a/gdsfactory/components/loop_mirror.py
+++ b/gdsfactory/components/loop_mirror.py
@@ -5,18 +5,21 @@ from __future__ import annotations
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.routing.route_single import route_single
-from gdsfactory.typings import ComponentSpec
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
 @gf.cell
 def loop_mirror(
-    component: ComponentSpec = "mmi1x2", bend90: ComponentSpec = "bend_euler"
+    component: ComponentSpec = "mmi1x2",
+    bend90: ComponentSpec = "bend_euler",
+    cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Returns Sagnac loop_mirror.
 
     Args:
         component: 1x2 splitter.
         bend90: 90 deg bend.
+        cross_section: cross_section settings.
 
     """
     c = Component()
@@ -29,6 +32,7 @@ def loop_mirror(
         cref.ports["o2"],
         straight=gf.components.straight,
         bend=bend90,
+        cross_section=cross_section,
     )
     c.add_port(name="o1", port=cref.ports["o1"])
     return c

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -72,14 +72,15 @@ def straight_all_angle(
 if __name__ == "__main__":
     import gdsfactory as gf
 
-    c = gf.Component()
-    w = straight(
+    # c = gf.Component()
+    c = straight(
         length=10,
+        width=2,
         # cross_section="rib_bbox",
     )
-    ref = c << w
-    ref.dxmin = 10
-    p = c.get_polygons_points()
-    p = list(p.values())
-    print(p[0][0])
+    # ref = c << w
+    # ref.dxmin = 10
+    # p = c.get_polygons_points()
+    # p = list(p.values())
+    # print(p[0][0])
     c.show()

--- a/gdsfactory/components/straight_heater_meander_doped.py
+++ b/gdsfactory/components/straight_heater_meander_doped.py
@@ -89,7 +89,9 @@ def straight_heater_meander_doped(
     )
 
     dummy = gf.Component()
-    route = gf.routing.route_single(dummy, p1, p2, radius=radius)
+    route = gf.routing.route_single(
+        dummy, p1, p2, radius=radius, cross_section=cross_section
+    )
     cross_section2 = cross_section
 
     straight_length = gf.snap.snap_to_grid2x(

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -558,6 +558,8 @@ routes:
     route_name1:
         links:
             mmi_short,o2: mmi_long,o1
+        settings:
+            cross_section: strip
 
 ports:
     o1: mmi_short,o1

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -276,7 +276,6 @@ def route_bundle(
 route_bundle_electrical = partial(
     route_bundle,
     bend=wire_corner,
-    cross_section="metal_routing",
     allow_width_mismatch=True,
 )
 

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -91,10 +91,11 @@ def route_bundle(
     component: Component,
     ports1: list[Port],
     ports2: list[Port],
+    cross_section: CrossSectionSpec | None = None,
+    layer: LayerSpecs | None = None,
     separation: float = 3.0,
     bend: ComponentSpec = "bend_euler",
     sort_ports: bool = False,
-    cross_section: CrossSectionSpec = "strip",
     start_straight_length: float = 0,
     end_straight_length: float = 0,
     min_straight_taper: float = 100,
@@ -120,10 +121,11 @@ def route_bundle(
         component: component to add the routes to.
         ports1: list of starting ports.
         ports2: list of end ports.
+        cross_section: CrossSection or function that returns a cross_section.
+        layer: layer to use for the route.
         separation: bundle separation (center to center). Defaults to cross_section.width + cross_section.gap
         bend: function for the bend. Defaults to euler.
         sort_ports: sort port coordinates.
-        cross_section: CrossSection or function that returns a cross_section.
         start_straight_length: straight length at the beginning of the route. If None, uses default value for the routing CrossSection.
         end_straight_length: end length at the beginning of the route. If None, uses default value for the routing CrossSection.
         min_straight_taper: minimum length for tapering the straight sections.
@@ -165,6 +167,16 @@ def route_bundle(
         c.plot()
 
     """
+    if cross_section is None:
+        if layer is None or route_width is None:
+            raise ValueError(
+                f"Either {cross_section=} or {layer=} and route_width must be provided"
+            )
+        else:
+            cross_section = gf.cross_section.cross_section(
+                layer=layer, width=route_width
+            )
+
     # convert single port to list
     if isinstance(ports1, Port):
         ports1 = [ports1]
@@ -422,5 +434,8 @@ if __name__ == "__main__":
             {"dy": 30, "dx": 50},
             {"dx": 90},
         ],
+        cross_section="strip",
+        # layer=(1, 0),
+        # route_width=0.2
     )
     c.show()

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -178,12 +178,8 @@ def route_bundle(
                 f"Either {cross_section=} or {layer=} and {route_width=} must be provided"
             )
 
-    # convert single port to list
-    if isinstance(ports1, Port):
-        ports1 = [ports1]
-
-    if isinstance(ports2, Port):
-        ports2 = [ports2]
+    ports1 = [ports1] if isinstance(ports1, Port) else list(ports1)
+    ports2 = [ports2] if isinstance(ports2, Port) else list(ports2)
 
     port_type = port_type or ports1[0].port_type
     dbu = component.kcl.dbu

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -55,11 +55,12 @@ def route_single(
     component: Component,
     port1: Port,
     port2: Port,
+    cross_section: CrossSectionSpec | MultiCrossSectionAngleSpec | None = None,
+    layer: LayerSpec | None = None,
     bend: ComponentSpec = bend_euler,
     straight: ComponentSpec = straight_function,
     start_straight_length: float = 0.0,
     end_straight_length: float = 0.0,
-    cross_section: CrossSectionSpec | MultiCrossSectionAngleSpec = "strip",
     waypoints: Coordinates | None = None,
     steps: Sequence[Mapping[Literal["x", "y", "dx", "dy"], int | float]] | None = None,
     port_type: str | None = None,
@@ -77,11 +78,12 @@ def route_single(
         component: to place the route into.
         port1: start port.
         port2: end port.
+        cross_section: spec.
+        layer: layer spec.
         bend: bend spec.
         straight: straight spec.
         start_straight_length: length of starting straight.
         end_straight_length: length of end straight.
-        cross_section: spec.
         waypoints: optional list of points to pass through.
         steps: optional list of steps to pass through.
         port_type: port type to route.
@@ -104,6 +106,16 @@ def route_single(
     """
     p1 = port1
     p2 = port2
+
+    if cross_section is None:
+        if layer is None or route_width is None:
+            raise ValueError(
+                f"Either {cross_section=} or {layer=} and route_width must be provided"
+            )
+        else:
+            cross_section = gf.cross_section.cross_section(
+                layer=layer, width=route_width
+            )
 
     port_type = port_type or p1.port_type
     if route_width:
@@ -213,7 +225,7 @@ def route_single_electrical(
     end_straight_length: float | None = None,
     layer: LayerSpec | None = None,
     width: float | None = None,
-    cross_section: CrossSectionSpec = "metal3",
+    cross_section: CrossSectionSpec = "metal_routing",
 ) -> None:
     """Places a route between two electrical ports.
 
@@ -370,5 +382,8 @@ if __name__ == "__main__":
             {"x": 120},
             {"y": 80},
         ],
+        # cross_section="strip",
+        layer=(1, 0),
+        route_width=0.5,
     )
     c.show()

--- a/gdsfactory/samples/13_component_netlist.py
+++ b/gdsfactory/samples/13_component_netlist.py
@@ -40,6 +40,8 @@ def netlist_yaml() -> Component:
 
     routes:
         optical:
+            settings:
+                cross_section: strip
             links:
                 mmi_short,o2: mmi_long,o3
 

--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -78,7 +78,12 @@
     "mmi1 = c << gf.components.mmi1x2()\n",
     "mmi2 = c << gf.components.mmi1x2()\n",
     "mmi2.dmove((100, 50))\n",
-    "route = gf.routing.route_single(c, port1=mmi1.ports[\"o2\"], port2=mmi2.ports[\"o1\"])\n",
+    "route = gf.routing.route_single(\n",
+    "    c,\n",
+    "    port1=mmi1.ports[\"o2\"],\n",
+    "    port2=mmi2.ports[\"o1\"],\n",
+    "    cross_section=gf.cross_section.strip,\n",
+    ")\n",
     "c"
    ]
   },
@@ -93,8 +98,25 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "mmi1 = c << gf.components.mmi1x2()\n",
+    "mmi2 = c << gf.components.mmi1x2()\n",
+    "mmi2.dmove((100, 50))\n",
+    "route = gf.routing.route_single(\n",
+    "    c, port1=mmi1.ports[\"o2\"], port2=mmi2.ports[\"o1\"], layer=(1, 0), route_width=2\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
    "metadata": {},
    "source": [
     "**Problem**: route_single with obstacles\n",
@@ -105,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,54 +137,20 @@
     "mmi2.dmove((110, 50))\n",
     "x = c << gf.components.cross(length=20)\n",
     "x.dmove((135, 20))\n",
-    "route = gf.routing.route_single(c, mmi1.ports[\"o2\"], mmi2.ports[\"o2\"])\n",
+    "route = gf.routing.route_single(\n",
+    "    c, mmi1.ports[\"o2\"], mmi2.ports[\"o2\"], cross_section=\"strip\"\n",
+    ")\n",
     "c"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "**Solution**: specify the route steps\n",
     "\n",
     "`route_single` allows you to define relative or absolute steps `x` or `y` for the route as well as with increments `dx` or `dy`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "10",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = gf.Component()\n",
-    "w = gf.components.straight()\n",
-    "left = c << w\n",
-    "right = c << w\n",
-    "right.dmove((100, 80))\n",
-    "\n",
-    "obstacle = gf.components.rectangle(size=(100, 10))\n",
-    "obstacle1 = c << obstacle\n",
-    "obstacle2 = c << obstacle\n",
-    "obstacle1.dymin = 40\n",
-    "obstacle2.dxmin = 25\n",
-    "\n",
-    "port1 = left.ports[\"o2\"]\n",
-    "port2 = right.ports[\"o2\"]\n",
-    "\n",
-    "routes = gf.routing.route_single(\n",
-    "    c,\n",
-    "    port1=port1,\n",
-    "    port2=port2,\n",
-    "    steps=[\n",
-    "        {\"x\": 20, \"y\": 0},\n",
-    "        {\"x\": 20, \"y\": 20},\n",
-    "        {\"x\": 120, \"y\": 20},\n",
-    "        {\"x\": 120, \"y\": 80},\n",
-    "    ],\n",
-    ")\n",
-    "c"
    ]
   },
   {
@@ -191,6 +179,44 @@
     "    c,\n",
     "    port1=port1,\n",
     "    port2=port2,\n",
+    "    cross_section=\"strip\",\n",
+    "    steps=[\n",
+    "        {\"x\": 20, \"y\": 0},\n",
+    "        {\"x\": 20, \"y\": 20},\n",
+    "        {\"x\": 120, \"y\": 20},\n",
+    "        {\"x\": 120, \"y\": 80},\n",
+    "    ],\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "w = gf.components.straight()\n",
+    "left = c << w\n",
+    "right = c << w\n",
+    "right.dmove((100, 80))\n",
+    "\n",
+    "obstacle = gf.components.rectangle(size=(100, 10))\n",
+    "obstacle1 = c << obstacle\n",
+    "obstacle2 = c << obstacle\n",
+    "obstacle1.dymin = 40\n",
+    "obstacle2.dxmin = 25\n",
+    "\n",
+    "port1 = left.ports[\"o2\"]\n",
+    "port2 = right.ports[\"o2\"]\n",
+    "\n",
+    "routes = gf.routing.route_single(\n",
+    "    c,\n",
+    "    port1=port1,\n",
+    "    port2=port2,\n",
+    "    cross_section=\"strip\",\n",
     "    steps=[\n",
     "        {\"x\": 20},\n",
     "        {\"y\": 20},\n",
@@ -203,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## route_bundle\n",
@@ -218,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +268,12 @@
     "\n",
     "c = gf.Component()\n",
     "routes = gf.routing.route_bundle(\n",
-    "    c, left_ports, right_ports, start_straight_length=50, sort_ports=True\n",
+    "    c,\n",
+    "    left_ports,\n",
+    "    right_ports,\n",
+    "    start_straight_length=50,\n",
+    "    sort_ports=True,\n",
+    "    cross_section=\"strip\",\n",
     ")\n",
     "c.add_ports(left_ports)\n",
     "c.add_ports(right_ports)\n",
@@ -252,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,14 +311,19 @@
     "\n",
     "c = gf.Component()\n",
     "routes = gf.routing.route_bundle(\n",
-    "    c, top_ports, bot_ports, separation=5.0, end_straight_length=100\n",
+    "    c,\n",
+    "    top_ports,\n",
+    "    bot_ports,\n",
+    "    separation=5.0,\n",
+    "    end_straight_length=100,\n",
+    "    cross_section=\"strip\",\n",
     ")\n",
     "c"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -298,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,11 +535,15 @@
     "\n",
     "    if config in [\"A\", \"C\"]:\n",
     "        for ports1, ports2 in zip(ports_A, ports_B):\n",
-    "            gf.routing.route_bundle(c, ports1, ports2, radius=5, sort_ports=True)\n",
+    "            gf.routing.route_bundle(\n",
+    "                c, ports1, ports2, radius=5, sort_ports=True, cross_section=\"strip\"\n",
+    "            )\n",
     "\n",
     "    elif config in [\"B\", \"D\"]:\n",
     "        for ports1, ports2 in zip(ports_A, ports_B):\n",
-    "            gf.routing.route_bundle(c, ports2, ports1, radius=5, sort_ports=True)\n",
+    "            gf.routing.route_bundle(\n",
+    "                c, ports2, ports1, radius=5, sort_ports=True, cross_section=\"strip\"\n",
+    "            )\n",
     "\n",
     "    return c\n",
     "\n",
@@ -515,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +625,9 @@
     "        ]\n",
     "\n",
     "    c = Component()\n",
-    "    gf.routing.route_bundle(c, ports1, ports2, radius=10.0, sort_ports=True)\n",
+    "    gf.routing.route_bundle(\n",
+    "        c, ports1, ports2, radius=10.0, sort_ports=True, cross_section=\"strip\"\n",
+    "    )\n",
     "    return c\n",
     "\n",
     "\n",
@@ -596,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,6 +694,7 @@
     "        ports2,\n",
     "        bend=gf.components.bend_euler,\n",
     "        radius=5,\n",
+    "        cross_section=\"strip\",\n",
     "    )\n",
     "\n",
     "    return c\n",
@@ -664,7 +707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +735,7 @@
     "    ]\n",
     "\n",
     "    c = gf.Component()\n",
-    "    gf.routing.route_bundle(c, ports1, ports2)\n",
+    "    gf.routing.route_bundle(c, ports1, ports2, cross_section=\"strip\")\n",
     "    return c\n",
     "\n",
     "\n",
@@ -703,7 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -750,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +803,11 @@
     "\n",
     "c2.dmove((100, 50))\n",
     "routes = gf.routing.route_bundle(\n",
-    "    c, [c1.ports[\"o4\"], c1.ports[\"o3\"]], [c2.ports[\"o1\"], c2.ports[\"o2\"]], radius=5\n",
+    "    c,\n",
+    "    [c1.ports[\"o4\"], c1.ports[\"o3\"]],\n",
+    "    [c2.ports[\"o1\"], c2.ports[\"o2\"]],\n",
+    "    radius=5,\n",
+    "    cross_section=\"strip\",\n",
     ")\n",
     "c"
    ]
@@ -768,7 +815,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,26 +834,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "**Problem**\n",
     "\n",
     "Sometimes 90 degrees routes do not have enough space for a Manhattan route"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = gf.Component()\n",
-    "c1 = c << gf.components.nxn(east=3, ysize=20)\n",
-    "c2 = c << gf.components.nxn(west=3)\n",
-    "c2.dmove((80, 0))\n",
-    "c"
    ]
   },
   {
@@ -820,12 +853,6 @@
     "c1 = c << gf.components.nxn(east=3, ysize=20)\n",
     "c2 = c << gf.components.nxn(west=3)\n",
     "c2.dmove((80, 0))\n",
-    "routes = gf.routing.route_bundle(\n",
-    "    c,\n",
-    "    list(c1.ports.filter(orientation=0)),\n",
-    "    list(c2.ports.filter(orientation=180)),\n",
-    "    on_collision=None,\n",
-    ")\n",
     "c"
    ]
   },
@@ -833,6 +860,27 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c1 = c << gf.components.nxn(east=3, ysize=20)\n",
+    "c2 = c << gf.components.nxn(west=3)\n",
+    "c2.dmove((80, 0))\n",
+    "routes = gf.routing.route_bundle(\n",
+    "    c,\n",
+    "    list(c1.ports.filter(orientation=0)),\n",
+    "    list(c2.ports.filter(orientation=180)),\n",
+    "    on_collision=None,\n",
+    "    cross_section=\"strip\",\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +901,7 @@
     "]\n",
     "left_ports.reverse()\n",
     "routes = gf.routing.route_bundle(\n",
-    "    c, right_ports, left_ports, radius=5, on_collision=None\n",
+    "    c, right_ports, left_ports, radius=5, on_collision=None, cross_section=\"strip\"\n",
     ")\n",
     "\n",
     "c"
@@ -861,7 +909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "**Solution**\n",
@@ -872,7 +920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -892,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +956,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -931,6 +979,7 @@
     "    c,\n",
     "    [port1],\n",
     "    [port2],\n",
+    "    cross_section=\"strip\",\n",
     "    steps=[\n",
     "        {\"dy\": 30, \"dx\": 50},\n",
     "        {\"dx\": 100},\n",
@@ -942,7 +991,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,6 +1014,7 @@
     "    c,\n",
     "    ports1,\n",
     "    ports2,\n",
+    "    cross_section=\"strip\",\n",
     "    steps=[\n",
     "        {\"dy\": 30, \"dx\": 50},\n",
     "        {\"dx\": 90},\n",
@@ -975,7 +1025,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Collision\n",
@@ -988,7 +1038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,6 +1062,7 @@
     "    ptop.ports,\n",
     "    start_straight_length=100,\n",
     "    separation=20,\n",
+    "    cross_section=\"metal_routing\",\n",
     "    bboxes=[\n",
     "        obstacle.bbox(),\n",
     "        pbot.bbox(),\n",
@@ -1026,7 +1077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,6 +1105,7 @@
     "    ptop.ports,\n",
     "    start_straight_length=100,\n",
     "    separation=20,\n",
+    "    cross_section=\"metal_routing\",\n",
     "    bboxes=[\n",
     "        obstacle_sized.bbox(),\n",
     "        pbot.bbox(),\n",
@@ -1067,7 +1119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "## route_bundle_all_angle\n",
@@ -1078,7 +1130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "You can also use it to connect rotated components that do not have a manhattan orientation (0, 90, 180, 270)"
@@ -1116,7 +1168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1137,6 +1189,14 @@
     "c.show()\n",
     "c"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1159,7 +1219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/04_routing_electrical.ipynb
+++ b/notebooks/04_routing_electrical.ipynb
@@ -57,7 +57,11 @@
     "pb = c << gf.components.pad_array(port_orientation=90, columns=3)\n",
     "pt.dmove((70, 200))\n",
     "route = gf.routing.route_single_electrical(\n",
-    "    c, pt.ports[\"e11\"], pb.ports[\"e11\"], start_straight_length=20\n",
+    "    c,\n",
+    "    pt.ports[\"e11\"],\n",
+    "    pb.ports[\"e11\"],\n",
+    "    start_straight_length=20,\n",
+    "    cross_section=\"metal_routing\",\n",
     ")\n",
     "c.plot()"
    ]
@@ -198,7 +202,12 @@
     "pt.dmove((100, 300))\n",
     "\n",
     "routes = gf.routing.route_bundle_electrical(\n",
-    "    c, pb.ports, pt.ports, start_straight_length=30, separation=30\n",
+    "    c,\n",
+    "    pb.ports,\n",
+    "    pt.ports,\n",
+    "    start_straight_length=30,\n",
+    "    separation=30,\n",
+    "    cross_section=\"metal_routing\",\n",
     ")\n",
     "c.plot()"
    ]
@@ -491,6 +500,14 @@
     "c = sample_reticle()\n",
     "c.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -513,7 +530,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/10_schematic.ipynb
+++ b/notebooks/10_schematic.ipynb
@@ -226,7 +226,7 @@
     "            p1=f\"s,o2_2_{i+1}\",\n",
     "            p2=f\"dbr,o1_{i+1}_1\",\n",
     "            name=\"splitter_to_dbr\",\n",
-    "            settings=dict(radius=5, sort_ports=True),\n",
+    "            settings=dict(radius=5, sort_ports=True, cross_section=\"strip\"),\n",
     "        )\n",
     "    )\n",
     "\n",
@@ -323,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/10_yaml_component.ipynb
+++ b/notebooks/10_yaml_component.ipynb
@@ -504,6 +504,8 @@
     "\n",
     "routes:\n",
     "    b1:\n",
+    "        settings:\n",
+    "          cross_section: strip\n",
     "        links:\n",
     "            sa<0.0>,o2: sa<1.0>,o1\n",
     "            sa<0.1>,o2: sa<1.1>,o1\n",
@@ -633,6 +635,14 @@
     "c = pic_cell(length_mmi=100)\n",
     "c.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/21_migration_guide_7_8.ipynb
+++ b/notebooks/21_migration_guide_7_8.ipynb
@@ -456,6 +456,7 @@
     "    ports2=top.ports,\n",
     "    radius=5,\n",
     "    sort_ports=True,\n",
+    "    cross_section=\"strip\",\n",
     ")\n",
     "c"
    ]
@@ -536,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/yaml_pics/routes.pic.yml
+++ b/notebooks/yaml_pics/routes.pic.yml
@@ -20,5 +20,4 @@ routes:
         links:
             mmi_short,o2: mmi_long,o1
         settings:
-            cross_section:
-                cross_section: strip
+            cross_section: strip

--- a/notebooks/yaml_pics/routes_mmi.pic.yml
+++ b/notebooks/yaml_pics/routes_mmi.pic.yml
@@ -16,3 +16,5 @@ routes:
     links:
       mmi_bottom,o4: mmi_top,o1
       mmi_bottom,o3: mmi_top,o2
+    settings:
+        cross_section: strip

--- a/notebooks/yaml_pics/routes_path_length_match.pic.yml
+++ b/notebooks/yaml_pics/routes_path_length_match.pic.yml
@@ -20,6 +20,7 @@ routes:
       extra_length: 500
       width: 2
       end_straight_length: 500
+      cross_section: strip
     links:
       t,e11: b,e11
       t,e12: b,e12

--- a/test-data-regression/test_netlists_awg_.yml
+++ b/test-data-regression/test_netlists_awg_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_1083_26000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000:
     component: bend_euler
     info:
       dy: 10
@@ -20,9 +20,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_30250_30000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000:
     component: bend_euler
     info:
       dy: 10
@@ -43,9 +43,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_32417_31500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500:
     component: bend_euler
     info:
       dy: 10
@@ -66,9 +66,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_3250_24500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500:
     component: bend_euler
     info:
       dy: 10
@@ -89,9 +89,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_34583_33000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000:
     component: bend_euler
     info:
       dy: 10
@@ -112,9 +112,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_36750_34500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500:
     component: bend_euler
     info:
       dy: 10
@@ -135,9 +135,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_38917_36000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000:
     component: bend_euler
     info:
       dy: 10
@@ -158,9 +158,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_41083_37500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500:
     component: bend_euler
     info:
       dy: 10
@@ -181,9 +181,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_43250_39000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000:
     component: bend_euler
     info:
       dy: 10
@@ -204,9 +204,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_45417_40500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500:
     component: bend_euler
     info:
       dy: 10
@@ -227,9 +227,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_47583_42000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000:
     component: bend_euler
     info:
       dy: 10
@@ -250,9 +250,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_49750_43500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500:
     component: bend_euler
     info:
       dy: 10
@@ -273,9 +273,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_5417_23000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000:
     component: bend_euler
     info:
       dy: 10
@@ -296,9 +296,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_7583_21500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500:
     component: bend_euler
     info:
       dy: 10
@@ -319,9 +319,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_9750_20000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000:
     component: bend_euler
     info:
       dy: 10
@@ -342,9 +342,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m1083_27500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500:
     component: bend_euler
     info:
       dy: 10
@@ -365,9 +365,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m3250_29000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000:
     component: bend_euler
     info:
       dy: 10
@@ -388,9 +388,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m5417_30500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500:
     component: bend_euler
     info:
       dy: 10
@@ -411,9 +411,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m7583_32000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000:
     component: bend_euler
     info:
       dy: 10
@@ -434,9 +434,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m9750_33500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500:
     component: bend_euler
     info:
       dy: 10
@@ -457,7 +457,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   free_propagation_region_17623e49_0_0:
     component: free_propagation_region
@@ -487,7 +487,7 @@ instances:
       wg_width: 0.5
       width1: 10
       width2: 20
-  straight_L10p5_N2_CSstrip_W0p5_19750_30000:
+  straight_L10p5_N2_CSstrip_19750_30000:
     component: straight
     info:
       length: 10.5
@@ -500,8 +500,7 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-      width: 0.5
-  straight_L10p5_N2_CSstrip_W0p5_55417_30500:
+  straight_L10p5_N2_CSstrip_55417_30500:
     component: straight
     info:
       length: 10.5
@@ -514,8 +513,7 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-      width: 0.5
-  straight_L10p5_N2_CSstrip_W0p5_m5417_30500:
+  straight_L10p5_N2_CSstrip_m5417_30500:
     component: straight
     info:
       length: 10.5
@@ -528,8 +526,7 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-      width: 0.5
-  straight_L12_N2_CSstrip_W0p5_57583_32000:
+  straight_L12_N2_CSstrip_57583_32000:
     component: straight
     info:
       length: 12
@@ -542,8 +539,7 @@ instances:
       cross_section: strip
       length: 12
       npoints: 2
-      width: 0.5
-  straight_L12_N2_CSstrip_W0p5_m7583_32000:
+  straight_L12_N2_CSstrip_m7583_32000:
     component: straight
     info:
       length: 12
@@ -556,8 +552,7 @@ instances:
       cross_section: strip
       length: 12
       npoints: 2
-      width: 0.5
-  straight_L13p5_N2_CSstrip_W0p5_59750_33500:
+  straight_L13p5_N2_CSstrip_59750_33500:
     component: straight
     info:
       length: 13.5
@@ -570,8 +565,7 @@ instances:
       cross_section: strip
       length: 13.5
       npoints: 2
-      width: 0.5
-  straight_L13p5_N2_CSstrip_W0p5_m9750_33500:
+  straight_L13p5_N2_CSstrip_m9750_33500:
     component: straight
     info:
       length: 13.5
@@ -584,8 +578,7 @@ instances:
       cross_section: strip
       length: 13.5
       npoints: 2
-      width: 0.5
-  straight_L14p834_N2_CSstrip_W0p5_17583_31500:
+  straight_L14p834_N2_CSstrip_17583_31500:
     component: straight
     info:
       length: 14.834
@@ -598,8 +591,7 @@ instances:
       cross_section: strip
       length: 14.834
       npoints: 2
-      width: 0.5
-  straight_L19p166_N2_CSstrip_W0p5_15417_33000:
+  straight_L19p166_N2_CSstrip_15417_33000:
     component: straight
     info:
       length: 19.166
@@ -612,8 +604,7 @@ instances:
       cross_section: strip
       length: 19.166
       npoints: 2
-      width: 0.5
-  straight_L1p5_N2_CSstrip_W0p5_42417_21500:
+  straight_L1p5_N2_CSstrip_42417_21500:
     component: straight
     info:
       length: 1.5
@@ -626,8 +617,7 @@ instances:
       cross_section: strip
       length: 1.5
       npoints: 2
-      width: 0.5
-  straight_L1p5_N2_CSstrip_W0p5_7583_21500:
+  straight_L1p5_N2_CSstrip_7583_21500:
     component: straight
     info:
       length: 1.5
@@ -640,8 +630,7 @@ instances:
       cross_section: strip
       length: 1.5
       npoints: 2
-      width: 0.5
-  straight_L23p5_N2_CSstrip_W0p5_13250_34500:
+  straight_L23p5_N2_CSstrip_13250_34500:
     component: straight
     info:
       length: 23.5
@@ -654,8 +643,7 @@ instances:
       cross_section: strip
       length: 23.5
       npoints: 2
-      width: 0.5
-  straight_L27p834_N2_CSstrip_W0p5_11083_36000:
+  straight_L27p834_N2_CSstrip_11083_36000:
     component: straight
     info:
       length: 27.834
@@ -668,8 +656,7 @@ instances:
       cross_section: strip
       length: 27.834
       npoints: 2
-      width: 0.5
-  straight_L32p1660000000_cc48b899_8917_37500:
+  straight_L32p1660000000_643231bb_8917_37500:
     component: straight
     info:
       length: 32.166
@@ -682,8 +669,7 @@ instances:
       cross_section: strip
       length: 32.166
       npoints: 2
-      width: 0.5
-  straight_L36p5_N2_CSstrip_W0p5_6750_39000:
+  straight_L36p5_N2_CSstrip_6750_39000:
     component: straight
     info:
       length: 36.5
@@ -696,8 +682,7 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-      width: 0.5
-  straight_L3_N2_CSstrip_W0p5_44583_23000:
+  straight_L3_N2_CSstrip_44583_23000:
     component: straight
     info:
       length: 3
@@ -710,8 +695,7 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-      width: 0.5
-  straight_L3_N2_CSstrip_W0p5_5417_23000:
+  straight_L3_N2_CSstrip_5417_23000:
     component: straight
     info:
       length: 3
@@ -724,8 +708,7 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-      width: 0.5
-  straight_L40p834_N2_CSstrip_W0p5_4583_40500:
+  straight_L40p834_N2_CSstrip_4583_40500:
     component: straight
     info:
       length: 40.834
@@ -738,8 +721,7 @@ instances:
       cross_section: strip
       length: 40.834
       npoints: 2
-      width: 0.5
-  straight_L45p1660000000_56131022_2417_42000:
+  straight_L45p1660000000_4d1de147_2417_42000:
     component: straight
     info:
       length: 45.166
@@ -752,8 +734,7 @@ instances:
       cross_section: strip
       length: 45.166
       npoints: 2
-      width: 0.5
-  straight_L49p5_N2_CSstrip_W0p5_250_43500:
+  straight_L49p5_N2_CSstrip_250_43500:
     component: straight
     info:
       length: 49.5
@@ -766,8 +747,7 @@ instances:
       cross_section: strip
       length: 49.5
       npoints: 2
-      width: 0.5
-  straight_L4p5_N2_CSstrip_W0p5_3250_24500:
+  straight_L4p5_N2_CSstrip_3250_24500:
     component: straight
     info:
       length: 4.5
@@ -780,8 +760,7 @@ instances:
       cross_section: strip
       length: 4.5
       npoints: 2
-      width: 0.5
-  straight_L4p5_N2_CSstrip_W0p5_46750_24500:
+  straight_L4p5_N2_CSstrip_46750_24500:
     component: straight
     info:
       length: 4.5
@@ -794,8 +773,7 @@ instances:
       cross_section: strip
       length: 4.5
       npoints: 2
-      width: 0.5
-  straight_L6_N2_CSstrip_W0p5_1083_26000:
+  straight_L6_N2_CSstrip_1083_26000:
     component: straight
     info:
       length: 6
@@ -808,8 +786,7 @@ instances:
       cross_section: strip
       length: 6
       npoints: 2
-      width: 0.5
-  straight_L6_N2_CSstrip_W0p5_48917_26000:
+  straight_L6_N2_CSstrip_48917_26000:
     component: straight
     info:
       length: 6
@@ -822,8 +799,7 @@ instances:
       cross_section: strip
       length: 6
       npoints: 2
-      width: 0.5
-  straight_L7p5_N2_CSstrip_W0p5_51083_27500:
+  straight_L7p5_N2_CSstrip_51083_27500:
     component: straight
     info:
       length: 7.5
@@ -836,8 +812,7 @@ instances:
       cross_section: strip
       length: 7.5
       npoints: 2
-      width: 0.5
-  straight_L7p5_N2_CSstrip_W0p5_m1083_27500:
+  straight_L7p5_N2_CSstrip_m1083_27500:
     component: straight
     info:
       length: 7.5
@@ -850,8 +825,7 @@ instances:
       cross_section: strip
       length: 7.5
       npoints: 2
-      width: 0.5
-  straight_L9_N2_CSstrip_W0p5_53250_29000:
+  straight_L9_N2_CSstrip_53250_29000:
     component: straight
     info:
       length: 9
@@ -864,8 +838,7 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
-      width: 0.5
-  straight_L9_N2_CSstrip_W0p5_m3250_29000:
+  straight_L9_N2_CSstrip_m3250_29000:
     component: straight
     info:
       length: 9
@@ -878,222 +851,221 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
-      width: 0.5
-name: awg_A10_O3_FPRIFFfree_p_d02e50a8
+name: awg_A10_O3_FPRIFFfree_p_a3247b17
 nets:
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_1083_26000,o1
-  p2: straight_L6_N2_CSstrip_W0p5_1083_26000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_1083_26000,o2
-  p2: straight_L27p834_N2_CSstrip_W0p5_11083_36000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_30250_30000,o1
-  p2: straight_L10p5_N2_CSstrip_W0p5_19750_30000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_30250_30000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000,o1
+  p2: straight_L6_N2_CSstrip_1083_26000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000,o2
+  p2: straight_L27p834_N2_CSstrip_11083_36000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000,o1
+  p2: straight_L10p5_N2_CSstrip_19750_30000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000,o2
   p2: free_propagation_region_b76b91f7_50000_0,E9
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_32417_31500,o1
-  p2: straight_L14p834_N2_CSstrip_W0p5_17583_31500,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_32417_31500,o2
-  p2: straight_L1p5_N2_CSstrip_W0p5_42417_21500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_3250_24500,o1
-  p2: straight_L4p5_N2_CSstrip_W0p5_3250_24500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_3250_24500,o2
-  p2: straight_L23p5_N2_CSstrip_W0p5_13250_34500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_34583_33000,o1
-  p2: straight_L19p166_N2_CSstrip_W0p5_15417_33000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_34583_33000,o2
-  p2: straight_L3_N2_CSstrip_W0p5_44583_23000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_36750_34500,o1
-  p2: straight_L23p5_N2_CSstrip_W0p5_13250_34500,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_36750_34500,o2
-  p2: straight_L4p5_N2_CSstrip_W0p5_46750_24500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_38917_36000,o1
-  p2: straight_L27p834_N2_CSstrip_W0p5_11083_36000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_38917_36000,o2
-  p2: straight_L6_N2_CSstrip_W0p5_48917_26000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_41083_37500,o1
-  p2: straight_L32p1660000000_cc48b899_8917_37500,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_41083_37500,o2
-  p2: straight_L7p5_N2_CSstrip_W0p5_51083_27500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_43250_39000,o1
-  p2: straight_L36p5_N2_CSstrip_W0p5_6750_39000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_43250_39000,o2
-  p2: straight_L9_N2_CSstrip_W0p5_53250_29000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_45417_40500,o1
-  p2: straight_L40p834_N2_CSstrip_W0p5_4583_40500,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_45417_40500,o2
-  p2: straight_L10p5_N2_CSstrip_W0p5_55417_30500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_47583_42000,o1
-  p2: straight_L45p1660000000_56131022_2417_42000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_47583_42000,o2
-  p2: straight_L12_N2_CSstrip_W0p5_57583_32000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_49750_43500,o1
-  p2: straight_L49p5_N2_CSstrip_W0p5_250_43500,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_49750_43500,o2
-  p2: straight_L13p5_N2_CSstrip_W0p5_59750_33500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_5417_23000,o1
-  p2: straight_L3_N2_CSstrip_W0p5_5417_23000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_5417_23000,o2
-  p2: straight_L19p166_N2_CSstrip_W0p5_15417_33000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_7583_21500,o1
-  p2: straight_L1p5_N2_CSstrip_W0p5_7583_21500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_7583_21500,o2
-  p2: straight_L14p834_N2_CSstrip_W0p5_17583_31500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_9750_20000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500,o1
+  p2: straight_L14p834_N2_CSstrip_17583_31500,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500,o2
+  p2: straight_L1p5_N2_CSstrip_42417_21500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500,o1
+  p2: straight_L4p5_N2_CSstrip_3250_24500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500,o2
+  p2: straight_L23p5_N2_CSstrip_13250_34500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000,o1
+  p2: straight_L19p166_N2_CSstrip_15417_33000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000,o2
+  p2: straight_L3_N2_CSstrip_44583_23000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500,o1
+  p2: straight_L23p5_N2_CSstrip_13250_34500,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500,o2
+  p2: straight_L4p5_N2_CSstrip_46750_24500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000,o1
+  p2: straight_L27p834_N2_CSstrip_11083_36000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000,o2
+  p2: straight_L6_N2_CSstrip_48917_26000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500,o1
+  p2: straight_L32p1660000000_643231bb_8917_37500,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500,o2
+  p2: straight_L7p5_N2_CSstrip_51083_27500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000,o1
+  p2: straight_L36p5_N2_CSstrip_6750_39000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000,o2
+  p2: straight_L9_N2_CSstrip_53250_29000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500,o1
+  p2: straight_L40p834_N2_CSstrip_4583_40500,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500,o2
+  p2: straight_L10p5_N2_CSstrip_55417_30500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000,o1
+  p2: straight_L45p1660000000_4d1de147_2417_42000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000,o2
+  p2: straight_L12_N2_CSstrip_57583_32000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500,o1
+  p2: straight_L49p5_N2_CSstrip_250_43500,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500,o2
+  p2: straight_L13p5_N2_CSstrip_59750_33500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000,o1
+  p2: straight_L3_N2_CSstrip_5417_23000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000,o2
+  p2: straight_L19p166_N2_CSstrip_15417_33000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500,o1
+  p2: straight_L1p5_N2_CSstrip_7583_21500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500,o2
+  p2: straight_L14p834_N2_CSstrip_17583_31500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000,o1
   p2: free_propagation_region_17623e49_0_0,E0
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_9750_20000,o2
-  p2: straight_L10p5_N2_CSstrip_W0p5_19750_30000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m1083_27500,o1
-  p2: straight_L7p5_N2_CSstrip_W0p5_m1083_27500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m1083_27500,o2
-  p2: straight_L32p1660000000_cc48b899_8917_37500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m3250_29000,o1
-  p2: straight_L9_N2_CSstrip_W0p5_m3250_29000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m3250_29000,o2
-  p2: straight_L36p5_N2_CSstrip_W0p5_6750_39000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m5417_30500,o1
-  p2: straight_L10p5_N2_CSstrip_W0p5_m5417_30500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m5417_30500,o2
-  p2: straight_L40p834_N2_CSstrip_W0p5_4583_40500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m7583_32000,o1
-  p2: straight_L12_N2_CSstrip_W0p5_m7583_32000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m7583_32000,o2
-  p2: straight_L45p1660000000_56131022_2417_42000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m9750_33500,o1
-  p2: straight_L13p5_N2_CSstrip_W0p5_m9750_33500,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m9750_33500,o2
-  p2: straight_L49p5_N2_CSstrip_W0p5_250_43500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000,o2
+  p2: straight_L10p5_N2_CSstrip_19750_30000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500,o1
+  p2: straight_L7p5_N2_CSstrip_m1083_27500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500,o2
+  p2: straight_L32p1660000000_643231bb_8917_37500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000,o1
+  p2: straight_L9_N2_CSstrip_m3250_29000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000,o2
+  p2: straight_L36p5_N2_CSstrip_6750_39000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500,o1
+  p2: straight_L10p5_N2_CSstrip_m5417_30500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500,o2
+  p2: straight_L40p834_N2_CSstrip_4583_40500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000,o1
+  p2: straight_L12_N2_CSstrip_m7583_32000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000,o2
+  p2: straight_L45p1660000000_4d1de147_2417_42000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500,o1
+  p2: straight_L13p5_N2_CSstrip_m9750_33500,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500,o2
+  p2: straight_L49p5_N2_CSstrip_250_43500,o1
 - p1: free_propagation_region_17623e49_0_0,E1
-  p2: straight_L1p5_N2_CSstrip_W0p5_7583_21500,o2
+  p2: straight_L1p5_N2_CSstrip_7583_21500,o2
 - p1: free_propagation_region_17623e49_0_0,E2
-  p2: straight_L3_N2_CSstrip_W0p5_5417_23000,o2
+  p2: straight_L3_N2_CSstrip_5417_23000,o2
 - p1: free_propagation_region_17623e49_0_0,E3
-  p2: straight_L4p5_N2_CSstrip_W0p5_3250_24500,o2
+  p2: straight_L4p5_N2_CSstrip_3250_24500,o2
 - p1: free_propagation_region_17623e49_0_0,E4
-  p2: straight_L6_N2_CSstrip_W0p5_1083_26000,o2
+  p2: straight_L6_N2_CSstrip_1083_26000,o2
 - p1: free_propagation_region_17623e49_0_0,E5
-  p2: straight_L7p5_N2_CSstrip_W0p5_m1083_27500,o2
+  p2: straight_L7p5_N2_CSstrip_m1083_27500,o2
 - p1: free_propagation_region_17623e49_0_0,E6
-  p2: straight_L9_N2_CSstrip_W0p5_m3250_29000,o2
+  p2: straight_L9_N2_CSstrip_m3250_29000,o2
 - p1: free_propagation_region_17623e49_0_0,E7
-  p2: straight_L10p5_N2_CSstrip_W0p5_m5417_30500,o2
+  p2: straight_L10p5_N2_CSstrip_m5417_30500,o2
 - p1: free_propagation_region_17623e49_0_0,E8
-  p2: straight_L12_N2_CSstrip_W0p5_m7583_32000,o2
+  p2: straight_L12_N2_CSstrip_m7583_32000,o2
 - p1: free_propagation_region_17623e49_0_0,E9
-  p2: straight_L13p5_N2_CSstrip_W0p5_m9750_33500,o2
+  p2: straight_L13p5_N2_CSstrip_m9750_33500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E0
-  p2: straight_L13p5_N2_CSstrip_W0p5_59750_33500,o2
+  p2: straight_L13p5_N2_CSstrip_59750_33500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E1
-  p2: straight_L12_N2_CSstrip_W0p5_57583_32000,o2
+  p2: straight_L12_N2_CSstrip_57583_32000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E2
-  p2: straight_L10p5_N2_CSstrip_W0p5_55417_30500,o2
+  p2: straight_L10p5_N2_CSstrip_55417_30500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E3
-  p2: straight_L9_N2_CSstrip_W0p5_53250_29000,o2
+  p2: straight_L9_N2_CSstrip_53250_29000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E4
-  p2: straight_L7p5_N2_CSstrip_W0p5_51083_27500,o2
+  p2: straight_L7p5_N2_CSstrip_51083_27500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E5
-  p2: straight_L6_N2_CSstrip_W0p5_48917_26000,o2
+  p2: straight_L6_N2_CSstrip_48917_26000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E6
-  p2: straight_L4p5_N2_CSstrip_W0p5_46750_24500,o2
+  p2: straight_L4p5_N2_CSstrip_46750_24500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E7
-  p2: straight_L3_N2_CSstrip_W0p5_44583_23000,o2
+  p2: straight_L3_N2_CSstrip_44583_23000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E8
-  p2: straight_L1p5_N2_CSstrip_W0p5_42417_21500,o2
+  p2: straight_L1p5_N2_CSstrip_42417_21500,o2
 placements:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_1083_26000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000:
     mirror: true
     rotation: 90
     x: 1.083
     y: 26
-  bend_euler_R10_A90_P0p5_2f1f5c6d_30250_30000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000:
     mirror: true
     rotation: 0
     x: 30.25
     y: 30
-  bend_euler_R10_A90_P0p5_2f1f5c6d_32417_31500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500:
     mirror: true
     rotation: 0
     x: 32.417
     y: 31.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_3250_24500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500:
     mirror: true
     rotation: 90
     x: 3.25
     y: 24.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_34583_33000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000:
     mirror: true
     rotation: 0
     x: 34.583
     y: 33
-  bend_euler_R10_A90_P0p5_2f1f5c6d_36750_34500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500:
     mirror: true
     rotation: 0
     x: 36.75
     y: 34.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_38917_36000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000:
     mirror: true
     rotation: 0
     x: 38.917
     y: 36
-  bend_euler_R10_A90_P0p5_2f1f5c6d_41083_37500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500:
     mirror: true
     rotation: 0
     x: 41.083
     y: 37.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_43250_39000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000:
     mirror: true
     rotation: 0
     x: 43.25
     y: 39
-  bend_euler_R10_A90_P0p5_2f1f5c6d_45417_40500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500:
     mirror: true
     rotation: 0
     x: 45.417
     y: 40.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_47583_42000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000:
     mirror: true
     rotation: 0
     x: 47.583
     y: 42
-  bend_euler_R10_A90_P0p5_2f1f5c6d_49750_43500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500:
     mirror: true
     rotation: 0
     x: 49.75
     y: 43.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_5417_23000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000:
     mirror: true
     rotation: 90
     x: 5.417
     y: 23
-  bend_euler_R10_A90_P0p5_2f1f5c6d_7583_21500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500:
     mirror: true
     rotation: 90
     x: 7.583
     y: 21.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_9750_20000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000:
     mirror: true
     rotation: 90
     x: 9.75
     y: 20
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m1083_27500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500:
     mirror: true
     rotation: 90
     x: -1.083
     y: 27.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m3250_29000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000:
     mirror: true
     rotation: 90
     x: -3.25
     y: 29
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m5417_30500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500:
     mirror: true
     rotation: 90
     x: -5.417
     y: 30.5
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m7583_32000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000:
     mirror: true
     rotation: 90
     x: -7.583
     y: 32
-  bend_euler_R10_A90_P0p5_2f1f5c6d_m9750_33500:
+  bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500:
     mirror: true
     rotation: 90
     x: -9.75
@@ -1108,142 +1080,142 @@ placements:
     rotation: 90
     x: 50
     y: 0
-  straight_L10p5_N2_CSstrip_W0p5_19750_30000:
+  straight_L10p5_N2_CSstrip_19750_30000:
     mirror: false
     rotation: 0
     x: 19.75
     y: 30
-  straight_L10p5_N2_CSstrip_W0p5_55417_30500:
+  straight_L10p5_N2_CSstrip_55417_30500:
     mirror: false
     rotation: 270
     x: 55.417
     y: 30.5
-  straight_L10p5_N2_CSstrip_W0p5_m5417_30500:
+  straight_L10p5_N2_CSstrip_m5417_30500:
     mirror: false
     rotation: 270
     x: -5.417
     y: 30.5
-  straight_L12_N2_CSstrip_W0p5_57583_32000:
+  straight_L12_N2_CSstrip_57583_32000:
     mirror: false
     rotation: 270
     x: 57.583
     y: 32
-  straight_L12_N2_CSstrip_W0p5_m7583_32000:
+  straight_L12_N2_CSstrip_m7583_32000:
     mirror: false
     rotation: 270
     x: -7.583
     y: 32
-  straight_L13p5_N2_CSstrip_W0p5_59750_33500:
+  straight_L13p5_N2_CSstrip_59750_33500:
     mirror: false
     rotation: 270
     x: 59.75
     y: 33.5
-  straight_L13p5_N2_CSstrip_W0p5_m9750_33500:
+  straight_L13p5_N2_CSstrip_m9750_33500:
     mirror: false
     rotation: 270
     x: -9.75
     y: 33.5
-  straight_L14p834_N2_CSstrip_W0p5_17583_31500:
+  straight_L14p834_N2_CSstrip_17583_31500:
     mirror: false
     rotation: 0
     x: 17.583
     y: 31.5
-  straight_L19p166_N2_CSstrip_W0p5_15417_33000:
+  straight_L19p166_N2_CSstrip_15417_33000:
     mirror: false
     rotation: 0
     x: 15.417
     y: 33
-  straight_L1p5_N2_CSstrip_W0p5_42417_21500:
+  straight_L1p5_N2_CSstrip_42417_21500:
     mirror: false
     rotation: 270
     x: 42.417
     y: 21.5
-  straight_L1p5_N2_CSstrip_W0p5_7583_21500:
+  straight_L1p5_N2_CSstrip_7583_21500:
     mirror: false
     rotation: 270
     x: 7.583
     y: 21.5
-  straight_L23p5_N2_CSstrip_W0p5_13250_34500:
+  straight_L23p5_N2_CSstrip_13250_34500:
     mirror: false
     rotation: 0
     x: 13.25
     y: 34.5
-  straight_L27p834_N2_CSstrip_W0p5_11083_36000:
+  straight_L27p834_N2_CSstrip_11083_36000:
     mirror: false
     rotation: 0
     x: 11.083
     y: 36
-  straight_L32p1660000000_cc48b899_8917_37500:
+  straight_L32p1660000000_643231bb_8917_37500:
     mirror: false
     rotation: 0
     x: 8.917
     y: 37.5
-  straight_L36p5_N2_CSstrip_W0p5_6750_39000:
+  straight_L36p5_N2_CSstrip_6750_39000:
     mirror: false
     rotation: 0
     x: 6.75
     y: 39
-  straight_L3_N2_CSstrip_W0p5_44583_23000:
+  straight_L3_N2_CSstrip_44583_23000:
     mirror: false
     rotation: 270
     x: 44.583
     y: 23
-  straight_L3_N2_CSstrip_W0p5_5417_23000:
+  straight_L3_N2_CSstrip_5417_23000:
     mirror: false
     rotation: 270
     x: 5.417
     y: 23
-  straight_L40p834_N2_CSstrip_W0p5_4583_40500:
+  straight_L40p834_N2_CSstrip_4583_40500:
     mirror: false
     rotation: 0
     x: 4.583
     y: 40.5
-  straight_L45p1660000000_56131022_2417_42000:
+  straight_L45p1660000000_4d1de147_2417_42000:
     mirror: false
     rotation: 0
     x: 2.417
     y: 42
-  straight_L49p5_N2_CSstrip_W0p5_250_43500:
+  straight_L49p5_N2_CSstrip_250_43500:
     mirror: false
     rotation: 0
     x: 0.25
     y: 43.5
-  straight_L4p5_N2_CSstrip_W0p5_3250_24500:
+  straight_L4p5_N2_CSstrip_3250_24500:
     mirror: false
     rotation: 270
     x: 3.25
     y: 24.5
-  straight_L4p5_N2_CSstrip_W0p5_46750_24500:
+  straight_L4p5_N2_CSstrip_46750_24500:
     mirror: false
     rotation: 270
     x: 46.75
     y: 24.5
-  straight_L6_N2_CSstrip_W0p5_1083_26000:
+  straight_L6_N2_CSstrip_1083_26000:
     mirror: false
     rotation: 270
     x: 1.083
     y: 26
-  straight_L6_N2_CSstrip_W0p5_48917_26000:
+  straight_L6_N2_CSstrip_48917_26000:
     mirror: false
     rotation: 270
     x: 48.917
     y: 26
-  straight_L7p5_N2_CSstrip_W0p5_51083_27500:
+  straight_L7p5_N2_CSstrip_51083_27500:
     mirror: false
     rotation: 270
     x: 51.083
     y: 27.5
-  straight_L7p5_N2_CSstrip_W0p5_m1083_27500:
+  straight_L7p5_N2_CSstrip_m1083_27500:
     mirror: false
     rotation: 270
     x: -1.083
     y: 27.5
-  straight_L9_N2_CSstrip_W0p5_53250_29000:
+  straight_L9_N2_CSstrip_53250_29000:
     mirror: false
     rotation: 270
     x: 53.25
     y: 29
-  straight_L9_N2_CSstrip_W0p5_m3250_29000:
+  straight_L9_N2_CSstrip_m3250_29000:
     mirror: false
     rotation: 270
     x: -3.25

--- a/test-data-regression/test_netlists_coh_rx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_rx_single_pol_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_225000_13750:
+  bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750:
     component: bend_euler
     info:
       dy: 10
@@ -20,9 +20,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_225000_m13750:
+  bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750:
     component: bend_euler
     info:
       dy: 10
@@ -43,9 +43,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_228500_11250:
+  bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250:
     component: bend_euler
     info:
       dy: 10
@@ -66,9 +66,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_228500_m11250:
+  bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250:
     component: bend_euler
     info:
       dy: 10
@@ -89,9 +89,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_235000_75000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000:
     component: bend_euler
     info:
       dy: 10
@@ -112,9 +112,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_235000_m75000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000:
     component: bend_euler
     info:
       dy: 10
@@ -135,9 +135,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_238500_25000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000:
     component: bend_euler
     info:
       dy: 10
@@ -158,9 +158,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_2f1f5c6d_238500_m25000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000:
     component: bend_euler
     info:
       dy: 10
@@ -181,7 +181,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   ge_detector_straight_si_857c1c1e_295000_25000:
     component: ge_detector_straight_si_contacts
@@ -273,7 +273,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-  straight_L36p5_N2_CSstrip_W0p5_238500_25000:
+  straight_L36p5_N2_CSstrip_238500_25000:
     component: straight
     info:
       length: 36.5
@@ -286,8 +286,7 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-      width: 0.5
-  straight_L36p5_N2_CSstrip_W0p5_238500_m25000:
+  straight_L36p5_N2_CSstrip_238500_m25000:
     component: straight
     info:
       length: 36.5
@@ -300,8 +299,7 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-      width: 0.5
-  straight_L3p5_N2_CSstrip_W0p5_218500_1250:
+  straight_L3p5_N2_CSstrip_218500_1250:
     component: straight
     info:
       length: 3.5
@@ -314,8 +312,7 @@ instances:
       cross_section: strip
       length: 3.5
       npoints: 2
-      width: 0.5
-  straight_L3p5_N2_CSstrip_W0p5_218500_m1250:
+  straight_L3p5_N2_CSstrip_218500_m1250:
     component: straight
     info:
       length: 3.5
@@ -328,8 +325,7 @@ instances:
       cross_section: strip
       length: 3.5
       npoints: 2
-      width: 0.5
-  straight_L3p75_N2_CSstrip_W0p5_228500_15000:
+  straight_L3p75_N2_CSstrip_228500_15000:
     component: straight
     info:
       length: 3.75
@@ -342,8 +338,7 @@ instances:
       cross_section: strip
       length: 3.75
       npoints: 2
-      width: 0.5
-  straight_L3p75_N2_CSstrip_W0p5_228500_m15000:
+  straight_L3p75_N2_CSstrip_228500_m15000:
     component: straight
     info:
       length: 3.75
@@ -356,8 +351,7 @@ instances:
       cross_section: strip
       length: 3.75
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_235000_75000:
+  straight_L40_N2_CSstrip_235000_75000:
     component: straight
     info:
       length: 40
@@ -370,8 +364,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_235000_m75000:
+  straight_L40_N2_CSstrip_235000_m75000:
     component: straight
     info:
       length: 40
@@ -384,8 +377,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L51p25_N2_CSstrip_W0p5_225000_65000:
+  straight_L51p25_N2_CSstrip_225000_65000:
     component: straight
     info:
       length: 51.25
@@ -398,8 +390,7 @@ instances:
       cross_section: strip
       length: 51.25
       npoints: 2
-      width: 0.5
-  straight_L51p25_N2_CSstrip_W0p5_225000_m65000:
+  straight_L51p25_N2_CSstrip_225000_m65000:
     component: straight
     info:
       length: 51.25
@@ -412,94 +403,93 @@ instances:
       cross_section: strip
       length: 51.25
       npoints: 2
-      width: 0.5
 name: coh_rx_single_pol_Bbend_352b2c0b
 nets:
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_225000_13750,o1
-  p2: straight_L51p25_N2_CSstrip_W0p5_225000_65000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_225000_13750,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750,o1
+  p2: straight_L51p25_N2_CSstrip_225000_65000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750,o2
   p2: mmi_90degree_hybrid_W0p_80ee73a1_0_0,I_out1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_225000_m13750,o1
-  p2: straight_L51p25_N2_CSstrip_W0p5_225000_m65000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_225000_m13750,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750,o1
+  p2: straight_L51p25_N2_CSstrip_225000_m65000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750,o2
   p2: mmi_90degree_hybrid_W0p_80ee73a1_0_0,I_out2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_228500_11250,o1
-  p2: straight_L3p75_N2_CSstrip_W0p5_228500_15000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_228500_11250,o2
-  p2: straight_L3p5_N2_CSstrip_W0p5_218500_1250,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_228500_m11250,o1
-  p2: straight_L3p75_N2_CSstrip_W0p5_228500_m15000,o2
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_228500_m11250,o2
-  p2: straight_L3p5_N2_CSstrip_W0p5_218500_m1250,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_235000_75000,o1
-  p2: straight_L40_N2_CSstrip_W0p5_235000_75000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_235000_75000,o2
-  p2: straight_L51p25_N2_CSstrip_W0p5_225000_65000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_235000_m75000,o1
-  p2: straight_L40_N2_CSstrip_W0p5_235000_m75000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_235000_m75000,o2
-  p2: straight_L51p25_N2_CSstrip_W0p5_225000_m65000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_238500_25000,o1
-  p2: straight_L36p5_N2_CSstrip_W0p5_238500_25000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_238500_25000,o2
-  p2: straight_L3p75_N2_CSstrip_W0p5_228500_15000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_238500_m25000,o1
-  p2: straight_L36p5_N2_CSstrip_W0p5_238500_m25000,o1
-- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_238500_m25000,o2
-  p2: straight_L3p75_N2_CSstrip_W0p5_228500_m15000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250,o1
+  p2: straight_L3p75_N2_CSstrip_228500_15000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250,o2
+  p2: straight_L3p5_N2_CSstrip_218500_1250,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250,o1
+  p2: straight_L3p75_N2_CSstrip_228500_m15000,o2
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250,o2
+  p2: straight_L3p5_N2_CSstrip_218500_m1250,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000,o1
+  p2: straight_L40_N2_CSstrip_235000_75000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000,o2
+  p2: straight_L51p25_N2_CSstrip_225000_65000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000,o1
+  p2: straight_L40_N2_CSstrip_235000_m75000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000,o2
+  p2: straight_L51p25_N2_CSstrip_225000_m65000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000,o1
+  p2: straight_L36p5_N2_CSstrip_238500_25000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000,o2
+  p2: straight_L3p75_N2_CSstrip_228500_15000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000,o1
+  p2: straight_L36p5_N2_CSstrip_238500_m25000,o1
+- p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000,o2
+  p2: straight_L3p75_N2_CSstrip_228500_m15000,o1
 - p1: ge_detector_straight_si_857c1c1e_295000_25000,o1
-  p2: straight_L36p5_N2_CSstrip_W0p5_238500_25000,o2
+  p2: straight_L36p5_N2_CSstrip_238500_25000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_75000,o1
-  p2: straight_L40_N2_CSstrip_W0p5_235000_75000,o2
+  p2: straight_L40_N2_CSstrip_235000_75000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_m25000,o1
-  p2: straight_L36p5_N2_CSstrip_W0p5_238500_m25000,o2
+  p2: straight_L36p5_N2_CSstrip_238500_m25000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_m75000,o1
-  p2: straight_L40_N2_CSstrip_W0p5_235000_m75000,o2
+  p2: straight_L40_N2_CSstrip_235000_m75000,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,LO_in
   p2: straight_L20_N2_CSstrip_m60000_m1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,Q_out1
-  p2: straight_L3p5_N2_CSstrip_W0p5_218500_1250,o2
+  p2: straight_L3p5_N2_CSstrip_218500_1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,Q_out2
-  p2: straight_L3p5_N2_CSstrip_W0p5_218500_m1250,o2
+  p2: straight_L3p5_N2_CSstrip_218500_m1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,signal_in
   p2: straight_L20_N2_CSstrip_m60000_3750,o2
 placements:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_225000_13750:
+  bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750:
     mirror: true
     rotation: 270
     x: 225
     y: 13.75
-  bend_euler_R10_A90_P0p5_2f1f5c6d_225000_m13750:
+  bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750:
     mirror: false
     rotation: 90
     x: 225
     y: -13.75
-  bend_euler_R10_A90_P0p5_2f1f5c6d_228500_11250:
+  bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250:
     mirror: true
     rotation: 270
     x: 228.5
     y: 11.25
-  bend_euler_R10_A90_P0p5_2f1f5c6d_228500_m11250:
+  bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250:
     mirror: false
     rotation: 90
     x: 228.5
     y: -11.25
-  bend_euler_R10_A90_P0p5_2f1f5c6d_235000_75000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000:
     mirror: false
     rotation: 180
     x: 235
     y: 75
-  bend_euler_R10_A90_P0p5_2f1f5c6d_235000_m75000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000:
     mirror: true
     rotation: 180
     x: 235
     y: -75
-  bend_euler_R10_A90_P0p5_2f1f5c6d_238500_25000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000:
     mirror: false
     rotation: 180
     x: 238.5
     y: 25
-  bend_euler_R10_A90_P0p5_2f1f5c6d_238500_m25000:
+  bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000:
     mirror: true
     rotation: 180
     x: 238.5
@@ -539,52 +529,52 @@ placements:
     rotation: 0
     x: -60
     y: -1.25
-  straight_L36p5_N2_CSstrip_W0p5_238500_25000:
+  straight_L36p5_N2_CSstrip_238500_25000:
     mirror: false
     rotation: 0
     x: 238.5
     y: 25
-  straight_L36p5_N2_CSstrip_W0p5_238500_m25000:
+  straight_L36p5_N2_CSstrip_238500_m25000:
     mirror: false
     rotation: 0
     x: 238.5
     y: -25
-  straight_L3p5_N2_CSstrip_W0p5_218500_1250:
+  straight_L3p5_N2_CSstrip_218500_1250:
     mirror: false
     rotation: 180
     x: 218.5
     y: 1.25
-  straight_L3p5_N2_CSstrip_W0p5_218500_m1250:
+  straight_L3p5_N2_CSstrip_218500_m1250:
     mirror: false
     rotation: 180
     x: 218.5
     y: -1.25
-  straight_L3p75_N2_CSstrip_W0p5_228500_15000:
+  straight_L3p75_N2_CSstrip_228500_15000:
     mirror: false
     rotation: 270
     x: 228.5
     y: 15
-  straight_L3p75_N2_CSstrip_W0p5_228500_m15000:
+  straight_L3p75_N2_CSstrip_228500_m15000:
     mirror: false
     rotation: 90
     x: 228.5
     y: -15
-  straight_L40_N2_CSstrip_W0p5_235000_75000:
+  straight_L40_N2_CSstrip_235000_75000:
     mirror: false
     rotation: 0
     x: 235
     y: 75
-  straight_L40_N2_CSstrip_W0p5_235000_m75000:
+  straight_L40_N2_CSstrip_235000_m75000:
     mirror: false
     rotation: 0
     x: 235
     y: -75
-  straight_L51p25_N2_CSstrip_W0p5_225000_65000:
+  straight_L51p25_N2_CSstrip_225000_65000:
     mirror: false
     rotation: 270
     x: 225
     y: 65
-  straight_L51p25_N2_CSstrip_W0p5_225000_m65000:
+  straight_L51p25_N2_CSstrip_225000_m65000:
     mirror: false
     rotation: 90
     x: 225

--- a/test-data-regression/test_netlists_grating_coupler_tree_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_tree_.yml
@@ -351,7 +351,7 @@ instances:
       taper_angle: 40
       taper_length: 16.6
       wavelength: 1.554
-  straight_L175p5_N2_CSstrip_W0p5_185500_4500:
+  straight_L175p5_N2_CSstrip_185500_4500:
     component: straight
     info:
       length: 175.5
@@ -364,8 +364,7 @@ instances:
       cross_section: strip
       length: 175.5
       npoints: 2
-      width: 0.5
-  straight_L175p5_N2_CSstrip_W0p5_m175500_4500:
+  straight_L175p5_N2_CSstrip_m175500_4500:
     component: straight
     info:
       length: 175.5
@@ -378,8 +377,7 @@ instances:
       cross_section: strip
       length: 175.5
       npoints: 2
-      width: 0.5
-  straight_L302p5_N2_CSstrip_W0p5_312500_9000:
+  straight_L302p5_N2_CSstrip_312500_9000:
     component: straight
     info:
       length: 302.5
@@ -392,8 +390,7 @@ instances:
       cross_section: strip
       length: 302.5
       npoints: 2
-      width: 0.5
-  straight_L302p5_N2_CSstrip_W0p5_m302500_9000:
+  straight_L302p5_N2_CSstrip_m302500_9000:
     component: straight
     info:
       length: 302.5
@@ -406,8 +403,7 @@ instances:
       cross_section: strip
       length: 302.5
       npoints: 2
-      width: 0.5
-  straight_L429p5_N2_CSstrip_W0p5_439500_13500:
+  straight_L429p5_N2_CSstrip_439500_13500:
     component: straight
     info:
       length: 429.5
@@ -420,8 +416,7 @@ instances:
       cross_section: strip
       length: 429.5
       npoints: 2
-      width: 0.5
-  straight_L429p5_N2_CSstrip_W0p5_m429500_13500:
+  straight_L429p5_N2_CSstrip_m429500_13500:
     component: straight
     info:
       length: 429.5
@@ -434,8 +429,7 @@ instances:
       cross_section: strip
       length: 429.5
       npoints: 2
-      width: 0.5
-  straight_L48p5_N2_CSstrip_W0p5_58500_0:
+  straight_L48p5_N2_CSstrip_58500_0:
     component: straight
     info:
       length: 48.5
@@ -448,8 +442,7 @@ instances:
       cross_section: strip
       length: 48.5
       npoints: 2
-      width: 0.5
-  straight_L48p5_N2_CSstrip_W0p5_m48500_0:
+  straight_L48p5_N2_CSstrip_m48500_0:
     component: straight
     info:
       length: 48.5
@@ -462,8 +455,7 @@ instances:
       cross_section: strip
       length: 48.5
       npoints: 2
-      width: 0.5
-  straight_L59p5_N2_CSstrip_W0p5_68500_m10000:
+  straight_L59p5_N2_CSstrip_68500_m10000:
     component: straight
     info:
       length: 59.5
@@ -476,8 +468,7 @@ instances:
       cross_section: strip
       length: 59.5
       npoints: 2
-      width: 0.5
-  straight_L59p5_N2_CSstrip_W0p5_m58500_m10000:
+  straight_L59p5_N2_CSstrip_m58500_m10000:
     component: straight
     info:
       length: 59.5
@@ -490,8 +481,7 @@ instances:
       cross_section: strip
       length: 59.5
       npoints: 2
-      width: 0.5
-  straight_L64_N2_CSstrip_W0p5_195500_m5500:
+  straight_L64_N2_CSstrip_195500_m5500:
     component: straight
     info:
       length: 64
@@ -504,8 +494,7 @@ instances:
       cross_section: strip
       length: 64
       npoints: 2
-      width: 0.5
-  straight_L64_N2_CSstrip_W0p5_m185500_m5500:
+  straight_L64_N2_CSstrip_m185500_m5500:
     component: straight
     info:
       length: 64
@@ -518,8 +507,7 @@ instances:
       cross_section: strip
       length: 64
       npoints: 2
-      width: 0.5
-  straight_L68p5_N2_CSstrip_W0p5_322500_m1000:
+  straight_L68p5_N2_CSstrip_322500_m1000:
     component: straight
     info:
       length: 68.5
@@ -532,8 +520,7 @@ instances:
       cross_section: strip
       length: 68.5
       npoints: 2
-      width: 0.5
-  straight_L68p5_N2_CSstrip_W0p5_m312500_m1000:
+  straight_L68p5_N2_CSstrip_m312500_m1000:
     component: straight
     info:
       length: 68.5
@@ -546,8 +533,7 @@ instances:
       cross_section: strip
       length: 68.5
       npoints: 2
-      width: 0.5
-  straight_L73_N2_CSstrip_W0p5_449500_3500:
+  straight_L73_N2_CSstrip_449500_3500:
     component: straight
     info:
       length: 73
@@ -560,8 +546,7 @@ instances:
       cross_section: strip
       length: 73
       npoints: 2
-      width: 0.5
-  straight_L73_N2_CSstrip_W0p5_m439500_3500:
+  straight_L73_N2_CSstrip_m439500_3500:
     component: straight
     info:
       length: 73
@@ -574,7 +559,6 @@ instances:
       cross_section: strip
       length: 73
       npoints: 2
-      width: 0.5
   straight_array_N4_S4_L10_CSstrip_0_0:
     component: straight_array
     info: {}
@@ -586,68 +570,68 @@ instances:
 name: grating_coupler_tree_N4_2a7d2c50
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500,o1
-  p2: straight_L64_N2_CSstrip_W0p5_195500_m5500,o1
+  p2: straight_L64_N2_CSstrip_195500_m5500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500,o2
-  p2: straight_L175p5_N2_CSstrip_W0p5_185500_4500,o1
+  p2: straight_L175p5_N2_CSstrip_185500_4500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_322500_m1000,o1
-  p2: straight_L68p5_N2_CSstrip_W0p5_322500_m1000,o1
+  p2: straight_L68p5_N2_CSstrip_322500_m1000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_322500_m1000,o2
-  p2: straight_L302p5_N2_CSstrip_W0p5_312500_9000,o1
+  p2: straight_L302p5_N2_CSstrip_312500_9000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_449500_3500,o1
-  p2: straight_L73_N2_CSstrip_W0p5_449500_3500,o1
+  p2: straight_L73_N2_CSstrip_449500_3500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_449500_3500,o2
-  p2: straight_L429p5_N2_CSstrip_W0p5_439500_13500,o1
+  p2: straight_L429p5_N2_CSstrip_439500_13500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o1
-  p2: straight_L59p5_N2_CSstrip_W0p5_68500_m10000,o1
+  p2: straight_L59p5_N2_CSstrip_68500_m10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o2
-  p2: straight_L48p5_N2_CSstrip_W0p5_58500_0,o1
+  p2: straight_L48p5_N2_CSstrip_58500_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m185500_m5500,o1
-  p2: straight_L64_N2_CSstrip_W0p5_m185500_m5500,o1
+  p2: straight_L64_N2_CSstrip_m185500_m5500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m185500_m5500,o2
-  p2: straight_L175p5_N2_CSstrip_W0p5_m175500_4500,o1
+  p2: straight_L175p5_N2_CSstrip_m175500_4500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m312500_m1000,o1
-  p2: straight_L68p5_N2_CSstrip_W0p5_m312500_m1000,o1
+  p2: straight_L68p5_N2_CSstrip_m312500_m1000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m312500_m1000,o2
-  p2: straight_L302p5_N2_CSstrip_W0p5_m302500_9000,o1
+  p2: straight_L302p5_N2_CSstrip_m302500_9000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m439500_3500,o1
-  p2: straight_L73_N2_CSstrip_W0p5_m439500_3500,o1
+  p2: straight_L73_N2_CSstrip_m439500_3500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m439500_3500,o2
-  p2: straight_L429p5_N2_CSstrip_W0p5_m429500_13500,o1
+  p2: straight_L429p5_N2_CSstrip_m429500_13500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o1
-  p2: straight_L59p5_N2_CSstrip_W0p5_m58500_m10000,o1
+  p2: straight_L59p5_N2_CSstrip_m58500_m10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o2
-  p2: straight_L48p5_N2_CSstrip_W0p5_m48500_0,o1
+  p2: straight_L48p5_N2_CSstrip_m48500_0,o1
 - p1: grating_coupler_ellipti_07e69d9a_195500_m69500,o1
-  p2: straight_L64_N2_CSstrip_W0p5_195500_m5500,o2
+  p2: straight_L64_N2_CSstrip_195500_m5500,o2
 - p1: grating_coupler_ellipti_07e69d9a_322500_m69500,o1
-  p2: straight_L68p5_N2_CSstrip_W0p5_322500_m1000,o2
+  p2: straight_L68p5_N2_CSstrip_322500_m1000,o2
 - p1: grating_coupler_ellipti_07e69d9a_449500_m69500,o1
-  p2: straight_L73_N2_CSstrip_W0p5_449500_3500,o2
+  p2: straight_L73_N2_CSstrip_449500_3500,o2
 - p1: grating_coupler_ellipti_07e69d9a_68500_m69500,o1
-  p2: straight_L59p5_N2_CSstrip_W0p5_68500_m10000,o2
+  p2: straight_L59p5_N2_CSstrip_68500_m10000,o2
 - p1: grating_coupler_ellipti_07e69d9a_m185500_m69500,o1
-  p2: straight_L64_N2_CSstrip_W0p5_m185500_m5500,o2
+  p2: straight_L64_N2_CSstrip_m185500_m5500,o2
 - p1: grating_coupler_ellipti_07e69d9a_m312500_m69500,o1
-  p2: straight_L68p5_N2_CSstrip_W0p5_m312500_m1000,o2
+  p2: straight_L68p5_N2_CSstrip_m312500_m1000,o2
 - p1: grating_coupler_ellipti_07e69d9a_m439500_m69500,o1
-  p2: straight_L73_N2_CSstrip_W0p5_m439500_3500,o2
+  p2: straight_L73_N2_CSstrip_m439500_3500,o2
 - p1: grating_coupler_ellipti_07e69d9a_m58500_m69500,o1
-  p2: straight_L59p5_N2_CSstrip_W0p5_m58500_m10000,o2
-- p1: straight_L175p5_N2_CSstrip_W0p5_185500_4500,o2
+  p2: straight_L59p5_N2_CSstrip_m58500_m10000,o2
+- p1: straight_L175p5_N2_CSstrip_185500_4500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o7
-- p1: straight_L175p5_N2_CSstrip_W0p5_m175500_4500,o2
+- p1: straight_L175p5_N2_CSstrip_m175500_4500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o2
-- p1: straight_L302p5_N2_CSstrip_W0p5_312500_9000,o2
+- p1: straight_L302p5_N2_CSstrip_312500_9000,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o6
-- p1: straight_L302p5_N2_CSstrip_W0p5_m302500_9000,o2
+- p1: straight_L302p5_N2_CSstrip_m302500_9000,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o3
-- p1: straight_L429p5_N2_CSstrip_W0p5_439500_13500,o2
+- p1: straight_L429p5_N2_CSstrip_439500_13500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o5
-- p1: straight_L429p5_N2_CSstrip_W0p5_m429500_13500,o2
+- p1: straight_L429p5_N2_CSstrip_m429500_13500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o4
-- p1: straight_L48p5_N2_CSstrip_W0p5_58500_0,o2
+- p1: straight_L48p5_N2_CSstrip_58500_0,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o8
-- p1: straight_L48p5_N2_CSstrip_W0p5_m48500_0,o2
+- p1: straight_L48p5_N2_CSstrip_m48500_0,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o1
 placements:
   bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500:
@@ -730,82 +714,82 @@ placements:
     rotation: 270
     x: -58.5
     y: -69.5
-  straight_L175p5_N2_CSstrip_W0p5_185500_4500:
+  straight_L175p5_N2_CSstrip_185500_4500:
     mirror: false
     rotation: 180
     x: 185.5
     y: 4.5
-  straight_L175p5_N2_CSstrip_W0p5_m175500_4500:
+  straight_L175p5_N2_CSstrip_m175500_4500:
     mirror: false
     rotation: 0
     x: -175.5
     y: 4.5
-  straight_L302p5_N2_CSstrip_W0p5_312500_9000:
+  straight_L302p5_N2_CSstrip_312500_9000:
     mirror: false
     rotation: 180
     x: 312.5
     y: 9
-  straight_L302p5_N2_CSstrip_W0p5_m302500_9000:
+  straight_L302p5_N2_CSstrip_m302500_9000:
     mirror: false
     rotation: 0
     x: -302.5
     y: 9
-  straight_L429p5_N2_CSstrip_W0p5_439500_13500:
+  straight_L429p5_N2_CSstrip_439500_13500:
     mirror: false
     rotation: 180
     x: 439.5
     y: 13.5
-  straight_L429p5_N2_CSstrip_W0p5_m429500_13500:
+  straight_L429p5_N2_CSstrip_m429500_13500:
     mirror: false
     rotation: 0
     x: -429.5
     y: 13.5
-  straight_L48p5_N2_CSstrip_W0p5_58500_0:
+  straight_L48p5_N2_CSstrip_58500_0:
     mirror: false
     rotation: 180
     x: 58.5
     y: 0
-  straight_L48p5_N2_CSstrip_W0p5_m48500_0:
+  straight_L48p5_N2_CSstrip_m48500_0:
     mirror: false
     rotation: 0
     x: -48.5
     y: 0
-  straight_L59p5_N2_CSstrip_W0p5_68500_m10000:
+  straight_L59p5_N2_CSstrip_68500_m10000:
     mirror: false
     rotation: 270
     x: 68.5
     y: -10
-  straight_L59p5_N2_CSstrip_W0p5_m58500_m10000:
+  straight_L59p5_N2_CSstrip_m58500_m10000:
     mirror: false
     rotation: 270
     x: -58.5
     y: -10
-  straight_L64_N2_CSstrip_W0p5_195500_m5500:
+  straight_L64_N2_CSstrip_195500_m5500:
     mirror: false
     rotation: 270
     x: 195.5
     y: -5.5
-  straight_L64_N2_CSstrip_W0p5_m185500_m5500:
+  straight_L64_N2_CSstrip_m185500_m5500:
     mirror: false
     rotation: 270
     x: -185.5
     y: -5.5
-  straight_L68p5_N2_CSstrip_W0p5_322500_m1000:
+  straight_L68p5_N2_CSstrip_322500_m1000:
     mirror: false
     rotation: 270
     x: 322.5
     y: -1
-  straight_L68p5_N2_CSstrip_W0p5_m312500_m1000:
+  straight_L68p5_N2_CSstrip_m312500_m1000:
     mirror: false
     rotation: 270
     x: -312.5
     y: -1
-  straight_L73_N2_CSstrip_W0p5_449500_3500:
+  straight_L73_N2_CSstrip_449500_3500:
     mirror: false
     rotation: 270
     x: 449.5
     y: 3.5
-  straight_L73_N2_CSstrip_W0p5_m439500_3500:
+  straight_L73_N2_CSstrip_m439500_3500:
     mirror: false
     rotation: 270
     x: -439.5

--- a/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/test-data-regression/test_netlists_loop_mirror_.yml
@@ -132,7 +132,7 @@ instances:
       length: 20
       npoints: 2
       width: 0.5
-name: loop_mirror_Cmmi1x2_Bbend_euler
+name: loop_mirror_Cmmi1x2_Bbe_15330a29
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625,o1
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_35500_m20625,o2

--- a/test-data-regression/test_settings_awg_.yml
+++ b/test-data-regression/test_settings_awg_.yml
@@ -1,8 +1,9 @@
 info: {}
-name: awg_A10_O3_FPRIFFfree_p_d02e50a8
+name: awg_A10_O3_FPRIFFfree_p_a3247b17
 settings:
   arm_spacing: 1
   arms: 10
+  cross_section: strip
   fpr_spacing: 50
   free_propagation_region_input_function: Ffree_propagation_region_Mgdsfactorypcomponentspawg_SI1
   free_propagation_region_output_function: Ffree_propagation_region_Mgdsfactorypcomponentspawg_SI10_W10_W20

--- a/test-data-regression/test_settings_loop_mirror_.yml
+++ b/test-data-regression/test_settings_loop_mirror_.yml
@@ -1,5 +1,6 @@
 info: {}
-name: loop_mirror_Cmmi1x2_Bbend_euler
+name: loop_mirror_Cmmi1x2_Bbe_15330a29
 settings:
   bend90: bend_euler
   component: mmi1x2
+  cross_section: strip

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -100,9 +100,7 @@ routes:
             mmi_bottom,o3: mmi_top,o2
 
         settings:
-            cross_section:
-                cross_section: strip
-
+            cross_section: strip
 """
 
 
@@ -168,7 +166,7 @@ def test_connections_different_factory() -> None:
     ].length
 
 
-sample_different_link_factory = """
+sample_path_length_matching = """
 name: sample_path_length_matching
 
 instances:
@@ -196,8 +194,8 @@ placements:
 
 routes:
     route1:
-        routing_strategy: route_bundle_path_length_match
         settings:
+            cross_section: metal_routing
             radius: 10
             extra_length: 500
         links:
@@ -228,6 +226,7 @@ routes:
     route1:
         routing_strategy: route_bundle_from_waypoints
         settings:
+            cross_section: strip
             waypoints:
                 - [0, 300]
                 - [400, 300]
@@ -268,6 +267,8 @@ placements:
         dy: -40
 routes:
     optical:
+        settings:
+            cross_section: strip
         links:
             mmi_top,o3: mmi_bot,o1
 """
@@ -295,6 +296,8 @@ placements:
         x: 20
 routes:
     optical:
+        settings:
+            cross_section: strip
         links:
             left,o:1:3: right,o:3:1
 """
@@ -321,6 +324,8 @@ placements:
         x: 20
 routes:
     optical:
+        settings:
+            cross_section: strip
         links:
             left,o:3:1: right,o:1:3
 """
@@ -554,6 +559,7 @@ routes:
       s,o2_2_7: dbr,o1_7_1
       s,o2_2_8: dbr,o1_8_1
     settings:
+      cross_section: strip
       radius: 5
       sort_ports: true
     routing_strategy: route_bundle
@@ -577,6 +583,8 @@ connections:
 
 routes:
     b1:
+        settings:
+            cross_section: strip
         links:
             sa1<3.0>,o2: sa1<4.0>,o1
             sa1<3.1>,o2: sa1<4.1>,o1
@@ -598,7 +606,7 @@ yaml_strings = dict(
     # sample_regex_connections=sample_regex_connections,
     sample_docstring=sample_docstring,
     # sample_waypoints=sample_waypoints,
-    # sample_different_link_factory=sample_different_link_factory,
+    # sample_path_length_matching=sample_path_length_matching,
     # sample_different_factory=sample_different_factory,
     sample_mirror_simple=sample_mirror_simple,
     sample_connections=sample_connections,
@@ -658,11 +666,13 @@ def test_gds_and_settings(
 
 
 if __name__ == "__main__":
-    test_sample()
+    # test_sample()
     # test_connections_2x2()
     # test_connections_regex_backwards()
     # test_connections_different_factory()
     # import gdsfactory as gf
 
-    # c = gf.read.from_yaml(sample_array2)
-    # c.show()
+    import gdsfactory as gf
+
+    c = gf.read.from_yaml(sample_array2)
+    c.show()

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -658,8 +658,8 @@ def test_gds_and_settings(
 
 
 if __name__ == "__main__":
-    # test_sample()
-    test_connections_2x2()
+    test_sample()
+    # test_connections_2x2()
     # test_connections_regex_backwards()
     # test_connections_different_factory()
     # import gdsfactory as gf

--- a/tests/routing/test_port_ordering.py
+++ b/tests/routing/test_port_ordering.py
@@ -64,7 +64,9 @@ def make_bundle(
         ports2_names.reverse()
     ports1 = [r1.ports[n] for n in ports1_names]
     ports2 = [r2.ports[n] for n in ports2_names]
-    gf.routing.route_bundle(c, ports1, ports2, sort_ports=sort_ports, separation=2.5)
+    gf.routing.route_bundle(
+        c, ports1, ports2, sort_ports=sort_ports, separation=2.5, cross_section="strip"
+    )
 
 
 @pytest.mark.parametrize("angle", MANHATTAN_ANGLES)

--- a/tests/routing/test_route_single_error.py
+++ b/tests/routing/test_route_single_error.py
@@ -19,6 +19,7 @@ def test_route_error() -> None:
     with pytest.raises(NotImplementedError):
         route = gf.routing.route_single(
             c,
+            cross_section="strip",
             port1=p2,
             port2=p1,
             steps=[
@@ -46,6 +47,7 @@ if __name__ == "__main__":
             c,
             port1=p2,
             port2=p1,
+            cross_section="strip",
             steps=[
                 {"x": 20, "y": 0},
                 {"x": 20, "y": 20},

--- a/tests/routing/test_route_single_from_steps.py
+++ b/tests/routing/test_route_single_from_steps.py
@@ -21,6 +21,7 @@ def test_route_from_steps() -> None:
     p2 = right.ports["o2"]
     gf.routing.route_single(
         c,
+        cross_section="strip",
         port1=p1,
         port2=p2,
         steps=[

--- a/tests/routing/test_routing_route_bundle.py
+++ b/tests/routing/test_routing_route_bundle.py
@@ -45,7 +45,12 @@ def test_route_bundle(
 
         c = gf.Component("test_route_bundle")
         routes = route_bundle(
-            c, top_ports, bot_ports, start_straight_length=5, end_straight_length=10
+            c,
+            top_ports,
+            bot_ports,
+            start_straight_length=5,
+            end_straight_length=10,
+            cross_section="strip",
         )
         lengths = {i: route.length for i, route in enumerate(routes)}
         if data_regression:
@@ -254,13 +259,13 @@ def test_connect_corner(
     i = 0
     for ports1, ports2 in zip(ports_A, ports_B):
         if config in {"A", "C"}:
-            routes = route_bundle(c, ports1, ports2)
+            routes = route_bundle(c, ports1, ports2, cross_section="strip")
             for route in routes:
                 lengths[i] = route.length
                 i += 1
 
         elif config in {"B", "D"}:
-            routes = route_bundle(c, ports2, ports1)
+            routes = route_bundle(c, ports2, ports1, cross_section="strip")
             for route in routes:
                 lengths[i] = route.length
                 i += 1
@@ -336,6 +341,7 @@ def test_route_bundle_udirect(
         bend=gf.components.bend_circular,
         end_straight_length=30,
         sort_ports=True,
+        cross_section="strip",
     )
     lengths = {i: route.length for i, route in enumerate(routes)}
 
@@ -402,6 +408,7 @@ def test_route_bundle_u_indirect(
         end_straight_length=15,
         start_straight_length=5,
         radius=5,
+        cross_section="strip",
     )
     lengths = {i: route.length for i, route in enumerate(routes)}
     if check:
@@ -434,7 +441,7 @@ def test_facing_ports(
     ]
 
     c = gf.Component("test_facing_ports")
-    routes = route_bundle(c, ports1, ports2)
+    routes = route_bundle(c, ports1, ports2, cross_section="strip")
 
     lengths = {i: route.length for i, route in enumerate(routes)}
     if check:

--- a/tests/routing/test_routing_route_bundle_corner.py
+++ b/tests/routing/test_routing_route_bundle_corner.py
@@ -4,7 +4,16 @@ import gdsfactory as gf
 from gdsfactory import Port
 
 
-def test_connect_corner(data_regression: DataRegressionFixture, N=6, config="A"):
+def test_connect_corner(
+    data_regression: DataRegressionFixture | None, N=6, config="A"
+) -> None:
+    """Test connecting two bundles of ports in a corner.
+
+    Args:
+        data_regression: regression test data
+        N: number of ports
+        config: configuration of the ports
+    """
     d = 10.0
     sep = 5.0
     c = gf.Component()
@@ -201,18 +210,23 @@ def test_connect_corner(data_regression: DataRegressionFixture, N=6, config="A")
     lengths = {}
     if config in ["A", "C"]:
         for ports1, ports2 in zip(ports_A, ports_B):
-            routes = gf.routing.route_bundle(c, ports1, ports2, radius=5)
+            routes = gf.routing.route_bundle(
+                c, ports1, ports2, radius=5, cross_section=gf.cross_section.strip
+            )
             for i, route in enumerate(routes):
                 lengths[i] = route.length
 
     elif config in ["B", "D"]:
         for ports1, ports2 in zip(ports_A, ports_B):
-            routes = gf.routing.route_bundle(c, ports2, ports1, radius=5)
+            routes = gf.routing.route_bundle(
+                c, ports2, ports1, radius=5, cross_section=gf.cross_section.strip
+            )
             for i, route in enumerate(routes):
                 lengths[i] = route.length
 
-    data_regression.check(lengths)
+    if data_regression:
+        data_regression.check(lengths)
 
 
 if __name__ == "__main__":
-    test_connect_corner(config="A")
+    test_connect_corner(None, config="A")

--- a/tests/routing/test_routing_route_bundle_obstacle.py
+++ b/tests/routing/test_routing_route_bundle_obstacle.py
@@ -27,6 +27,7 @@ def test_route_bundle_obstacle(
         start_straight_length=100,
         separation=20,
         bboxes=[obstacle.bbox()],  # can avoid obstacles
+        cross_section=gf.cross_section.metal_routing,
     )
 
     for i, route in enumerate(routes):
@@ -55,5 +56,6 @@ if __name__ == "__main__":
         start_straight_length=100,
         separation=20,
         bboxes=[obstacle.bbox()],  # can avoid obstacles
+        cross_section=gf.cross_section.metal_routing,
     )
     c.show()

--- a/tests/routing/test_routing_route_bundle_optical.py
+++ b/tests/routing/test_routing_route_bundle_optical.py
@@ -26,7 +26,9 @@ def test_route_bundle_optical(
         d.ports["o1"],
     ]
 
-    routes = gf.routing.route_bundle(c, ports1, ports2, sort_ports=True, radius=10)
+    routes = gf.routing.route_bundle(
+        c, ports1, ports2, sort_ports=True, radius=10, cross_section="strip"
+    )
     for i, route in enumerate(routes):
         lengths[i] = route.length
 
@@ -49,7 +51,9 @@ def test_route_bundle_optical2(
     ports2 = d.ports.filter(orientation=180)
     ports2.reverse()
 
-    routes = gf.routing.route_bundle(c, ports1, ports2, sort_ports=True)
+    routes = gf.routing.route_bundle(
+        c, ports1, ports2, sort_ports=True, cross_section="strip"
+    )
 
     for i, route in enumerate(routes):
         lengths[i] = route.length

--- a/tests/routing/test_routing_route_bundle_sort_ports.py
+++ b/tests/routing/test_routing_route_bundle_sort_ports.py
@@ -29,7 +29,9 @@ def test_route_bundle_sort_ports(
         for i in range(N)
     ]
     left_ports.reverse()
-    routes = gf.routing.route_bundle(c, right_ports, left_ports, sort_ports=True)
+    routes = gf.routing.route_bundle(
+        c, right_ports, left_ports, sort_ports=True, cross_section="strip"
+    )
 
     for i, route in enumerate(routes):
         lengths[i] = route.length
@@ -61,7 +63,9 @@ if __name__ == "__main__":
         for i in range(N)
     ]
     left_ports.reverse()
-    routes = gf.routing.route_bundle(c, right_ports, left_ports, sort_ports=True)
+    routes = gf.routing.route_bundle(
+        c, right_ports, left_ports, sort_ports=True, cross_section="strip"
+    )
 
     for i, route in enumerate(routes):
         lengths[i] = route.length

--- a/tests/routing/test_routing_route_bundle_u_direct_different_x.py
+++ b/tests/routing/test_routing_route_bundle_u_direct_different_x.py
@@ -32,7 +32,7 @@ def test_route_bundle_u_direct_different_x(
         d.ports["o1"],
     ]
 
-    routes = gf.routing.route_bundle(c, ports1, ports2)
+    routes = gf.routing.route_bundle(c, ports1, ports2, cross_section="strip")
     lengths = {}
     for i, route in enumerate(routes):
         lengths[i] = route.length
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         d.ports["o1"],
     ]
 
-    routes = gf.routing.route_bundle(c, ports1, ports2)
+    routes = gf.routing.route_bundle(c, ports1, ports2, cross_section="strip")
     lengths = {}
     for i, route in enumerate(routes):
         lengths[i] = route.length

--- a/tests/routing/test_routing_route_bundle_udirect.py
+++ b/tests/routing/test_routing_route_bundle_udirect.py
@@ -106,6 +106,7 @@ def test_route_connect_bundle_udirect(
         radius=10.0,
         sort_ports=True,
         separation=10,
+        cross_section="strip",
     )
     lengths = {i: route.length for i, route in enumerate(routes)}
     if check:

--- a/tests/routing/test_routing_route_bundle_udirect.py
+++ b/tests/routing/test_routing_route_bundle_udirect.py
@@ -29,7 +29,9 @@ def test_route_bundle_udirect_pads(
 
     pbports.reverse()
 
-    routes = gf.routing.route_bundle_electrical(c, pbports, ptports, radius=5)
+    routes = gf.routing.route_bundle_electrical(
+        c, pbports, ptports, radius=5, cross_section="metal_routing"
+    )
 
     lengths = {}
     for i, route in enumerate(routes):
@@ -98,18 +100,18 @@ def test_route_connect_bundle_udirect(
             for i in range(N)
         ]
 
-    c = Component()
-    routes = gf.routing.route_bundle(
-        c,
-        ports1,
-        ports2,
-        radius=10.0,
-        sort_ports=True,
-        separation=10,
-        cross_section="strip",
-    )
-    lengths = {i: route.length for i, route in enumerate(routes)}
     if check:
+        c = Component()
+        routes = gf.routing.route_bundle(
+            c,
+            ports1,
+            ports2,
+            radius=10.0,
+            sort_ports=True,
+            separation=10,
+            cross_section="strip",
+        )
+        lengths = {i: route.length for i, route in enumerate(routes)}
         data_regression.check(lengths)
 
 

--- a/tests/routing/test_routing_route_bundle_uindirect.py
+++ b/tests/routing/test_routing_route_bundle_uindirect.py
@@ -73,6 +73,7 @@ def test_connect_bundle_u_indirect(
         bend=gf.components.bend_euler,
         radius=5,
         sort_ports=True,
+        cross_section=gf.cross_section.strip,
     )
     lengths = {i: route.length for i, route in enumerate(routes)}
     if check:


### PR DESCRIPTION
- remove `strip` as the default cross_section for routing. Default values are confusing when they don't always work
- route functions now tale an optional route_with and layer, for simpler routes, or a cross-section
- make sure it works with route_width parameter