### PR TITLE
Fix add fiber array excluded ports

### DIFF
--- a/gdsfactory/components/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_coupler_elliptical.py
@@ -212,7 +212,12 @@ def grating_coupler_elliptical(
     x = np.round(taper_length + x_output, 3)
 
     c.add_port(
-        name="o1", center=(x_output, 0), width=wg_width, orientation=180, layer=layer
+        name="o1",
+        center=(x_output, 0),
+        width=wg_width,
+        orientation=180,
+        layer=layer,
+        port_type="optical",
     )
 
     if layer_slab:

--- a/test-data-regression/test_settings_sample_excluded_ports_.yml
+++ b/test-data-regression/test_settings_sample_excluded_ports_.yml
@@ -1,0 +1,3 @@
+info: {}
+name: sample_excluded_ports
+settings: {}

--- a/tests/routing/test_add_fiber_array.py
+++ b/tests/routing/test_add_fiber_array.py
@@ -15,12 +15,18 @@ def sample_fiber_array() -> Component:
 
 
 @gf.cell
+def sample_excluded_ports() -> Component:
+    component = gf.components.crossing()
+    return gf.routing.add_fiber_array(component=component, excluded_ports=["o1"])
+
+
+@gf.cell
 def sample_fiber_single() -> Component:
     c = gf.components.coupler(gap=0.244, length=5.67)
     return gf.routing.add_fiber_single(component=c)
 
 
-components = [sample_fiber_array, sample_fiber_single]
+components = [sample_fiber_array, sample_fiber_single, sample_excluded_ports]
 
 
 @pytest.fixture(params=components, scope="function")
@@ -40,6 +46,6 @@ def test_settings(component: Component, data_regression: DataRegressionFixture) 
 
 
 if __name__ == "__main__":
-    c = sample_fiber_array()
+    c = sample_excluded_ports()
     c.pprint_ports()
     c.show()


### PR DESCRIPTION
- fix https://github.com/gdsfactory/gdsfactory/issues/3334
- add test for it

## Summary by Sourcery

Fix the handling of excluded ports in the fiber array routing and add a corresponding test case to ensure correct functionality.

Bug Fixes:
- Fix the issue with excluded ports in the fiber array routing by ensuring ports to be routed are correctly filtered.

Tests:
- Add a new test case for the fiber array routing to verify the handling of excluded ports.