### PR TITLE
add tests for python3.13

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ keywords = ["eda", "photonics", "python"]
 license = {file = "LICENSE"}
 name = "gdsfactory"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 version = "8.18.0"
 
 [project.optional-dependencies]


### PR DESCRIPTION
- test python 3.13
- don't allow 3.14

## Summary by Sourcery

Update the CI workflow to test the codebase against Python 3.13 and restrict the project's Python version compatibility to below 3.14.

Build:
- Restrict Python version compatibility to below 3.14 in the project configuration.

CI:
- Update CI configuration to test against Python 3.13.