### PR TITLE
add test for test_write_test_manifest

### DIFF
--- a/gdsfactory/labels/write_test_manifest.py
+++ b/gdsfactory/labels/write_test_manifest.py
@@ -5,7 +5,6 @@ import json
 import pathlib
 
 import gdsfactory as gf
-from gdsfactory.samples.sample_reticle import sample_reticle
 from gdsfactory.typings import Iterable
 
 
@@ -63,7 +62,7 @@ def write_test_manifest(
         for _ci in ci.each():
             cell = c.kcl[_ci.inst_cell().cell_index()]
 
-            if cell.info["doe"]:
+            if cell.info.get("doe"):
                 disp = (_ci.trans() * _ci.inst_trans()).disp
                 dtrans = _ci.dtrans() * _ci.inst_dtrans()
                 ports = {
@@ -91,6 +90,8 @@ def write_test_manifest(
 
 if __name__ == "__main__":
     import pandas as pd
+
+    from gdsfactory.samples.sample_reticle import sample_reticle
 
     c = sample_reticle()
     # cit = c.begin_instances_rec()

--- a/gdsfactory/samples/sample_reticle.py
+++ b/gdsfactory/samples/sample_reticle.py
@@ -85,7 +85,7 @@ def sample_reticle(grid: bool = False) -> gf.Component:
         return gf.grid(components)
     c = gf.pack(components)
     if len(c) > 1:
-        c = gf.pack(c)[0]
+        c = gf.pack(c)
     return c[0]
 
 

--- a/gdsfactory/samples/sample_reticle_with_labels.py
+++ b/gdsfactory/samples/sample_reticle_with_labels.py
@@ -137,7 +137,7 @@ def sample_reticle_with_labels(grid: bool = False) -> gf.Component:
         return gf.grid(components)
     c = gf.pack(components)
     if len(c) > 1:
-        c = gf.pack(c)[0]
+        c = gf.pack(c)
     return c[0]
 
 

--- a/tests/labels/write_test_manifest.py
+++ b/tests/labels/write_test_manifest.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+import gdsfactory as gf
+from gdsfactory.samples.sample_reticle import sample_reticle
+
+
+def test_write_test_manifest():
+    c = sample_reticle()
+    gdspath = c.write_gds()
+    csvpath = gdspath.with_suffix(".csv")
+    gf.labels.write_test_manifest(component=c, csvpath=csvpath)
+    df = pd.read_csv(csvpath)
+    assert len(df) == 27
+
+
+if __name__ == "__main__":
+    c = sample_reticle()
+    gdspath = c.write_gds()
+    csvpath = gdspath.with_suffix(".csv")
+    gf.labels.write_test_manifest(component=c, csvpath=csvpath)
+    df = pd.read_csv(csvpath)
+    print(len(df))


### PR DESCRIPTION
- add test for write_test_manifest

## Summary by Sourcery

Tests:
- Add a test for the 'write_test_manifest' function to ensure it generates a CSV file with the expected number of entries.