### PR TITLE
More consitent cutback parameters

### DIFF
--- a/gdsfactory/components/cutback_bend.py
+++ b/gdsfactory/components/cutback_bend.py
@@ -72,7 +72,7 @@ def cutback_bend(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=90
     )
-    c.info["n_bends"] = rows * cols * 2 + cols * 2 - 2
+    c.info["components"] = rows * cols * 2 + cols * 2 - 2
     return c
 
 
@@ -128,7 +128,7 @@ def cutback_bend90(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=0
     )
-    c.info["n_bends"] = rows * cols * 4
+    c.info["components"] = rows * cols * 4
     return c
 
 
@@ -171,7 +171,7 @@ def staircase(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=0
     )
-    c.info["n_bends"] = 2 * rows
+    c.info["components"] = 2 * rows
     return c
 
 
@@ -230,7 +230,7 @@ def cutback_bend180(
     c = component_sequence(
         sequence=s, symbol_to_component=symbol_to_component, start_orientation=0
     )
-    c.info["n_bends"] = rows * cols * 2 + cols * 2 - 2
+    c.info["components"] = rows * cols * 2 + cols * 2 - 2
     return c
 
 

--- a/test-data-regression/test_settings_cutback_bend180_.yml
+++ b/test-data-regression/test_settings_cutback_bend180_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 82
+  components: 82
 name: cutback_bend180_CFbend__5a8124e5
 settings:
   cols: 6

--- a/test-data-regression/test_settings_cutback_bend180circular_.yml
+++ b/test-data-regression/test_settings_cutback_bend180circular_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 82
+  components: 82
 name: cutback_bend180_CFbend__92908eb9
 settings:
   cols: 6

--- a/test-data-regression/test_settings_cutback_bend90_.yml
+++ b/test-data-regression/test_settings_cutback_bend90_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 144
+  components: 144
 name: cutback_bend90_Cbend_eu_378c1fb8
 settings:
   cols: 6

--- a/test-data-regression/test_settings_cutback_bend90circular_.yml
+++ b/test-data-regression/test_settings_cutback_bend90circular_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 144
+  components: 144
 name: cutback_bend90_Cbend_ci_790928a7
 settings:
   cols: 6

--- a/test-data-regression/test_settings_cutback_bend_.yml
+++ b/test-data-regression/test_settings_cutback_bend_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 68
+  components: 68
 name: cutback_bend_Cbend_eule_117ca8a7
 settings:
   cols: 5

--- a/test-data-regression/test_settings_staircase_.yml
+++ b/test-data-regression/test_settings_staircase_.yml
@@ -1,5 +1,5 @@
 info:
-  n_bends: 8
+  components: 8
 name: staircase_Cbend_euler_S_c2f7854d
 settings:
   component: bend_euler


### PR DESCRIPTION
## Summary by Sourcery

Rename 'n_bends' to 'components' in component info dictionaries and update corresponding test data regression files for consistency.

Enhancements:
- Rename 'n_bends' to 'components' in component info dictionaries for consistency.

Tests:
- Update test data regression files to reflect the renaming of 'n_bends' to 'components'.