### PR TITLE
Fix `Component.get_labels` returns texts in wrong locations

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -734,23 +734,18 @@ class ComponentBase:
         """
         from gdsfactory import get_layer
 
-        labels = []
-
-        layer = get_layer(layer)
+        layer_enum = get_layer(layer)
 
         if recursive:
-            iterator = self.begin_shapes_rec(layer)
-
-            while not (iterator.at_end()):
-                shape = iterator.shape()
-                iterator.next()
-                if shape.is_text():
-                    labels.append(shape.dtext.transformed(iterator.dtrans()))
+            return [
+                shape.dtext.transformed(iterator.dtrans())
+                for iterator in self.begin_shapes_rec(layer_enum)
+                if (shape := iterator.shape()).is_text()
+            ]
         else:
-            labels.extend(
-                shape.dtext for shape in self.shapes(layer).each(kdb.Shapes.STexts)
-            )
-        return labels
+            return [
+                shape.dtext for shape in self.shapes(layer_enum).each(kdb.Shapes.STexts)
+            ]
 
     def get_paths(self, layer: LayerSpec, recursive: bool = True) -> list[kf.kdb.DPath]:
         """Returns a list of paths.

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -633,7 +633,7 @@ def get_cross_section(
     return get_active_pdk().get_cross_section(cross_section, **kwargs)
 
 
-def get_layer(layer: LayerSpec) -> int:
+def get_layer(layer: LayerSpec) -> LayerEnum:
     return get_active_pdk().get_layer(layer)
 
 


### PR DESCRIPTION
The `iterator.next()` call in the following section was in the wrong position. It should have been after the label appending (cf. the sample code from KLayout, https://www.klayout.de/doc-qt5/code/class_RecursiveShapeIterator.html). I fixed this and refactored the code to bare list comprehensions.

```python
            while not (iterator.at_end()):
                shape = iterator.shape()
                iterator.next()
                if shape.is_text():
                    labels.append(shape.dtext.transformed(iterator.dtrans()))
```

## Commits

- **Fix incorrect iteration for `Component.get_labels` and refactor**
- **More correct type for `get_layer()`**

## Summary by Sourcery

Fix the iteration logic in `Component.get_labels` to return labels in the correct locations and refactor the method for better readability. Update the return type of `get_layer()` to `LayerEnum` for more accurate type representation.

Bug Fixes:
- Fix incorrect iteration in the `Component.get_labels` method to ensure labels are returned in the correct locations.

Enhancements:
- Refactor the `Component.get_labels` method for improved readability and efficiency.