### PR TITLE
add flatten section to docs

### DIFF
--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -99,13 +99,45 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "## Offset"
+    "## Flatten\n",
+    "\n",
+    "Hierarchical GDS uses references to optimize memory usage, but there are times when you may want to merge all polygons. In such cases, you can flatten the GDS to absorb all the references."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "c = gf.Component()\n",
+    "e = c << gf.components.ellipse(\n",
+    "    radii=(10, 5), layer=(1, 0)\n",
+    ")  # Ellipse. equivalent to c.add_ref(gf.components.ellipse(radii=(10, 5), layer=(1, 0))\n",
+    "r = (\n",
+    "    c << gf.components.rectangle(size=(15, 5), layer=(2, 0))\n",
+    ")  # Rectangle. equivalent to c.add_ref(gf.components.rectangle(size=(15, 5), layer=(2, 0))\n",
+    "print(len(c.insts))  # 2 component instances\n",
+    "c.flatten()\n",
+    "print(len(c.insts))  # 0 in the flattened component\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Offset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "To avoid acute angles you can run over / under (dilation+erosion)."
@@ -162,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Outline"
@@ -187,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Round corners"
@@ -213,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Union"
@@ -278,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Importing GDS files"
@@ -329,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "source": [
     "`gf.import_gds()` allows you to easily import external GDSII files.  It imports a single cell from the external GDS file and converts it into a gdsfactory component."
@@ -338,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Copying and extracting geometry"
@@ -359,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Import Images into GDS\n",
@@ -409,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Dummy Fill / Tiling\n",
@@ -451,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -523,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a new section on 'Flatten' to the documentation, explaining the process of merging all polygons in a hierarchical GDS by absorbing references.