### PR TITLE
update get cells function

### DIFF
--- a/gdsfactory/cell.py
+++ b/gdsfactory/cell.py
@@ -70,7 +70,7 @@ def cell(
     """Decorator to convert a function into a Component."""
     if post_process is None:
         post_process = []
-    return _cell(  # type: ignore
+    c = _cell(  # type: ignore
         _func,
         set_settings=set_settings,
         set_name=set_name,
@@ -87,3 +87,5 @@ def cell(
         info=info,
         post_process=post_process,
     )
+    c.is_gf_cell = True
+    return c

--- a/gdsfactory/components/triangles.py
+++ b/gdsfactory/components/triangles.py
@@ -87,7 +87,7 @@ def triangle2(spacing: float = 3, **kwargs):
 
 
 @cell
-def triangle4(**kwargs):
+def triangle4(**kwargs) -> Component:
     r"""Return 4 triangles.
 
     Args:

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -5,8 +5,6 @@ from collections.abc import Iterable
 from functools import partial
 from inspect import getmembers, isfunction, signature
 
-from kfactory import logger
-
 from gdsfactory.typings import Any, Callable, Component
 
 

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -20,7 +20,7 @@ def get_cells(
         modules: A module or an iterable of modules.
         ignore_non_decorated: only include functions that are decorated with gf.cell
         ignore_underscored: only include functions that do not start with '_'
-        ignore partials: only include functions, not partials
+        ignore_partials: only include functions, not partials
     """
     modules = modules if isinstance(modules, Iterable) else [modules]
     cells = {}

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -10,34 +10,65 @@ from kfactory import logger
 from gdsfactory.typings import Any, Callable, Component
 
 
-def get_cells(modules: Any, verbose: bool = False) -> dict[str, Callable]:
+def get_cells(
+    modules: Any,
+    ignore_non_decorated: bool = False,
+    ignore_underscored: bool = True,
+    ignore_partials: bool = False,
+) -> dict[str, Callable]:
     """Returns PCells (component functions) from a module or list of modules.
 
     Args:
         modules: A module or an iterable of modules.
-        verbose: If true, prints in case any errors occur.
+        ignore_non_decorated: only include functions that are decorated with gf.cell
+        ignore_underscored: only include functions that do not start with '_'
+        ignore partials: only include functions, not partials
     """
-    # Ensure modules is iterable
     modules = modules if isinstance(modules, Iterable) else [modules]
-
     cells = {}
     for module in modules:
         for name, member in getmembers(module):
-            if not name.startswith("_") and (
-                callable(member) and (isfunction(member) or isinstance(member, partial))
+            if is_cell(
+                member,
+                ignore_non_decorated=ignore_non_decorated,
+                ignore_underscored=ignore_underscored,
+                ignore_partials=ignore_partials,
+                name=name,
             ):
-                try:
-                    r = signature(
-                        member.func if isinstance(member, partial) else member
-                    ).return_annotation
-                    if r == Component or (
-                        isinstance(r, str) and r.endswith("Component")
-                    ):
-                        cells[name] = member
-                except ValueError as e:
-                    if verbose:
-                        logger.warn(f"error in {name}: {e}")
+                cells[name] = member
     return cells
+
+
+def is_cell(
+    func: Any,
+    ignore_non_decorated: bool = False,
+    ignore_underscored: bool = True,
+    ignore_partials: bool = False,
+    name: str = "",
+) -> bool:
+    try:
+        if not name:
+            name = func.__name__
+        if not callable(func):
+            return False
+        if not ignore_partials and isinstance(func, partial):
+            return is_cell(
+                func.func,
+                ignore_non_decorated=ignore_non_decorated,
+                ignore_underscored=ignore_underscored,
+                ignore_partials=ignore_partials,
+                name=name,
+            )
+        if ignore_underscored and name.startswith("_"):
+            return False
+        if getattr(func, "is_gf_cell", False):
+            return True
+        if not ignore_non_decorated:
+            r = signature(func).return_annotation
+            return r == Component or (isinstance(r, str) and r.endswith("Component"))
+    except Exception:
+        pass
+    return False
 
 
 def get_cells_from_dict(cells: dict[str, Callable]) -> dict[str, Callable]:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
@@ -1,0 +1,16 @@
+info:
+  dy: 10
+  length: 16.637
+  min_bend_radius: 7.061
+  pdk: fab_c
+  radius: 10
+  route_info_length: 16.637
+  route_info_min_bend_radius: 7.061
+  route_info_n_bend_90: 1
+  route_info_type: xs_7d758a01
+  route_info_weight: 16.637
+  route_info_xs_7d758a01_length: 16.637
+  width: 1
+name: bend_euler_nc_CSstrip_nc
+settings:
+  cross_section: strip_nc

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_no_.yml
@@ -1,0 +1,16 @@
+info:
+  dy: 10
+  length: 16.637
+  min_bend_radius: 7.061
+  pdk: fab_c
+  radius: 10
+  route_info_length: 16.637
+  route_info_min_bend_radius: 7.061
+  route_info_n_bend_90: 1
+  route_info_type: xs_578c5a00
+  route_info_weight: 16.637
+  route_info_xs_578c5a00_length: 16.637
+  width: 0.9
+name: bend_euler_no_CSstrip_no
+settings:
+  cross_section: strip_no

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_sc_.yml
@@ -1,0 +1,16 @@
+info:
+  dy: 10
+  length: 16.637
+  min_bend_radius: 7.061
+  pdk: fab_c
+  radius: 10
+  route_info_length: 16.637
+  route_info_min_bend_radius: 7.061
+  route_info_n_bend_90: 1
+  route_info_type: xs_0f381f28
+  route_info_weight: 16.637
+  route_info_xs_0f381f28_length: 16.637
+  width: 0.5
+name: bend_euler_sc_CSstrip_sc
+settings:
+  cross_section: strip_sc

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_so_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_so_.yml
@@ -1,0 +1,16 @@
+info:
+  dy: 10
+  length: 16.637
+  min_bend_radius: 7.061
+  pdk: fab_c
+  radius: 10
+  route_info_length: 16.637
+  route_info_min_bend_radius: 7.061
+  route_info_n_bend_90: 1
+  route_info_type: xs_220cafc3
+  route_info_weight: 16.637
+  route_info_xs_220cafc3_length: 16.637
+  width: 0.4
+name: bend_euler_so_CSstrip_so
+settings:
+  cross_section: strip_so

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_gc_sc_.yml
@@ -1,0 +1,6 @@
+info:
+  pdk: fab_c
+  polarization: te
+  wavelength: 1.554
+name: gc_sc
+settings: {}

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_nc_.yml
@@ -1,0 +1,6 @@
+info:
+  pdk: fab_c
+name: mmi1x2_nc_WM3_CSstrip_nc
+settings:
+  cross_section: strip_nc
+  width_mmi: 3

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_no_.yml
@@ -1,0 +1,6 @@
+info:
+  pdk: fab_c
+name: mmi1x2_no_WM3_CSstrip_no
+settings:
+  cross_section: strip_no
+  width_mmi: 3

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_sc_.yml
@@ -1,0 +1,6 @@
+info:
+  pdk: fab_c
+name: mmi1x2_sc_WM3_CSstrip_sc
+settings:
+  cross_section: strip_sc
+  width_mmi: 3

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_so_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_mmi1x2_so_.yml
@@ -1,0 +1,6 @@
+info:
+  pdk: fab_c
+name: mmi1x2_so_WM3_CSstrip_so
+settings:
+  cross_section: strip_so
+  width_mmi: 3

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  pdk: fab_c
+  route_info_length: 10
+  route_info_type: xs_7d758a01
+  route_info_weight: 10
+  route_info_xs_7d758a01_length: 10
+  width: 1
+name: straight_nc_CSstrip_nc
+settings:
+  cross_section: strip_nc

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_no_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  pdk: fab_c
+  route_info_length: 10
+  route_info_type: xs_578c5a00
+  route_info_weight: 10
+  route_info_xs_578c5a00_length: 10
+  width: 0.9
+name: straight_no_CSstrip_no
+settings:
+  cross_section: strip_no

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_sc_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  pdk: fab_c
+  route_info_length: 10
+  route_info_type: xs_7d758a01
+  route_info_weight: 10
+  route_info_xs_7d758a01_length: 10
+  width: 1
+name: straight_sc_CSstrip_nc
+settings:
+  cross_section: strip_nc

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_so_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_so_.yml
@@ -1,0 +1,11 @@
+info:
+  length: 10
+  pdk: fab_c
+  route_info_length: 10
+  route_info_type: xs_220cafc3
+  route_info_weight: 10
+  route_info_xs_220cafc3_length: 10
+  width: 0.4
+name: straight_so_CSstrip_so
+settings:
+  cross_section: strip_so

--- a/test-data-regression/test_netlists_triangle2_.yml
+++ b/test-data-regression/test_netlists_triangle2_.yml
@@ -1,0 +1,33 @@
+instances:
+  triangle_X10_X0_Y20_Y0_LWG_0_0:
+    component: triangle
+    info: {}
+    settings:
+      layer: WG
+      x: 10
+      xtop: 0
+      y: 20
+      ybot: 0
+  triangle_X10_X0_Y20_Y0_LWG_0_m3000:
+    component: triangle
+    info: {}
+    settings:
+      layer: WG
+      x: 10
+      xtop: 0
+      y: 20
+      ybot: 0
+name: triangle2_S3
+nets: []
+placements:
+  triangle_X10_X0_Y20_Y0_LWG_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+  triangle_X10_X0_Y20_Y0_LWG_0_m3000:
+    mirror: true
+    rotation: 0
+    x: 0
+    y: -3
+ports: {}

--- a/test-data-regression/test_netlists_triangle4_.yml
+++ b/test-data-regression/test_netlists_triangle4_.yml
@@ -1,0 +1,15 @@
+instances:
+  triangle2_S3_0_0:
+    component: triangle2
+    info: {}
+    settings:
+      spacing: 3
+name: triangle4
+nets: []
+placements:
+  triangle2_S3_0_0:
+    mirror: true
+    rotation: 180
+    x: 0
+    y: 0
+ports: {}

--- a/test-data-regression/test_settings_triangle2_.yml
+++ b/test-data-regression/test_settings_triangle2_.yml
@@ -1,6 +1,4 @@
-function: triangle2
 info: {}
-module: gdsfactory.components.triangles
-name: triangle2
+name: triangle2_S3
 settings:
   spacing: 3

--- a/test-data-regression/test_settings_triangle4_.yml
+++ b/test-data-regression/test_settings_triangle4_.yml
@@ -1,5 +1,3 @@
-function: triangle4
 info: {}
-module: gdsfactory.components.triangles
 name: triangle4
 settings: {}


### PR DESCRIPTION
Currently some tests are failing, but I'll leave it up to you @joamatab to check the severity of those regressions.

## Summary by Sourcery

Update the get_cells function to include new filtering options for PCells and refactor the code for better clarity. Add regression tests for triangle2 and triangle4 components to ensure correct netlist generation.

New Features:
- Introduce the ability to filter PCells based on decoration, underscore prefix, and partials in the get_cells function.

Enhancements:
- Refactor the get_cells function to use a new helper function is_cell for improved readability and maintainability.

Tests:
- Add new test data regression files for triangle2 and triangle4 components to verify netlist generation.