### PR TITLE
Update layer_views.py

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -674,7 +674,7 @@ class LayerView(BaseModel):
         layer_in_name = False
         match = re.search(layer_pattern, name)
         if match:
-            name = name[: match.start()].strip()
+            name = (name[:match.start()] + name[match.end():]).strip()
             layer_in_name = True
         return clean_name(name, remove_dots=True), layer_in_name
 

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -674,7 +674,7 @@ class LayerView(BaseModel):
         layer_in_name = False
         match = re.search(layer_pattern, name)
         if match:
-            name = (name[:match.start()] + name[match.end():]).strip()
+            name = (name[: match.start()] + name[match.end() :]).strip()
             layer_in_name = True
         return clean_name(name, remove_dots=True), layer_in_name
 


### PR DESCRIPTION
I encountered an issue when importing a Klayout Layer Properties file, where only the last layer was returned. The issue was in the `_process_name` method, which checks if the layer is present in the name. If the layer is found, the name is shortened by removing the layer and all characters after it. When the layer is at the start of the name, this results in an empty string, causing all layer entries to overwrite the previous one. I modified the name cleanup process to remove the layer while retaining preceding and succeeding characters.

