### PR TITLE
remove routing_warnings

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -45,7 +45,7 @@ jobs:
           make test-data
       - name: Test with pytest
         run: |
-          make test
+          make uv-test
   test_code_coverage:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,7 +1072,7 @@ Documentation
 - Fix cs and transitions [#2158](https://github.com/gdsfactory/gdsfactory/pull/2158)
 - add via_stack_heater_m2 [#2178](https://github.com/gdsfactory/gdsfactory/pull/2178)
 - Fix lvs demo [#2175](https://github.com/gdsfactory/gdsfactory/pull/2175)
-- warn_connect_with_width_layer_or_type_missmatch [#2176](https://github.com/gdsfactory/gdsfactory/pull/2176)
+- warn_connect_with_width_layer_or_type_mismatch [#2176](https://github.com/gdsfactory/gdsfactory/pull/2176)
 - more representative implants generic_process [#2177](https://github.com/gdsfactory/gdsfactory/pull/2177)
 - remove enforce_port_ordering arg from get_bundle_from_waypoint params [#2174](https://github.com/gdsfactory/gdsfactory/pull/2174)
 - fixes difftest to use XOR instead of NOT [#2172](https://github.com/gdsfactory/gdsfactory/pull/2172)

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,13 @@ test-data-gds:
 	git clone git@github.com:gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
 test: test-data-gds
-	uv run pytest -s
+	pytest -s
 
 test-force:
-	uv run pytest --force-regen -s
+	run pytest --force-regen -s
+
+uv-test: test-data-gds
+	uv run pytest -s
 
 cov:
 	uv run pytest --cov=gdsfactory

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -3,9 +3,13 @@ import inspect
 
 import gdsfactory as gf
 from gdsfactory.config import PATH
+from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json
 
 filepath = PATH.repo / "docs" / "components.rst"
+
+
+cells = get_cells([gf.components])
 
 skip = {
     "grating_coupler_elliptical_te",
@@ -58,13 +62,13 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
 """
     )
 
-    for name in sorted(gf.components.cells.keys()):
+    for name in sorted(cells.keys()):
         # Skip if the name is in the skip list or starts with "_"
         if name in skip or name.startswith("_"):
             continue
 
         # Get the cell function or object
-        cell = gf.components.cells[name]
+        cell = cells[name]
 
         # Skip if it's an instance of functools.partial
         if skip_partials and isinstance(cell, functools.partial):

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -1,11 +1,9 @@
-"""Each component factory component returns a component.
+"""Each Parametric cell returns a component.
 
 Make sure your components get imported here so the PDK registers them.
 """
 
 from __future__ import annotations
-
-import sys
 
 from gdsfactory.components.add_fiber_array_optical_south_electrical_north import (
     add_fiber_array_optical_south_electrical_north,
@@ -302,7 +300,6 @@ from gdsfactory.components.via_stack import (
 from gdsfactory.components.via_stack_with_offset import via_stack_with_offset
 from gdsfactory.components.wafer import wafer
 from gdsfactory.components.wire import wire_corner, wire_corner45, wire_straight
-from gdsfactory.get_factories import get_cells
 
 __all__ = [
     "awg",
@@ -571,5 +568,3 @@ __all__ = [
     "hexagon",
     "octagon",
 ]
-
-cells = get_cells(sys.modules[__name__])

--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -44,17 +44,16 @@ LAYER_CONNECTIVITY = [
 @cache
 def get_generic_pdk() -> Pdk:
     import gdsfactory as gf
-    from gdsfactory.components import cells
     from gdsfactory.config import PATH
     from gdsfactory.cross_section import cross_sections
-    from gdsfactory.generic_tech.containers import containers
+    from gdsfactory.generic_tech import containers
     from gdsfactory.generic_tech.simulation_settings import materials_index
+    from gdsfactory.get_factories import get_cells
     from gdsfactory.pdk import Pdk, constants
 
     LAYER_VIEWS = LayerViews(filepath=PATH.klayout_yaml)
 
-    cells = cells.copy()
-    cells.update(containers)
+    cells = get_cells([containers, gf.components])
 
     layer_transitions = {
         LAYER.WG: partial(gf.c.taper, cross_section="strip", length=10),

--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -59,6 +59,7 @@ def get_generic_pdk() -> Pdk:
     layer_transitions = {
         LAYER.WG: partial(gf.c.taper, cross_section="strip", length=10),
         (LAYER.WG, LAYER.WGN): "taper_sc_nc",
+        (LAYER.WGN, LAYER.WG): "taper_nc_sc",
         LAYER.M3: "taper_electrical",
     }
 

--- a/gdsfactory/generic_tech/containers.py
+++ b/gdsfactory/generic_tech/containers.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import sys
-
 from gdsfactory.add_padding import add_padding_container
 from gdsfactory.components.add_termination import add_termination
-from gdsfactory.get_factories import get_cells
 from gdsfactory.routing import add_pads_bot, add_pads_top
 from gdsfactory.routing.add_electrical_pads_shortest import add_electrical_pads_shortest
 from gdsfactory.routing.add_electrical_pads_top import add_electrical_pads_top
@@ -23,5 +20,3 @@ __all__ = [
     "add_pads_top",
     "add_pads_bot",
 ]
-
-containers = get_cells(sys.modules[__name__])

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -112,36 +112,25 @@ def route_single(
             raise ValueError(
                 f"Either {cross_section=} or {layer=} and route_width must be provided"
             )
-        else:
+        elif layer is not None or route_width is not None or radius is not None:
             cross_section = gf.cross_section.cross_section(
                 layer=layer, width=route_width
             )
 
     port_type = port_type or p1.port_type
-    if route_width:
-        xs = gf.get_cross_section(cross_section, width=route_width)
-    else:
-        xs = gf.get_cross_section(cross_section)
+    xs = gf.get_cross_section(cross_section)
     width = route_width or xs.width
     radius = radius or xs.radius
-    width_dbu = width / component.kcl.dbu
 
-    bend90 = gf.get_component(
-        bend, cross_section=cross_section, radius=radius, width=width
-    )
+    bend90 = gf.get_component(bend, cross_section=cross_section, radius=radius)
     if auto_taper:
         p1 = add_auto_tapers(component, [p1], cross_section)[0]
         p2 = add_auto_tapers(component, [p2], cross_section)[0]
 
-    def straight_dbu(
-        length: int,
-        width: int = width_dbu,
-        cross_section=cross_section,
-    ) -> Component:
+    def straight_dbu(length: int, cross_section=cross_section, **kwargs) -> Component:
         return gf.get_component(
             straight,
             length=length * component.kcl.dbu,
-            width=width * component.kcl.dbu,
             cross_section=cross_section,
         )
 
@@ -356,34 +345,45 @@ if __name__ == "__main__":
     # p1 = bot.ports["e1"]
     # r = gf.routing.route_single(c, p0, p1, cross_section="metal_routing")
     # c.show()
-    import gdsfactory as gf
+    # import gdsfactory as gf
 
-    c = gf.Component("route_single_from_steps_sample")
-    w = gf.components.straight()
-    left = c << w
-    right = c << w
-    right.dmove((500, 80))
+    # c = gf.Component("route_single_from_steps_sample")
+    # w = gf.components.straight()
+    # left = c << w
+    # right = c << w
+    # right.dmove((500, 80))
 
-    obstacle = gf.components.rectangle(size=(100, 10), port_type=None)
-    obstacle1 = c << obstacle
-    obstacle2 = c << obstacle
-    obstacle1.dymin = 40
-    obstacle2.dxmin = 25
+    # obstacle = gf.components.rectangle(size=(100, 10), port_type=None)
+    # obstacle1 = c << obstacle
+    # obstacle2 = c << obstacle
+    # obstacle1.dymin = 40
+    # obstacle2.dxmin = 25
 
-    p1 = left.ports["o2"]
-    p2 = right.ports["o2"]
-    route_single(
+    # p1 = left.ports["o2"]
+    # p2 = right.ports["o2"]
+    # route_single(
+    #     c,
+    #     port1=p1,
+    #     port2=p2,
+    #     # steps=[
+    #     #     {"x": 20},
+    #     #     {"y": 20},
+    #     #     {"x": 120},
+    #     #     {"y": 80},
+    #     # ],
+    #     cross_section="strip",
+    #     # layer=(2, 0),
+    #     route_width=0.9,
+    # )
+
+    c = gf.Component()
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.dmove((100, 50))
+    route = gf.routing.route_single(
         c,
-        port1=p1,
-        port2=p2,
-        # steps=[
-        #     {"x": 20},
-        #     {"y": 20},
-        #     {"x": 120},
-        #     {"y": 80},
-        # ],
-        cross_section="strip",
-        # layer=(2, 0),
-        route_width=0.9,
+        port1=mmi1.ports["o2"],
+        port2=mmi2.ports["o1"],
+        cross_section="rib",  # layer=(1, 0), route_width=2
     )
     c.show()

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -376,14 +376,27 @@ if __name__ == "__main__":
     #     route_width=0.9,
     # )
 
+    # c = gf.Component()
+    # mmi1 = c << gf.components.mmi1x2()
+    # mmi2 = c << gf.components.mmi1x2()
+    # mmi2.dmove((100, 50))
+    # route = gf.routing.route_single(
+    #     c,
+    #     port1=mmi1.ports["o2"],
+    #     port2=mmi2.ports["o1"],
+    #     cross_section="rib",  # layer=(1, 0), route_width=2
+    # )
+    # c.show()
+
     c = gf.Component()
-    mmi1 = c << gf.components.mmi1x2()
-    mmi2 = c << gf.components.mmi1x2()
-    mmi2.dmove((100, 50))
+    s1 = c << gf.components.straight()
+    s2 = c << gf.components.straight(width=2)
+    s2.dmove((100, 50))
     route = gf.routing.route_single(
         c,
-        port1=mmi1.ports["o2"],
-        port2=mmi2.ports["o1"],
-        cross_section="rib",  # layer=(1, 0), route_width=2
+        port1=s1.ports["o2"],
+        port2=s2.ports["o1"],
+        cross_section="strip",
+        auto_taper=True,
     )
     c.show()

--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -7,18 +7,14 @@
    "source": [
     "# Routing\n",
     "\n",
-    "Optical and high speed RF ports have an orientation that routes need to follow to avoid sharp turns that produce reflections.\n",
+    "Optical and high-speed RF ports have specific orientation requirements to ensure that routes avoid sharp turns, which can cause signal reflections.\n",
     "\n",
-    "we have routing functions that route:\n",
+    "We offer routing functions tailored for these requirements:\n",
     "\n",
-    "- single route between 2 ports\n",
-    "    - `route_single`\n",
-    "- group of routes between 2 groups of ports using a bundle/river/bus router. At the moment it works only when all ports on each group have the same orientation.\n",
-    "    - `route_bundle` (supports bundles or ports, waypoints and steps)\n",
+    "- `route_single`: Routes a single connection between two ports.\n",
+    "- `route_bundle`: Routes multiple connections between two port groups using a bundle/river/bus router. It also accommodates waypoints and routing steps.\n",
     "\n",
-    "The most useful function is `route_bundle` which supports both single and groups of routes, and can also route with length matching, which ensures that all routes have the same length.\n",
-    "\n",
-    "The biggest limitation is that it requires to have all the ports with the same orientation, for that you can use `gf.routing.route_ports_to_side`"
+    "The most versatile function is `route_bundle`, as it handles both single and grouped routes with length matching, ensuring all routes are of equal length."
    ]
   },
   {
@@ -1192,9 +1188,108 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "42",
+   "metadata": {},
+   "source": [
+    "## auto_taper\n",
+    "\n",
+    "Both `route_single` and `route_bundle` have a `auto_taper` parameter. \n",
+    "\n",
+    "For auto_taper to work you need to define how to transition different between different layers and widths.\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "layer_transitions = {\n",
+    "    LAYER.WG: partial(gf.c.taper, cross_section=\"strip\", length=10),\n",
+    "    (LAYER.WG, LAYER.WGN): \"taper_sc_nc\",\n",
+    "    (LAYER.WGN, LAYER.WG): \"taper_nc_sc\",\n",
+    "    LAYER.M3: \"taper_electrical\",\n",
+    "}\n",
+    "\n",
+    "return Pdk(\n",
+    "    name=\"generic\",\n",
+    "    cells=cells,\n",
+    "    cross_sections=cross_sections,\n",
+    "    layers=LAYER,\n",
+    "    layer_stack=LAYER_STACK,\n",
+    "    layer_views=LAYER_VIEWS,\n",
+    "    layer_transitions=layer_transitions,\n",
+    "    materials_index=materials_index,\n",
+    "    constants=constants,\n",
+    "    connectivity=LAYER_CONNECTIVITY,\n",
+    ")\n",
+    "\n",
+    "```\n",
+    "\n",
+    "For example, in the code below if you have a width mismatch between two ports, the router will automatically add a taper to transition between the two widths, only if `auto_taper=True`, otherwise it will raise an error.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "s1 = c << gf.components.straight()\n",
+    "s2 = c << gf.components.straight(width=2)\n",
+    "s2.dmove((40, 50))\n",
+    "route = gf.routing.route_single(\n",
+    "    c,\n",
+    "    port1=s1.ports[\"o2\"],\n",
+    "    port2=s2.ports[\"o1\"],\n",
+    "    cross_section=\"strip\",\n",
+    "    auto_taper=True,\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from gdsfactory.routing.auto_taper import auto_taper_to_cross_section\n",
+    "\n",
+    "\n",
+    "@gf.cell\n",
+    "def silicon_nitride_strip(width_nitride: float = 1) -> gf.Component:\n",
+    "    c = gf.Component()\n",
+    "    ref = c << gf.c.straight(\n",
+    "        cross_section=gf.cross_section.nitride, width=width_nitride\n",
+    "    )\n",
+    "    port1 = auto_taper_to_cross_section(\n",
+    "        c, port=ref[\"o1\"], cross_section=gf.cross_section.strip\n",
+    "    )\n",
+    "    c.add_port(name=\"o1\", port=port1)\n",
+    "    c.add_port(name=\"o2\", port=ref[\"o2\"])\n",
+    "    return c\n",
+    "\n",
+    "\n",
+    "c = silicon_nitride_strip(width_nitride=1)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = silicon_nitride_strip(width_nitride=4)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/test-data-regression/test_netlists_add_electrical_pads_top_.yml
+++ b/test-data-regression/test_netlists_add_electrical_pads_top_.yml
@@ -1,0 +1,59 @@
+instances:
+  pad_array_Ppad_S150_150_b7790e28_25000_155000:
+    component: pad_array
+    info: {}
+    settings:
+      centered_ports: false
+      columns: 2
+      layer: MTOP
+      orientation: null
+      pad: pad
+      port_orientation: 270
+      rows: 1
+      size:
+      - 100
+      - 100
+      spacing:
+      - 150
+      - 150
+  straight_L200_N2_CSmetal_routing_0_0:
+    component: straight
+    info:
+      length: 200
+      route_info_length: 200
+      route_info_metal_routing_length: 200
+      route_info_type: metal_routing
+      route_info_weight: 200
+      width: 10
+    settings:
+      cross_section: metal_routing
+      length: 200
+      npoints: 2
+name: Unnamed_1943
+nets: []
+placements:
+  pad_array_Ppad_S150_150_b7790e28_25000_155000:
+    mirror: false
+    rotation: 0
+    x: 25
+    y: 155
+  straight_L200_N2_CSmetal_routing_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+ports:
+  e1: pad_array_Ppad_S150_150_b7790e28_25000_155000,e12
+  e2: pad_array_Ppad_S150_150_b7790e28_25000_155000,e11
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 2 unconnected electrical ports!
+      ports:
+      - straight_L200_N2_CSmetal_routing_0_0,e1
+      - straight_L200_N2_CSmetal_routing_0_0,e2
+      values:
+      - - 0
+        - 0
+      - - 200000
+        - 0

--- a/test-data-regression/test_netlists_add_fiber_array_.yml
+++ b/test-data-regression/test_netlists_add_fiber_array_.yml
@@ -1,0 +1,525 @@
+instances:
+  bend_euler_RNone_A90_P0_d7c3a5a9_175500_m83551:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_185500_m28471:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_195500_m38471:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_m155500_m93551:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_m165500_m38471:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_m175500_m28471:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000:
+    component: bend_euler
+    info:
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
+      route_info_n_bend_90: 1
+      route_info_strip_length: 16.637
+      route_info_type: strip
+      route_info_weight: 16.637
+      width: 0.5
+    settings:
+      allow_min_radius_violation: false
+      angle: 90
+      cross_section: strip
+      layer: null
+      npoints: null
+      p: 0.5
+      radius: null
+      width: null
+      with_arc_floorplan: true
+  grating_coupler_ellipti_7b8aa449_195500_m38000:
+    component: grating_coupler_elliptical_trenches
+    info:
+      period: 0.676
+      polarization: te
+      wavelength: 1.53
+    settings:
+      cross_section: strip
+      end_straight_length: 0.2
+      fiber_angle: 15
+      grating_line_width: 0.343
+      layer_trench: SHALLOW_ETCH
+      n_periods: 30
+      ncladding: 1.443
+      neff: 2.638
+      p_start: 26
+      polarization: te
+      taper: taper
+      taper_angle: 35
+      taper_length: 16.6
+      trenches_extra_angle: 9
+      wavelength: 1.53
+  grating_coupler_ellipti_7b8aa449_68500_m38000:
+    component: grating_coupler_elliptical_trenches
+    info:
+      period: 0.676
+      polarization: te
+      wavelength: 1.53
+    settings:
+      cross_section: strip
+      end_straight_length: 0.2
+      fiber_angle: 15
+      grating_line_width: 0.343
+      layer_trench: SHALLOW_ETCH
+      n_periods: 30
+      ncladding: 1.443
+      neff: 2.638
+      p_start: 26
+      polarization: te
+      taper: taper
+      taper_angle: 35
+      taper_length: 16.6
+      trenches_extra_angle: 9
+      wavelength: 1.53
+  grating_coupler_ellipti_7b8aa449_m185500_m38000:
+    component: grating_coupler_elliptical_trenches
+    info:
+      period: 0.676
+      polarization: te
+      wavelength: 1.53
+    settings:
+      cross_section: strip
+      end_straight_length: 0.2
+      fiber_angle: 15
+      grating_line_width: 0.343
+      layer_trench: SHALLOW_ETCH
+      n_periods: 30
+      ncladding: 1.443
+      neff: 2.638
+      p_start: 26
+      polarization: te
+      taper: taper
+      taper_angle: 35
+      taper_length: 16.6
+      trenches_extra_angle: 9
+      wavelength: 1.53
+  grating_coupler_ellipti_7b8aa449_m58500_m38000:
+    component: grating_coupler_elliptical_trenches
+    info:
+      period: 0.676
+      polarization: te
+      wavelength: 1.53
+    settings:
+      cross_section: strip
+      end_straight_length: 0.2
+      fiber_angle: 15
+      grating_line_width: 0.343
+      layer_trench: SHALLOW_ETCH
+      n_periods: 30
+      ncladding: 1.443
+      neff: 2.638
+      p_start: 26
+      polarization: te
+      taper: taper
+      taper_angle: 35
+      taper_length: 16.6
+      trenches_extra_angle: 9
+      wavelength: 1.53
+  straight_L10_N2_CSstrip_0_0:
+    component: straight
+    info:
+      length: 10
+      route_info_length: 10
+      route_info_strip_length: 10
+      route_info_type: strip
+      route_info_weight: 10
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 10
+      npoints: 2
+  straight_L28p471_N2_CSstrip_68500_m10000:
+    component: straight
+    info:
+      length: 28.471
+      route_info_length: 28.471
+      route_info_strip_length: 28.471
+      route_info_type: strip
+      route_info_weight: 28.471
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 28.471
+      npoints: 2
+  straight_L28p471_N2_CSstrip_m58500_m10000:
+    component: straight
+    info:
+      length: 28.471
+      route_info_length: 28.471
+      route_info_strip_length: 28.471
+      route_info_type: strip
+      route_info_weight: 28.471
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 28.471
+      npoints: 2
+  straight_L321_N2_CSstrip_165500_m93551:
+    component: straight
+    info:
+      length: 321
+      route_info_length: 321
+      route_info_strip_length: 321
+      route_info_type: strip
+      route_info_weight: 321
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 321
+      npoints: 2
+  straight_L45p08_N2_CSstrip_175500_m38471:
+    component: straight
+    info:
+      length: 45.08
+      route_info_length: 45.08
+      route_info_strip_length: 45.08
+      route_info_type: strip
+      route_info_weight: 45.08
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 45.08
+      npoints: 2
+  straight_L45p08_N2_CSstrip_m165500_m83551:
+    component: straight
+    info:
+      length: 45.08
+      route_info_length: 45.08
+      route_info_strip_length: 45.08
+      route_info_type: strip
+      route_info_weight: 45.08
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 45.08
+      npoints: 2
+  straight_L48p5_N2_CSstrip_58500_0:
+    component: straight
+    info:
+      length: 48.5
+      route_info_length: 48.5
+      route_info_strip_length: 48.5
+      route_info_type: strip
+      route_info_weight: 48.5
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 48.5
+      npoints: 2
+  straight_L48p5_N2_CSstrip_m48500_0:
+    component: straight
+    info:
+      length: 48.5
+      route_info_length: 48.5
+      route_info_strip_length: 48.5
+      route_info_type: strip
+      route_info_weight: 48.5
+      width: 0.5
+    settings:
+      cross_section: strip
+      length: 48.5
+      npoints: 2
+name: Unnamed_2025
+nets:
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_175500_m83551,o1
+  p2: straight_L45p08_N2_CSstrip_175500_m38471,o2
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_175500_m83551,o2
+  p2: straight_L321_N2_CSstrip_165500_m93551,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_185500_m28471,o1
+  p2: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m38471,o2
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_185500_m28471,o2
+  p2: straight_L45p08_N2_CSstrip_175500_m38471,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m38471,o1
+  p2: grating_coupler_ellipti_7b8aa449_195500_m38000,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o1
+  p2: straight_L28p471_N2_CSstrip_68500_m10000,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o2
+  p2: straight_L48p5_N2_CSstrip_58500_0,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m155500_m93551,o1
+  p2: straight_L321_N2_CSstrip_165500_m93551,o2
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m155500_m93551,o2
+  p2: straight_L45p08_N2_CSstrip_m165500_m83551,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m165500_m38471,o1
+  p2: straight_L45p08_N2_CSstrip_m165500_m83551,o2
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m165500_m38471,o2
+  p2: bend_euler_RNone_A90_P0_d7c3a5a9_m175500_m28471,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m175500_m28471,o2
+  p2: grating_coupler_ellipti_7b8aa449_m185500_m38000,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o1
+  p2: straight_L28p471_N2_CSstrip_m58500_m10000,o1
+- p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o2
+  p2: straight_L48p5_N2_CSstrip_m48500_0,o1
+- p1: grating_coupler_ellipti_7b8aa449_68500_m38000,o1
+  p2: straight_L28p471_N2_CSstrip_68500_m10000,o2
+- p1: grating_coupler_ellipti_7b8aa449_m58500_m38000,o1
+  p2: straight_L28p471_N2_CSstrip_m58500_m10000,o2
+- p1: straight_L10_N2_CSstrip_0_0,o1
+  p2: straight_L48p5_N2_CSstrip_m48500_0,o2
+- p1: straight_L10_N2_CSstrip_0_0,o2
+  p2: straight_L48p5_N2_CSstrip_58500_0,o2
+placements:
+  bend_euler_RNone_A90_P0_d7c3a5a9_175500_m83551:
+    mirror: true
+    rotation: 270
+    x: 175.5
+    y: -83.551
+  bend_euler_RNone_A90_P0_d7c3a5a9_185500_m28471:
+    mirror: false
+    rotation: 180
+    x: 185.5
+    y: -28.471
+  bend_euler_RNone_A90_P0_d7c3a5a9_195500_m38471:
+    mirror: false
+    rotation: 90
+    x: 195.5
+    y: -38.471
+  bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000:
+    mirror: false
+    rotation: 90
+    x: 68.5
+    y: -10
+  bend_euler_RNone_A90_P0_d7c3a5a9_m155500_m93551:
+    mirror: true
+    rotation: 180
+    x: -155.5
+    y: -93.551
+  bend_euler_RNone_A90_P0_d7c3a5a9_m165500_m38471:
+    mirror: false
+    rotation: 90
+    x: -165.5
+    y: -38.471
+  bend_euler_RNone_A90_P0_d7c3a5a9_m175500_m28471:
+    mirror: false
+    rotation: 180
+    x: -175.5
+    y: -28.471
+  bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000:
+    mirror: true
+    rotation: 90
+    x: -58.5
+    y: -10
+  grating_coupler_ellipti_7b8aa449_195500_m38000:
+    mirror: false
+    rotation: 270
+    x: 195.5
+    y: -38
+  grating_coupler_ellipti_7b8aa449_68500_m38000:
+    mirror: false
+    rotation: 270
+    x: 68.5
+    y: -38
+  grating_coupler_ellipti_7b8aa449_m185500_m38000:
+    mirror: false
+    rotation: 270
+    x: -185.5
+    y: -38
+  grating_coupler_ellipti_7b8aa449_m58500_m38000:
+    mirror: false
+    rotation: 270
+    x: -58.5
+    y: -38
+  straight_L10_N2_CSstrip_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+  straight_L28p471_N2_CSstrip_68500_m10000:
+    mirror: false
+    rotation: 270
+    x: 68.5
+    y: -10
+  straight_L28p471_N2_CSstrip_m58500_m10000:
+    mirror: false
+    rotation: 270
+    x: -58.5
+    y: -10
+  straight_L321_N2_CSstrip_165500_m93551:
+    mirror: false
+    rotation: 180
+    x: 165.5
+    y: -93.551
+  straight_L45p08_N2_CSstrip_175500_m38471:
+    mirror: false
+    rotation: 270
+    x: 175.5
+    y: -38.471
+  straight_L45p08_N2_CSstrip_m165500_m83551:
+    mirror: false
+    rotation: 90
+    x: -165.5
+    y: -83.551
+  straight_L48p5_N2_CSstrip_58500_0:
+    mirror: false
+    rotation: 180
+    x: 58.5
+    y: 0
+  straight_L48p5_N2_CSstrip_m48500_0:
+    mirror: false
+    rotation: 0
+    x: -48.5
+    y: 0
+ports: {}

--- a/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m226250:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m53250:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m129125:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m150375:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375:
     component: bend_euler
     info:
       dy: 10
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   coh_tx_single_pol_BPSFa_4ee171aa_0_0:
     component: coh_tx_single_pol
@@ -144,7 +144,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L65p875_N2_CSstrip_W0p5_m80000_m216250:
+  straight_L65p875_N2_CSstrip_m80000_m216250:
     component: straight
     info:
       length: 65.875
@@ -157,8 +157,7 @@ instances:
       cross_section: strip
       length: 65.875
       npoints: 2
-      width: 0.5
-  straight_L65p875_N2_CSstrip_W0p5_m80000_m63250:
+  straight_L65p875_N2_CSstrip_m80000_m63250:
     component: straight
     info:
       length: 65.875
@@ -171,8 +170,7 @@ instances:
       cross_section: strip
       length: 65.875
       npoints: 2
-      width: 0.5
-  straight_L7p25_N2_CSstrip_W0p5_m70000_m226250:
+  straight_L7p25_N2_CSstrip_m70000_m226250:
     component: straight
     info:
       length: 7.25
@@ -185,8 +183,7 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
-  straight_L7p25_N2_CSstrip_W0p5_m70000_m53250:
+  straight_L7p25_N2_CSstrip_m70000_m53250:
     component: straight
     info:
       length: 7.25
@@ -199,46 +196,45 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
 name: coh_tx_dual_pol_Smmi1x2_a3c36516
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m226250,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m70000_m226250,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m226250,o2
-  p2: straight_L65p875_N2_CSstrip_W0p5_m80000_m216250,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m53250,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m70000_m53250,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m53250,o2
-  p2: straight_L65p875_N2_CSstrip_W0p5_m80000_m63250,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m129125,o1
-  p2: straight_L65p875_N2_CSstrip_W0p5_m80000_m63250,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m129125,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250,o1
+  p2: straight_L7p25_N2_CSstrip_m70000_m226250,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250,o2
+  p2: straight_L65p875_N2_CSstrip_m80000_m216250,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250,o1
+  p2: straight_L7p25_N2_CSstrip_m70000_m53250,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250,o2
+  p2: straight_L65p875_N2_CSstrip_m80000_m63250,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125,o1
+  p2: straight_L65p875_N2_CSstrip_m80000_m63250,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m105500_m139750,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m150375,o1
-  p2: straight_L65p875_N2_CSstrip_W0p5_m80000_m216250,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m150375,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375,o1
+  p2: straight_L65p875_N2_CSstrip_m80000_m216250,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m105500_m139750,o3
 - p1: coh_tx_single_pol_BPSFa_4ee171aa_0_0,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m70000_m53250,o2
+  p2: straight_L7p25_N2_CSstrip_m70000_m53250,o2
 - p1: coh_tx_single_pol_BPSFa_4ee171aa_0_m173000,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m70000_m226250,o2
+  p2: straight_L7p25_N2_CSstrip_m70000_m226250,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m226250:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250:
     mirror: true
     rotation: 180
     x: -70
     y: -226.25
-  bend_euler_R10_A90_P0p5_f9fcb00b_m70000_m53250:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250:
     mirror: false
     rotation: 180
     x: -70
     y: -53.25
-  bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m129125:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125:
     mirror: true
     rotation: 270
     x: -80
     y: -129.125
-  bend_euler_R10_A90_P0p5_f9fcb00b_m80000_m150375:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375:
     mirror: false
     rotation: 90
     x: -80
@@ -258,22 +254,22 @@ placements:
     rotation: 0
     x: -105.5
     y: -139.75
-  straight_L65p875_N2_CSstrip_W0p5_m80000_m216250:
+  straight_L65p875_N2_CSstrip_m80000_m216250:
     mirror: false
     rotation: 90
     x: -80
     y: -216.25
-  straight_L65p875_N2_CSstrip_W0p5_m80000_m63250:
+  straight_L65p875_N2_CSstrip_m80000_m63250:
     mirror: false
     rotation: 270
     x: -80
     y: -63.25
-  straight_L7p25_N2_CSstrip_W0p5_m70000_m226250:
+  straight_L7p25_N2_CSstrip_m70000_m226250:
     mirror: false
     rotation: 0
     x: -70
     y: -226.25
-  straight_L7p25_N2_CSstrip_W0p5_m70000_m53250:
+  straight_L7p25_N2_CSstrip_m70000_m53250:
     mirror: false
     rotation: 0
     x: -70

--- a/test-data-regression/test_netlists_coh_tx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_single_pol_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_428250_0:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_428250_m106500:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_438250_m42625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_438250_m63875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875:
     component: bend_euler
     info:
       dy: 10
@@ -93,9 +93,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m17250_0:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0:
     component: bend_euler
     info:
       dy: 10
@@ -117,9 +117,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m17250_m106500:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500:
     component: bend_euler
     info:
       dy: 10
@@ -141,9 +141,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m42625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625:
     component: bend_euler
     info:
       dy: 10
@@ -165,9 +165,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m63875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875:
     component: bend_euler
     info:
       dy: 10
@@ -189,7 +189,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   mmi1x2_WNone_WT1_LT10_L_4e0f7121_463750_m53250:
     component: mmi1x2
@@ -288,7 +288,7 @@ instances:
       cross_section: strip
       length: 100
       npoints: 2
-  straight_L32p625_N2_CSstrip_W0p5_438250_m10000:
+  straight_L32p625_N2_CSstrip_438250_m10000:
     component: straight
     info:
       length: 32.625
@@ -301,8 +301,7 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-      width: 0.5
-  straight_L32p625_N2_CSstrip_W0p5_438250_m96500:
+  straight_L32p625_N2_CSstrip_438250_m96500:
     component: straight
     info:
       length: 32.625
@@ -315,8 +314,7 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-      width: 0.5
-  straight_L32p625_N2_CSstrip_W0p5_m27250_m10000:
+  straight_L32p625_N2_CSstrip_m27250_m10000:
     component: straight
     info:
       length: 32.625
@@ -329,8 +327,7 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-      width: 0.5
-  straight_L32p625_N2_CSstrip_W0p5_m27250_m96500:
+  straight_L32p625_N2_CSstrip_m27250_m96500:
     component: straight
     info:
       length: 32.625
@@ -343,7 +340,6 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-      width: 0.5
   straight_L40_N2_CSstrip_281000_0:
     component: straight
     info:
@@ -370,7 +366,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L7p25_N2_CSstrip_W0p5_428250_0:
+  straight_L7p25_N2_CSstrip_428250_0:
     component: straight
     info:
       length: 7.25
@@ -383,8 +379,7 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
-  straight_L7p25_N2_CSstrip_W0p5_428250_m106500:
+  straight_L7p25_N2_CSstrip_428250_m106500:
     component: straight
     info:
       length: 7.25
@@ -397,8 +392,7 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
-  straight_L7p25_N2_CSstrip_W0p5_m17250_0:
+  straight_L7p25_N2_CSstrip_m17250_0:
     component: straight
     info:
       length: 7.25
@@ -411,8 +405,7 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
-  straight_L7p25_N2_CSstrip_W0p5_m17250_m106500:
+  straight_L7p25_N2_CSstrip_m17250_m106500:
     component: straight
     info:
       length: 7.25
@@ -425,7 +418,6 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-      width: 0.5
   straight_pin_L100_CSpin_f2ba7e88_331000_m106500:
     component: straight_pin
     info: {}
@@ -438,91 +430,91 @@ instances:
       via_stack_width: 10
 name: coh_tx_single_pol_BPSFa_4ee171aa
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_428250_0,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_428250_0,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_428250_0,o2
-  p2: straight_L32p625_N2_CSstrip_W0p5_438250_m10000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_428250_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_428250_m106500,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_428250_m106500,o2
-  p2: straight_L32p625_N2_CSstrip_W0p5_438250_m96500,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_438250_m42625,o1
-  p2: straight_L32p625_N2_CSstrip_W0p5_438250_m10000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_438250_m42625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0,o1
+  p2: straight_L7p25_N2_CSstrip_428250_0,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0,o2
+  p2: straight_L32p625_N2_CSstrip_438250_m10000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500,o1
+  p2: straight_L7p25_N2_CSstrip_428250_m106500,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500,o2
+  p2: straight_L32p625_N2_CSstrip_438250_m96500,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625,o1
+  p2: straight_L32p625_N2_CSstrip_438250_m10000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_463750_m53250,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_438250_m63875,o1
-  p2: straight_L32p625_N2_CSstrip_W0p5_438250_m96500,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_438250_m63875,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875,o1
+  p2: straight_L32p625_N2_CSstrip_438250_m96500,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_463750_m53250,o3
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m17250_0,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m17250_0,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m17250_0,o2
-  p2: straight_L32p625_N2_CSstrip_W0p5_m27250_m10000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m17250_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m17250_m106500,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m17250_m106500,o2
-  p2: straight_L32p625_N2_CSstrip_W0p5_m27250_m96500,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m42625,o1
-  p2: straight_L32p625_N2_CSstrip_W0p5_m27250_m10000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m42625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0,o1
+  p2: straight_L7p25_N2_CSstrip_m17250_0,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0,o2
+  p2: straight_L32p625_N2_CSstrip_m27250_m10000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500,o1
+  p2: straight_L7p25_N2_CSstrip_m17250_m106500,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500,o2
+  p2: straight_L32p625_N2_CSstrip_m27250_m96500,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625,o1
+  p2: straight_L32p625_N2_CSstrip_m27250_m10000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m52750_m53250,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m63875,o1
-  p2: straight_L32p625_N2_CSstrip_W0p5_m27250_m96500,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m63875,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875,o1
+  p2: straight_L32p625_N2_CSstrip_m27250_m96500,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m52750_m53250,o3
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_0,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m17250_0,o2
+  p2: straight_L7p25_N2_CSstrip_m17250_0,o2
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_0,o2
   p2: straight_L40_N2_CSstrip_281000_0,o1
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_W0p5_m17250_m106500,o2
+  p2: straight_L7p25_N2_CSstrip_m17250_m106500,o2
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_m106500,o2
   p2: straight_L40_N2_CSstrip_281000_m106500,o1
 - p1: straight_L100_N2_CSstrip_321000_0,o1
   p2: straight_L40_N2_CSstrip_281000_0,o2
 - p1: straight_L100_N2_CSstrip_321000_0,o2
-  p2: straight_L7p25_N2_CSstrip_W0p5_428250_0,o2
+  p2: straight_L7p25_N2_CSstrip_428250_0,o2
 - p1: straight_L40_N2_CSstrip_281000_m106500,o2
   p2: straight_pin_L100_CSpin_f2ba7e88_331000_m106500,o1
-- p1: straight_L7p25_N2_CSstrip_W0p5_428250_m106500,o2
+- p1: straight_L7p25_N2_CSstrip_428250_m106500,o2
   p2: straight_pin_L100_CSpin_f2ba7e88_331000_m106500,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_428250_0:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0:
     mirror: true
     rotation: 0
     x: 428.25
     y: 0
-  bend_euler_R10_A90_P0p5_f9fcb00b_428250_m106500:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500:
     mirror: false
     rotation: 0
     x: 428.25
     y: -106.5
-  bend_euler_R10_A90_P0p5_f9fcb00b_438250_m42625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625:
     mirror: false
     rotation: 270
     x: 438.25
     y: -42.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_438250_m63875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875:
     mirror: true
     rotation: 90
     x: 438.25
     y: -63.875
-  bend_euler_R10_A90_P0p5_f9fcb00b_m17250_0:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0:
     mirror: false
     rotation: 180
     x: -17.25
     y: 0
-  bend_euler_R10_A90_P0p5_f9fcb00b_m17250_m106500:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500:
     mirror: true
     rotation: 180
     x: -17.25
     y: -106.5
-  bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m42625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625:
     mirror: true
     rotation: 270
     x: -27.25
     y: -42.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_m27250_m63875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875:
     mirror: false
     rotation: 90
     x: -27.25
@@ -552,22 +544,22 @@ placements:
     rotation: 0
     x: 321
     y: 0
-  straight_L32p625_N2_CSstrip_W0p5_438250_m10000:
+  straight_L32p625_N2_CSstrip_438250_m10000:
     mirror: false
     rotation: 270
     x: 438.25
     y: -10
-  straight_L32p625_N2_CSstrip_W0p5_438250_m96500:
+  straight_L32p625_N2_CSstrip_438250_m96500:
     mirror: false
     rotation: 90
     x: 438.25
     y: -96.5
-  straight_L32p625_N2_CSstrip_W0p5_m27250_m10000:
+  straight_L32p625_N2_CSstrip_m27250_m10000:
     mirror: false
     rotation: 270
     x: -27.25
     y: -10
-  straight_L32p625_N2_CSstrip_W0p5_m27250_m96500:
+  straight_L32p625_N2_CSstrip_m27250_m96500:
     mirror: false
     rotation: 90
     x: -27.25
@@ -582,22 +574,22 @@ placements:
     rotation: 0
     x: 281
     y: -106.5
-  straight_L7p25_N2_CSstrip_W0p5_428250_0:
+  straight_L7p25_N2_CSstrip_428250_0:
     mirror: false
     rotation: 180
     x: 428.25
     y: 0
-  straight_L7p25_N2_CSstrip_W0p5_428250_m106500:
+  straight_L7p25_N2_CSstrip_428250_m106500:
     mirror: false
     rotation: 180
     x: 428.25
     y: -106.5
-  straight_L7p25_N2_CSstrip_W0p5_m17250_0:
+  straight_L7p25_N2_CSstrip_m17250_0:
     mirror: false
     rotation: 0
     x: -17.25
     y: 0
-  straight_L7p25_N2_CSstrip_W0p5_m17250_m106500:
+  straight_L7p25_N2_CSstrip_m17250_m106500:
     mirror: false
     rotation: 0
     x: -17.25

--- a/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R30_A90_P0p5_cf61f3e7_0_889000:
+  bend_euler_R30_A90_P0p5_6f642382_0_889000:
     component: bend_euler
     info:
       dy: 30
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R30_A90_P0p5_cf61f3e7_m1000_127000:
+  bend_euler_R30_A90_P0p5_6f642382_m1000_127000:
     component: bend_euler
     info:
       dy: 30
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R30_A90_P0p5_cf61f3e7_m30000_792000:
+  bend_euler_R30_A90_P0p5_6f642382_m30000_792000:
     component: bend_euler
     info:
       dy: 30
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R30_A90_P0p5_cf61f3e7_m31000_30000:
+  bend_euler_R30_A90_P0p5_6f642382_m31000_30000:
     component: bend_euler
     info:
       dy: 30
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   extend_ports_Cedge_coup_a17a8c07_0_0:
     component: extend_ports
@@ -113,7 +113,7 @@ instances:
       - o1
       - o2
       port_type: optical
-  straight_L67_N2_CSstrip_W0p5_m30000_859000:
+  straight_L67_N2_CSstrip_m30000_859000:
     component: straight
     info:
       length: 67
@@ -126,8 +126,7 @@ instances:
       cross_section: strip
       length: 67
       npoints: 2
-      width: 0.5
-  straight_L67_N2_CSstrip_W0p5_m31000_97000:
+  straight_L67_N2_CSstrip_m31000_97000:
     component: straight
     info:
       length: 67
@@ -140,42 +139,41 @@ instances:
       cross_section: strip
       length: 67
       npoints: 2
-      width: 0.5
 name: edge_coupler_array_with_0e29eb5f
 nets:
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_0_889000,o1
+- p1: bend_euler_R30_A90_P0p5_6f642382_0_889000,o1
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o8
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_0_889000,o2
-  p2: straight_L67_N2_CSstrip_W0p5_m30000_859000,o1
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m1000_127000,o1
+- p1: bend_euler_R30_A90_P0p5_6f642382_0_889000,o2
+  p2: straight_L67_N2_CSstrip_m30000_859000,o1
+- p1: bend_euler_R30_A90_P0p5_6f642382_m1000_127000,o1
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o2
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m1000_127000,o2
-  p2: straight_L67_N2_CSstrip_W0p5_m31000_97000,o1
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m30000_792000,o1
-  p2: straight_L67_N2_CSstrip_W0p5_m30000_859000,o2
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m30000_792000,o2
+- p1: bend_euler_R30_A90_P0p5_6f642382_m1000_127000,o2
+  p2: straight_L67_N2_CSstrip_m31000_97000,o1
+- p1: bend_euler_R30_A90_P0p5_6f642382_m30000_792000,o1
+  p2: straight_L67_N2_CSstrip_m30000_859000,o2
+- p1: bend_euler_R30_A90_P0p5_6f642382_m30000_792000,o2
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o7
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m31000_30000,o1
-  p2: straight_L67_N2_CSstrip_W0p5_m31000_97000,o2
-- p1: bend_euler_R30_A90_P0p5_cf61f3e7_m31000_30000,o2
+- p1: bend_euler_R30_A90_P0p5_6f642382_m31000_30000,o1
+  p2: straight_L67_N2_CSstrip_m31000_97000,o2
+- p1: bend_euler_R30_A90_P0p5_6f642382_m31000_30000,o2
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o1
 placements:
-  bend_euler_R30_A90_P0p5_cf61f3e7_0_889000:
+  bend_euler_R30_A90_P0p5_6f642382_0_889000:
     mirror: false
     rotation: 180
     x: 0
     y: 889
-  bend_euler_R30_A90_P0p5_cf61f3e7_m1000_127000:
+  bend_euler_R30_A90_P0p5_6f642382_m1000_127000:
     mirror: false
     rotation: 180
     x: -1
     y: 127
-  bend_euler_R30_A90_P0p5_cf61f3e7_m30000_792000:
+  bend_euler_R30_A90_P0p5_6f642382_m30000_792000:
     mirror: false
     rotation: 270
     x: -30
     y: 792
-  bend_euler_R30_A90_P0p5_cf61f3e7_m31000_30000:
+  bend_euler_R30_A90_P0p5_6f642382_m31000_30000:
     mirror: false
     rotation: 270
     x: -31
@@ -185,12 +183,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L67_N2_CSstrip_W0p5_m30000_859000:
+  straight_L67_N2_CSstrip_m30000_859000:
     mirror: false
     rotation: 270
     x: -30
     y: 859
-  straight_L67_N2_CSstrip_W0p5_m31000_97000:
+  straight_L67_N2_CSstrip_m31000_97000:
     mirror: false
     rotation: 270
     x: -31

--- a/test-data-regression/test_netlists_grating_coupler_loss_fiber_array_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_loss_fiber_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -45,7 +45,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   grating_coupler_ellipti_7b8aa449_0_0:
     component: grating_coupler_elliptical_trenches
@@ -91,7 +91,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_W0p5_117000_49529:
+  straight_L107_N2_CSstrip_117000_49529:
     component: straight
     info:
       length: 107
@@ -104,8 +104,7 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     component: straight
     info:
       length: 40
@@ -118,8 +117,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_127000_39529:
+  straight_L40_N2_CSstrip_127000_39529:
     component: straight
     info:
       length: 40
@@ -132,28 +130,27 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
 name: grating_coupler_loss_fi_1149cf5f
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o1
-  p2: straight_L107_N2_CSstrip_W0p5_117000_49529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529,o1
-  p2: straight_L40_N2_CSstrip_W0p5_127000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529,o2
-  p2: straight_L107_N2_CSstrip_W0p5_117000_49529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
+  p2: straight_L107_N2_CSstrip_117000_49529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o1
+  p2: straight_L40_N2_CSstrip_127000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o2
+  p2: straight_L107_N2_CSstrip_117000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_127000_39529,o2
+  p2: straight_L40_N2_CSstrip_127000_39529,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
     rotation: 180
     x: 10
     y: 49.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529:
     mirror: false
     rotation: 90
     x: 127
@@ -168,17 +165,17 @@ placements:
     rotation: 270
     x: 127
     y: 0
-  straight_L107_N2_CSstrip_W0p5_117000_49529:
+  straight_L107_N2_CSstrip_117000_49529:
     mirror: false
     rotation: 180
     x: 117
     y: 49.529
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_127000_39529:
+  straight_L40_N2_CSstrip_127000_39529:
     mirror: false
     rotation: 270
     x: 127

--- a/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/test-data-regression/test_netlists_loop_mirror_.yml
@@ -108,7 +108,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L1p25_N2_CSstrip_W0p5_45500_m9375:
+  straight_L1p25_N2_CSstrip_45500_m9375:
     component: straight
     info:
       length: 1.25
@@ -121,8 +121,7 @@ instances:
       cross_section: strip
       length: 1.25
       npoints: 2
-      width: 0.5
-  straight_L20_N2_CSstrip_W0p5_35500_625:
+  straight_L20_N2_CSstrip_35500_625:
     component: straight
     info:
       length: 20
@@ -135,7 +134,6 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-      width: 0.5
 name: loop_mirror_Cmmi1x2_Bbe_15330a29
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625,o1
@@ -143,15 +141,15 @@ nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o3
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_625,o1
-  p2: straight_L20_N2_CSstrip_W0p5_35500_625,o1
+  p2: straight_L20_N2_CSstrip_35500_625,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_625,o2
-  p2: straight_L1p25_N2_CSstrip_W0p5_45500_m9375,o1
+  p2: straight_L1p25_N2_CSstrip_45500_m9375,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_m20625,o1
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_45500_m10625,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_45500_m10625,o1
-  p2: straight_L1p25_N2_CSstrip_W0p5_45500_m9375,o2
+  p2: straight_L1p25_N2_CSstrip_45500_m9375,o2
 - p1: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o2
-  p2: straight_L20_N2_CSstrip_W0p5_35500_625,o2
+  p2: straight_L20_N2_CSstrip_35500_625,o2
 placements:
   bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625:
     mirror: false
@@ -178,12 +176,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L1p25_N2_CSstrip_W0p5_45500_m9375:
+  straight_L1p25_N2_CSstrip_45500_m9375:
     mirror: false
     rotation: 270
     x: 45.5
     y: -9.375
-  straight_L20_N2_CSstrip_W0p5_35500_625:
+  straight_L20_N2_CSstrip_35500_625:
     mirror: false
     rotation: 180
     x: 35.5

--- a/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_264000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   grating_coupler_ellipti_7b8aa449_0_0:
     component: grating_coupler_elliptical_trenches
@@ -183,7 +183,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_W0p5_117000_49529:
+  straight_L107_N2_CSstrip_117000_49529:
     component: straight
     info:
       length: 107
@@ -196,8 +196,7 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: 0.5
-  straight_L107_N2_CSstrip_W0p5_371000_49529:
+  straight_L107_N2_CSstrip_371000_49529:
     component: straight
     info:
       length: 107
@@ -210,8 +209,7 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     component: straight
     info:
       length: 40
@@ -224,8 +222,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_127000_39529:
+  straight_L40_N2_CSstrip_127000_39529:
     component: straight
     info:
       length: 40
@@ -238,8 +235,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_254000_39529:
+  straight_L40_N2_CSstrip_254000_39529:
     component: straight
     info:
       length: 40
@@ -252,8 +248,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_381000_39529:
+  straight_L40_N2_CSstrip_381000_39529:
     component: straight
     info:
       length: 40
@@ -266,50 +261,49 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
 name: loss_deembedding_ch12_3_0220c4ef
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o1
-  p2: straight_L107_N2_CSstrip_W0p5_117000_49529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529,o1
-  p2: straight_L40_N2_CSstrip_W0p5_127000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529,o2
-  p2: straight_L107_N2_CSstrip_W0p5_117000_49529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_264000_49529,o1
-  p2: straight_L107_N2_CSstrip_W0p5_371000_49529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_264000_49529,o2
-  p2: straight_L40_N2_CSstrip_W0p5_254000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529,o1
-  p2: straight_L40_N2_CSstrip_W0p5_381000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529,o2
-  p2: straight_L107_N2_CSstrip_W0p5_371000_49529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
+  p2: straight_L107_N2_CSstrip_117000_49529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o1
+  p2: straight_L40_N2_CSstrip_127000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o2
+  p2: straight_L107_N2_CSstrip_117000_49529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529,o1
+  p2: straight_L107_N2_CSstrip_371000_49529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529,o2
+  p2: straight_L40_N2_CSstrip_254000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o1
+  p2: straight_L40_N2_CSstrip_381000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o2
+  p2: straight_L107_N2_CSstrip_371000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_127000_39529,o2
+  p2: straight_L40_N2_CSstrip_127000_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_254000_39529,o2
+  p2: straight_L40_N2_CSstrip_254000_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_381000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_381000_39529,o2
+  p2: straight_L40_N2_CSstrip_381000_39529,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
     rotation: 180
     x: 10
     y: 49.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_127000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529:
     mirror: false
     rotation: 90
     x: 127
     y: 39.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_264000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529:
     mirror: false
     rotation: 180
     x: 264
     y: 49.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529:
     mirror: false
     rotation: 90
     x: 381
@@ -334,32 +328,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L107_N2_CSstrip_W0p5_117000_49529:
+  straight_L107_N2_CSstrip_117000_49529:
     mirror: false
     rotation: 180
     x: 117
     y: 49.529
-  straight_L107_N2_CSstrip_W0p5_371000_49529:
+  straight_L107_N2_CSstrip_371000_49529:
     mirror: false
     rotation: 180
     x: 371
     y: 49.529
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_127000_39529:
+  straight_L40_N2_CSstrip_127000_39529:
     mirror: false
     rotation: 270
     x: 127
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_254000_39529:
+  straight_L40_N2_CSstrip_254000_39529:
     mirror: false
     rotation: 270
     x: 254
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_381000_39529:
+  straight_L40_N2_CSstrip_381000_39529:
     mirror: false
     rotation: 270
     x: 381

--- a/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_254000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -45,7 +45,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   bend_euler_RNone_A90_P0_d7c3a5a9_107000_m471:
     component: bend_euler
@@ -279,7 +279,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L234_N2_CSstrip_W0p5_244000_49529:
+  straight_L234_N2_CSstrip_244000_49529:
     component: straight
     info:
       length: 234
@@ -292,8 +292,7 @@ instances:
       cross_section: strip
       length: 234
       npoints: 2
-      width: 0.5
-  straight_L274_N2_CSstrip_W0p5_391000_m46417:
+  straight_L274_N2_CSstrip_391000_m46417:
     component: straight
     info:
       length: 274
@@ -306,8 +305,7 @@ instances:
       cross_section: strip
       length: 274
       npoints: 2
-      width: 0.5
-  straight_L35p946_N2_CSstrip_W0p5_107000_m36417:
+  straight_L35p946_N2_CSstrip_107000_m36417:
     component: straight
     info:
       length: 35.946
@@ -320,8 +318,7 @@ instances:
       cross_section: strip
       length: 35.946
       npoints: 2
-      width: 0.5
-  straight_L35p946_N2_CSstrip_W0p5_401000_m471:
+  straight_L35p946_N2_CSstrip_401000_m471:
     component: straight
     info:
       length: 35.946
@@ -334,8 +331,7 @@ instances:
       cross_section: strip
       length: 35.946
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     component: straight
     info:
       length: 40
@@ -348,8 +344,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_254000_39529:
+  straight_L40_N2_CSstrip_254000_39529:
     component: straight
     info:
       length: 40
@@ -362,48 +357,47 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
 name: loss_deembedding_ch13_2_f0d5a16c
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o1
-  p2: straight_L234_N2_CSstrip_W0p5_244000_49529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_254000_39529,o1
-  p2: straight_L40_N2_CSstrip_W0p5_254000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_254000_39529,o2
-  p2: straight_L234_N2_CSstrip_W0p5_244000_49529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
+  p2: straight_L234_N2_CSstrip_244000_49529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529,o1
+  p2: straight_L40_N2_CSstrip_254000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529,o2
+  p2: straight_L234_N2_CSstrip_244000_49529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_107000_m471,o1
-  p2: straight_L35p946_N2_CSstrip_W0p5_107000_m36417,o2
+  p2: straight_L35p946_N2_CSstrip_107000_m36417,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_107000_m471,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_117000_9529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_9529,o2
   p2: grating_coupler_ellipti_7b8aa449_127000_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_m46417,o1
-  p2: straight_L274_N2_CSstrip_W0p5_391000_m46417,o2
+  p2: straight_L274_N2_CSstrip_391000_m46417,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_m46417,o2
-  p2: straight_L35p946_N2_CSstrip_W0p5_107000_m36417,o1
+  p2: straight_L35p946_N2_CSstrip_107000_m36417,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_381000_m471,o1
   p2: grating_coupler_ellipti_7b8aa449_381000_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_381000_m471,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_391000_9529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_391000_9529,o2
-  p2: straight_L35p946_N2_CSstrip_W0p5_401000_m471,o1
+  p2: straight_L35p946_N2_CSstrip_401000_m471,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_401000_m36417,o1
-  p2: straight_L35p946_N2_CSstrip_W0p5_401000_m471,o2
+  p2: straight_L35p946_N2_CSstrip_401000_m471,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_401000_m36417,o2
-  p2: straight_L274_N2_CSstrip_W0p5_391000_m46417,o1
+  p2: straight_L274_N2_CSstrip_391000_m46417,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_254000_39529,o2
+  p2: straight_L40_N2_CSstrip_254000_39529,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
     rotation: 180
     x: 10
     y: 49.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_254000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529:
     mirror: false
     rotation: 90
     x: 254
@@ -458,32 +452,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L234_N2_CSstrip_W0p5_244000_49529:
+  straight_L234_N2_CSstrip_244000_49529:
     mirror: false
     rotation: 180
     x: 244
     y: 49.529
-  straight_L274_N2_CSstrip_W0p5_391000_m46417:
+  straight_L274_N2_CSstrip_391000_m46417:
     mirror: false
     rotation: 180
     x: 391
     y: -46.417
-  straight_L35p946_N2_CSstrip_W0p5_107000_m36417:
+  straight_L35p946_N2_CSstrip_107000_m36417:
     mirror: false
     rotation: 90
     x: 107
     y: -36.417
-  straight_L35p946_N2_CSstrip_W0p5_401000_m471:
+  straight_L35p946_N2_CSstrip_401000_m471:
     mirror: false
     rotation: 270
     x: 401
     y: -0.471
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_254000_39529:
+  straight_L40_N2_CSstrip_254000_39529:
     mirror: false
     rotation: 270
     x: 254

--- a/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_137000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_254000_29529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529:
     component: bend_euler
     info:
       dy: 10
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   grating_coupler_ellipti_7b8aa449_0_0:
     component: grating_coupler_elliptical_trenches
@@ -183,7 +183,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_W0p5_244000_39529:
+  straight_L107_N2_CSstrip_244000_39529:
     component: straight
     info:
       length: 107
@@ -196,8 +196,7 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: 0.5
-  straight_L30_N2_CSstrip_W0p5_127000_29529:
+  straight_L30_N2_CSstrip_127000_29529:
     component: straight
     info:
       length: 30
@@ -210,8 +209,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
-      width: 0.5
-  straight_L30_N2_CSstrip_W0p5_254000_29529:
+  straight_L30_N2_CSstrip_254000_29529:
     component: straight
     info:
       length: 30
@@ -224,8 +222,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
-      width: 0.5
-  straight_L361_N2_CSstrip_W0p5_371000_49529:
+  straight_L361_N2_CSstrip_371000_49529:
     component: straight
     info:
       length: 361
@@ -238,8 +235,7 @@ instances:
       cross_section: strip
       length: 361
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     component: straight
     info:
       length: 40
@@ -252,8 +248,7 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
-  straight_L40_N2_CSstrip_W0p5_381000_39529:
+  straight_L40_N2_CSstrip_381000_39529:
     component: straight
     info:
       length: 40
@@ -266,50 +261,49 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-      width: 0.5
 name: loss_deembedding_ch14_2_d0b63223
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o1
-  p2: straight_L361_N2_CSstrip_W0p5_371000_49529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_137000_39529,o1
-  p2: straight_L107_N2_CSstrip_W0p5_244000_39529,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_137000_39529,o2
-  p2: straight_L30_N2_CSstrip_W0p5_127000_29529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_254000_29529,o1
-  p2: straight_L30_N2_CSstrip_W0p5_254000_29529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_254000_29529,o2
-  p2: straight_L107_N2_CSstrip_W0p5_244000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529,o1
-  p2: straight_L40_N2_CSstrip_W0p5_381000_39529,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529,o2
-  p2: straight_L361_N2_CSstrip_W0p5_371000_49529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
+  p2: straight_L361_N2_CSstrip_371000_49529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529,o1
+  p2: straight_L107_N2_CSstrip_244000_39529,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529,o2
+  p2: straight_L30_N2_CSstrip_127000_29529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529,o1
+  p2: straight_L30_N2_CSstrip_254000_29529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529,o2
+  p2: straight_L107_N2_CSstrip_244000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o1
+  p2: straight_L40_N2_CSstrip_381000_39529,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o2
+  p2: straight_L361_N2_CSstrip_371000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_0_39529,o2
+  p2: straight_L40_N2_CSstrip_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L30_N2_CSstrip_W0p5_127000_29529,o2
+  p2: straight_L30_N2_CSstrip_127000_29529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L30_N2_CSstrip_W0p5_254000_29529,o2
+  p2: straight_L30_N2_CSstrip_254000_29529,o2
 - p1: grating_coupler_ellipti_7b8aa449_381000_0,o1
-  p2: straight_L40_N2_CSstrip_W0p5_381000_39529,o2
+  p2: straight_L40_N2_CSstrip_381000_39529,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_10000_49529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
     rotation: 180
     x: 10
     y: 49.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_137000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529:
     mirror: false
     rotation: 180
     x: 137
     y: 39.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_254000_29529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529:
     mirror: false
     rotation: 90
     x: 254
     y: 29.529
-  bend_euler_R10_A90_P0p5_f9fcb00b_381000_39529:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529:
     mirror: false
     rotation: 90
     x: 381
@@ -334,32 +328,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L107_N2_CSstrip_W0p5_244000_39529:
+  straight_L107_N2_CSstrip_244000_39529:
     mirror: false
     rotation: 180
     x: 244
     y: 39.529
-  straight_L30_N2_CSstrip_W0p5_127000_29529:
+  straight_L30_N2_CSstrip_127000_29529:
     mirror: false
     rotation: 270
     x: 127
     y: 29.529
-  straight_L30_N2_CSstrip_W0p5_254000_29529:
+  straight_L30_N2_CSstrip_254000_29529:
     mirror: false
     rotation: 270
     x: 254
     y: 29.529
-  straight_L361_N2_CSstrip_W0p5_371000_49529:
+  straight_L361_N2_CSstrip_371000_49529:
     mirror: false
     rotation: 180
     x: 371
     y: 49.529
-  straight_L40_N2_CSstrip_W0p5_0_39529:
+  straight_L40_N2_CSstrip_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_W0p5_381000_39529:
+  straight_L40_N2_CSstrip_381000_39529:
     mirror: false
     rotation: 270
     x: 381

--- a/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/test-data-regression/test_netlists_splitter_tree_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_25500_10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_25500_m10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_35500_25000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_35500_m25000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000:
     component: bend_euler
     info:
       dy: 10
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   bend_s_S90_11p875_N99_C_62bc90bd_105500_24375:
     component: bend_s
@@ -214,7 +214,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L44p5_N2_CSstrip_W0p5_35500_25000:
+  straight_L44p5_N2_CSstrip_35500_25000:
     component: straight
     info:
       length: 44.5
@@ -227,8 +227,7 @@ instances:
       cross_section: strip
       length: 44.5
       npoints: 2
-      width: 0.5
-  straight_L44p5_N2_CSstrip_W0p5_35500_m25000:
+  straight_L44p5_N2_CSstrip_35500_m25000:
     component: straight
     info:
       length: 44.5
@@ -241,8 +240,7 @@ instances:
       cross_section: strip
       length: 44.5
       npoints: 2
-      width: 0.5
-  straight_L4p375_N2_CSstrip_W0p5_25500_15000:
+  straight_L4p375_N2_CSstrip_25500_15000:
     component: straight
     info:
       length: 4.375
@@ -255,8 +253,7 @@ instances:
       cross_section: strip
       length: 4.375
       npoints: 2
-      width: 0.5
-  straight_L4p375_N2_CSstrip_W0p5_25500_m15000:
+  straight_L4p375_N2_CSstrip_25500_m15000:
     component: straight
     info:
       length: 4.375
@@ -269,25 +266,24 @@ instances:
       cross_section: strip
       length: 4.375
       npoints: 2
-      width: 0.5
 name: splitter_tree_Cmmi1x2_N_4888501b
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_25500_10625,o1
-  p2: straight_L4p375_N2_CSstrip_W0p5_25500_15000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_25500_10625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625,o1
+  p2: straight_L4p375_N2_CSstrip_25500_15000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625,o2
   p2: coupler_0_0,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_25500_m10625,o1
-  p2: straight_L4p375_N2_CSstrip_W0p5_25500_m15000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_25500_m10625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625,o1
+  p2: straight_L4p375_N2_CSstrip_25500_m15000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625,o2
   p2: coupler_0_0,o3
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_35500_25000,o1
-  p2: straight_L44p5_N2_CSstrip_W0p5_35500_25000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_35500_25000,o2
-  p2: straight_L4p375_N2_CSstrip_W0p5_25500_15000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_35500_m25000,o1
-  p2: straight_L44p5_N2_CSstrip_W0p5_35500_m25000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_35500_m25000,o2
-  p2: straight_L4p375_N2_CSstrip_W0p5_25500_m15000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000,o1
+  p2: straight_L44p5_N2_CSstrip_35500_25000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000,o2
+  p2: straight_L4p375_N2_CSstrip_25500_15000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000,o1
+  p2: straight_L44p5_N2_CSstrip_35500_m25000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000,o2
+  p2: straight_L4p375_N2_CSstrip_25500_m15000,o1
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_24375,o1
   p2: coupler_1_1,o3
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_25625,o1
@@ -297,26 +293,26 @@ nets:
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_m25625,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
-  p2: straight_L44p5_N2_CSstrip_W0p5_35500_m25000,o2
+  p2: straight_L44p5_N2_CSstrip_35500_m25000,o2
 - p1: coupler_1_1,o1
-  p2: straight_L44p5_N2_CSstrip_W0p5_35500_25000,o2
+  p2: straight_L44p5_N2_CSstrip_35500_25000,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_25500_10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625:
     mirror: true
     rotation: 270
     x: 25.5
     y: 10.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_25500_m10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625:
     mirror: false
     rotation: 90
     x: 25.5
     y: -10.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_35500_25000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000:
     mirror: false
     rotation: 180
     x: 35.5
     y: 25
-  bend_euler_R10_A90_P0p5_f9fcb00b_35500_m25000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000:
     mirror: true
     rotation: 180
     x: 35.5
@@ -356,22 +352,22 @@ placements:
     rotation: 0
     x: 90
     y: 25
-  straight_L44p5_N2_CSstrip_W0p5_35500_25000:
+  straight_L44p5_N2_CSstrip_35500_25000:
     mirror: false
     rotation: 0
     x: 35.5
     y: 25
-  straight_L44p5_N2_CSstrip_W0p5_35500_m25000:
+  straight_L44p5_N2_CSstrip_35500_m25000:
     mirror: false
     rotation: 0
     x: 35.5
     y: -25
-  straight_L4p375_N2_CSstrip_W0p5_25500_15000:
+  straight_L4p375_N2_CSstrip_25500_15000:
     mirror: false
     rotation: 270
     x: 25.5
     y: 15
-  straight_L4p375_N2_CSstrip_W0p5_25500_m15000:
+  straight_L4p375_N2_CSstrip_25500_m15000:
     mirror: false
     rotation: 90
     x: 25.5

--- a/test-data-regression/test_netlists_switch_tree_.yml
+++ b/test-data-regression/test_netlists_switch_tree_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_f9fcb00b_411000_10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625:
     component: bend_euler
     info:
       dy: 10
@@ -21,9 +21,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_411000_m10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625:
     component: bend_euler
     info:
       dy: 10
@@ -45,9 +45,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_421000_50000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000:
     component: bend_euler
     info:
       dy: 10
@@ -69,9 +69,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
-  bend_euler_R10_A90_P0p5_f9fcb00b_421000_m50000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000:
     component: bend_euler
     info:
       dy: 10
@@ -93,7 +93,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: 0.5
+      width: null
       with_arc_floorplan: true
   bend_s_S500_24p375_N99__7434ea4c_901000_49375:
     component: bend_s
@@ -262,7 +262,7 @@ instances:
       straight_x_top: Fstraight_heater_metal_undercut_Mgdsfactorypcomponentspstraight_heater_metal_SWUFalse_LSI0p1_LU5_LUS0
       straight_y: null
       with_splitter: true
-  straight_L29p375_N2_CSstrip_W0p5_411000_40000:
+  straight_L29p375_N2_CSstrip_411000_40000:
     component: straight
     info:
       length: 29.375
@@ -275,8 +275,7 @@ instances:
       cross_section: strip
       length: 29.375
       npoints: 2
-      width: 0.5
-  straight_L29p375_N2_CSstrip_W0p5_411000_m40000:
+  straight_L29p375_N2_CSstrip_411000_m40000:
     component: straight
     info:
       length: 29.375
@@ -289,8 +288,7 @@ instances:
       cross_section: strip
       length: 29.375
       npoints: 2
-      width: 0.5
-  straight_L69_N2_CSstrip_W0p5_421000_50000:
+  straight_L69_N2_CSstrip_421000_50000:
     component: straight
     info:
       length: 69
@@ -303,8 +301,7 @@ instances:
       cross_section: strip
       length: 69
       npoints: 2
-      width: 0.5
-  straight_L69_N2_CSstrip_W0p5_421000_m50000:
+  straight_L69_N2_CSstrip_421000_m50000:
     component: straight
     info:
       length: 69
@@ -317,25 +314,24 @@ instances:
       cross_section: strip
       length: 69
       npoints: 2
-      width: 0.5
 name: splitter_tree_CFmzi_Mgd_25171b11
 nets:
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_411000_10625,o1
-  p2: straight_L29p375_N2_CSstrip_W0p5_411000_40000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_411000_10625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625,o1
+  p2: straight_L29p375_N2_CSstrip_411000_40000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625,o2
   p2: coupler_0_0,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_411000_m10625,o1
-  p2: straight_L29p375_N2_CSstrip_W0p5_411000_m40000,o2
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_411000_m10625,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625,o1
+  p2: straight_L29p375_N2_CSstrip_411000_m40000,o2
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625,o2
   p2: coupler_0_0,o3
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_421000_50000,o1
-  p2: straight_L69_N2_CSstrip_W0p5_421000_50000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_421000_50000,o2
-  p2: straight_L29p375_N2_CSstrip_W0p5_411000_40000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_421000_m50000,o1
-  p2: straight_L69_N2_CSstrip_W0p5_421000_m50000,o1
-- p1: bend_euler_R10_A90_P0p5_f9fcb00b_421000_m50000,o2
-  p2: straight_L29p375_N2_CSstrip_W0p5_411000_m40000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000,o1
+  p2: straight_L69_N2_CSstrip_421000_50000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000,o2
+  p2: straight_L29p375_N2_CSstrip_411000_40000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000,o1
+  p2: straight_L69_N2_CSstrip_421000_m50000,o1
+- p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000,o2
+  p2: straight_L29p375_N2_CSstrip_411000_m40000,o1
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_49375,o1
   p2: coupler_1_1,o3
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_50625,o1
@@ -345,26 +341,26 @@ nets:
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_m50625,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
-  p2: straight_L69_N2_CSstrip_W0p5_421000_m50000,o2
+  p2: straight_L69_N2_CSstrip_421000_m50000,o2
 - p1: coupler_1_1,o1
-  p2: straight_L69_N2_CSstrip_W0p5_421000_50000,o2
+  p2: straight_L69_N2_CSstrip_421000_50000,o2
 placements:
-  bend_euler_R10_A90_P0p5_f9fcb00b_411000_10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625:
     mirror: true
     rotation: 270
     x: 411
     y: 10.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_411000_m10625:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625:
     mirror: false
     rotation: 90
     x: 411
     y: -10.625
-  bend_euler_R10_A90_P0p5_f9fcb00b_421000_50000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000:
     mirror: false
     rotation: 180
     x: 421
     y: 50
-  bend_euler_R10_A90_P0p5_f9fcb00b_421000_m50000:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000:
     mirror: true
     rotation: 180
     x: 421
@@ -404,22 +400,22 @@ placements:
     rotation: 0
     x: 500
     y: 50
-  straight_L29p375_N2_CSstrip_W0p5_411000_40000:
+  straight_L29p375_N2_CSstrip_411000_40000:
     mirror: false
     rotation: 270
     x: 411
     y: 40
-  straight_L29p375_N2_CSstrip_W0p5_411000_m40000:
+  straight_L29p375_N2_CSstrip_411000_m40000:
     mirror: false
     rotation: 90
     x: 411
     y: -40
-  straight_L69_N2_CSstrip_W0p5_421000_50000:
+  straight_L69_N2_CSstrip_421000_50000:
     mirror: false
     rotation: 0
     x: 421
     y: 50
-  straight_L69_N2_CSstrip_W0p5_421000_m50000:
+  straight_L69_N2_CSstrip_421000_m50000:
     mirror: false
     rotation: 0
     x: 421

--- a/test-data-regression/test_settings_add_electrical_pads_shortest_.yml
+++ b/test-data-regression/test_settings_add_electrical_pads_shortest_.yml
@@ -1,47 +1,18 @@
-function: add_electrical_pads_shortest
-info: {}
-module: gdsfactory.routing.add_electrical_pads_shortest
-name: mzi_add_electrical_pads_shortest_componentmzi_669c248e
+info:
+  length: 200
+  route_info_length: 200
+  route_info_metal_routing_length: 200
+  route_info_type: metal_routing
+  route_info_weight: 200
+  width: 10
+name: add_electrical_pads_sho_823c7cb1
 settings:
-  component:
-    function: mzi
-    module: gdsfactory.components.mzi
-    settings:
-      add_electrical_ports_bot: true
-      add_optical_ports_arms: false
-      bend:
-        function: bend_euler
-      combiner:
-        function: mmi2x2
-      cross_section: strip
-      cross_section_x_bot: null
-      cross_section_x_top: null
-      delta_length: 10.0
-      extend_ports_straight_x: null
-      length_x: 100
-      length_y: 2.0
-      min_length: 0.01
-      mirror_bot: false
-      nbends: 2
-      port_e0_combiner: o4
-      port_e0_splitter: o4
-      port_e1_combiner: o3
-      port_e1_splitter: o3
-      splitter:
-        function: mmi2x2
-      straight:
-        function: straight
-      straight_x_bot: null
-      straight_x_top: straight_heater_metal
-      straight_y: null
-      with_splitter: true
+  component: Fstraight_Mgdsfactorypcomponentspstraight_SCSmetal_routing_L200
   layer: M3
   pad: pad
-  pad_port_spacing: 50.0
-  port_names: null
+  pad_port_spacing: 50
+  pad_size:
+  - 100
+  - 100
   port_orientation: 90
-  select_ports:
-    function: select_ports
-    module: gdsfactory.port
-    settings:
-      port_type: electrical
+  select_ports: Fselect_ports_Mgdsfactorypport_SPTelectrical

--- a/test-data-regression/test_settings_add_electrical_pads_top_.yml
+++ b/test-data-regression/test_settings_add_electrical_pads_top_.yml
@@ -1,50 +1,9 @@
-function: add_electrical_pads_top
-info: {}
-module: gdsfactory.routing.add_electrical_pads_top
-name: mzi_add_electrical_pads_top_componentmzi_669c248e
-settings:
-  component:
-    function: mzi
-    module: gdsfactory.components.mzi
-    settings:
-      add_electrical_ports_bot: true
-      add_optical_ports_arms: false
-      bend:
-        function: bend_euler
-      combiner:
-        function: mmi2x2
-      cross_section: strip
-      cross_section_x_bot: null
-      cross_section_x_top: null
-      delta_length: 10.0
-      extend_ports_straight_x: null
-      length_x: 100
-      length_y: 2.0
-      min_length: 0.01
-      mirror_bot: false
-      nbends: 2
-      port_e0_combiner: o4
-      port_e0_splitter: o4
-      port_e1_combiner: o3
-      port_e1_splitter: o3
-      splitter:
-        function: mmi2x2
-      straight:
-        function: straight
-      straight_x_bot: null
-      straight_x_top: straight_heater_metal
-      straight_y: null
-      with_splitter: true
-  direction: top
-  layer: MTOP
-  pad_array:
-    function: pad_array
-  port_names: null
-  select_ports:
-    function: select_ports
-    module: gdsfactory.port
-    settings:
-      port_type: electrical
-  spacing:
-    - 0.0
-    - 100.0
+info:
+  length: 200
+  route_info_length: 200
+  route_info_metal_routing_length: 200
+  route_info_type: metal_routing
+  route_info_weight: 200
+  width: 10
+name: Unnamed_1820
+settings: {}

--- a/test-data-regression/test_settings_add_fiber_array_.yml
+++ b/test-data-regression/test_settings_add_fiber_array_.yml
@@ -5,5 +5,5 @@ info:
   route_info_type: strip
   route_info_weight: 10
   width: 0.5
-name: Unnamed_1826
+name: Unnamed_1823
 settings: {}

--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
-from gdsfactory.components import cells
+import gdsfactory as gf
 from gdsfactory.config import PATH
 from gdsfactory.difftest import difftest
+from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json
+
+cells = get_cells([gf.components])
 
 skip_test = {
     "version_stamp",

--- a/tests/components/test_netlists.py
+++ b/tests/components/test_netlists.py
@@ -5,7 +5,9 @@ import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
-from gdsfactory.components import cells
+from gdsfactory.get_factories import get_cells
+
+cells = get_cells([gf.components])
 
 skip_test = {
     "add_fiber_array_optical_south_electrical_north",


### PR DESCRIPTION
## Summary by Sourcery

Remove the width parameter from test netlists and update the CI workflow to use a new make target for testing.

Enhancements:
- Remove the width parameter from various instances in test netlists, setting it to null instead.

CI:
- Update the CI workflow to use a new make target 'uv-test' for running tests with pytest.