### PR TITLE
fix via_bbox_offsets

### DIFF
--- a/gdsfactory/components/via.py
+++ b/gdsfactory/components/via.py
@@ -14,8 +14,9 @@ def via(
     gap: tuple[float, float] | None = None,
     enclosure: float = 1.0,
     layer: LayerSpec = "VIAC",
-    bbox_layers: tuple[tuple[int, int], ...] | None = None,
+    bbox_layers: tuple[LayerSpec, ...] | None = None,
     bbox_offset: float = 0,
+    bbox_offsets: tuple[float, ...] | None = None,
 ) -> Component:
     """Rectangular via.
 
@@ -29,6 +30,7 @@ def via(
         layer: via layer.
         bbox_layers: layers for the bounding box.
         bbox_offset: in um.
+        bbox_offsets: List of offsets for each bbox_layer.
 
     .. code::
 
@@ -65,9 +67,16 @@ def via(
     c.add_polygon([(-a, -b), (a, -b), (a, b), (-a, b)], layer=layer)
 
     bbox_layers = bbox_layers or []
-    a = (width + bbox_offset) / 2
-    b = (height + bbox_offset) / 2
-    for layer in bbox_layers:
+    bbox_offsets = bbox_offsets or [bbox_offset] * len(bbox_layers)
+
+    if len(bbox_offsets) != len(bbox_layers):
+        raise ValueError(
+            f"bbox_offsets {bbox_offsets=} should have the same length as bbox_layers {bbox_layers=}"
+        )
+
+    for layer, bbox_offset in zip(bbox_layers, bbox_offsets):
+        a = (width + 2 * bbox_offset) / 2
+        b = (height + 2 * bbox_offset) / 2
         c.add_polygon([(-a, -b), (a, -b), (a, b), (-a, b)], layer=layer)
 
     return c

--- a/test-data-regression/test_netlists_via1_.yml
+++ b/test-data-regression/test_netlists_via1_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_3d643c37
+name: via_S0p7_0p7_S2_2_GNone_bcb63a01
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via2_.yml
+++ b/test-data-regression/test_netlists_via2_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_c4f19208
+name: via_S0p7_0p7_S2_2_GNone_c1ab00a8
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via_.yml
+++ b/test-data-regression/test_netlists_via_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_6d4c344f
+name: via_S0p7_0p7_S2_2_GNone_8696e860
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via_chain_.yml
+++ b/test-data-regression/test_netlists_via_chain_.yml
@@ -77,7 +77,7 @@ instances:
       size:
       - 6.4
       - 2.7
-  via_S0p7_0p7_S2_2_GNone_3d643c37_4050_350:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_4050_350:
     component: via
     dax: 3.7
     day: 0
@@ -94,6 +94,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -176,7 +177,7 @@ placements:
     rotation: 0
     x: 2.2
     y: 0.35
-  via_S0p7_0p7_S2_2_GNone_3d643c37_4050_350:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_4050_350:
     mirror: false
     rotation: 0
     x: 4.05

--- a/test-data-regression/test_netlists_via_stack_.yml
+++ b/test-data-regression/test_netlists_via_stack_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +26,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -54,12 +56,12 @@ instances:
 name: via_stack_S11_11_LM1_M2_70ad5a55
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_m3_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +26,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -54,12 +56,12 @@ instances:
 name: via_stack_S11_11_LHEATE_6668a8d5
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +26,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -54,12 +56,12 @@ instances:
 name: via_stack_S11_11_LHEATE_6668a8d5
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_mtop_mini_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_mtop_mini_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_0_0:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_0_0:
     component: via
     info:
       enclosure: 2
@@ -10,6 +10,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -19,7 +20,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_0_0:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_0_0:
     component: via
     info:
       enclosure: 1
@@ -30,6 +31,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -42,12 +44,12 @@ instances:
 name: via_stack_S4_4_LHEATER__3471ec57
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_0_0:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_c4f19208_0_0:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +26,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -54,12 +56,12 @@ instances:
 name: via_stack_S11_11_LM1_M2_70ad5a55
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_npp_m1_.yml
+++ b/test-data-regression/test_netlists_via_stack_npp_m1_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIAC
@@ -28,7 +29,7 @@ instances:
 name: via_stack_S11_11_LWG_NP_848fefcc
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S7_0p7_S2_2_GNone_E_43625195_0_m3000:
+  via_S7_0p7_S2_2_GNone_E_7483948b_0_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +26,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S9_0p7_S2_2_GNone_E_20b54705_0_m4000:
+  via_S9_0p7_S2_2_GNone_E_f82cd750_0_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIAC
@@ -54,12 +56,12 @@ instances:
 name: via_stack_S11_11_LSLAB9_59d26b38
 nets: []
 placements:
-  via_S7_0p7_S2_2_GNone_E_43625195_0_m3000:
+  via_S7_0p7_S2_2_GNone_E_7483948b_0_m3000:
     mirror: false
     rotation: 0
     x: 0
     y: -3
-  via_S9_0p7_S2_2_GNone_E_20b54705_0_m4000:
+  via_S9_0p7_S2_2_GNone_E_f82cd750_0_m4000:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m3_.yml
@@ -1,5 +1,32 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+    component: via
+    dax: 2
+    day: 0
+    dbx: 0
+    dby: 2
+    info:
+      enclosure: 1
+      xsize: 0.7
+      xspacing: 2
+      ysize: 0.7
+      yspacing: 2
+    na: 5
+    nb: 5
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      enclosure: 1
+      gap: null
+      layer: VIAC
+      size:
+      - 0.7
+      - 0.7
+      spacing:
+      - 2
+      - 2
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +43,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 2
       gap: null
       layer: VIA1
@@ -25,7 +53,7 @@ instances:
       spacing:
       - 2
       - 2
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -42,32 +70,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
-      enclosure: 1
-      gap: null
-      layer: VIAC
-      size:
-      - 0.7
-      - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
-    component: via
-    dax: 2
-    day: 0
-    dbx: 0
-    dby: 2
-    info:
-      enclosure: 1
-      xsize: 0.7
-      xspacing: 2
-      ysize: 0.7
-      yspacing: 2
-    na: 5
-    nb: 5
-    settings:
-      bbox_layers: null
-      bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIA2
@@ -80,17 +83,17 @@ instances:
 name: via_stack_S11_11_LSLAB9_d3decdcf
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_3d643c37_m3000_m3000:
-    mirror: false
-    rotation: 0
-    x: -3
-    y: -3
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4
     y: -4
-  via_S0p7_0p7_S2_2_GNone_c4f19208_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+    mirror: false
+    rotation: 0
+    x: -3
+    y: -3
+  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
@@ -1,5 +1,5 @@
 instances:
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
     component: via
     dax: 2
     day: 0
@@ -16,6 +16,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIAC
@@ -28,7 +29,7 @@ instances:
 name: via_stack_S11_11_LSLAB9_2473fd1e
 nets: []
 placements:
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m4000_m4000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_with_offset_.yml
+++ b/test-data-regression/test_netlists_via_stack_with_offset_.yml
@@ -44,7 +44,7 @@ instances:
       size:
       - 10
       - 10
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m3000_2000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m3000_2000:
     component: via
     dax: 2
     day: 0
@@ -61,6 +61,7 @@ instances:
     settings:
       bbox_layers: null
       bbox_offset: 0
+      bbox_offsets: null
       enclosure: 1
       gap: null
       layer: VIAC
@@ -88,7 +89,7 @@ placements:
     rotation: 0
     x: 0
     y: 5
-  via_S0p7_0p7_S2_2_GNone_6d4c344f_m3000_2000:
+  via_S0p7_0p7_S2_2_GNone_8696e860_m3000_2000:
     mirror: false
     rotation: 0
     x: -3

--- a/test-data-regression/test_netlists_viac_.yml
+++ b/test-data-regression/test_netlists_viac_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_6d4c344f
+name: via_S0p7_0p7_S2_2_GNone_8696e860
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_via1_.yml
+++ b/test-data-regression/test_settings_via1_.yml
@@ -4,7 +4,7 @@ info:
   xspacing: 2
   ysize: 0.7
   yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_3d643c37
+name: via_S0p7_0p7_S2_2_GNone_bcb63a01
 settings:
   bbox_offset: 0
   enclosure: 2

--- a/test-data-regression/test_settings_via2_.yml
+++ b/test-data-regression/test_settings_via2_.yml
@@ -4,7 +4,7 @@ info:
   xspacing: 2
   ysize: 0.7
   yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_c4f19208
+name: via_S0p7_0p7_S2_2_GNone_c1ab00a8
 settings:
   bbox_offset: 0
   enclosure: 1

--- a/test-data-regression/test_settings_via_.yml
+++ b/test-data-regression/test_settings_via_.yml
@@ -4,7 +4,7 @@ info:
   xspacing: 2
   ysize: 0.7
   yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_6d4c344f
+name: via_S0p7_0p7_S2_2_GNone_8696e860
 settings:
   bbox_offset: 0
   enclosure: 1

--- a/test-data-regression/test_settings_viac_.yml
+++ b/test-data-regression/test_settings_viac_.yml
@@ -4,7 +4,7 @@ info:
   xspacing: 2
   ysize: 0.7
   yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_6d4c344f
+name: via_S0p7_0p7_S2_2_GNone_8696e860
 settings:
   bbox_offset: 0
   enclosure: 1

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -157,7 +157,6 @@ routes:
 
 def test_connections_different_factory() -> None:
     c = from_yaml(sample_different_factory)
-    c.show()
     lengths = [914043, 947026, 947026]
     assert c.routes["electrical-tl,e3-tr,e1"].length == lengths[0], c.routes[
         "electrical-tl,e3-tr,e1"

--- a/tests/test_get_netlist.py
+++ b/tests/test_get_netlist.py
@@ -97,7 +97,7 @@ def test_get_netlist_cell_array_connecting() -> None:
     with pytest.warns(UserWarning):
         # because the component-array has automatic external ports, we assume no internal self-connections
         # we expect a ValueError to be thrown where the serendipitous connections are
-        c.get_netlist()
+        c.get_netlist(allow_multiple=False)
 
 
 def test_get_netlist_simple() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Fix the via component to handle bounding box offsets correctly by adding a 'bbox_offsets' parameter and updating related test cases.

Bug Fixes:
- Fix the via component to correctly handle bounding box offsets by introducing a new parameter 'bbox_offsets'.

Enhancements:
- Ensure that the length of 'bbox_offsets' matches the length of 'bbox_layers' and raise a ValueError if they do not match.

Tests:
- Update test cases to reflect changes in via component naming and settings, including the addition of 'bbox_offsets'.