### PR TITLE
fix missing start/end angles arg in route_bundle

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -306,6 +306,8 @@ def route_bundle(
         route_width=width_dbu,
         sort_ports=sort_ports,
         waypoints=_waypoints,
+        end_angles=end_angles,
+        start_angles=start_angles,
     )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing start_angles and end_angles arguments to the straight_dbu function call in route_bundle.py.