### PR TITLE
fix cutback_component

### DIFF
--- a/gdsfactory/components/cutback_component.py
+++ b/gdsfactory/components/cutback_component.py
@@ -52,9 +52,10 @@ def cutback_component(
 
     component = gf.get_component(component, **kwargs)
     bendu = gf.get_component(bend180, cross_section=xs)
-    straight_component = straight(
-        length=straight_length or xs.radius * 2, cross_section=xs
-    )
+
+    straight_length = xs.radius * 2 if straight_length is None else straight_length
+    straight_component = straight(length=straight_length, cross_section=xs)
+
     straight_pair = straight(length=straight_length_pair or 0, cross_section=xs)
 
     # Define a map between symbols and (component, input port, output port)


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3383

thanks to @Arka-noid for the fix

## Summary by Sourcery

Bug Fixes:
- Fix the calculation of straight_length in the cutback_component function to handle None values correctly.