### PR TITLE
Fix Type Hints

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -79,7 +79,7 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
 
         kwargs = ", ".join(
             [
-                f"{p}={repr(clean_value_json(sig.parameters[p].default))}"
+                f"{p}={clean_value_json(sig.parameters[p].default)!r}"
                 for p in sig.parameters
                 if isinstance(sig.parameters[p].default, int | float | str | tuple)
                 and p not in skip_settings

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Any
 
 import kfactory as kf
 import numpy as np
+import numpy.typing as npt
 import yaml
-from typing_extensions import TypeVar
 
 import gdsfactory as gf
 from gdsfactory.component import container
@@ -37,12 +37,11 @@ LayerSpec = Layer | str | int
 LayerSpecs = tuple[LayerSpec, ...]
 nm = 1e-3
 
-T = TypeVar("T")
-
 
 def _rotate(
-    vector: np.typing.NDArray[T], rotation_matrix: np.typing.NDArray[T]
-) -> np.typing.NDArray[T]:
+    vector: npt.NDArray[np.floating[Any]],
+    rotation_matrix: npt.NDArray[np.floating[Any]],
+) -> npt.NDArray[np.floating[Any]]:
     """Rotate a vector by a rotation matrix."""
     return rotation_matrix @ vector
 

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -14,7 +14,7 @@ import json
 import warnings
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import kfactory as kf
 import numpy as np
@@ -320,7 +320,7 @@ def add_outline(
     component: Component,
     reference: Instance | None = None,
     layer: LayerSpec = "DEVREC",
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Adds devices outline bounding box in layer.
 
@@ -352,7 +352,7 @@ def add_pins_siepic(
     port_type: str = "optical",
     layer: LayerSpec = "PORT",
     pin_length: float = 10 * nm,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Add pins.
 
@@ -393,7 +393,7 @@ def add_pins(
     component: Component,
     port_type: str | None = None,
     function: Callable = add_pin_rectangle_inside,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Add Pin port markers.
 

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -11,14 +11,14 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.port import Port, read_port_markers, sort_ports_clockwise
 from gdsfactory.snap import snap_to_grid
-from gdsfactory.typings import LayerSpec
+from gdsfactory.typings import AngleInDegrees, LayerSpec
 
 
 def add_ports_from_markers_square(
     component: Component,
     pin_layer: LayerSpec = "DEVREC",
     port_layer: LayerSpec | None = None,
-    orientation: int | None = 90,
+    orientation: AngleInDegrees | None = 90,
     min_pin_area_um2: float = 0,
     max_pin_area_um2: float | None = 150 * 150,
     pin_extra_width: float = 0.0,
@@ -44,7 +44,7 @@ def add_ports_from_markers_square(
     port_name_prefix = port_name_prefix or port_name_prefix_default
     port_markers = read_port_markers(component, (pin_layer,))
     port_names = port_names or [
-        f"{port_name_prefix}{i+1}" for i in range(len(port_markers.polygons))
+        f"{port_name_prefix}{i + 1}" for i in range(len(port_markers.polygons))
     ]
     layer = port_layer or pin_layer
 
@@ -175,7 +175,7 @@ def add_ports_from_markers_center(
     ports = []
 
     for i, p in enumerate(port_markers):
-        port_name = f"{port_name_prefix}{i+1}" if port_name_prefix else str(i)
+        port_name = f"{port_name_prefix}{i + 1}" if port_name_prefix else str(i)
         bbox = p.bbox()
         pxmin, pymin, pxmax, pymax = bbox.left, bbox.bottom, bbox.right, bbox.top
 
@@ -386,7 +386,7 @@ def add_ports_from_boxes(
 
     port_markers = component.get_boxes(layer=pin_layer)
     for i, p in enumerate(port_markers):
-        port_name = f"{port_name_prefix}{i+1}" if port_name_prefix else str(i)
+        port_name = f"{port_name_prefix}{i + 1}" if port_name_prefix else str(i)
         bbox = p.bbox()
         pxmin, pymin, pxmax, pymax = bbox.left, bbox.bottom, bbox.right, bbox.top
 
@@ -506,7 +506,7 @@ def add_ports_from_labels(
     get_name_from_label: bool = False,
     layer_label: LayerSpec | None = None,
     fail_on_duplicates: bool = False,
-    port_orientation: float | None = None,
+    port_orientation: AngleInDegrees | None = None,
     guess_port_orientation: bool = True,
     port_filter_prefix: str | None = None,
 ) -> Component:
@@ -548,7 +548,7 @@ def add_ports_from_labels(
         if get_name_from_label:
             port_name = label.string
         else:
-            port_name = f"{port_name_prefix}{i+1}" if port_name_prefix else i
+            port_name = f"{port_name_prefix}{i + 1}" if port_name_prefix else i
 
         orientation = port_orientation
 
@@ -627,7 +627,7 @@ def add_ports_from_siepic_pins(
             orientation = 3
 
         c.create_port(
-            name=f"{port_prefix}{i+1}",
+            name=f"{port_prefix}{i + 1}",
             dwidth=round(path.width / c.kcl.dbu) * c.kcl.dbu,
             dcplx_trans=gf.kdb.DCplxTrans(
                 1, orientation, False, path.bbox().center().to_v()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -8,7 +8,6 @@ from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import kfactory as kf
-import klayout.db as db  # noqa: F401
 import klayout.lay as lay
 import numpy as np
 import yaml
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
     from gdsfactory.typings import (
+        AngleInDegrees,
         ComponentSpec,
         CrossSection,
         CrossSectionSpec,
@@ -309,7 +309,7 @@ class ComponentBase:
         port: kf.Port | None = None,
         center: tuple[float, float] | kf.kdb.DPoint | None = None,
         width: float | None = None,
-        orientation: float | None = None,
+        orientation: "AngleInDegrees | None" = None,
         layer: LayerSpec | None = None,
         port_type: str = "optical",
         keep_mirror: bool = False,
@@ -824,7 +824,9 @@ class ComponentBase:
         gdsdir = gdsdir or GDSDIR_TEMP
         gdsdir = pathlib.Path(gdsdir)
         gdsdir.mkdir(parents=True, exist_ok=True)
-        gdspath = gdspath or gdsdir / f"{self.name[:kf.config.max_cellname_length]}.gds"
+        gdspath = (
+            gdspath or gdsdir / f"{self.name[: kf.config.max_cellname_length]}.gds"
+        )
         gdspath = pathlib.Path(gdspath)
 
         if not gdspath.parent.is_dir():
@@ -1037,12 +1039,10 @@ class ComponentBase:
                 connections = net.get("connections", {})
                 connections = _nets_to_connections(nets, connections)
                 placements = net["placements"]
-                G.add_edges_from(
-                    [
-                        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                        for k, v in connections.items()
-                    ]
-                )
+                G.add_edges_from([
+                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                    for k, v in connections.items()
+                ])
                 pos |= {k: (v["x"], v["y"]) for k, v in placements.items()}
                 labels |= {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 
@@ -1051,12 +1051,10 @@ class ComponentBase:
             connections = netlist.get("connections", {})
             connections = _nets_to_connections(nets, connections)
             placements = netlist["placements"]
-            G.add_edges_from(
-                [
-                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                    for k, v in connections.items()
-                ]
-            )
+            G.add_edges_from([
+                (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                for k, v in connections.items()
+            ])
             pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
             labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1039,10 +1039,12 @@ class ComponentBase:
                 connections = net.get("connections", {})
                 connections = _nets_to_connections(nets, connections)
                 placements = net["placements"]
-                G.add_edges_from([
-                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                    for k, v in connections.items()
-                ])
+                G.add_edges_from(
+                    [
+                        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                        for k, v in connections.items()
+                    ]
+                )
                 pos |= {k: (v["x"], v["y"]) for k, v in placements.items()}
                 labels |= {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 
@@ -1051,10 +1053,12 @@ class ComponentBase:
             connections = netlist.get("connections", {})
             connections = _nets_to_connections(nets, connections)
             placements = netlist["placements"]
-            G.add_edges_from([
-                (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                for k, v in connections.items()
-            ])
+            G.add_edges_from(
+                [
+                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                    for k, v in connections.items()
+                ]
+            )
             pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
             labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 

--- a/gdsfactory/components/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/add_fiber_array_optical_south_electrical_north.py
@@ -1,5 +1,7 @@
+from typing import Any
+
 import gdsfactory as gf
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec
 
 
 def add_fiber_array_optical_south_electrical_north(
@@ -12,10 +14,10 @@ def add_fiber_array_optical_south_electrical_north(
     fiber_spacing: float = 127.0,
     pad_gc_spacing: float = 250.0,
     electrical_port_names: list[str] | None = None,
-    electrical_port_orientation: float | None = 90,
+    electrical_port_orientation: AngleInDegrees | None = 90,
     npads: int | None = None,
     port_types_grating_couplers: list[str] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> gf.Component:
     """Returns a fiber array with Optical gratings on South and Electrical pads on North.
 

--- a/gdsfactory/components/array_component.py
+++ b/gdsfactory/components/array_component.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import gdsfactory as gf
 from gdsfactory import cell
 from gdsfactory.component import Component
-from gdsfactory.typings import Callable, ComponentSpec, Float2, Iterable
+from gdsfactory.typings import Callable, ComponentSpec, Float2
 
 
 @cell
@@ -65,7 +67,7 @@ def array(
             for iy in range(ref.nb):
                 for port in component.ports:
                     port = port.copy(ref.trans * gf.kdb.Trans(ix * ref.a + iy * ref.b))
-                    name = f"{port.name}_{iy+1}_{ix+1}"
+                    name = f"{port.name}_{iy + 1}_{ix + 1}"
                     c.add_port(name, port=port)
 
     if post_process:

--- a/gdsfactory/components/cdsem_coupler.py
+++ b/gdsfactory/components/cdsem_coupler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from functools import partial
 
 import numpy as np
@@ -10,7 +11,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.coupler_straight import coupler_straight
 from gdsfactory.components.text_rectangular import text_rectangular
-from gdsfactory.typings import ComponentFactory, CrossSectionSpec, Iterable
+from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
 text_rectangular_mini = partial(text_rectangular, size=1)
 

--- a/gdsfactory/components/compass.py
+++ b/gdsfactory/components/compass.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import gdsfactory as gf
-from gdsfactory import cell
+from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.snap import snap_to_grid2x
-from gdsfactory.typings import Ints, LayerSpec
+from gdsfactory.typings import Ints, LayerSpec, Size
 
 
 @cell
 def compass(
-    size=(4.0, 2.0),
+    size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",
     port_type: str | None = "electrical",
     port_inclusion: float = 0.0,

--- a/gdsfactory/components/component_sequence.py
+++ b/gdsfactory/components/component_sequence.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import ComponentSpec
+from gdsfactory.typings import AngleInDegrees, ComponentSpec
 
 
 class SequenceGenerator:
@@ -47,7 +47,7 @@ class SequenceGenerator:
         self.end_sequence = end_sequence
         self.repeated_sequence = repeated_sequence
 
-    def get_sequence(self, n=2):
+    def get_sequence(self, n: int = 2) -> str:
         return self.start_sequence + n * self.repeated_sequence + self.end_sequence
 
 
@@ -59,7 +59,7 @@ def parse_component_name(name: str) -> tuple[str, bool]:
     return (name[1:], True) if len(name) != 1 and name[0] == "!" else (name, False)
 
 
-def _flip_ref(c_ref, port_name):
+def _flip_ref(c_ref: Component, port_name: str) -> Component:
     a = c_ref.ports[port_name].orientation
     if a in [0, 180]:
         y = c_ref.ports[port_name].dcenter[1]
@@ -75,7 +75,7 @@ def component_sequence(
     ports_map: dict[str, tuple[str, str]] | None = None,
     port_name1: str = "o1",
     port_name2: str = "o2",
-    start_orientation: float = 0.0,
+    start_orientation: AngleInDegrees = 0.0,
 ) -> Component:
     """Returns component from ASCII sequence.
 
@@ -126,9 +126,9 @@ def component_sequence(
     name_start_device, do_flip = parse_component_name(symbol)
     component_input, input_port, prev_port = symbol_to_component[name_start_device]
     prev_device = component.add_ref(component_input, name=f"{symbol}{index}")
-    named_references_counter.update(
-        {name_start_device: 1}
-    )  # sourcery skip:simplify-dictionary-update
+    named_references_counter.update({
+        name_start_device: 1
+    })  # sourcery skip:simplify-dictionary-update
 
     if do_flip:
         prev_device = _flip_ref(prev_device, input_port)
@@ -161,9 +161,9 @@ def component_sequence(
         index += 1
         component_i, input_port, next_port = symbol_to_component[s]
         component_i = gf.get_component(component_i)
-        named_references_counter.update(
-            {s: 1}
-        )  # sourcery skip:simplify-dictionary-update
+        named_references_counter.update({
+            s: 1
+        })  # sourcery skip:simplify-dictionary-update
         alias = f"{s}{named_references_counter[s]}"
         ref = component.add_ref(component_i, name=alias)
 

--- a/gdsfactory/components/component_sequence.py
+++ b/gdsfactory/components/component_sequence.py
@@ -126,9 +126,9 @@ def component_sequence(
     name_start_device, do_flip = parse_component_name(symbol)
     component_input, input_port, prev_port = symbol_to_component[name_start_device]
     prev_device = component.add_ref(component_input, name=f"{symbol}{index}")
-    named_references_counter.update({
-        name_start_device: 1
-    })  # sourcery skip:simplify-dictionary-update
+    named_references_counter.update(
+        {name_start_device: 1}
+    )  # sourcery skip:simplify-dictionary-update
 
     if do_flip:
         prev_device = _flip_ref(prev_device, input_port)
@@ -161,9 +161,9 @@ def component_sequence(
         index += 1
         component_i, input_port, next_port = symbol_to_component[s]
         component_i = gf.get_component(component_i)
-        named_references_counter.update({
-            s: 1
-        })  # sourcery skip:simplify-dictionary-update
+        named_references_counter.update(
+            {s: 1}
+        )  # sourcery skip:simplify-dictionary-update
         alias = f"{s}{named_references_counter[s]}"
         ref = component.add_ref(component_i, name=alias)
 

--- a/gdsfactory/components/coupler.py
+++ b/gdsfactory/components/coupler.py
@@ -11,8 +11,8 @@ from gdsfactory.typings import CrossSectionSpec
 def coupler(
     gap: float = 0.236,
     length: float = 20.0,
-    dy: float = 4.0,
-    dx: float = 10.0,
+    dy: Delta = 4.0,
+    dx: Delta = 10.0,
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
 ) -> Component:

--- a/gdsfactory/components/coupler_asymmetric.py
+++ b/gdsfactory/components/coupler_asymmetric.py
@@ -10,8 +10,8 @@ from gdsfactory.typings import CrossSectionSpec
 @gf.cell
 def coupler_asymmetric(
     gap: float = 0.234,
-    dy: float = 2.5,
-    dx: float = 10.0,
+    dy: Delta = 2.5,
+    dx: Delta = 10.0,
     cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Bend coupled to straight waveguide.

--- a/gdsfactory/components/coupler_full.py
+++ b/gdsfactory/components/coupler_full.py
@@ -9,8 +9,8 @@ from gdsfactory.typings import CrossSectionSpec
 @gf.cell
 def coupler_full(
     coupling_length: float = 40.0,
-    dx: float = 10.0,
-    dy: float = 4.8,
+    dx: Delta = 10.0,
+    dy: Delta = 4.8,
     gap: float = 0.5,
     dw: float = 0.1,
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/coupler_symmetric.py
+++ b/gdsfactory/components/coupler_symmetric.py
@@ -10,8 +10,8 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 def coupler_symmetric(
     bend: ComponentSpec = bend_s,
     gap: float = 0.234,
-    dy: float = 4.0,
-    dx: float = 10.0,
+    dy: Delta = 4.0,
+    dx: Delta = 10.0,
     cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     r"""Two coupled straights with bends.

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -221,7 +221,7 @@ def crossing_etched(
 def crossing45(
     crossing: ComponentSpec = crossing,
     port_spacing: float = 40.0,
-    dx: float | None = None,
+    dx: Delta | None = None,
     alpha: float = 0.08,
     npoints: int = 101,
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/disk.py
+++ b/gdsfactory/components/disk.py
@@ -4,7 +4,12 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory import Component
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+from gdsfactory.typings import (
+    AngleInDegrees,
+    ComponentSpec,
+    CrossSectionSpec,
+    LayerSpec,
+)
 
 
 def _compute_parameters(xs_bend, wrap_angle_deg, radius):
@@ -139,7 +144,7 @@ def disk_heater(
     heater_width: float = 5.0,
     heater_extent: float = 2.0,
     via_width: float = 10.0,
-    port_orientation: float | None = 90,
+    port_orientation: AngleInDegrees | None = 90,
 ) -> Component:
     """Disk Resonator with top metal heater.
 

--- a/gdsfactory/components/litho_steps.py
+++ b/gdsfactory/components/litho_steps.py
@@ -28,7 +28,7 @@ def litho_steps(
 
     height /= 2
     T1 = pc.text(
-        text=f"{str(line_widths[-1])}", size=height, justify="center", layer=layer
+        text=f"{line_widths[-1]!s}", size=height, justify="center", layer=layer
     )
 
     ref = D.add_ref(T1)

--- a/gdsfactory/components/mzit.py
+++ b/gdsfactory/components/mzit.py
@@ -14,7 +14,7 @@ def mzit(
     w0: float = 0.5,
     w1: float = 0.45,
     w2: float = 0.55,
-    dy: float = 2.0,
+    dy: Delta = 2.0,
     delta_length: float = 10.0,
     length: float = 1.0,
     coupler_length1: float = 5.0,
@@ -132,7 +132,7 @@ def mzit(
     dx = (delta_length - 2 * dy) / 2
     assert (
         delta_length >= 4 * dy
-    ), f"`delta_length`={delta_length} needs to be at least {4*dy}"
+    ), f"`delta_length`={delta_length} needs to be at least {4 * dy}"
 
     wg2b = c << straight(length=dx, cross_section=cross_section, width=w2)
     wg2b.connect("o1", t2.ports["o2"])

--- a/gdsfactory/components/pad.py
+++ b/gdsfactory/components/pad.py
@@ -17,7 +17,7 @@ def pad(
     bbox_layers: tuple[LayerSpec, ...] | None = None,
     bbox_offsets: tuple[float, ...] | None = None,
     port_inclusion: float = 0,
-    port_orientation: float | None = 0,
+    port_orientation: AngleInDegrees | None = 0,
     port_orientations: Ints | None = (180, 90, 0, -90),
 ) -> Component:
     """Returns rectangular pad with ports.
@@ -87,8 +87,8 @@ def pad_array(
     spacing: tuple[float, float] = (150.0, 150.0),
     columns: int = 6,
     rows: int = 1,
-    port_orientation: float = 0,
-    orientation: float | None = None,
+    port_orientation: AngleInDegrees = 0,
+    orientation: AngleInDegrees | None = None,
     size: Float2 = (100.0, 100.0),
     layer: LayerSpec = "MTOP",
     centered_ports: bool = False,
@@ -136,7 +136,7 @@ def pad_array(
                     center[1] -= size[1] / 2
 
             c.add_port(
-                name=f"e{row+1}{col+1}",
+                name=f"e{row + 1}{col + 1}",
                 center=center,
                 width=width,
                 orientation=port_orientation,

--- a/gdsfactory/components/polarization_splitter_rotator.py
+++ b/gdsfactory/components/polarization_splitter_rotator.py
@@ -21,7 +21,7 @@ def polarization_splitter_rotator(
     gap: float = 0.15,
     width_out: float = 0.54,
     length_out: float = 14.33,
-    dy: float = 5.0,
+    dy: Delta = 5.0,
     cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Returns polarization splitter rotator.

--- a/gdsfactory/components/rectangle.py
+++ b/gdsfactory/components/rectangle.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import partial
+from typing import Any
 
 import numpy as np
 
-from gdsfactory import cell
+from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.components.compass import compass
-from gdsfactory.typings import Ints, Iterable, LayerSpec, LayerSpecs
+from gdsfactory.typings import Ints, LayerSpec, LayerSpecs, Size
 
 
 @cell
 def rectangle(
-    size=(4.0, 2.0),
+    size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",
     centered: bool = False,
     port_type: str | None = "electrical",
@@ -40,17 +42,17 @@ def rectangle(
 
 
 fiber_size = 10.4
-marker_te = partial(rectangle, size=[fiber_size, fiber_size], layer="TE", centered=True)
-marker_tm = partial(rectangle, size=[fiber_size, fiber_size], layer="TM", centered=True)
+marker_te = partial(rectangle, size=(fiber_size, fiber_size), layer="TE", centered=True)
+marker_tm = partial(rectangle, size=(fiber_size, fiber_size), layer="TM", centered=True)
 
 
 @cell
 def rectangles(
-    size=(4.0, 2.0),
-    offsets: Iterable[float] | None = None,
+    size: Size = (4.0, 2.0),
+    offsets: Sequence[float] | None = None,
     layers: LayerSpecs = ("WG", "SLAB150"),
     centered: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns overimposed rectangles.
 
@@ -79,7 +81,7 @@ def rectangles(
 
     """
     c = Component()
-    size = np.array(size)
+    size_np = np.array(size, dtype=np.float64)
     ref0 = None
     offsets = offsets or [0] * len(layers)
 
@@ -87,7 +89,7 @@ def rectangles(
         raise ValueError(f"len(offsets) != len(layers) {len(offsets)} != {len(layers)}")
     for layer, offset in zip(layers, offsets):
         ref = c << rectangle(
-            size=tuple(size + 2 * offset), layer=layer, centered=centered, **kwargs
+            size=tuple(size_np + 2 * offset), layer=layer, centered=centered, **kwargs
         )
         if ref0:
             ref.dcenter = ref0.dcenter

--- a/gdsfactory/components/ring_heater.py
+++ b/gdsfactory/components/ring_heater.py
@@ -21,7 +21,7 @@ def ring_double_heater(
     cross_section_waveguide_heater: CrossSectionSpec = "strip_heater_metal",
     cross_section: CrossSectionSpec = "strip",
     via_stack: ComponentSpec = "via_stack_heater_mtop_mini",
-    port_orientation: float | None = None,
+    port_orientation: AngleInDegrees | None = None,
     via_stack_offset: Float2 = (1, 0),
     with_drop: bool = True,
 ) -> Component:

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.cross_section import CrossSectionSpec
@@ -12,7 +14,7 @@ def straight(
     length: float = 10.0,
     npoints: int = 2,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns a Straight waveguide.
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -434,9 +434,9 @@ class Transition(CrossSection):
         if isinstance(width_type, str):
             return width_type
         t_values = np.linspace(0, 1, 10)
-        return ",".join([
-            str(round(width, 3)) for width in width_type(t_values, *self.width)
-        ])
+        return ",".join(
+            [str(round(width, 3)) for width in width_type(t_values, *self.width)]
+        )
 
     @property
     def width(self) -> tuple[float, float]:
@@ -563,15 +563,17 @@ def cross_section(
         cladding_centers = cladding_centers or [0] * len(cladding_layers)
 
         if (
-            len({
-                len(x)
-                for x in (
-                    cladding_layers,
-                    cladding_offsets,
-                    cladding_simplify,
-                    cladding_centers,
-                )
-            })
+            len(
+                {
+                    len(x)
+                    for x in (
+                        cladding_layers,
+                        cladding_offsets,
+                        cladding_simplify,
+                        cladding_centers,
+                    )
+                }
+            )
             > 1
         ):
             raise ValueError(

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -279,7 +279,7 @@ class CrossSection(BaseModel):
         width_function: Callable | None = None,
         offset_function: Callable | None = None,
         sections: tuple[Section, ...] | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> CrossSection:
         """Returns copy of the cross_section with new parameters.
 
@@ -434,9 +434,9 @@ class Transition(CrossSection):
         if isinstance(width_type, str):
             return width_type
         t_values = np.linspace(0, 1, 10)
-        return ",".join(
-            [str(round(width, 3)) for width in width_type(t_values, *self.width)]
-        )
+        return ",".join([
+            str(round(width, 3)) for width in width_type(t_values, *self.width)
+        ])
 
     @property
     def width(self) -> tuple[float, float]:
@@ -563,17 +563,15 @@ def cross_section(
         cladding_centers = cladding_centers or [0] * len(cladding_layers)
 
         if (
-            len(
-                {
-                    len(x)
-                    for x in (
-                        cladding_layers,
-                        cladding_offsets,
-                        cladding_simplify,
-                        cladding_centers,
-                    )
-                }
-            )
+            len({
+                len(x)
+                for x in (
+                    cladding_layers,
+                    cladding_offsets,
+                    cladding_simplify,
+                    cladding_centers,
+                )
+            })
             > 1
         ):
             raise ValueError(
@@ -621,7 +619,7 @@ def strip(
     layer: LayerSpec = "WG",
     radius: float = 10.0,
     radius_min: float = 5,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Strip cross_section."""
     return cross_section(
@@ -642,7 +640,7 @@ def rib(
     cladding_layers: LayerSpecs = ("SLAB90",),
     cladding_offsets: Floats = (3,),
     cladding_simplify: Floats = (50 * nm,),
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Rib cross_section."""
     return cross_section(
@@ -665,7 +663,7 @@ def rib_bbox(
     radius_min: float | None = None,
     bbox_layers: LayerSpecs = ("SLAB90",),
     bbox_offsets: Floats = (3,),
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Rib cross_section."""
     return cross_section(
@@ -687,7 +685,7 @@ def rib2(
     radius: float = radius_rib,
     radius_min: float | None = None,
     width_slab: float = 6,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Rib cross_section."""
     sections = (
@@ -709,7 +707,7 @@ def nitride(
     layer: LayerSpec = "WGN",
     radius: float = radius_nitride,
     radius_min: float | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Strip cross_section."""
     return cross_section(
@@ -729,7 +727,7 @@ def strip_rib_tip(
     layer_slab: LayerSpec = "SLAB90",
     radius: float = 10.0,
     radius_min: float | None = 5,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Strip cross_section."""
     sections = (Section(width=width_tip, layer=layer_slab, name="slab"),)
@@ -752,7 +750,7 @@ def strip_nitride_tip(
     width_tip_silicon: float = 0.1,
     radius: float = radius_nitride,
     radius_min: float | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Strip cross_section."""
     sections = (
@@ -823,7 +821,7 @@ def rib_with_trenches(
     layer_trench: LayerSpec = "DEEP_ETCH",
     wg_marking_layer: LayerSpec | None = None,
     sections: tuple[Section, ...] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return CrossSection of rib waveguide defined by trenches.
 
@@ -921,7 +919,7 @@ def l_with_trenches(
     layer_trench: LayerSpec = "DEEP_ETCH",
     mirror: bool = False,
     sections: tuple[Section, ...] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return CrossSection of l waveguide defined by trenches.
 
@@ -995,7 +993,7 @@ def metal1(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
     return cross_section(
@@ -1015,7 +1013,7 @@ def metal2(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
     return cross_section(
@@ -1035,7 +1033,7 @@ def metal3(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
     return cross_section(
@@ -1055,7 +1053,7 @@ def metal_routing(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
     return cross_section(
@@ -1075,7 +1073,7 @@ def heater_metal(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
     return cross_section(
@@ -1095,7 +1093,7 @@ def npp(
     radius: float | None = None,
     port_names=port_names_electrical,
     port_types=port_types_electrical,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return Doped NPP cross_section."""
     return cross_section(
@@ -1124,7 +1122,7 @@ def pin(
     via_width: float = 1,
     via_offsets: tuple[float, ...] | None = None,
     sections: tuple[Section, ...] | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Rib PIN doped cross_section.
 
@@ -1239,7 +1237,7 @@ def pn(
     cladding_offsets: Floats | None = None,
     cladding_simplify: Floats | None = None,
     slab_inset: float | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Rib PN doped cross_section.
 
@@ -1429,7 +1427,7 @@ def pn_with_trenches(
     cladding_simplify: Floats | None = cladding_simplify_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Rib PN doped cross_section.
 
@@ -1636,7 +1634,7 @@ def pn_with_trenches_asymmetric(
     cladding_offsets: Floats | None = cladding_offsets_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Rib PN doped cross_section with asymmetric dimensions left and right.
 
@@ -1856,7 +1854,7 @@ def l_wg_doped_with_trenches(
     cladding_offsets: Floats | None = cladding_offsets_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """L waveguide PN doped cross_section.
 
@@ -2010,7 +2008,7 @@ def strip_heater_metal_undercut(
     layer_heater: LayerSpec = "HEATER",
     layer_trench: LayerSpec = "DEEPTRENCH",
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Returns strip cross_section with top metal and undercut trenches on both.
 
@@ -2085,7 +2083,7 @@ def strip_heater_metal(
     heater_width: float = 2.5,
     layer_heater: LayerSpec = "HEATER",
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Returns strip cross_section with top heater metal.
 
@@ -2136,7 +2134,7 @@ def strip_heater_doped(
     layers_heater: LayerSpecs = ("WG", "NPP"),
     bbox_offsets_heater: tuple[float, ...] = (0, 0.1),
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Returns strip cross_section with N++ doped heaters on both sides.
 
@@ -2213,7 +2211,7 @@ def rib_heater_doped(
     with_top_heater: bool = True,
     with_bot_heater: bool = True,
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Returns rib cross_section with N++ doped heaters on both sides.
 
@@ -2303,7 +2301,7 @@ def rib_heater_doped_via_stack(
     with_top_heater: bool = True,
     with_bot_heater: bool = True,
     sections: Sections | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Returns rib cross_section with N++ doped heaters on both sides.
 
@@ -2437,7 +2435,7 @@ def pn_ge_detector_si_contacts(
     cladding_layers: Layers | None = cladding_layers_optical,
     cladding_offsets: Floats | None = cladding_offsets_optical,
     cladding_simplify: Floats | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> CrossSection:
     """Linear Ge detector cross section based on a lateral p(i)n junction.
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Iterable
 from functools import partial, wraps
 from inspect import getmembers, signature
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import numpy as np
 from kfactory import logger
@@ -29,20 +29,26 @@ from gdsfactory.config import CONF, ErrorType
 
 if TYPE_CHECKING:
     from gdsfactory.component import Component
+    from gdsfactory.typings import (
+        PortNames,
+        PortTypes,
+    )
+
 
 nm = 1e-3
 
 
-Layer = tuple[int, int]
-Layers = tuple[Layer, ...]
-WidthTypes = Literal["sine", "linear", "parabolic"]
+Layer: TypeAlias = tuple[int, int]
+Layers: TypeAlias = tuple[Layer, ...]
+WidthTypes: TypeAlias = Literal["sine", "linear", "parabolic"]
 
-LayerSpec = Layer | str
-LayerSpecs = Iterable[LayerSpec]
+LayerSpec: TypeAlias = Layer | str
+LayerSpecs: TypeAlias = Iterable[LayerSpec]
 
-Floats = tuple[float, ...]
-port_names_electrical = ("e1", "e2")
-port_types_electrical = ("electrical", "electrical")
+Floats: TypeAlias = tuple[float, ...]
+
+port_names_electrical: "PortNames" = ("e1", "e2")
+port_types_electrical: "PortTypes" = ("electrical", "electrical")
 cladding_layers_optical = None
 cladding_offsets_optical = None
 cladding_simplify_optical = None
@@ -353,7 +359,7 @@ class CrossSection(BaseModel):
 
     def add_bbox(
         self,
-        component,
+        component: Component,
         top: float | None = None,
         bottom: float | None = None,
         right: float | None = None,
@@ -434,9 +440,9 @@ class Transition(CrossSection):
         if isinstance(width_type, str):
             return width_type
         t_values = np.linspace(0, 1, 10)
-        return ",".join(
-            [str(round(width, 3)) for width in width_type(t_values, *self.width)]
-        )
+        return ",".join([
+            str(round(width, 3)) for width in width_type(t_values, *self.width)
+        ])
 
     @property
     def width(self) -> tuple[float, float]:
@@ -454,7 +460,7 @@ cross_sections = {}
 _cross_section_default_names = {}
 
 
-def xsection(func):
+def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
     """Decorator to register a cross section function.
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
@@ -469,7 +475,7 @@ def xsection(func):
     _cross_section_default_names[default_xs.name] = func.__name__
 
     @wraps(func)
-    def newfunc(**kwargs):
+    def newfunc(**kwargs: Any) -> CrossSection:
         xs = func(**kwargs)
         if xs.name in _cross_section_default_names:
             xs._name = _cross_section_default_names[xs.name]
@@ -486,12 +492,12 @@ def cross_section(
     sections: tuple[Section, ...] | None = None,
     port_names: tuple[str, str] = ("o1", "o2"),
     port_types: tuple[str, str] = ("optical", "optical"),
-    bbox_layers: LayerSpecs | None = None,
-    bbox_offsets: Floats | None = None,
-    cladding_layers: LayerSpecs | None = None,
-    cladding_offsets: Floats | None = None,
-    cladding_simplify: Floats | None = None,
-    cladding_centers: Floats | None = None,
+    bbox_layers: "LayerSpecs | None" = None,
+    bbox_offsets: "Floats | None" = None,
+    cladding_layers: "LayerSpecs | None" = None,
+    cladding_offsets: "Floats | None" = None,
+    cladding_simplify: "Floats | None" = None,
+    cladding_centers: "Floats | None" = None,
     radius: float | None = 10.0,
     radius_min: float | None = None,
     main_section_name: str = "_default",
@@ -563,17 +569,15 @@ def cross_section(
         cladding_centers = cladding_centers or [0] * len(cladding_layers)
 
         if (
-            len(
-                {
-                    len(x)
-                    for x in (
-                        cladding_layers,
-                        cladding_offsets,
-                        cladding_simplify,
-                        cladding_centers,
-                    )
-                }
-            )
+            len({
+                len(x)
+                for x in (
+                    cladding_layers,
+                    cladding_offsets,
+                    cladding_simplify,
+                    cladding_centers,
+                )
+            })
             > 1
         ):
             raise ValueError(
@@ -993,8 +997,8 @@ def metal1(
     width: float = 10,
     layer: LayerSpec = "M1",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
@@ -1013,8 +1017,8 @@ def metal2(
     width: float = 10,
     layer: LayerSpec = "M2",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
@@ -1033,8 +1037,8 @@ def metal3(
     width: float = 10,
     layer: LayerSpec = "M3",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
@@ -1053,8 +1057,8 @@ def metal_routing(
     width: float = 10,
     layer: LayerSpec = "M3",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
@@ -1073,8 +1077,8 @@ def heater_metal(
     width: float = 2.5,
     layer: LayerSpec = "HEATER",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
@@ -1093,8 +1097,8 @@ def npp(
     width: float = 0.5,
     layer: LayerSpec = "NPP",
     radius: float | None = None,
-    port_names=port_names_electrical,
-    port_types=port_types_electrical,
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
     **kwargs: Any,
 ) -> CrossSection:
     """Return Doped NPP cross_section."""
@@ -1235,9 +1239,9 @@ def pn(
     width_metal: float = 1.0,
     port_names: tuple[str, str] = ("o1", "o2"),
     sections: tuple[Section, ...] | None = None,
-    cladding_layers: LayerSpecs | None = None,
-    cladding_offsets: Floats | None = None,
-    cladding_simplify: Floats | None = None,
+    cladding_layers: "LayerSpecs | None" = None,
+    cladding_offsets: "Floats | None" = None,
+    cladding_simplify: "Floats | None" = None,
     slab_inset: float | None = None,
     **kwargs: Any,
 ) -> CrossSection:
@@ -1423,10 +1427,10 @@ def pn_with_trenches(
     width_via: float = 1.0,
     layer_metal: LayerSpec | None = None,
     width_metal: float = 1.0,
-    port_names: tuple[str, str] = ("o1", "o2"),
+    port_names: "PortNames" = ("o1", "o2"),
     cladding_layers: Layers | None = cladding_layers_optical,
-    cladding_offsets: Floats | None = cladding_offsets_optical,
-    cladding_simplify: Floats | None = cladding_simplify_optical,
+    cladding_offsets: "Floats | None" = cladding_offsets_optical,
+    cladding_simplify: "Floats | None" = cladding_simplify_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
     **kwargs: Any,
@@ -1633,7 +1637,7 @@ def pn_with_trenches_asymmetric(
     width_metal: float = 1.0,
     port_names: tuple[str, str] = ("o1", "o2"),
     cladding_layers: Layers | None = cladding_layers_optical,
-    cladding_offsets: Floats | None = cladding_offsets_optical,
+    cladding_offsets: "Floats | None" = cladding_offsets_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
     **kwargs: Any,
@@ -1853,7 +1857,7 @@ def l_wg_doped_with_trenches(
     width_metal: float = 1.0,
     port_names: tuple[str, str] = ("o1", "o2"),
     cladding_layers: Layers | None = cladding_layers_optical,
-    cladding_offsets: Floats | None = cladding_offsets_optical,
+    cladding_offsets: "Floats | None" = cladding_offsets_optical,
     wg_marking_layer: LayerSpec | None = None,
     sections: Sections | None = None,
     **kwargs: Any,
@@ -2435,8 +2439,8 @@ def pn_ge_detector_si_contacts(
     layer_metal: LayerSpec | None = None,
     port_names: tuple[str, str] = ("o1", "o2"),
     cladding_layers: Layers | None = cladding_layers_optical,
-    cladding_offsets: Floats | None = cladding_offsets_optical,
-    cladding_simplify: Floats | None = None,
+    cladding_offsets: "Floats | None" = cladding_offsets_optical,
+    cladding_simplify: "Floats | None" = None,
     **kwargs: Any,
 ) -> CrossSection:
     """Linear Ge detector cross section based on a lateral p(i)n junction.

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -440,9 +440,9 @@ class Transition(CrossSection):
         if isinstance(width_type, str):
             return width_type
         t_values = np.linspace(0, 1, 10)
-        return ",".join([
-            str(round(width, 3)) for width in width_type(t_values, *self.width)
-        ])
+        return ",".join(
+            [str(round(width, 3)) for width in width_type(t_values, *self.width)]
+        )
 
     @property
     def width(self) -> tuple[float, float]:
@@ -569,15 +569,17 @@ def cross_section(
         cladding_centers = cladding_centers or [0] * len(cladding_layers)
 
         if (
-            len({
-                len(x)
-                for x in (
-                    cladding_layers,
-                    cladding_offsets,
-                    cladding_simplify,
-                    cladding_centers,
-                )
-            })
+            len(
+                {
+                    len(x)
+                    for x in (
+                        cladding_layers,
+                        cladding_offsets,
+                        cladding_simplify,
+                        cladding_centers,
+                    )
+                }
+            )
             > 1
         ):
             raise ValueError(

--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -62,7 +62,7 @@ def _get_font_by_name(name: str):
     return _get_font_by_file(font_file)
 
 
-def _get_glyph(font, letter):  # noqa: C901
+def _get_glyph(font, letter):
     """Get a block reference to the given letter."""
     if not isinstance(letter, str) and len(letter) == 1:
         raise TypeError(f"Letter must be a string of length 1. Got: {letter!r}")

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -203,19 +203,23 @@ def get_polygons_points(
         all_points = []
         for polygon in polygons:
             if scale:
-                points = np.array([
-                    (point.x * scale, point.y * scale)
-                    for point in polygon.to_simple_polygon()
-                    .to_dtype(component_or_instance.kcl.dbu)
-                    .each_point()
-                ])
+                points = np.array(
+                    [
+                        (point.x * scale, point.y * scale)
+                        for point in polygon.to_simple_polygon()
+                        .to_dtype(component_or_instance.kcl.dbu)
+                        .each_point()
+                    ]
+                )
             else:
-                points = np.array([
-                    (point.x, point.y)
-                    for point in polygon.to_simple_polygon()
-                    .to_dtype(component_or_instance.kcl.dbu)
-                    .each_point()
-                ])
+                points = np.array(
+                    [
+                        (point.x, point.y)
+                        for point in polygon.to_simple_polygon()
+                        .to_dtype(component_or_instance.kcl.dbu)
+                        .each_point()
+                    ]
+                )
             all_points.append(points)
         polygons_points[layer] = all_points
     return polygons_points

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -93,7 +93,7 @@ def extract(
     return c
 
 
-def move_to_center(component: Component, dx: float = 0, dy: float = 0) -> gf.Component:
+def move_to_center(component: Component, dx: Delta = 0, dy: Delta = 0) -> gf.Component:
     """Moves the component to the center of the bounding box."""
     c = component
     c.transform(
@@ -104,7 +104,7 @@ def move_to_center(component: Component, dx: float = 0, dy: float = 0) -> gf.Com
 
 
 def move_port(
-    component: Component, port_name: str, dx: float = 0, dy: float = 0
+    component: Component, port_name: str, dx: Delta = 0, dy: Delta = 0
 ) -> gf.Component:
     """Moves the component port to a specific location.
 
@@ -203,23 +203,19 @@ def get_polygons_points(
         all_points = []
         for polygon in polygons:
             if scale:
-                points = np.array(
-                    [
-                        (point.x * scale, point.y * scale)
-                        for point in polygon.to_simple_polygon()
-                        .to_dtype(component_or_instance.kcl.dbu)
-                        .each_point()
-                    ]
-                )
+                points = np.array([
+                    (point.x * scale, point.y * scale)
+                    for point in polygon.to_simple_polygon()
+                    .to_dtype(component_or_instance.kcl.dbu)
+                    .each_point()
+                ])
             else:
-                points = np.array(
-                    [
-                        (point.x, point.y)
-                        for point in polygon.to_simple_polygon()
-                        .to_dtype(component_or_instance.kcl.dbu)
-                        .each_point()
-                    ]
-                )
+                points = np.array([
+                    (point.x, point.y)
+                    for point in polygon.to_simple_polygon()
+                    .to_dtype(component_or_instance.kcl.dbu)
+                    .each_point()
+                ])
             all_points.append(points)
         polygons_points[layer] = all_points
     return polygons_points

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -26,17 +26,19 @@ def get_cells(
     modules = modules if isinstance(modules, Iterable) else [modules]
     cells: dict[str, ComponentFactory] = {}
     for module in modules:
-        cells.update({
-            name: member
-            for name, member in getmembers(module)
-            if is_cell(
-                member,
-                ignore_non_decorated=ignore_non_decorated,
-                ignore_underscored=ignore_underscored,
-                ignore_partials=ignore_partials,
-                name=name,
-            )
-        })
+        cells.update(
+            {
+                name: member
+                for name, member in getmembers(module)
+                if is_cell(
+                    member,
+                    ignore_non_decorated=ignore_non_decorated,
+                    ignore_underscored=ignore_underscored,
+                    ignore_partials=ignore_partials,
+                    name=name,
+                )
+            }
+        )
     return cells
 
 

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -6,7 +6,7 @@ from functools import partial
 from inspect import getmembers, isfunction, signature
 from typing import Any
 
-from gdsfactory.typings import Component
+from gdsfactory.typings import Component, ComponentFactory
 
 
 def get_cells(
@@ -14,7 +14,7 @@ def get_cells(
     ignore_non_decorated: bool = False,
     ignore_underscored: bool = True,
     ignore_partials: bool = False,
-) -> dict[str, Callable]:
+) -> dict[str, ComponentFactory]:
     """Returns PCells (component functions) from a module or list of modules.
 
     Args:
@@ -24,17 +24,19 @@ def get_cells(
         ignore_partials: only include functions, not partials
     """
     modules = modules if isinstance(modules, Iterable) else [modules]
-    cells = {}
+    cells: dict[str, ComponentFactory] = {}
     for module in modules:
-        for name, member in getmembers(module):
+        cells.update({
+            name: member
+            for name, member in getmembers(module)
             if is_cell(
                 member,
                 ignore_non_decorated=ignore_non_decorated,
                 ignore_underscored=ignore_underscored,
                 ignore_partials=ignore_partials,
                 name=name,
-            ):
-                cells[name] = member
+            )
+        })
     return cells
 
 

--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -73,12 +73,12 @@ def grid(
         ),
         align_x=align_x,
         align_y=align_y,
-        rotation=round(rotation // 90),
+        rotation=round(rotation // 90),  # type: ignore
         mirror=mirror,
     )
     for i, instances_list in enumerate(instances):
         for j, instance in enumerate(instances_list):
-            if instances_list is not None and instance is not None:
+            if instance is not None:
                 c.add_ports(instance.ports, prefix=f"{j}_{i}_")
     return c
 

--- a/gdsfactory/labels/write_test_manifest.py
+++ b/gdsfactory/labels/write_test_manifest.py
@@ -3,9 +3,9 @@
 import csv
 import json
 import pathlib
+from collections.abc import Iterable
 
 import gdsfactory as gf
-from gdsfactory.typings import Iterable
 
 
 def write_test_manifest(

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -579,26 +579,24 @@ def transition_exponential(y1, y2, exp=0.5):
     return lambda t: y1 + (y2 - y1) * t**exp
 
 
-adiabatic_polyfit_TE1550SOI_220nm = np.array(
-    [
-        1.02478963e-09,
-        -8.65556534e-08,
-        3.32415694e-06,
-        -7.68408985e-05,
-        1.19282177e-03,
-        -1.31366332e-02,
-        1.05721429e-01,
-        -6.31057637e-01,
-        2.80689677e00,
-        -9.26867694e00,
-        2.24535191e01,
-        -3.90664800e01,
-        4.71899278e01,
-        -3.74726005e01,
-        1.77381560e01,
-        -1.12666286e00,
-    ]
-)
+adiabatic_polyfit_TE1550SOI_220nm = np.array([
+    1.02478963e-09,
+    -8.65556534e-08,
+    3.32415694e-06,
+    -7.68408985e-05,
+    1.19282177e-03,
+    -1.31366332e-02,
+    1.05721429e-01,
+    -6.31057637e-01,
+    2.80689677e00,
+    -9.26867694e00,
+    2.24535191e01,
+    -3.90664800e01,
+    4.71899278e01,
+    -3.74726005e01,
+    1.77381560e01,
+    -1.12666286e00,
+])
 
 
 def transition_adiabatic(
@@ -858,12 +856,10 @@ def extrude(
             p_pts = p_sec.points
 
             # This excludes the first point, so length of output array is smaller by 1
-            p_xy_segment_lengths = np.array(
-                [
-                    np.diff(p_pts[:, 0]),
-                    np.diff(p_pts[:, 1]),
-                ]
-            ).T
+            p_xy_segment_lengths = np.array([
+                np.diff(p_pts[:, 0]),
+                np.diff(p_pts[:, 1]),
+            ]).T
 
             # Using the axis=1 makes output equivalent to [np.linalg.norm(p_xy_segment_lengths[i, :])
             #                                              for i
@@ -963,13 +959,11 @@ def extrude(
             new_start_point = v_start_inset + p_pts[start_diff_idx + 1, :]
             new_stop_point = v_stop_inset + p_pts[stop_diff_idx, :]
 
-            p_sec = Path(
-                [
-                    new_start_point,
-                    *p_pts[start_diff_idx + 1 : stop_diff_idx],
-                    new_stop_point,
-                ]
-            )
+            p_sec = Path([
+                new_start_point,
+                *p_pts[start_diff_idx + 1 : stop_diff_idx],
+                new_stop_point,
+            ])
 
         if callable(offset_function):
             p_sec.offset(offset_function)
@@ -1552,13 +1546,11 @@ def spiral_archimedean(
         p.plot()
 
     """
-    return Path(
-        [
-            (separation / np.pi * theta + min_bend_radius)
-            * np.array((np.sin(theta), np.cos(theta)))
-            for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
-        ]
-    )
+    return Path([
+        (separation / np.pi * theta + min_bend_radius)
+        * np.array((np.sin(theta), np.cos(theta)))
+        for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+    ])
 
 
 def _compute_segments(points):

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 from numpy import mod, pi
 
 from gdsfactory import logger
@@ -29,6 +30,7 @@ from gdsfactory.cross_section import CrossSection, Section, Transition
 
 if TYPE_CHECKING:
     from gdsfactory.typings import (
+        AngleInDegrees,
         ComponentSpec,
         Coordinates,
         CrossSectionSpec,
@@ -577,26 +579,24 @@ def transition_exponential(y1, y2, exp=0.5):
     return lambda t: y1 + (y2 - y1) * t**exp
 
 
-adiabatic_polyfit_TE1550SOI_220nm = np.array(
-    [
-        1.02478963e-09,
-        -8.65556534e-08,
-        3.32415694e-06,
-        -7.68408985e-05,
-        1.19282177e-03,
-        -1.31366332e-02,
-        1.05721429e-01,
-        -6.31057637e-01,
-        2.80689677e00,
-        -9.26867694e00,
-        2.24535191e01,
-        -3.90664800e01,
-        4.71899278e01,
-        -3.74726005e01,
-        1.77381560e01,
-        -1.12666286e00,
-    ]
-)
+adiabatic_polyfit_TE1550SOI_220nm = np.array([
+    1.02478963e-09,
+    -8.65556534e-08,
+    3.32415694e-06,
+    -7.68408985e-05,
+    1.19282177e-03,
+    -1.31366332e-02,
+    1.05721429e-01,
+    -6.31057637e-01,
+    2.80689677e00,
+    -9.26867694e00,
+    2.24535191e01,
+    -3.90664800e01,
+    4.71899278e01,
+    -3.74726005e01,
+    1.77381560e01,
+    -1.12666286e00,
+])
 
 
 def transition_adiabatic(
@@ -856,9 +856,10 @@ def extrude(
             p_pts = p_sec.points
 
             # This excludes the first point, so length of output array is smaller by 1
-            p_xy_segment_lengths = np.array(
-                [np.diff(p_pts[:, 0]), np.diff(p_pts[:, 1])]
-            ).T
+            p_xy_segment_lengths = np.array([
+                np.diff(p_pts[:, 0]),
+                np.diff(p_pts[:, 1]),
+            ]).T
 
             # Using the axis=1 makes output equivalent to [np.linalg.norm(p_xy_segment_lengths[i, :])
             #                                              for i
@@ -958,13 +959,11 @@ def extrude(
             new_start_point = v_start_inset + p_pts[start_diff_idx + 1, :]
             new_stop_point = v_stop_inset + p_pts[stop_diff_idx, :]
 
-            p_sec = Path(
-                [
-                    new_start_point,
-                    *p_pts[start_diff_idx + 1 : stop_diff_idx],
-                    new_stop_point,
-                ]
-            )
+            p_sec = Path([
+                new_start_point,
+                *p_pts[start_diff_idx + 1 : stop_diff_idx],
+                new_stop_point,
+            ])
 
         if callable(offset_function):
             p_sec.offset(offset_function)
@@ -1239,7 +1238,7 @@ def extrude_transition(
 
 
 def _rotated_delta(
-    point: np.ndarray, center: np.ndarray, orientation: float
+    point: np.ndarray, center: npt.NDArray[np.float64], orientation: AngleInDegrees
 ) -> np.ndarray:
     """Gets the rotated distance of a point from a center.
 
@@ -1547,13 +1546,11 @@ def spiral_archimedean(
         p.plot()
 
     """
-    return Path(
-        [
-            (separation / np.pi * theta + min_bend_radius)
-            * np.array((np.sin(theta), np.cos(theta)))
-            for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
-        ]
-    )
+    return Path([
+        (separation / np.pi * theta + min_bend_radius)
+        * np.array((np.sin(theta), np.cos(theta)))
+        for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+    ])
 
 
 def _compute_segments(points):

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -579,24 +579,26 @@ def transition_exponential(y1, y2, exp=0.5):
     return lambda t: y1 + (y2 - y1) * t**exp
 
 
-adiabatic_polyfit_TE1550SOI_220nm = np.array([
-    1.02478963e-09,
-    -8.65556534e-08,
-    3.32415694e-06,
-    -7.68408985e-05,
-    1.19282177e-03,
-    -1.31366332e-02,
-    1.05721429e-01,
-    -6.31057637e-01,
-    2.80689677e00,
-    -9.26867694e00,
-    2.24535191e01,
-    -3.90664800e01,
-    4.71899278e01,
-    -3.74726005e01,
-    1.77381560e01,
-    -1.12666286e00,
-])
+adiabatic_polyfit_TE1550SOI_220nm = np.array(
+    [
+        1.02478963e-09,
+        -8.65556534e-08,
+        3.32415694e-06,
+        -7.68408985e-05,
+        1.19282177e-03,
+        -1.31366332e-02,
+        1.05721429e-01,
+        -6.31057637e-01,
+        2.80689677e00,
+        -9.26867694e00,
+        2.24535191e01,
+        -3.90664800e01,
+        4.71899278e01,
+        -3.74726005e01,
+        1.77381560e01,
+        -1.12666286e00,
+    ]
+)
 
 
 def transition_adiabatic(
@@ -856,10 +858,12 @@ def extrude(
             p_pts = p_sec.points
 
             # This excludes the first point, so length of output array is smaller by 1
-            p_xy_segment_lengths = np.array([
-                np.diff(p_pts[:, 0]),
-                np.diff(p_pts[:, 1]),
-            ]).T
+            p_xy_segment_lengths = np.array(
+                [
+                    np.diff(p_pts[:, 0]),
+                    np.diff(p_pts[:, 1]),
+                ]
+            ).T
 
             # Using the axis=1 makes output equivalent to [np.linalg.norm(p_xy_segment_lengths[i, :])
             #                                              for i
@@ -959,11 +963,13 @@ def extrude(
             new_start_point = v_start_inset + p_pts[start_diff_idx + 1, :]
             new_stop_point = v_stop_inset + p_pts[stop_diff_idx, :]
 
-            p_sec = Path([
-                new_start_point,
-                *p_pts[start_diff_idx + 1 : stop_diff_idx],
-                new_stop_point,
-            ])
+            p_sec = Path(
+                [
+                    new_start_point,
+                    *p_pts[start_diff_idx + 1 : stop_diff_idx],
+                    new_stop_point,
+                ]
+            )
 
         if callable(offset_function):
             p_sec.offset(offset_function)
@@ -1546,11 +1552,13 @@ def spiral_archimedean(
         p.plot()
 
     """
-    return Path([
-        (separation / np.pi * theta + min_bend_radius)
-        * np.array((np.sin(theta), np.cos(theta)))
-        for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
-    ])
+    return Path(
+        [
+            (separation / np.pi * theta + min_bend_radius)
+            * np.array((np.sin(theta), np.cos(theta)))
+            for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+        ]
+    )
 
 
 def _compute_segments(points):

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -37,7 +37,6 @@ from gdsfactory.typings import (
     MaterialSpec,
     PathType,
     RoutingStrategies,
-    RoutingStrategy,
     Transition,
 )
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -615,7 +615,12 @@ def get_active_pdk(name: str | None = None) -> Pdk:
 
 
 def get_material_index(material: MaterialSpec, *args: Any, **kwargs: Any) -> Component:
-    return get_active_pdk().get_material_index(material, *args, **kwargs)
+    active_pdk = get_active_pdk()
+    if not hasattr(active_pdk, "get_material_index"):
+        raise NotImplementedError(
+            "The active PDK does not implement 'get_material_index'"
+        )
+    return active_pdk.get_material_index(material, *args, **kwargs)
 
 
 def get_component(

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -36,6 +36,8 @@ from gdsfactory.typings import (
     LayerSpec,
     MaterialSpec,
     PathType,
+    RoutingStrategies,
+    RoutingStrategy,
     Transition,
 )
 
@@ -169,9 +171,7 @@ class Pdk(BaseModel):
     )
     constants: dict[str, Any] = constants
     materials_index: dict[str, MaterialSpec] = Field(default_factory=dict)
-    routing_strategies: (
-        dict[str, Callable[..., kf.routing.generic.ManhattanRoute]] | None
-    ) = None
+    routing_strategies: RoutingStrategies | None = None
     bend_points_distance: float = 20 * nm
     connectivity: list[ConnectivitySpec] | None = None
     max_cellname_length: int = CONF.max_cellname_length
@@ -630,7 +630,7 @@ def get_cell(cell: CellSpec, **kwargs: Any) -> ComponentFactory:
 
 
 def get_cross_section(
-    cross_section: CrossSectionSpec, **kwargs
+    cross_section: CrossSectionSpec, **kwargs: Any
 ) -> CrossSection | Transition:
     return get_active_pdk().get_cross_section(cross_section, **kwargs)
 
@@ -641,7 +641,7 @@ def get_layer(layer: LayerSpec) -> LayerEnum:
 
 def get_layer_name(layer: LayerSpec) -> str:
     layer_index = get_layer(layer)
-    return str(get_active_pdk().layers(layer_index))
+    return str(get_active_pdk().layers(layer_index))  # type: ignore
 
 
 def get_layer_tuple(layer: LayerSpec) -> tuple[int, int]:
@@ -673,12 +673,10 @@ def _set_active_pdk(pdk: Pdk) -> None:
     _ACTIVE_PDK = pdk
 
 
-def get_routing_strategies() -> (
-    dict[str, Callable[..., list[kf.routing.generic.ManhattanRoute]]]
-):
+def get_routing_strategies() -> RoutingStrategies:
     """Gets a dictionary of named routing functions available to the PDK, if defined, or gdsfactory defaults otherwise."""
     from gdsfactory.routing.factories import (
-        routing_strategy as default_routing_strategies,
+        routing_strategies as default_routing_strategies,
     )
 
     routing_strategies = get_active_pdk().routing_strategies

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -45,7 +45,7 @@ from gdsfactory.cross_section import CrossSectionSpec
 
 if TYPE_CHECKING:
     from gdsfactory.component import Component
-    from gdsfactory.typings import PathType
+    from gdsfactory.typings import ComponentFactory, PathType
 
 Layer = tuple[int, int]
 Layers = tuple[Layer, ...]
@@ -442,9 +442,7 @@ def get_ports_facing(ports: list[Port], direction: str = "W") -> list[Port]:
     return direction_ports[direction]
 
 
-def deco_rename_ports(
-    component_factory: Callable[..., Component],
-) -> Callable[..., Component]:
+def deco_rename_ports(component_factory: "ComponentFactory") -> "ComponentFactory":  # noqa: UP037
     @functools.wraps(component_factory)
     def auto_named_component_factory(*args: Any, **kwargs: Any) -> Component:
         component = component_factory(*args, **kwargs)
@@ -511,7 +509,7 @@ def _rename_ports_counter_clockwise(
     ports = east_ports + north_ports + west_ports + south_ports
 
     for i, p in enumerate(ports):
-        p.name = f"{prefix}{i+1}" if prefix else i + 1
+        p.name = f"{prefix}{i + 1}" if prefix else i + 1
 
 
 def _rename_ports_clockwise(direction_ports: PortsMap, prefix: str = "") -> None:
@@ -532,7 +530,7 @@ def _rename_ports_clockwise(direction_ports: PortsMap, prefix: str = "") -> None
     ports = west_ports + north_ports + east_ports + south_ports
 
     for i, p in enumerate(ports):
-        p.name = f"{prefix}{i+1}" if prefix else i + 1
+        p.name = f"{prefix}{i + 1}" if prefix else i + 1
 
 
 def _rename_ports_clockwise_top_right(
@@ -554,7 +552,7 @@ def _rename_ports_clockwise_top_right(
     ports = east_ports + south_ports + west_ports + north_ports
 
     for i, p in enumerate(ports):
-        p.name = f"{prefix}{i+1}" if prefix else i + 1
+        p.name = f"{prefix}{i + 1}" if prefix else i + 1
 
 
 def rename_ports_by_orientation(

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -45,7 +45,7 @@ from gdsfactory.cross_section import CrossSectionSpec
 
 if TYPE_CHECKING:
     from gdsfactory.component import Component
-    from gdsfactory.typings import ComponentFactory, PathType
+    from gdsfactory.typings import AngleInDegrees, ComponentFactory, PathType
 
 Layer = tuple[int, int]
 Layers = tuple[Layer, ...]
@@ -111,7 +111,7 @@ class Port(kf.Port):
     def __init__(
         self,
         name: str,
-        orientation: float | None,
+        orientation: AngleInDegrees | None,
         center: tuple[float, float] | kf.kdb.Point | kf.kdb.DPoint,
         width: float | None = None,
         layer: LayerSpec | None = None,
@@ -177,7 +177,7 @@ PortsMap = dict[str, list[Port]]
 def port_array(
     center: tuple[float, float] = (0.0, 0.0),
     width: float = 0.5,
-    orientation: float = 0,
+    orientation: AngleInDegrees = 0,
     pitch: tuple[float, float] = (10.0, 0.0),
     n: int = 2,
     **kwargs: Any,
@@ -324,7 +324,7 @@ def select_ports(
     layer: LayerSpec | None = None,
     prefix: str | None = None,
     suffix: str | None = None,
-    orientation: int | None = None,
+    orientation: AngleInDegrees | None = None,
     width: float | None = None,
     layers_excluded: tuple[tuple[int, int], ...] | None = None,
     port_type: str | None = None,
@@ -442,7 +442,7 @@ def get_ports_facing(ports: list[Port], direction: str = "W") -> list[Port]:
     return direction_ports[direction]
 
 
-def deco_rename_ports(component_factory: "ComponentFactory") -> "ComponentFactory":  # noqa: UP037
+def deco_rename_ports(component_factory: "ComponentFactory") -> "ComponentFactory":
     @functools.wraps(component_factory)
     def auto_named_component_factory(*args: Any, **kwargs: Any) -> Component:
         component = component_factory(*args, **kwargs)

--- a/gdsfactory/read/from_gdspaths.py
+++ b/gdsfactory/read/from_gdspaths.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import pathlib
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from gdsfactory import logger
 from gdsfactory.component import Component
 from gdsfactory.read.import_gds import import_gds
-from gdsfactory.typings import ComponentOrPath, PathType
+
+if TYPE_CHECKING:
+    from gdsfactory.typings import ComponentOrPath, PathType
 
 
-def from_gdspaths(cells: tuple[ComponentOrPath, ...]) -> Component:
+def from_gdspaths(cells: "Sequence[ComponentOrPath]") -> Component:
     """Combine all GDS files or gf.components into a gf.component.
 
     Args:
@@ -28,7 +32,7 @@ def from_gdspaths(cells: tuple[ComponentOrPath, ...]) -> Component:
     return component
 
 
-def from_gdsdir(dirpath: PathType) -> Component:
+def from_gdsdir(dirpath: "PathType") -> Component:
     """Merges GDS cells from a directory into a single Component."""
     dirpath = pathlib.Path(dirpath)
     assert dirpath.exists(), f"{dirpath} does not exist"

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -112,18 +112,23 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
             continue
 
         parameters_string = (
-            ", ".join([
-                f"{p_name}:{p['type']}={p['value']}" for p_name, p in parameters.items()
-            ])
+            ", ".join(
+                [
+                    f"{p_name}:{p['type']}={p['value']}"
+                    for p_name, p in parameters.items()
+                ]
+            )
             if parameters
             else ""
         )
         parameters_doc = (
-            "\n    ".join([
-                f"  {p_name}: {p['doc']} (min: {p['min']}, max: {p['max']}, {p['unit']})."
-                for p_name, p in parameters.items()
-                if hasattr(p, "min")
-            ])
+            "\n    ".join(
+                [
+                    f"  {p_name}: {p['doc']} (min: {p['min']}, max: {p['max']}, {p['unit']})."
+                    for p_name, p in parameters.items()
+                    if hasattr(p, "min")
+                ]
+            )
             if parameters
             else ""
         )
@@ -136,10 +141,12 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
         )
 
         parameters_labels = (
-            "\n".join([
-                f"    c.add_label(text=f'{p_name}', position=(xc, yc-{i}/{len(parameters)}/2*ysize), layer=layer_label)\n"
-                for i, p_name in enumerate(parameters_colon)
-            ])
+            "\n".join(
+                [
+                    f"    c.add_label(text=f'{p_name}', position=(xc, yc-{i}/{len(parameters)}/2*ysize), layer=layer_label)\n"
+                    for i, p_name in enumerate(parameters_colon)
+                ]
+            )
             if layer_label and parameters_colon
             else ""
         )

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -7,16 +7,20 @@ from __future__ import annotations
 
 import pathlib
 import warnings
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import yaml
 
 from gdsfactory.serialization import convert_tuples_to_lists
-from gdsfactory.typings import LayerSpec, PathType
+
+if TYPE_CHECKING:
+    from gdsfactory.typings import LayerSpec, PathType
 
 
 def from_updk(
-    filepath: PathType,
-    filepath_out: PathType | None = None,
+    filepath: "PathType",
+    filepath_out: "PathType | None" = None,
     layer_bbox: tuple[int, int] = (68, 0),
     layer_bbmetal: tuple[int, int] | None = None,
     layer_label: tuple[int, int] | None = None,
@@ -24,9 +28,9 @@ def from_updk(
     layer_pin: tuple[int, int] | None = None,
     layer_pin_optical: tuple[int, int] | None = None,
     layer_pin_electrical: tuple[int, int] | None = None,
-    optical_xsections: list[str] | None = None,
-    electrical_xsections: list[str] | None = None,
-    layer_text: LayerSpec | None = None,
+    optical_xsections: Sequence[str] | None = None,
+    electrical_xsections: Sequence[str] | None = None,
+    layer_text: "LayerSpec | None" = None,
     text_size: float = 2.0,
     activate_pdk: bool = False,
     read_xsections: bool = True,
@@ -108,23 +112,18 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
             continue
 
         parameters_string = (
-            ", ".join(
-                [
-                    f"{p_name}:{p['type']}={p['value']}"
-                    for p_name, p in parameters.items()
-                ]
-            )
+            ", ".join([
+                f"{p_name}:{p['type']}={p['value']}" for p_name, p in parameters.items()
+            ])
             if parameters
             else ""
         )
         parameters_doc = (
-            "\n    ".join(
-                [
-                    f"  {p_name}: {p['doc']} (min: {p['min']}, max: {p['max']}, {p['unit']})."
-                    for p_name, p in parameters.items()
-                    if hasattr(p, "min")
-                ]
-            )
+            "\n    ".join([
+                f"  {p_name}: {p['doc']} (min: {p['min']}, max: {p['max']}, {p['unit']})."
+                for p_name, p in parameters.items()
+                if hasattr(p, "min")
+            ])
             if parameters
             else ""
         )
@@ -137,12 +136,10 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
         )
 
         parameters_labels = (
-            "\n".join(
-                [
-                    f"    c.add_label(text=f'{p_name}', position=(xc, yc-{i}/{len(parameters)}/2*ysize), layer=layer_label)\n"
-                    for i, p_name in enumerate(parameters_colon)
-                ]
-            )
+            "\n".join([
+                f"    c.add_label(text=f'{p_name}', position=(xc, yc-{i}/{len(parameters)}/2*ysize), layer=layer_label)\n"
+                for i, p_name in enumerate(parameters_colon)
+            ])
             if layer_label and parameters_colon
             else ""
         )

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -64,6 +64,7 @@ from gdsfactory.add_pins import add_instance_label
 from gdsfactory.component import Component, ComponentReference, Instance
 from gdsfactory.schematic import Bundle, Netlist, Placement
 from gdsfactory.schematic import Instance as NetlistInstance
+from gdsfactory.typings import RoutingStrategies
 
 valid_placement_keys = [
     "x",
@@ -866,7 +867,7 @@ def _add_routes(
     c: Component,
     refs: dict[str, ComponentReference],
     routes: dict[str, Bundle],
-    routing_strategies: dict[str, Callable] | None = None,
+    routing_strategies: RoutingStrategies | None = None,
 ):
     """Add routes to component."""
     from gdsfactory.pdk import get_routing_strategies

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -666,7 +666,7 @@ def cell_from_yaml(
 
 def from_yaml(
     yaml_str: str | pathlib.Path | IO[Any] | dict[str, Any],
-    routing_strategy: dict[str, Callable] | None = None,
+    routing_strategy: RoutingStrategies | None = None,
     label_instance_function: Callable = add_instance_label,
     name: str | None = None,
 ) -> Component:

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -62,6 +62,7 @@ import yaml
 
 from gdsfactory.add_pins import add_instance_label
 from gdsfactory.component import Component, ComponentReference, Instance
+from gdsfactory.port import Port
 from gdsfactory.schematic import Bundle, Netlist, Placement
 from gdsfactory.schematic import Instance as NetlistInstance
 from gdsfactory.typings import RoutingStrategies
@@ -202,7 +203,7 @@ def _move_ref(
     return _get_anchor_value_from_name(instances[instance_name_ref], port_name, x_or_y)
 
 
-def _parse_maybe_arrayed_instance(inst_spec: str) -> tuple:
+def _parse_maybe_arrayed_instance(inst_spec: str) -> tuple[str, int | None, int | None]:
     """Parse an instance specifier that may or may not be arrayed.
 
     Returns the instance name, and the a and b indices if they are present.
@@ -1089,7 +1090,7 @@ def _get_directed_connections(connections: dict[str, str]):
     return ret
 
 
-def _split_route_link(s):
+def _split_route_link(s: str) -> tuple[str, list[str] | None]:
     if s.count(":") == 2:
         ip, *jk = s.split(":")
     elif s.count(":") == 0:
@@ -1105,7 +1106,7 @@ def _split_route_link(s):
         return i, [f"{p}"]
     j, k = jk
 
-    def _try_int(i):
+    def _try_int(i: str) -> int:
         try:
             return int(i)
         except ValueError:
@@ -1122,10 +1123,12 @@ def _split_route_link(s):
     )
 
 
-def _get_ports_from_portnames(refs, i, ps):
+def _get_ports_from_portnames(
+    refs: dict[str, ComponentReference], i: str, ps: list[str]
+) -> list[Port]:
     i, ia, ib = _parse_maybe_arrayed_instance(i)
     ref = refs[i]
-    ports = []
+    ports: list[Port] = []
     for p in ps:
         if p not in ref.ports:
             raise ValueError(f"{p} not in ports of {i} ({[p.name for p in ref.ports]})")

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -1,5 +1,5 @@
 import pathlib
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from inspect import Parameter, Signature, signature
 from io import IOBase
 from typing import IO, Any

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -10,6 +10,7 @@ from kfactory import cell
 
 from gdsfactory.component import Component
 from gdsfactory.read.from_yaml import from_yaml
+from gdsfactory.typings import ComponentFactory, RoutingStrategies
 
 __all__ = ["cell_from_yaml_template"]
 
@@ -69,8 +70,8 @@ def _split_yaml_definition(subpic_yaml):
 def cell_from_yaml_template(
     filename: _YamlDefinition,
     name: str,
-    routing_strategy: dict[str, Callable] | None = None,
-) -> Callable:
+    routing_strategy: RoutingStrategies | None = None,
+) -> ComponentFactory:
     """Gets a PIC factory function from a yaml definition, which can optionally be a jinja template.
 
     Args:
@@ -90,7 +91,9 @@ def cell_from_yaml_template(
     )
 
 
-def get_default_settings_dict(default_settings):
+def get_default_settings_dict(
+    default_settings: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
     settings = {}
     for k, v in default_settings.items():
         try:
@@ -110,8 +113,8 @@ def get_default_settings_dict(default_settings):
 
 
 def yaml_cell(
-    yaml_definition: _YamlDefinition, name: str, routing_strategy
-) -> Callable[..., Component]:
+    yaml_definition: _YamlDefinition, name: str, routing_strategy: RoutingStrategies
+) -> ComponentFactory:
     """The "cell" decorator equivalent for yaml files. Generates a proper cell function for yaml-defined circuits.
 
     Args:
@@ -164,7 +167,9 @@ def _evaluate_yaml_template(main_file, default_settings, settings):
     return template.render(**complete_settings)
 
 
-def _pic_from_templated_yaml(evaluated_text, name, routing_strategy) -> Component:
+def _pic_from_templated_yaml(
+    evaluated_text, name, routing_strategy: RoutingStrategies
+) -> Component:
     """Creates a component from a  *.pic.yml file.
 
     This is a lower-level function. See from_yaml_template() for more common usage.

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -52,7 +52,7 @@ def split_default_settings_from_yaml(yaml_lines: Iterable[str]) -> tuple[str, st
     return other_string, settings_string
 
 
-def _split_yaml_definition(subpic_yaml):
+def _split_yaml_definition(subpic_yaml: _YamlDefinition) -> tuple[str, dict[str, Any]]:
     if isinstance(subpic_yaml, IOBase):
         f = subpic_yaml
         subpic_text = f.readlines()
@@ -101,7 +101,7 @@ def get_default_settings_dict(
             if isinstance(v, list):
                 v = tuple(v)
             settings[k] = v
-        except TypeError as te:
+        except TypeError as te:  # noqa: PERF203
             raise TypeError(
                 f'Default setting "{k}" should be a dictionary with "value" defined.'
             ) from te
@@ -128,7 +128,7 @@ def yaml_cell(
     yaml_body, default_settings_def = _split_yaml_definition(yaml_definition)
     default_settings = get_default_settings_dict(default_settings_def)
 
-    def _yaml_func(**kwargs):
+    def _yaml_func(**kwargs: Any) -> Component:
         evaluated_text = _evaluate_yaml_template(yaml_body, default_settings, kwargs)
         return _pic_from_templated_yaml(evaluated_text, name, routing_strategy)
 
@@ -160,7 +160,9 @@ def yaml_cell(
     return cell(_yaml_func)
 
 
-def _evaluate_yaml_template(main_file, default_settings, settings):
+def _evaluate_yaml_template(
+    main_file: str, default_settings: dict[str, Any], settings: dict[str, Any]
+) -> str:
     template = jinja2.Template(main_file)
     complete_settings = dict(default_settings)
     complete_settings.update(settings)
@@ -168,7 +170,7 @@ def _evaluate_yaml_template(main_file, default_settings, settings):
 
 
 def _pic_from_templated_yaml(
-    evaluated_text, name, routing_strategy: RoutingStrategies
+    evaluated_text: str, name: str, routing_strategy: RoutingStrategies
 ) -> Component:
     """Creates a component from a  *.pic.yml file.
 

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -13,6 +13,8 @@ from gdsfactory.read.from_yaml import from_yaml
 
 __all__ = ["cell_from_yaml_template"]
 
+_YamlDefinition = str | IO[Any] | pathlib.Path
+
 
 def split_default_settings_from_yaml(yaml_lines: Iterable[str]) -> tuple[str, str]:
     """Separates out the 'default_settings' block from the rest of the file body.
@@ -65,7 +67,7 @@ def _split_yaml_definition(subpic_yaml):
 
 
 def cell_from_yaml_template(
-    filename: str | IO[Any] | pathlib.Path,
+    filename: _YamlDefinition,
     name: str,
     routing_strategy: dict[str, Callable] | None = None,
 ) -> Callable:
@@ -107,7 +109,9 @@ def get_default_settings_dict(default_settings):
     return settings
 
 
-def yaml_cell(yaml_definition, name: str, routing_strategy) -> Callable[..., Component]:
+def yaml_cell(
+    yaml_definition: _YamlDefinition, name: str, routing_strategy
+) -> Callable[..., Component]:
     """The "cell" decorator equivalent for yaml files. Generates a proper cell function for yaml-defined circuits.
 
     Args:

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Hashable, Iterable
 from functools import cache
 from pathlib import Path
+from typing import Any
 
 import kfactory as kf
 from kfactory import KCLayout
 
 from gdsfactory.component import Component
+from gdsfactory.typings import PostProcesses
 
 
 @cache
 def import_gds(
     gdspath: str | Path,
     cellname: str | None = None,
-    post_process: Hashable[Iterable[Callable[[Component], None]]] | None = None,
+    post_process: PostProcesses | None = None,
     rename_duplicated_cells: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Reads a GDS file and returns a Component.
 
@@ -72,7 +73,7 @@ def import_gds_with_conflicts(
     gdspath: str | Path,
     cellname: str | None = None,
     name: str | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Reads a GDS file and returns a Component.
 

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -20,7 +20,7 @@ def add_electrical_pads_shortest(
     pad_size: tuple[float, float] = (100.0, 100.0),
     select_ports: Callable = select_ports_electrical,
     port_names: Strs | None = None,
-    port_orientation: float = 90,
+    port_orientation: AngleInDegrees = 90,
     layer: gf.typings.LayerSpec = "M3",
 ) -> Component:
     """Returns new Component with a pad by each electrical port.
@@ -78,7 +78,7 @@ def add_electrical_pads_shortest(
             p.dx = port.dx
             route_quad(c, port, p.ports["e2"], layer=layer)
 
-        c.add_port(port=p.ports["pad"], name=f"elec-{component.name}-{i+1}")
+        c.add_port(port=p.ports["pad"], name=f"elec-{component.name}-{i + 1}")
 
     c.add_ports(ref.ports)
 

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -7,7 +7,13 @@ from gdsfactory.component import Component
 from gdsfactory.components.wire import wire_straight
 from gdsfactory.port import select_ports_electrical
 from gdsfactory.routing.route_quad import route_quad
-from gdsfactory.typings import Callable, ComponentSpec, Strs
+from gdsfactory.typings import (
+    AngleInDegrees,
+    ComponentSpec,
+    LayerSpec,
+    PortsFactory,
+    Strs,
+)
 
 _wire_long = partial(wire_straight, length=200.0)
 
@@ -18,10 +24,10 @@ def add_electrical_pads_shortest(
     pad: ComponentSpec = "pad",
     pad_port_spacing: float = 50.0,
     pad_size: tuple[float, float] = (100.0, 100.0),
-    select_ports: Callable = select_ports_electrical,
+    select_ports: PortsFactory = select_ports_electrical,
     port_names: Strs | None = None,
     port_orientation: AngleInDegrees = 90,
-    layer: gf.typings.LayerSpec = "M3",
+    layer: LayerSpec = "M3",
 ) -> Component:
     """Returns new Component with a pad by each electrical port.
 

--- a/gdsfactory/routing/add_electrical_pads_top.py
+++ b/gdsfactory/routing/add_electrical_pads_top.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -22,7 +23,7 @@ def add_electrical_pads_top(
     select_ports: Callable = select_ports_electrical,
     port_names: Strs | None = None,
     layer: LayerSpec = "MTOP",
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with electrical ports connected to top pad array.
 

--- a/gdsfactory/routing/add_electrical_pads_top_dc.py
+++ b/gdsfactory/routing/add_electrical_pads_top_dc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory import cell
@@ -23,7 +24,7 @@ def add_electrical_pads_top_dc(
     pad_array: ComponentFactory = pad_array270,
     select_ports: Callable = select_ports_electrical,
     port_names: Strs | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with electrical ports connected to top pad array.
 

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 import gdsfactory as gf
@@ -13,7 +12,7 @@ from gdsfactory.typings import (
     ComponentSpec,
     ComponentSpecOrList,
     CrossSectionSpec,
-    Ports,
+    PortsFactory,
 )
 
 
@@ -21,7 +20,7 @@ def add_fiber_array(
     component: ComponentSpec = straight_function,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     gc_port_name: str = "o1",
-    select_ports: Callable[..., Ports] = select_ports_optical,
+    select_ports: PortsFactory = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
     start_straight_length: float = 0,
     end_straight_length: float = 0,
@@ -104,7 +103,7 @@ def add_fiber_array(
         )
 
     if gc_port_name not in gc.ports:
-        raise ValueError(f"gc_port_name={gc_port_name!r} not in {gc.ports.keys()}")
+        raise ValueError(f"gc_port_name={gc_port_name!r} not in {list(gc.ports)}")
 
     component_new = Component()
 

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -12,6 +13,7 @@ from gdsfactory.typings import (
     ComponentSpec,
     ComponentSpecOrList,
     CrossSectionSpec,
+    Ports,
 )
 
 
@@ -19,11 +21,11 @@ def add_fiber_array(
     component: ComponentSpec = straight_function,
     grating_coupler: ComponentSpecOrList = grating_coupler_te,
     gc_port_name: str = "o1",
-    select_ports: Callable = select_ports_optical,
+    select_ports: Callable[..., Ports] = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
     start_straight_length: float = 0,
     end_straight_length: float = 0,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns component with south routes and grating_couplers.
 

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -27,7 +28,7 @@ def add_fiber_single(
     with_loopback: bool = True,
     loopback_spacing: float = 100.0,
     straight: ComponentSpec = straight_function,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns component with south routes and grating_couplers.
 

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
@@ -31,7 +32,7 @@ def add_pads_bot(
     route_width: float | list[float] | None = 0,
     bboxes: list | None = None,
     avoid_component_bbox: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with ports connected bottom pads.
 
@@ -159,7 +160,7 @@ def add_pads_top(
     route_width: float | list[float] | None = 0,
     bboxes: list | None = None,
     avoid_component_bbox: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with ports connected top pads.
 

--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import warnings
 
+import kfactory as kf
+
 import gdsfactory as gf
 from gdsfactory.port import Port
-from gdsfactory.typings import (
-    Component,
-    CrossSectionSpec,
-)
+from gdsfactory.typings import CrossSectionSpec
 
 
 def add_auto_tapers(
-    component: Component,
-    ports: list[Port],
+    component: gf.Component,
+    ports: list[kf.Port],
     cross_section: CrossSectionSpec,
 ) -> list[Port]:
     """Adds tapers to the ports of a component (to be used for routing) and returns the new lists of ports.
@@ -31,7 +30,7 @@ def add_auto_tapers(
 
 
 def auto_taper_to_cross_section(
-    component: Component, port: Port, cross_section: CrossSectionSpec
+    component: gf.Component, port: Port, cross_section: CrossSectionSpec
 ) -> Port:
     """Creates a taper from a port to a given cross section and places it in the component. The opposite port of the taper will be returned.
 
@@ -52,7 +51,7 @@ def auto_taper_to_cross_section(
 
     if port_layer != cs_layer:
         try:
-            taper = pdk.layer_transitions[(port_layer, cs_layer)]
+            taper = pdk.layer_transitions[port_layer, cs_layer]
         except KeyError as e:
             raise KeyError(
                 f"No registered tapers between routing layers {gf.get_layer_name(port_layer)!r} and {gf.get_layer_name(cs_layer)!r}!"

--- a/gdsfactory/routing/factories.py
+++ b/gdsfactory/routing/factories.py
@@ -5,9 +5,10 @@ from gdsfactory.routing.route_bundle import (
     route_bundle_electrical,
 )
 from gdsfactory.routing.route_bundle_all_angle import route_bundle_all_angle
+from gdsfactory.typings import RoutingStrategies
 
-routing_strategy = dict(
-    route_bundle=route_bundle,
-    route_bundle_electrical=route_bundle_electrical,
-    route_bundle_all_angle=route_bundle_all_angle,
-)
+routing_strategies: RoutingStrategies = {
+    "route_bundle": route_bundle,
+    "route_bundle_electrical": route_bundle_electrical,
+    "route_bundle_all_angle": route_bundle_all_angle,
+}

--- a/gdsfactory/routing/fanout2x2.py
+++ b/gdsfactory/routing/fanout2x2.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.bend_s import bend_s
 from gdsfactory.components.straight import straight
 from gdsfactory.port import select_ports_optical
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec, PortsFactory
 
 
 @gf.cell
@@ -16,9 +16,9 @@ def fanout2x2(
     port_spacing: float = 20.0,
     bend_length: float | None = None,
     npoints: int = 101,
-    select_ports: Callable = select_ports_optical,
+    select_ports: PortsFactory = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns component with Sbend fanout routes.
 

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -27,7 +27,6 @@ from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.routing.sort_ports import get_port_x, get_port_y
 from gdsfactory.typings import (
     STEP_DIRECTIVES,
-    Component,
     ComponentSpec,
     Coordinates,
     CrossSectionSpec,
@@ -89,7 +88,7 @@ def get_min_spacing(
 
 
 def route_bundle(
-    component: Component,
+    component: gf.Component,
     ports1: Sequence[Port | kf.Port] | Port | kf.Port,
     ports2: Sequence[Port | kf.Port] | Port | kf.Port,
     cross_section: CrossSectionSpec | None = None,
@@ -212,7 +211,7 @@ def route_bundle(
     taper_cell = gf.get_component(taper) if taper else None
     bend90 = (
         bend
-        if isinstance(bend, Component)
+        if isinstance(bend, gf.Component)
         else gf.get_component(
             bend, cross_section=cross_section, radius=radius, width=width
         )
@@ -220,7 +219,7 @@ def route_bundle(
 
     def straight_dbu(
         length: int, cross_section: CrossSectionSpec = xs, **kwargs: Any
-    ) -> Component:
+    ) -> gf.Component:
         return gf.get_component(
             straight,
             length=c.kcl.to_um(length),

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -90,8 +90,8 @@ def get_min_spacing(
 
 def route_bundle(
     component: Component,
-    ports1: list[Port | kf.Port] | Port | kf.Port,
-    ports2: list[Port | kf.Port] | Port | kf.Port,
+    ports1: Sequence[Port | kf.Port] | Port | kf.Port,
+    ports2: Sequence[Port | kf.Port] | Port | kf.Port,
     cross_section: CrossSectionSpec | None = None,
     layer: LayerSpecs | None = None,
     separation: float = 3.0,

--- a/gdsfactory/routing/route_bundle_all_angle.py
+++ b/gdsfactory/routing/route_bundle_all_angle.py
@@ -11,7 +11,8 @@ from kfactory.routing.aa.optical import (
 
 from gdsfactory.components.bend_euler import bend_euler_all_angle
 from gdsfactory.components.straight import straight_all_angle
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Port
+from gdsfactory.port import Port
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
 def route_bundle_all_angle(

--- a/gdsfactory/routing/route_bundle_sbend.py
+++ b/gdsfactory/routing/route_bundle_sbend.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.components.bend_s import bend_s as bend_s_function
 from gdsfactory.port import Port
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
-from gdsfactory.typings import Component, ComponentSpec
+from gdsfactory.typings import Any, Component, ComponentSpec
 
 
 def route_bundle_sbend(
@@ -14,7 +14,7 @@ def route_bundle_sbend(
     bend_s: ComponentSpec = bend_s_function,
     sort_ports: bool = True,
     enforce_port_ordering: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     """Places sbend routes from ports1 to ports2.
 

--- a/gdsfactory/routing/route_dubin.py
+++ b/gdsfactory/routing/route_dubin.py
@@ -218,27 +218,29 @@ def pi_to_pi(angle):
     return angle
 
 
-def linear(START, END, STEPS):
+def linear(
+    start: tuple[float, float, float], end: tuple[float, float, float], steps: int
+) -> tuple[list[float], list[float]]:
     """Creates a list of points on lines between a given start point and end point.
 
     start/end: [x, y, angle], the start/end point with given jaw angle.
     """
-    x = []
-    y = []
-    Dx = END[0] - START[0]
-    Dy = END[1] - START[1]
-    dx = Dx / STEPS
-    dy = Dy / STEPS
-    for step in range(STEPS + 1):
-        x.append(step * dx + START[0])
-        y.append(step * dy + START[1])
+    x: list[float] = []
+    y: list[float] = []
+    dx = end[0] - start[0]
+    dy = end[1] - start[1]
+    dx = dx / steps
+    dy = dy / steps
+    for step in range(steps + 1):
+        x.append(step * dx + start[0])
+        y.append(step * dy + start[1])
     return x, y
 
 
-def arrow_orientation(ANGLE):
+def arrow_orientation(angle: float) -> tuple[float, float]:
     """Returns x, y setoffs for a given angle to orient the arrows marking the yaw of the start and end points."""
-    alpha_x = m.cos(m.radians(ANGLE))
-    alpha_y = m.sin(m.radians(ANGLE))
+    alpha_x = m.cos(m.radians(angle))
+    alpha_y = m.sin(m.radians(angle))
     return alpha_x, alpha_y
 
 

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import kfactory as kf
 
 import gdsfactory as gf
-from gdsfactory.component import Component
+from gdsfactory.component import Component, ComponentReference
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.grating_coupler_elliptical_trenches import grating_coupler_te
 from gdsfactory.components.straight import straight as straight_function
@@ -15,11 +16,11 @@ from gdsfactory.routing.route_bundle import get_min_spacing, route_bundle
 from gdsfactory.routing.route_single import route_single
 from gdsfactory.routing.utils import direction_ports_from_list_ports
 from gdsfactory.typings import (
-    ComponentReference,
     ComponentSpec,
     ComponentSpecOrList,
     Coordinates,
     CrossSectionSpec,
+    PortsFactory,
     Strs,
 )
 
@@ -47,7 +48,7 @@ def route_fiber_array(
     component_name: str | None = None,
     x_grating_offset: float = 0,
     port_names: Strs | None = None,
-    select_ports: Callable = select_ports_optical,
+    select_ports: PortsFactory = select_ports_optical,
     radius: float | None = None,
     radius_loopback: float | None = None,
     cross_section: CrossSectionSpec = strip,
@@ -59,9 +60,9 @@ def route_fiber_array(
     auto_taper: bool = True,
     waypoints: Coordinates | None = None,
     steps: Sequence[Mapping[str, int | float]] | None = None,
-    bboxes: list | None = None,
+    bboxes: list[tuple[float, float, float, float]] | None = None,
     avoid_component_bbox: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with fiber array.
 
@@ -185,7 +186,7 @@ def route_fiber_array(
         or (component.dxsize > fiber_spacing)
     )
 
-    def has_p(side) -> bool:
+    def has_p(side: str) -> bool:
         return len(direction_ports[side]) > 0
 
     list_ew_ports_on_sides = [has_p(side) for side in ["E", "W"]]
@@ -413,7 +414,7 @@ def demo() -> None:
 if __name__ == "__main__":
 
     @gf.cell
-    def mzi_with_bend(radius=10, **kwargs):
+    def mzi_with_bend(radius: float = 10, **kwargs: Any) -> Component:
         c = gf.Component()
         bend = c.add_ref(gf.components.bend_euler(radius=radius, **kwargs))
         mzi = c.add_ref(gf.components.mzi(**kwargs))

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -129,16 +129,15 @@ def route_fiber_array(
 
     to_route = [p for p in to_route if p.name not in excluded_ports]
 
-    ports_not_terminated = []
-    for port in component_to_route.ports:
-        if port.name not in port_names:
-            ports_not_terminated.append(port)
+    ports_not_terminated = [
+        port for port in component_to_route.ports if port.name not in port_names
+    ]
 
-    N = len(to_route)
+    n = len(to_route)
 
     # optical_ports_labels = [p.name for p in ports]
     # print(optical_ports_labels)
-    if N == 0:
+    if n == 0:
         return [], [], 0
 
     # grating_coupler can either be a component/function or a list of components/functions
@@ -147,7 +146,7 @@ def route_fiber_array(
         grating_coupler = grating_couplers[0]
     else:
         grating_coupler = gf.get_component(grating_coupler)
-        grating_couplers = [grating_coupler] * N
+        grating_couplers = [grating_coupler] * n
 
     gc_port_names = [port.name for port in grating_coupler.ports]
     if gc_port_name not in gc_port_names:
@@ -169,19 +168,19 @@ def route_fiber_array(
     delta_gr_min = 2 * dy + 1
 
     # Get the center along x axis
-    x_c = round(sum(p.dx for p in to_route) / N, 1)
+    x_c = round(sum(p.dx for p in to_route) / n, 1)
 
     # Sort the list of optical ports:
     direction_ports = direction_ports_from_list_ports(to_route)
     separation = straight_separation
 
-    K = len(to_route)
-    K = K + 1 if K % 2 else K
+    k = len(to_route)
+    k = k + 1 if k % 2 else k
 
     # Set routing type if not specified
     pxs = [p.dx for p in to_route]
     is_big_component = (
-        (K > 2)
+        (k > 2)
         or (max(pxs) - min(pxs) > fiber_spacing - delta_gr_min)
         or (component.dxsize > fiber_spacing)
     )
@@ -224,7 +223,7 @@ def route_fiber_array(
     y0_optical = (
         component.dymin - fanout_length - grating_coupler.ports[gc_port_name].dx - dy
     )
-    y0_optical += -K / 2 * separation
+    y0_optical += -k / 2 * separation
 
     if max_y0_optical is not None:
         y0_optical = round(min(max_y0_optical, y0_optical), 1)
@@ -248,8 +247,8 @@ def route_fiber_array(
     north_start.reverse()  # Sort right to left
     # ordered_ports = north_start + west_ports + south_ports + east_ports + north_finish
 
-    nb_ports_per_line = N // nb_optical_ports_lines
-    y_gr_gap = (K / nb_optical_ports_lines + 1) * separation
+    nb_ports_per_line = n // nb_optical_ports_lines
+    y_gr_gap = (k / nb_optical_ports_lines + 1) * separation
     gr_coupler_y_sep = grating_coupler.dysize + y_gr_gap + dy
     offset = (nb_ports_per_line - 1) * fiber_spacing / 2 - x_grating_offset
     io_gratings_lines = []  # [[gr11, gr12, gr13...], [gr21, gr22, gr23...] ...]

--- a/gdsfactory/routing/route_ports_to_side.py
+++ b/gdsfactory/routing/route_ports_to_side.py
@@ -34,7 +34,7 @@ def route_ports_to_side(
     side: Literal["north", "east", "south", "west"] = "north",
     x: float | None = None,
     y: float | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     """Routes ports to a given side.
 
@@ -95,19 +95,27 @@ def route_ports_to_side(
     return func_route(component, ports, xy, side=side, **kwargs)
 
 
-def route_ports_to_north(list_ports, **kwargs):
+def route_ports_to_north(
+    list_ports: list[Port], **kwargs: Any
+) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     return route_ports_to_side(list_ports, side="north", **kwargs)
 
 
-def route_ports_to_south(list_ports, **kwargs):
+def route_ports_to_south(
+    list_ports: list[Port], **kwargs: Any
+) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     return route_ports_to_side(list_ports, side="south", **kwargs)
 
 
-def route_ports_to_west(list_ports, **kwargs):
+def route_ports_to_west(
+    list_ports: list[Port], **kwargs: Any
+) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     return route_ports_to_side(list_ports, side="west", **kwargs)
 
 
-def route_ports_to_east(list_ports, **kwargs):
+def route_ports_to_east(
+    list_ports: list[Port], **kwargs: Any
+) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     return route_ports_to_side(list_ports, side="east", **kwargs)
 
 
@@ -127,7 +135,7 @@ def route_ports_to_x(
     dx_start: float | None = None,
     dy_start: float | None = None,
     side: Literal["east", "west"] = "east",
-    **routing_func_args,
+    **routing_func_args: Any,
 ) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     """Returns route to x.
 
@@ -233,7 +241,11 @@ def route_ports_to_x(
     ports = []
 
     def add_port(
-        p, y, l_elements, l_ports, start_straight_length=start_straight_length
+        port: Port,
+        y: float,
+        l_elements: list[ManhattanRoute],
+        l_ports: list[Port],
+        start_straight_length: float = start_straight_length,
     ) -> None:
         if side == "west":
             angle = 0
@@ -241,7 +253,7 @@ def route_ports_to_x(
         elif side == "east":
             angle = 180
 
-        new_port = p.copy()
+        new_port = port.copy()
         new_port.orientation = angle
         new_port.dx = x + extension_length
         new_port.dy = y
@@ -252,7 +264,7 @@ def route_ports_to_x(
         l_elements += [
             route_single(
                 component,
-                p,
+                port,
                 new_port,
                 start_straight_length=start_straight_length,
                 radius=radius,
@@ -456,23 +468,27 @@ def route_ports_to_y(
     backward_ports_thru_west.sort(key=sort_key_west_to_east)
     backward_ports_thru_east.sort(key=sort_key_east_to_west)
 
-    routes = []
-    ports = []
+    routes: list[ManhattanRoute] = []
+    ports: list[Port] = []
 
     def add_port(
-        p, x, l_elements, l_ports, start_straight_length=start_straight_length
-    ):
+        port: Port,
+        x: float,
+        l_elements: list[ManhattanRoute],
+        l_ports: list[Port],
+        start_straight_length: float = start_straight_length,
+    ) -> None:
         if side == "south":
             angle = 90
 
         elif side == "north":
             angle = 270
 
-        new_port = p.copy()
+        new_port = port.copy()
         new_port.orientation = angle
         new_port.dcenter = (x, y + extension_length)
 
-        if np.sum(np.abs((np.array(new_port.center) - p.center) ** 2)) < 1:
+        if np.sum(np.abs((np.array(new_port.center) - port.center) ** 2)) < 1:
             l_ports += [flipped(new_port)]
             return
 
@@ -480,7 +496,7 @@ def route_ports_to_y(
             l_elements += [
                 route_single(
                     component,
-                    p,
+                    port,
                     new_port,
                     start_straight_length=start_straight_length,
                     radius=radius,
@@ -491,7 +507,7 @@ def route_ports_to_y(
 
         except Exception as error:
             raise ValueError(
-                f"Could not connect {p.name!r} to {new_port.name!r} {error}"
+                f"Could not connect {port.name!r} to {new_port.name!r} {error}"
             ) from error
 
     x_optical_left = x0_left

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 
 import gdsfactory as gf
 from gdsfactory.port import Port
 
 
-def _get_rotated_basis(theta):
+def _get_rotated_basis(
+    theta: float,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Returns basis vectors rotated CCW by theta (in degrees)."""
     theta = np.radians(theta)
     e1 = np.array([np.cos(theta), np.sin(theta)])
@@ -57,7 +60,9 @@ def route_quad(
 
     """
 
-    def get_port_edges(port, width):
+    def get_port_edges(
+        port: Port, width: float
+    ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         _, e1 = _get_rotated_basis(port.orientation)
         pt1 = port.dcenter + e1 * width / 2
         pt2 = port.dcenter - e1 * width / 2

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -28,7 +28,7 @@ To generate a route:
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Literal
+from typing import Any, Literal
 
 import kfactory as kf
 from kfactory.routing.electrical import route_elec
@@ -128,7 +128,11 @@ def route_single(
         p1 = add_auto_tapers(component, [p1], cross_section)[0]
         p2 = add_auto_tapers(component, [p2], cross_section)[0]
 
-    def straight_dbu(length: int, cross_section=cross_section, **kwargs) -> Component:
+    def straight_dbu(
+        length: int,
+        cross_section: CrossSectionSpec | MultiCrossSectionAngleSpec = cross_section,
+        **kwargs: Any,
+    ) -> Component:
         return gf.get_component(
             straight,
             length=c.kcl.to_um(length),

--- a/gdsfactory/routing/route_single_from_steps.py
+++ b/gdsfactory/routing/route_single_from_steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Mapping, Sequence
 from functools import partial
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 from kfactory.routing.generic import ManhattanRoute
@@ -31,7 +31,7 @@ def route_single_from_steps(
     port_type: str | None = None,
     allow_width_mismatch: bool = False,
     auto_taper: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> ManhattanRoute:
     """Places a route formed by the given waypoints steps.
 

--- a/gdsfactory/routing/route_south.py
+++ b/gdsfactory/routing/route_south.py
@@ -140,9 +140,9 @@ def route_south(
     def get_index_port_closest_to_x(
         x: float, component_references: list[ComponentReference]
     ) -> np.intp:
-        return np.array([
-            abs(x - p.ports[gc_port_name].dx) for p in component_references
-        ]).argmin()
+        return np.array(
+            [abs(x - p.ports[gc_port_name].dx) for p in component_references]
+        ).argmin()
 
     def gen_port_from_port(
         x: float, y: float, p: Port, cross_section: CrossSection

--- a/gdsfactory/routing/route_south.py
+++ b/gdsfactory/routing/route_south.py
@@ -9,12 +9,12 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.components.bend_euler import bend_euler
 from gdsfactory.components.straight import straight as straight_function
-from gdsfactory.cross_section import strip
+from gdsfactory.cross_section import CrossSection, strip
 from gdsfactory.port import Port, select_ports_optical
 from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.routing.route_single import route_single
 from gdsfactory.routing.utils import direction_ports_from_list_ports
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Strs
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Radius, Strs
 
 
 def route_south(
@@ -137,12 +137,16 @@ def route_south(
     north_start.reverse()  # Sort right to left
     ordered_ports = north_start + west_ports + south_ports + east_ports + north_finish
 
-    def get_index_port_closest_to_x(x, list_ports):
-        return np.array(
-            [abs(x - p.ports[gc_port_name].dx) for p in list_ports]
-        ).argmin()
+    def get_index_port_closest_to_x(
+        x: float, component_references: list[ComponentReference]
+    ) -> np.intp:
+        return np.array([
+            abs(x - p.ports[gc_port_name].dx) for p in component_references
+        ]).argmin()
 
-    def gen_port_from_port(x, y, p, cross_section):
+    def gen_port_from_port(
+        x: float, y: float, p: Port, cross_section: CrossSection
+    ) -> Port:
         return Port(
             name=p.name,
             center=(x, y),
@@ -286,7 +290,7 @@ if __name__ == "__main__":
     c = gf.Component()
 
     @gf.cell
-    def mzi_with_bend(radius=10):
+    def mzi_with_bend(radius: Radius = 10) -> Component:
         c = gf.Component()
         bend = c.add_ref(gf.components.bend_euler(radius=radius))
         mzi = c.add_ref(gf.components.mzi())

--- a/gdsfactory/routing/validation.py
+++ b/gdsfactory/routing/validation.py
@@ -2,13 +2,14 @@ from warnings import warn
 
 import numpy as np
 
+import gdsfactory as gf
 from gdsfactory.config import CONF
 from gdsfactory.port import Port
 from gdsfactory.routing.utils import RouteWarning
 
 
 def make_error_traces(
-    component, ports1: list[Port], ports2: list[Port], message: str
+    component: gf.Component, ports1: list[Port], ports2: list[Port], message: str
 ) -> None:
     """Creates a set of error traces showing the intended connectivity between ports1 and ports2.
 
@@ -53,7 +54,7 @@ def is_invalid_bundle_topology(ports1: list[Port], ports2: list[Port]) -> bool:
     from shapely import intersection_all
 
     # this is not really quite angle, but a threshold to check if dot products are effectively above/below zero, excluding numerical errors
-    ANGLE_TOLERANCE = 1e-10
+    angle_tolerance = 1e-10
 
     if len(ports1) < 2:
         # if there's only one route, the bundle topology is always valid
@@ -85,9 +86,9 @@ def is_invalid_bundle_topology(ports1: list[Port], ports2: list[Port]) -> bool:
 
     intersections = intersection_all(lines)
     # print(intersections)
-    if intersections.is_empty and all(s < -ANGLE_TOLERANCE for s in ports_facing):
+    if intersections.is_empty and all(s < -angle_tolerance for s in ports_facing):
         return True
-    elif not intersections.is_empty and all(s > ANGLE_TOLERANCE for s in ports_facing):
+    elif not intersections.is_empty and all(s > angle_tolerance for s in ports_facing):
         return True
 
     # NOTE: there are more complicated cases we are ignoring for now and giving "the benefit of the doubt"

--- a/gdsfactory/samples/01_component_pcell_with_parameters.py
+++ b/gdsfactory/samples/01_component_pcell_with_parameters.py
@@ -2,7 +2,7 @@ import gdsfactory as gf
 
 
 @gf.cell
-def mzi_with_bend(radius=10):
+def mzi_with_bend(radius: float = 10) -> gf.Component:
     c = gf.Component()
     bend = c.add_ref(gf.components.bend_euler(radius=radius))
     mzi = c.add_ref(gf.components.mzi())

--- a/gdsfactory/samples/06_remapping_layers.py
+++ b/gdsfactory/samples/06_remapping_layers.py
@@ -22,7 +22,7 @@ def remap_layers() -> Component:
     return c
 
 
-def test_remap_layers():
+def test_remap_layers() -> None:
     c = remap_layers()
     assert c.layers == [(2, 0)]
 

--- a/gdsfactory/samples/12_component_refs.py
+++ b/gdsfactory/samples/12_component_refs.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import Layer
+from gdsfactory.typings import ComponentFactory, Layer
 
 
 @gf.cell
@@ -64,8 +64,8 @@ def crossing_arm(
 
 @gf.cell
 def crossing(
-    arm=crossing_arm,
-    cross_section="strip",
+    arm: ComponentFactory = crossing_arm,
+    cross_section: str = "strip",
 ) -> Component:
     """Waveguide crossing.
 

--- a/gdsfactory/samples/20_components.py
+++ b/gdsfactory/samples/20_components.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Any
 
 import gdsfactory as gf
 
 
-def straight_wide1(width=10, **kwargs) -> gf.Component:
+def straight_wide1(width: float = 10, **kwargs: Any) -> gf.Component:
     return gf.components.straight(width=width, **kwargs)
 
 

--- a/gdsfactory/samples/30_lidar_pcell.py
+++ b/gdsfactory/samples/30_lidar_pcell.py
@@ -9,11 +9,14 @@ Exercise2. Make a PCell.
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory.typings import Spacing
 
 
 @gf.cell
 def lidar(
-    noutputs=2**2, antenna_pitch=2.0, splitter_tree_spacing=(50.0, 70.0)
+    noutputs: int = 2**2,
+    antenna_pitch: float = 2.0,
+    splitter_tree_spacing: Spacing = (50.0, 70.0),
 ) -> gf.Component:
     """LiDAR demo.
 
@@ -31,7 +34,7 @@ def lidar(
 
     # phase Shifters
     phase_shifter = gf.components.straight_heater_meander()
-    phase_shifter_optical_ports = []
+    phase_shifter_optical_ports: list[gf.Port] = []
 
     for i, port in enumerate(
         splitter_tree.ports.filter(orientation=0, port_type="optical")

--- a/gdsfactory/samples/34_route_edge_coupler.py
+++ b/gdsfactory/samples/34_route_edge_coupler.py
@@ -7,10 +7,13 @@ from functools import partial
 import gdsfactory as gf
 import gdsfactory.components as pc
 from gdsfactory.generic_tech import LAYER
+from gdsfactory.typings import Size
 
 
 @gf.cell
-def sample_reticle(size=(1000, 1000), ec="edge_coupler_silicon") -> gf.Component:
+def sample_reticle(
+    size: Size = (1000, 1000), ec: str = "edge_coupler_silicon"
+) -> gf.Component:
     """Returns MZI with edge couplers.
 
     Args:

--- a/gdsfactory/samples/34_route_edge_coupler_bend_s.py
+++ b/gdsfactory/samples/34_route_edge_coupler_bend_s.py
@@ -7,13 +7,14 @@ from functools import partial
 import gdsfactory as gf
 import gdsfactory.components as pc
 from gdsfactory.generic_tech import LAYER
+from gdsfactory.typings import ComponentFactory, Size
 
 
 @gf.cell
 def sample_reticle(
-    size=(1500, 2000),
-    ec="edge_coupler_silicon",
-    bend_s=partial(gf.c.bend_s, size=(100, 100)),
+    size: Size = (1500, 2000),
+    ec: str = "edge_coupler_silicon",
+    bend_s: ComponentFactory = partial(gf.c.bend_s, size=(100, 100)),
 ) -> gf.Component:
     """Returns MZI with edge couplers.
 

--- a/gdsfactory/samples/big_device.py
+++ b/gdsfactory/samples/big_device.py
@@ -31,7 +31,7 @@ def big_device(
     w, h = size
     dx = w / 2
     dy = h / 2
-    N = nports
+    n = nports
 
     xs = gf.get_cross_section(cross_section)
     layer = xs.layer
@@ -44,37 +44,37 @@ def big_device(
     component.add_polygon(points, layer=layer)
     ports = []
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"W{i}",
-            center=p0 + (-dx, (i - N / 2) * spacing),
+            center=p0 + (-dx, (i - n / 2) * spacing),
             orientation=180,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"E{i}",
-            center=p0 + (dx, (i - N / 2) * spacing),
+            center=p0 + (dx, (i - n / 2) * spacing),
             orientation=0,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"N{i}",
-            center=p0 + ((i - N / 2) * spacing, dy),
+            center=p0 + ((i - n / 2) * spacing, dy),
             orientation=90,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"S{i}",
-            center=p0 + ((i - N / 2) * spacing, -dy),
+            center=p0 + ((i - n / 2) * spacing, -dy),
             orientation=-90,
             **port_settings,
         )

--- a/gdsfactory/samples/big_device_electrical.py
+++ b/gdsfactory/samples/big_device_electrical.py
@@ -31,7 +31,7 @@ def big_device(
     w, h = size
     dx = w / 2
     dy = h / 2
-    N = nports
+    n = nports
 
     xs = gf.get_cross_section(cross_section)
     layer = xs.layer
@@ -44,37 +44,37 @@ def big_device(
     component.add_polygon(points, layer=layer)
     ports = []
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"W{i}",
-            center=p0 + (-dx, (i - N / 2) * spacing),
+            center=p0 + (-dx, (i - n / 2) * spacing),
             orientation=180,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"E{i}",
-            center=p0 + (dx, (i - N / 2) * spacing),
+            center=p0 + (dx, (i - n / 2) * spacing),
             orientation=0,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"N{i}",
-            center=p0 + ((i - N / 2) * spacing, dy),
+            center=p0 + ((i - n / 2) * spacing, dy),
             orientation=90,
             **port_settings,
         )
         ports.append(port)
 
-    for i in range(N):
+    for i in range(n):
         port = Port(
             name=f"S{i}",
-            center=p0 + ((i - N / 2) * spacing, -dy),
+            center=p0 + ((i - n / 2) * spacing, -dy),
             orientation=-90,
             **port_settings,
         )

--- a/gdsfactory/samples/demo/lvs.py
+++ b/gdsfactory/samples/demo/lvs.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory.typings import ComponentFactory
 
 
 @gf.cell
-def pads_correct(pad=gf.components.pad, cross_section="metal3") -> gf.Component:
+def pads_correct(
+    pad: ComponentFactory = gf.components.pad, cross_section: str = "metal3"
+) -> gf.Component:
     """Returns 2 pads connected with metal wires."""
     c = gf.Component()
 
@@ -36,7 +39,9 @@ def pads_correct(pad=gf.components.pad, cross_section="metal3") -> gf.Component:
 
 
 @gf.cell
-def pads_shorted(pad=gf.components.pad, cross_section="metal3") -> gf.Component:
+def pads_shorted(
+    pad: ComponentFactory = gf.components.pad, cross_section: str = "metal3"
+) -> gf.Component:
     """Returns 2 pads connected with metal wires."""
     c = gf.Component()
     pad = gf.components.pad()

--- a/gdsfactory/samples/pdk/fab_c.py
+++ b/gdsfactory/samples/pdk/fab_c.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import partial
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.cross_section import get_cross_sections, strip
@@ -98,22 +99,22 @@ cell = partial(gf.cell, post_process=(_add_pins,), info=dict(pdk="fab_c"))
 
 
 @cell
-def straight_sc(cross_section="strip_nc", **kwargs):
+def straight_sc(cross_section: str = "strip_nc", **kwargs: Any) -> gf.Component:
     return gf.components.straight(cross_section=cross_section, **kwargs)
 
 
 @cell
-def straight_so(cross_section="strip_so", **kwargs):
+def straight_so(cross_section: str = "strip_so", **kwargs: Any) -> gf.Component:
     return gf.components.straight(cross_section=cross_section, **kwargs)
 
 
 @cell
-def straight_nc(cross_section="strip_nc", **kwargs):
+def straight_nc(cross_section: str = "strip_nc", **kwargs: Any) -> gf.Component:
     return gf.components.straight(cross_section=cross_section, **kwargs)
 
 
 @cell
-def straight_no(cross_section="strip_no", **kwargs):
+def straight_no(cross_section: str = "strip_no", **kwargs: Any) -> gf.Component:
     return gf.components.straight(cross_section=cross_section, **kwargs)
 
 
@@ -123,22 +124,22 @@ def straight_no(cross_section="strip_no", **kwargs):
 
 
 @cell
-def bend_euler_sc(cross_section="strip_sc", **kwargs):
+def bend_euler_sc(cross_section: str = "strip_sc", **kwargs: Any) -> gf.Component:
     return gf.components.bend_euler(cross_section=cross_section, **kwargs)
 
 
 @cell
-def bend_euler_so(cross_section="strip_so", **kwargs):
+def bend_euler_so(cross_section: str = "strip_so", **kwargs: Any) -> gf.Component:
     return gf.components.bend_euler(cross_section=cross_section, **kwargs)
 
 
 @cell
-def bend_euler_nc(cross_section="strip_nc", **kwargs):
+def bend_euler_nc(cross_section: str = "strip_nc", **kwargs: Any) -> gf.Component:
     return gf.components.bend_euler(cross_section=cross_section, **kwargs)
 
 
 @cell
-def bend_euler_no(cross_section="strip_no", **kwargs):
+def bend_euler_no(cross_section: str = "strip_no", **kwargs: Any) -> gf.Component:
     return gf.components.bend_euler(cross_section=cross_section, **kwargs)
 
 
@@ -148,28 +149,36 @@ def bend_euler_no(cross_section="strip_no", **kwargs):
 
 
 @cell
-def mmi1x2_sc(width_mmi=3, cross_section="strip_sc", **kwargs):
+def mmi1x2_sc(
+    width_mmi: float = 3, cross_section: str = "strip_sc", **kwargs: Any
+) -> gf.Component:
     return gf.components.mmi1x2(
         cross_section=cross_section, width_mmi=width_mmi, **kwargs
     )
 
 
 @cell
-def mmi1x2_so(width_mmi=3, cross_section="strip_so", **kwargs):
+def mmi1x2_so(
+    width_mmi: float = 3, cross_section: str = "strip_so", **kwargs: Any
+) -> gf.Component:
     return gf.components.mmi1x2(
         cross_section=cross_section, width_mmi=width_mmi, **kwargs
     )
 
 
 @cell
-def mmi1x2_nc(width_mmi=3, cross_section="strip_nc", **kwargs):
+def mmi1x2_nc(
+    width_mmi: float = 3, cross_section: str = "strip_nc", **kwargs: Any
+) -> gf.Component:
     return gf.components.mmi1x2(
         cross_section=cross_section, width_mmi=width_mmi, **kwargs
     )
 
 
 @cell
-def mmi1x2_no(width_mmi=3, cross_section="strip_no", **kwargs):
+def mmi1x2_no(
+    width_mmi: float = 3, cross_section: str = "strip_no", **kwargs: Any
+) -> gf.Component:
     return gf.components.mmi1x2(
         cross_section=cross_section, width_mmi=width_mmi, **kwargs
     )
@@ -187,7 +196,7 @@ _gc_nc = partial(
 
 
 @cell
-def gc_sc(**kwargs):
+def gc_sc(**kwargs: Any) -> gf.Component:
     return _gc_nc(**kwargs)
 
 

--- a/gdsfactory/samples/pdk/fab_d/phase_shifters.py
+++ b/gdsfactory/samples/pdk/fab_d/phase_shifters.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from functools import partial
+from pathlib import Path
 
 import pydantic
 
 import gdsfactory as gf
-from gdsfactory.typings import Layer
+from gdsfactory.typings import ComponentFactory, Layer
 
 
 @pydantic.dataclasses.dataclass
@@ -57,7 +58,9 @@ component_factory = dict(
 )
 
 
-def write_library(component_factory, dirpath) -> None:
+def write_library(
+    component_factory: dict[str, ComponentFactory], dirpath: Path
+) -> None:
     for function in component_factory.values():
         component = function()
         component.write_gds(gdsdir=dirpath, with_metadata=True)

--- a/gdsfactory/samples/pdk/test_fab_c.py
+++ b/gdsfactory/samples/pdk/test_fab_c.py
@@ -21,6 +21,9 @@ def test_gds(component_name: str) -> None:
 
 """
 
+from collections.abc import Generator
+from typing import Any
+
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
@@ -32,16 +35,16 @@ cell_names = list(cells.keys())
 
 
 @pytest.fixture(autouse=True)
-def activate_pdk():
+def activate_pdk() -> Generator[None, Any, None]:
     from gdsfactory.samples.pdk.fab_c import PDK
 
     PDK.activate()
     yield
-    PDK = get_generic_pdk()
-    PDK.activate()
+    pdk = get_generic_pdk()
+    pdk.activate()
 
 
-def test_to_updk():
+def test_to_updk() -> None:
     from gdsfactory.samples.pdk.fab_c import PDK
 
     PDK.activate()
@@ -50,7 +53,7 @@ def test_to_updk():
 
 
 @pytest.fixture(params=cell_names, scope="function")
-def component_name(request) -> str:
+def component_name(request: pytest.FixtureRequest) -> str:
     return request.param
 
 

--- a/gdsfactory/samples/sample_reticle.py
+++ b/gdsfactory/samples/sample_reticle.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 
 
 @gf.cell
-def spiral_gc(**kwargs) -> gf.Component:
+def spiral_gc(**kwargs: Any) -> gf.Component:
     """Returns a spiral double with Grating Couplers.
 
     Args:
@@ -34,7 +36,7 @@ def spiral_gc(**kwargs) -> gf.Component:
 
 
 @gf.cell
-def mzi_gc(length_x=10, **kwargs) -> gf.Component:
+def mzi_gc(length_x: float = 10, **kwargs: Any) -> gf.Component:
     """Returns a MZI with Grating Couplers.
 
     Args:

--- a/gdsfactory/samples/sample_reticle_electrical_with_labels.py
+++ b/gdsfactory/samples/sample_reticle_electrical_with_labels.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 from gdsfactory.typings import LayerSpec, PortsOrList
 
@@ -27,7 +29,7 @@ def label_farthest_right_port(
     return component
 
 
-def resistance_sheet(width: float = 5, **kwargs) -> gf.Component:
+def resistance_sheet(width: float = 5, **kwargs: Any) -> gf.Component:
     """Returns a resistance sheet.
 
     Args:
@@ -50,7 +52,7 @@ def resistance_sheet(width: float = 5, **kwargs) -> gf.Component:
 
 
 def via_chain(
-    num_vias: float = 100, component_name="via_chain", **kwargs
+    num_vias: float = 100, component_name: str = "via_chain", **kwargs: Any
 ) -> gf.Component:
     """Returns a chain of vias.
 

--- a/gdsfactory/samples/sample_reticle_with_labels.py
+++ b/gdsfactory/samples/sample_reticle_with_labels.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 from gdsfactory.typings import LayerSpec, PortsOrList
 
@@ -27,7 +29,7 @@ def label_farthest_right_port(
     return component
 
 
-def spiral_gc(length: float = 0, **kwargs) -> gf.Component:
+def spiral_gc(length: float = 0, **kwargs: Any) -> gf.Component:
     """Returns a spiral double with Grating Couplers.
 
     Args:
@@ -56,7 +58,7 @@ def spiral_gc(length: float = 0, **kwargs) -> gf.Component:
     return c
 
 
-def mzi_gc(length_x=10, **kwargs) -> gf.Component:
+def mzi_gc(length_x: float = 10, **kwargs: Any) -> gf.Component:
     """Returns a MZI with Grating Couplers.
 
     Args:

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -149,10 +149,12 @@ def to_yaml_graph_networkx(
     connections = netlist.connections
     placements = netlist.placements
     graph = nx.Graph()
-    graph.add_edges_from([
-        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-        for k, v in connections.items()
-    ])
+    graph.add_edges_from(
+        [
+            (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+            for k, v in connections.items()
+        ]
+    )
     pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
     labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -148,10 +148,12 @@ def to_yaml_graph_networkx(
     connections = netlist.connections
     placements = netlist.placements
     graph = nx.Graph()
-    graph.add_edges_from([
-        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-        for k, v in connections.items()
-    ])
+    graph.add_edges_from(
+        [
+            (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+            for k, v in connections.items()
+        ]
+    )
     pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
     labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -9,8 +9,9 @@ from graphviz import Digraph
 from pydantic import BaseModel, Field, model_validator
 
 import gdsfactory
+from gdsfactory.component import Component
 from gdsfactory.config import PATH
-from gdsfactory.typings import Anchor, Component, Delta
+from gdsfactory.typings import Anchor, Delta
 
 
 class Instance(BaseModel):
@@ -148,12 +149,10 @@ def to_yaml_graph_networkx(
     connections = netlist.connections
     placements = netlist.placements
     graph = nx.Graph()
-    graph.add_edges_from(
-        [
-            (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-            for k, v in connections.items()
-        ]
-    )
+    graph.add_edges_from([
+        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+        for k, v in connections.items()
+    ])
     pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
     labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -1,14 +1,16 @@
 import json
 import warnings
+from pathlib import Path
 from typing import Any
 
 import networkx as nx
 import yaml
+from graphviz import Digraph
 from pydantic import BaseModel, Field, model_validator
 
 import gdsfactory
 from gdsfactory.config import PATH
-from gdsfactory.typings import Anchor, Component
+from gdsfactory.typings import Anchor, Component, Delta
 
 
 class Instance(BaseModel):
@@ -36,7 +38,7 @@ class Instance(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def update_settings_and_info(cls, values):
+    def update_settings_and_info(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validator to update component, settings and info based on the component."""
         component = values.get("component")
         settings = values.get("settings", {})
@@ -60,8 +62,8 @@ class Placement(BaseModel):
     ymin: str | float | None = None
     xmax: str | float | None = None
     ymax: str | float | None = None
-    dx: float = 0
-    dy: float = 0
+    dx: Delta = 0
+    dy: Delta = 0
     port: str | Anchor | None = None
     rotation: float = 0
     mirror: bool | str | float = False
@@ -95,7 +97,7 @@ class Net(BaseModel):
     settings: dict[str, Any] = Field(default_factory=dict)
     name: str | None = None
 
-    def __init__(self, **data):
+    def __init__(self, **data: Any) -> None:
         """Initialize the net."""
         global _route_counter
         super().__init__(**data)
@@ -139,34 +141,39 @@ class Netlist(BaseModel):
 _route_counter = 0
 
 
-def to_yaml_graph_networkx(netlist: Netlist, nets):
+def to_yaml_graph_networkx(
+    netlist: Netlist, nets: list[Net]
+) -> tuple[nx.Graph, dict[str, str], dict[str, tuple[float, float]]]:
     """Generates a netlist graph using NetworkX."""
     connections = netlist.connections
     placements = netlist.placements
-    G = nx.Graph()
-    G.add_edges_from(
-        [
-            (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-            for k, v in connections.items()
-        ]
-    )
+    graph = nx.Graph()
+    graph.add_edges_from([
+        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+        for k, v in connections.items()
+    ])
     pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
     labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
 
     for node, placement in placements.items():
-        if not G.has_node(
+        if not graph.has_node(
             node
         ):  # Check if the node is already in the graph (from connections), to avoid duplication.
-            G.add_node(node)
+            graph.add_node(node)
             pos[node] = (placement.x, placement.y)
 
     for net in nets:
-        G.add_edge(net.p1.split(",")[0], net.p2.split(",")[0])
+        graph.add_edge(net.p1.split(",")[0], net.p2.split(",")[0])
 
-    return G, labels, pos
+    return graph, labels, pos
 
 
-def to_graphviz(instances, placements, nets, show_ports=True):
+def to_graphviz(
+    instances: dict[str, Instance],
+    placements: dict[str, Placement],
+    nets: list[Net],
+    show_ports: bool = True,
+) -> Digraph:
     """Generates a netlist graph using Graphviz."""
     from graphviz import Digraph
 
@@ -317,7 +324,7 @@ class Schematic(BaseModel):
         else:
             self.netlist.routes[net.name].links[net.p1] = net.p2
 
-    def to_graphviz(self, show_ports=True):
+    def to_graphviz(self, show_ports: bool = True) -> Digraph:
         """Generates a netlist graph using Graphviz.
 
         Args:
@@ -327,15 +334,17 @@ class Schematic(BaseModel):
             self.netlist.instances, self.placements, self.nets, show_ports
         )
 
-    def to_yaml_graph_networkx(self):
+    def to_yaml_graph_networkx(
+        self,
+    ) -> tuple[nx.Graph, dict[str, str], dict[str, tuple[float, float]]]:
         return to_yaml_graph_networkx(self.netlist, self.nets)
 
-    def plot_graphviz(self):
+    def plot_graphviz(self) -> None:
         """Plots the netlist graph (Automatic fallback to networkx)."""
         dot = self.to_graphviz()
         plot_graphviz(dot)
 
-    def plot_schematic_networkx(self):
+    def plot_schematic_networkx(self) -> None:
         """Plots the netlist graph (Automatic fallback to networkx)."""
         warnings.warn(
             "plot_schematic_networkx is deprecated. Use plot_graphviz instead",
@@ -344,7 +353,9 @@ class Schematic(BaseModel):
         self.plot_graphviz()
 
 
-def plot_graphviz(graph, interactive=False, splines: str = "ortho") -> None:
+def plot_graphviz(
+    graph: Digraph, interactive: bool = False, splines: str = "ortho"
+) -> None:
     """Plots the netlist graph (Automatic fallback to networkx)."""
     from IPython.display import Image, display
 
@@ -362,7 +373,7 @@ def plot_graphviz(graph, interactive=False, splines: str = "ortho") -> None:
 
 
 def write_schema(
-    model: BaseModel = Netlist, schema_path_json=PATH.schema_netlist
+    model: BaseModel = Netlist, schema_path_json: Path = PATH.schema_netlist
 ) -> None:
     s = model.model_json_schema()
     schema_path_yaml = schema_path_json.with_suffix(".yaml")

--- a/gdsfactory/symbols.py
+++ b/gdsfactory/symbols.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
+from typing import Any, Protocol
 
-from gdsfactory import cell
+from gdsfactory.cell import cell
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, LayerSpecs
 
@@ -12,7 +13,13 @@ _F = Callable[..., Component]
 symbol = cell
 
 
-def symbol_from_cell(func: _F, to_symbol: Callable[[Component, ...], Component]) -> _F:
+class ToSymbol(Protocol):
+    def __call__(
+        self, component: Component, *args: Any, **kwargs: Any
+    ) -> Component: ...
+
+
+def symbol_from_cell(func: _F, to_symbol: ToSymbol) -> _F:
     """Creates a symbol function from a component function.
 
     Args:
@@ -24,12 +31,12 @@ def symbol_from_cell(func: _F, to_symbol: Callable[[Component, ...], Component])
     """
 
     @functools.wraps(func)
-    def _symbol(*args, **kwargs):
+    def _symbol(*args: Any, **kwargs: Any) -> Component:
         component = func(*args, **kwargs)
-        symbol = to_symbol(component, prefix=f"SYMBOL_{func.__name__}")
-        return symbol
+        c_symbol = to_symbol(component, prefix=f"SYMBOL_{func.__name__}")
+        return c_symbol
 
-    _symbol._symbol = True
+    _symbol._symbol = True  # type: ignore
     return _symbol
 
 
@@ -72,7 +79,7 @@ def floorplan_with_block_letters(
     max_w, max_h = w * (1 - margin), h * (1 - margin)
     text_init_size = 3.0
     text_init = text(
-        component.function_name,
+        component.function_name or "",
         size=text_init_size,
         layer=text_layer,
         justify="center",
@@ -85,7 +92,10 @@ def floorplan_with_block_letters(
     scaling = min(w_scaling, h_scaling)
     text_size = text_init_size * scaling
     text_component = text(
-        component.function_name, size=text_size, layer=text_layer, justify="center"
+        component.function_name or "",
+        size=text_size,
+        layer=text_layer,
+        justify="center",
     )
 
     text = sym << text_component
@@ -108,6 +118,6 @@ def floorplan_with_block_letters(
 if __name__ == "__main__":
     import gdsfactory as gf
 
-    c = gf.c.mmi1x2()
+    c = gf.c.mmi1x2()  # type: ignore
     s = floorplan_with_block_letters(c)
     s.show()

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -157,18 +157,18 @@ class KLayoutTechnology(BaseModel):
         lyt_path.write_bytes(make_pretty_xml(root))
         print(f"Wrote {str(lyt_path)!r}")
 
-    def _define_connections(self, root) -> None:
+    def _define_connections(self, root: ET.Element) -> None:
         if not self.connectivity:
             return
         src_element = [e for e in list(root) if e.tag == "connectivity"]
         if len(src_element) != 1:
             raise KeyError("Could not get a single index for the src element.")
         src_element = src_element[0]
-        layers = set()
+        layers: set[str] = set()
         for first_layer_name, *layer_names in self.connectivity:
             connection = ",".join(
                 [first_layer_name]
-                + (layer_names if len(layer_names) == 2 else [""] + layer_names)
+                + (layer_names if len(layer_names) == 2 else ["", *layer_names])
             )
 
             for layer_name in layer_names:

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -516,11 +516,13 @@ class LayerStack(BaseModel):
         ]
 
         # Define input layers
-        out = "\n".join([
-            f"{layer_name} = input({level.derived_layer.layer[0]}, {level.derived_layer.layer[1]})"
-            for layer_name, level in layers.items()
-            if level.derived_layer
-        ])
+        out = "\n".join(
+            [
+                f"{layer_name} = input({level.derived_layer.layer[0]}, {level.derived_layer.layer[1]})"
+                for layer_name, level in layers.items()
+                if level.derived_layer
+            ]
+        )
         out += "\n\n"
 
         # Remove all etched layers from the grown layers
@@ -533,11 +535,13 @@ class LayerStack(BaseModel):
                     unetched_layers.remove(level.derived_layer.layer)
 
         # Define layers
-        out += "\n".join([
-            f"{layer_name} = input({level.layer.layer[0]}, {level.layer.layer[1]})"
-            for layer_name, level in layers.items()
-            if hasattr(level.layer, "layer")
-        ])
+        out += "\n".join(
+            [
+                f"{layer_name} = input({level.layer.layer[0]}, {level.layer.layer[1]})"
+                for layer_name, level in layers.items()
+                if hasattr(level.layer, "layer")
+            ]
+        )
         out += "\n\n"
 
         # Define unetched layers

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -516,9 +516,9 @@ class LayerView(BaseModel):
 
     def __str__(self) -> str:
         """Returns a formatted view of properties and their values."""
-        return "LayerView:\n\t" + "\n\t".join([
-            f"{k}: {v}" for k, v in self.model_dump().items()
-        ])
+        return "LayerView:\n\t" + "\n\t".join(
+            [f"{k}: {v}" for k, v in self.model_dump().items()]
+        )
 
     def __repr__(self) -> str:
         """Returns a formatted view of properties and their values."""
@@ -1049,9 +1049,9 @@ class LayerViews(BaseModel):
 
             if name is None or order is None:
                 continue
-            pattern = "\n".join([
-                line.text for line in dither_block.find("pattern").iter()
-            ])
+            pattern = "\n".join(
+                [line.text for line in dither_block.find("pattern").iter()]
+            )
 
             if name in dither_patterns:
                 warnings.warn(

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -6,12 +6,13 @@ You can maintain LayerViews in YAML (.yaml) or Klayout XML file (.lyp)
 
 from __future__ import annotations
 
+import builtins
 import os
 import pathlib
 import re
-import typing
 import warnings
 import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import yaml
@@ -30,7 +31,7 @@ from gdsfactory.technology.yaml_utils import (
     add_tuple_yaml_presenter,
 )
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, DictStrAny, MappingIntStrAny
 
     from gdsfactory.component import Component
@@ -296,7 +297,7 @@ class HatchPattern(BaseModel):
 
     @field_validator("custom_pattern")
     @classmethod
-    def check_pattern_klayout(cls, pattern: str | None, **kwargs) -> str | None:
+    def check_pattern_klayout(cls, pattern: str | None, **kwargs: Any) -> str | None:
         if pattern is None:
             return None
         lines = pattern.splitlines()
@@ -342,7 +343,7 @@ class LineStyle(BaseModel):
 
     @field_validator("custom_style")
     @classmethod
-    def check_pattern(cls, pattern: str | None, **kwargs) -> str | None:
+    def check_pattern(cls, pattern: str | None, **kwargs: Any) -> str | None:
         if pattern is None:
             return None
 
@@ -421,7 +422,7 @@ class LayerView(BaseModel):
     marked: bool = False
     xfill: bool = False
     animation: int = 0
-    group_members: typing.Dict[str, LayerView] | None = Field(default={})  # noqa: UP006
+    group_members: builtins.dict[str, LayerView] | None = Field(default={})
 
     def __init__(
         self,
@@ -429,7 +430,7 @@ class LayerView(BaseModel):
         gds_datatype: int | None = None,
         color: ColorType | None = None,
         brightness: int | None = None,
-        **data,
+        **data: Any,
     ) -> None:
         """Initialize LayerView object."""
         if (gds_layer is not None) and (gds_datatype is not None):
@@ -515,9 +516,9 @@ class LayerView(BaseModel):
 
     def __str__(self) -> str:
         """Returns a formatted view of properties and their values."""
-        return "LayerView:\n\t" + "\n\t".join(
-            [f"{k}: {v}" for k, v in self.model_dump().items()]
-        )
+        return "LayerView:\n\t" + "\n\t".join([
+            f"{k}: {v}" for k, v in self.model_dump().items()
+        ])
 
     def __repr__(self) -> str:
         """Returns a formatted view of properties and their values."""
@@ -773,7 +774,7 @@ class LayerViews(BaseModel):
         self,
         filepath: PathLike | None = None,
         layers: LayerEnum | None = None,
-        **data,
+        **data: Any,
     ) -> None:
         """Initialize LayerViews object.
 
@@ -814,7 +815,7 @@ class LayerViews(BaseModel):
                 self.add_layer_view(name=name, layer_view=lv)
 
     def add_layer_view(
-        self, name: str, layer_view: LayerView | None = None, **kwargs
+        self, name: str, layer_view: LayerView | None = None, **kwargs: Any
     ) -> None:
         """Adds a layer to LayerViews.
 
@@ -865,12 +866,10 @@ class LayerViews(BaseModel):
         Args:
             exclude_groups: Whether to exclude LayerViews that contain other LayerViews.
         """
-        layers = {}
+        layers: dict[str, LayerView] = {}
         for name, view in self.layer_views.items():
             if view.group_members and not exclude_groups:
-                for member_name, member in view.group_members.items():
-                    layers[member_name] = member
-                continue
+                layers.update(view.group_members.items())
             layers[name] = view
         return layers
 
@@ -899,7 +898,7 @@ class LayerViews(BaseModel):
         else:
             return self.layer_views[name]
 
-    def __getitem__(self, val: str):
+    def __getitem__(self, val: str) -> LayerView:
         """Allows accessing to the layer names like ls['gold2'].
 
         Args:
@@ -955,7 +954,7 @@ class LayerViews(BaseModel):
         """
         import gdsfactory as gf
 
-        D = gf.Component()
+        component = gf.Component()
         scale = size / 100
         num_layers = len(self.get_layer_views())
         matrix_size = int(np.ceil(np.sqrt(num_layers)))
@@ -964,10 +963,10 @@ class LayerViews(BaseModel):
         )
         for n, layer in enumerate(sorted_layers):
             layer_tuple = layer.layer
-            R = gf.components.rectangle(
+            rectangle = gf.components.rectangle(
                 size=(100 * scale, 100 * scale), layer=layer_tuple
             )
-            T = gf.components.text(
+            text = gf.components.text(
                 text=f"{layer.name}\n{layer_tuple[0]} / {layer_tuple[1]}",
                 size=20 * scale,
                 position=(50 * scale, -20 * scale),
@@ -977,13 +976,13 @@ class LayerViews(BaseModel):
 
             xloc = n % matrix_size
             yloc = int(n // matrix_size)
-            ref = D.add_ref(R)
+            ref = component.add_ref(rectangle)
             ref.dmovex((100 + spacing) * xloc * scale)
             ref.dmovey(-(100 + spacing) * yloc * scale)
-            ref = D.add_ref(T)
+            ref = component.add_ref(text)
             ref.dmovex((100 + spacing) * xloc * scale)
             ref.dmovey(-(100 + spacing) * yloc * scale)
-        return D
+        return component
 
     def to_lyp(
         self, filepath: str | pathlib.Path, overwrite: bool = True
@@ -1050,9 +1049,9 @@ class LayerViews(BaseModel):
 
             if name is None or order is None:
                 continue
-            pattern = "\n".join(
-                [line.text for line in dither_block.find("pattern").iter()]
-            )
+            pattern = "\n".join([
+                line.text for line in dither_block.find("pattern").iter()
+            ])
 
             if name in dither_patterns:
                 warnings.warn(

--- a/gdsfactory/technology/xml_utils.py
+++ b/gdsfactory/technology/xml_utils.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 from xml.dom.minidom import Node
 
 
-def _strip_xml(node) -> None:
+def _strip_xml(node: Node) -> None:
     """Strip XML of excess whitespace.
 
     Source: https://stackoverflow.com/a/16919069

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -175,6 +175,13 @@ ConductorConductorName: TypeAlias = tuple[str, str]
 ConductorViaConductorName: TypeAlias = tuple[str, str, str] | tuple[str, str]
 ConnectivitySpec: TypeAlias = ConductorConductorName | ConductorViaConductorName
 
+RoutingStrategy: TypeAlias = Callable[
+    ...,
+    list[kf.routing.generic.ManhattanRoute]
+    | list[kf.routing.aa.optical.OpticalAllAngleRoute],
+]
+RoutingStrategies: TypeAlias = dict[str, RoutingStrategy]
+
 
 class TypedArray(np.ndarray):
     """based on https://github.com/samuelcolvin/pydantic/issues/380."""

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import (
     Any,
     Generator,
@@ -81,8 +81,8 @@ class Step:
 
     x: float | None = None
     y: float | None = None
-    dx: float | None = None
-    dy: float | None = None
+    dx: Delta | None = None
+    dy: Delta | None = None
 
 
 Anchor = Literal[
@@ -112,6 +112,10 @@ Ints: TypeAlias = tuple[int, ...] | list[int]
 Size: TypeAlias = tuple[float, float]
 Position: TypeAlias = tuple[float, float]
 Spacing: TypeAlias = tuple[float, float]
+Radius: TypeAlias = float
+
+Delta: TypeAlias = float
+AngleInDegrees: TypeAlias = float
 
 Layer: TypeAlias = tuple[int, int]
 Layers: TypeAlias = tuple[Layer, ...] | list[Layer]
@@ -154,7 +158,7 @@ ComponentSpecOrComponent: TypeAlias = (
 )  # PCell function, function name, dict or Component
 
 ComponentSpecs: TypeAlias = tuple[ComponentSpec, ...]
-ComponentSpecsOrComponents: TypeAlias = tuple[ComponentSpecOrComponent, ...]
+ComponentSpecsOrComponents: TypeAlias = Sequence[ComponentSpecOrComponent]
 ComponentFactories: TypeAlias = tuple[ComponentFactory, ...]
 
 ComponentSpecOrList: TypeAlias = ComponentSpec | list[ComponentSpec]
@@ -198,7 +202,7 @@ class TypedArray(np.ndarray[Any, np.dtype[Any]]):
 
 
 class ArrayMeta(type):
-    def __getitem__(self, t: np.dtype[Any]) -> type[npt.NDArray[Any]]:
+    def __getitem__(cls, t: np.dtype[Any]) -> type[npt.NDArray[Any]]:
         return type("Array", (TypedArray,), {"inner_type": t})
 
 
@@ -207,6 +211,7 @@ class Array(np.ndarray[Any, np.dtype[Any]], metaclass=ArrayMeta):
 
 
 __all__ = (
+    "AngleInDegrees",
     "Any",
     "Component",
     "ComponentAllAngle",
@@ -222,16 +227,17 @@ __all__ = (
     "CrossSectionFactory",
     "CrossSectionOrFactory",
     "CrossSectionSpec",
+    "Delta",
     "Float2",
     "Float3",
     "Floats",
+    "Instance",
     "Int2",
     "Int3",
     "Ints",
-    "Instance",
     "Layer",
-    "LayerMap",
     "LayerLevel",
+    "LayerMap",
     "LayerSpec",
     "LayerSpecs",
     "LayerStack",
@@ -245,11 +251,12 @@ __all__ = (
     "Ports",
     "PortsList",
     "PortsOrList",
+    "Position",
+    "Radius",
+    "RoutingStrategies",
     "Section",
+    "Size",
+    "Spacing",
     "Strs",
     "WidthTypes",
-    "RoutingStrategies",
-    "Size",
-    "Position",
-    "Spacing",
 )

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -24,13 +24,7 @@ from __future__ import annotations
 import dataclasses
 import pathlib
 from collections.abc import Callable, Sequence
-from typing import (
-    Any,
-    Generator,
-    Literal,
-    ParamSpec,
-    TypeAlias,
-)
+from typing import Any, Generator, Literal, ParamSpec, TypeAlias
 
 import kfactory as kf
 import numpy as np
@@ -43,7 +37,7 @@ from gdsfactory.component import (
     ComponentBase,
     ComponentReference,
 )
-from gdsfactory.cross_section import CrossSection, Section, Transition, WidthTypes
+from gdsfactory.cross_section import CrossSection, Transition
 from gdsfactory.port import Port
 from gdsfactory.technology import LayerLevel, LayerMap, LayerStack, LayerViews
 
@@ -85,7 +79,7 @@ class Step:
     dy: Delta | None = None
 
 
-Anchor = Literal[
+Anchor: TypeAlias = Literal[
     "ce",
     "cw",
     "nc",
@@ -97,14 +91,13 @@ Anchor = Literal[
     "center",
     "cc",
 ]
-Axis = Literal["x", "y"]
-NSEW = Literal["N", "S", "E", "W"]
-
+Axis: TypeAlias = Literal["x", "y"]
+NSEW: TypeAlias = Literal["N", "S", "E", "W"]
 
 Float2: TypeAlias = tuple[float, float]
 Float3: TypeAlias = tuple[float, float, float]
-Floats: TypeAlias = tuple[float, ...] | list[float]
-Strs: TypeAlias = tuple[str, ...] | list[str]
+Floats: TypeAlias = Sequence[float]
+Strs: TypeAlias = Sequence[str]
 Int2: TypeAlias = tuple[int, int]
 Int3: TypeAlias = tuple[int, int, int]
 Ints: TypeAlias = tuple[int, ...] | list[int]
@@ -118,44 +111,49 @@ Delta: TypeAlias = float
 AngleInDegrees: TypeAlias = float
 
 Layer: TypeAlias = tuple[int, int]
-Layers: TypeAlias = tuple[Layer, ...] | list[Layer]
+Layers: TypeAlias = Sequence[Layer]
 LayerSpec: TypeAlias = LayerEnum | str | tuple[int, int]
-LayerSpecs: TypeAlias = list[LayerSpec] | tuple[LayerSpec, ...]
+LayerSpecs: TypeAlias = Sequence[LayerSpec]
 
 ComponentParams = ParamSpec("ComponentParams")
 ComponentFactory: TypeAlias = Callable[..., Component]
 ComponentFactoryDict: TypeAlias = dict[str, ComponentFactory]
 PathType: TypeAlias = str | pathlib.Path
-PathTypes: TypeAlias = tuple[PathType, ...]
+PathTypes: TypeAlias = Sequence[PathType]
 Metadata: TypeAlias = dict[str, int | float | str]
-PostProcess: TypeAlias = tuple[Callable[[Component], None], ...]
-
+PostProcess: TypeAlias = Callable[[Component], None]
+PostProcesses: TypeAlias = Sequence[PostProcess]
 MaterialSpec: TypeAlias = str | float | tuple[float, float] | Callable[..., Any]
 
-Instance = ComponentReference
+Instance: TypeAlias = ComponentReference
 ComponentOrPath: TypeAlias = PathType | Component
 ComponentOrReference: TypeAlias = Component | ComponentReference
 NameToFunctionDict: TypeAlias = dict[str, ComponentFactory]
 Number: TypeAlias = float | int
 Coordinate: TypeAlias = tuple[float, float]
-Coordinates: TypeAlias = tuple[Coordinate, ...] | list[Coordinate]
+Coordinates: TypeAlias = Sequence[Coordinate]
 CrossSectionFactory: TypeAlias = Callable[..., CrossSection]
-TransitionFactory: TypeAlias = Callable[..., Transition]
 CrossSectionOrFactory: TypeAlias = CrossSection | Callable[..., CrossSection]
+PortFactory: TypeAlias = Callable[..., kf.Port]
+PortsFactory: TypeAlias = Callable[..., list[kf.Port]]
 PortSymmetries: TypeAlias = dict[str, list[str]]
 PortsDict: TypeAlias = dict[str, Port]
 PortsList: TypeAlias = list[Port]
-Ports = kf.Ports
+Ports: TypeAlias = kf.Ports
 PortsOrList: TypeAlias = Ports | PortsList
+
+PortType: TypeAlias = str
+PortName: TypeAlias = str
+
+PortTypes: TypeAlias = Sequence[PortType]
+PortNames: TypeAlias = Sequence[PortName]
 
 Sparameters: TypeAlias = dict[str, npt.NDArray[np.float64]]
 
-ComponentSpec: TypeAlias = (
-    str | ComponentFactory | dict[str, Any] | kf.KCell
-)  # PCell function, function name, dict or Component
+ComponentSpec: TypeAlias = str | ComponentFactory | dict[str, Any] | kf.KCell
 ComponentSpecOrComponent: TypeAlias = (
     str | ComponentFactory | dict[str, Any] | kf.KCell | Component
-)  # PCell function, function name, dict or Component
+)
 
 ComponentSpecs: TypeAlias = tuple[ComponentSpec, ...]
 ComponentSpecsOrComponents: TypeAlias = Sequence[ComponentSpecOrComponent]
@@ -163,8 +161,8 @@ ComponentFactories: TypeAlias = tuple[ComponentFactory, ...]
 
 ComponentSpecOrList: TypeAlias = ComponentSpec | list[ComponentSpec]
 CellSpec: TypeAlias = (
-    str | ComponentFactory | dict[str, Any]
-)  # PCell function, function name or dict
+    str | ComponentFactory | dict[str, Any]  # PCell function, function name or dict
+)
 
 ComponentSpecDict: TypeAlias = dict[str, ComponentSpec]
 CrossSectionSpec: TypeAlias = (
@@ -179,12 +177,12 @@ ConductorConductorName: TypeAlias = tuple[str, str]
 ConductorViaConductorName: TypeAlias = tuple[str, str, str] | tuple[str, str]
 ConnectivitySpec: TypeAlias = ConductorConductorName | ConductorViaConductorName
 
-_RoutingStrategy: TypeAlias = Callable[
+RoutingStrategy: TypeAlias = Callable[
     ...,
     list[kf.routing.generic.ManhattanRoute]
     | list[kf.routing.aa.optical.OpticalAllAngleRoute],
 ]
-RoutingStrategies: TypeAlias = dict[str, _RoutingStrategy]
+RoutingStrategies: TypeAlias = dict[str, RoutingStrategy]
 
 
 class TypedArray(np.ndarray[Any, np.dtype[Any]]):
@@ -213,7 +211,6 @@ class Array(np.ndarray[Any, np.dtype[Any]], metaclass=ArrayMeta):
 __all__ = (
     "AngleInDegrees",
     "Any",
-    "Component",
     "ComponentAllAngle",
     "ComponentBase",
     "ComponentFactory",
@@ -248,15 +245,18 @@ __all__ = (
     "Number",
     "PathType",
     "PathTypes",
+    "PortName",
+    "PortNames",
+    "PortType",
+    "PortTypes",
     "Ports",
     "PortsList",
     "PortsOrList",
     "Position",
+    "PostProcesses",
     "Radius",
     "RoutingStrategies",
-    "Section",
     "Size",
     "Spacing",
     "Strs",
-    "WidthTypes",
 )

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import TypeAlias
 
 import kfactory as kf
-from IPython.terminal.embed import embed
+from IPython.terminal.embed import embed  # type: ignore[unused-ignore]
 from watchdog.events import (
     DirCreatedEvent,
     DirDeletedEvent,
@@ -127,7 +127,9 @@ class FileWatcher(FileSystemEventHandler):
 
         what = "directory" if event.is_directory else "file"
         src_path = self._get_path(event.src_path)
-        if what == "file" and src_path.endswith(".pic.yml") or src_path.endswith(".py"):
+        if (what == "file" and src_path.endswith(".pic.yml")) or src_path.endswith(
+            ".py"
+        ):
             self.logger.info("Created %s: %s", what, src_path)
             self.get_component(src_path)
 
@@ -152,15 +154,15 @@ class FileWatcher(FileSystemEventHandler):
             src_path = event.dest_path.decode("utf-8")
         else:
             src_path = event.dest_path
-        if what == "file" and src_path.endswith(".pic.yml") or src_path.endswith(".py"):
+        if (what == "file" and src_path.endswith(".pic.yml")) or src_path.endswith(
+            ".py"
+        ):
             self.logger.info("Modified %s: %s", what, src_path)
             self.get_component(src_path)
 
     def get_component(self, filepath: PathType) -> Component | None:
         import git
         import git.repo as gr
-
-        print("-----------------------------------")
 
         from gdsfactory.get_factories import get_cells_from_dict
 
@@ -204,7 +206,7 @@ class FileWatcher(FileSystemEventHandler):
                             kf.show(gdspath)
 
                 else:
-                    print("Changed file {filepath} ignored (not .pic.yml or .py)")
+                    print(f"Changed file {filepath} ignored (not .pic.yml or .py)")
 
         except Exception as e:
             traceback.print_exc(file=sys.stdout)

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from types import SimpleNamespace
 
 import kfactory as kf
-from IPython.terminal.embed import embed
+from IPython.terminal.embed import embed  # type: ignore
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -27,7 +27,7 @@ class FileWatcher(FileSystemEventHandler):
     """Captures *.py or *.pic.yml file change events."""
 
     def __init__(
-        self, path: str | None = None, run_main: bool = False, run_cells: bool = True
+        self, path: str, run_main: bool = False, run_cells: bool = True
     ) -> None:
         """Initialize the YAML event handler.
 
@@ -66,7 +66,7 @@ class FileWatcher(FileSystemEventHandler):
         self.stopping.set()
         self.thread.join()
 
-    def update_cell(self, src_path, update: bool = False) -> Callable:
+    def update_cell(self, src_path: PathType, update: bool = False) -> Callable:
         """Parses a YAML file to a cell function and registers into active pdk.
 
         Args:

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -34,6 +34,7 @@ def get_script(gdspath: PathType, module: str | None = None) -> str:
         module: if any includes plot directive.
 
     """
+    gdspath = pathlib.Path(gdspath)
     cell = clean_name(gdspath.stem)
     gdspath = gdspath.stem + gdspath.suffix
 
@@ -97,7 +98,7 @@ def get_import_gds_script(dirpath: PathType, module: str | None = None) -> str:
 
 
 def write_cells_recursively(
-    gdspath: PathType | None = None,
+    gdspath: PathType,
     dirpath: pathlib.Path | None = None,
 ) -> dict[str, Path]:
     """Write gdstk cells recursively.
@@ -114,7 +115,7 @@ def write_cells_recursively(
     dirpath = pathlib.Path(dirpath).absolute()
     dirpath.mkdir(exist_ok=True, parents=True)
 
-    gdspaths = {}
+    gdspaths: dict[str, Path] = {}
 
     for cell_index in gf.kcl.each_cell_bottom_up():
         component = gf.kcl[cell_index]
@@ -125,7 +126,7 @@ def write_cells_recursively(
 
 
 def write_cells(
-    gdspath: PathType | None = None,
+    gdspath: PathType,
     dirpath: PathType | None = None,
 ) -> dict[str, Path]:
     """Writes cells into separate GDS files.
@@ -145,7 +146,7 @@ def write_cells(
     dirpath = pathlib.Path(dirpath).absolute()
     dirpath.mkdir(exist_ok=True, parents=True)
 
-    gdspaths = {}
+    gdspaths: dict[str, Path] = {}
 
     for component in components:
         gdspath = dirpath / f"{component.name}.gds"
@@ -155,7 +156,7 @@ def write_cells(
 
 
 if __name__ == "__main__":
-    c = gf.c.mzi()
+    c = gf.c.mzi()  # type: ignore
     gdspath = c.write_gds()
     gf.clear_cache()
     write_cells_recursively(gdspath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ ignore = [
   "ANN102",  # Missing cls type annotation
   "ANN401",  # typing.Any is not allowed
   "RUF015",  # Using next() instead of [0]
-  "UP037",  # Remove quotes from type annotations
+  "UP037"  # Remove quotes from type annotations
 ]
 select = [
   "B",  # flake8-bugbear
@@ -166,10 +166,10 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"gdsfactory/samples/*.py" = ["N999"]
 "gdsfactory/typings.py" = ["UP035"]
 "notebooks/*.ipynb" = ["F821", 'E402', 'F405', 'F403', "D103"]
 "tests/*.py" = ["D103"]
-"gdsfactory/samples/*.py" = ["N999"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,10 @@ python_files = ["gdsfactory/*.py", "tests/*.py"]
 testpaths = ["gdsfactory", "tests"]
 
 [tool.ruff]
-extend-exclude = ['docs/notebooks/']
+extend-exclude = ['docs/notebooks/', 'notebooks/']
 fix = true
+
+[tool.ruff.lint]
 ignore = [
   "B008",  # do not perform function calls in argument defaults
   "B028",  # stacklevel
@@ -140,7 +142,13 @@ ignore = [
   "D102",  # public method docstrings
   "D103",  # public function docstrings
   "D104",  # public package docstrings
-  "E501"  # line too long, handled by black
+  "E501",  # line too long, handled by black
+  "RUF005",  # Consider {expression} instead of concatenation
+  "ANN101",  # Missing self type annotation
+  "ANN102",  # Missing cls type annotation
+  "ANN401",  # typing.Any is not allowed
+  "RUF015",  # Using next() instead of [0]
+  "UP037",  # Remove quotes from type annotations
 ]
 select = [
   "B",  # flake8-bugbear
@@ -151,15 +159,19 @@ select = [
   "I",  # isort
   "T10",  # flake8-debugger
   "UP",  # pyupgrade
-  "W"  # pycodestyle warnings
+  "W",  # pycodestyle warnings
+  "PERF",  # performance improvements
+  "RUF",  # ruff
+  "ANN"  # flake8-annotations
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "gdsfactory/typings.py" = ["UP035"]
 "notebooks/*.ipynb" = ["F821", 'E402', 'F405', 'F403', "D103"]
 "tests/*.py" = ["D103"]
+"gdsfactory/samples/*.py" = ["N999"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.setuptools.package-data]

--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -26,7 +26,7 @@ cells_to_test = set(cells.keys()) - skip_test
 
 
 @pytest.fixture(params=cells_to_test)
-def component_name(request) -> str:
+def component_name(request: pytest.FixtureRequest) -> str:
     return request.param
 
 

--- a/tests/components/test_extension.py
+++ b/tests/components/test_extension.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.generic_tech import LAYER
+from gdsfactory.typings import Layer
 
 extend_ports = gf.components.extend_ports
 
@@ -33,7 +34,9 @@ def test_extend_ports() -> None:
     p = assert_polygons(c4, 1)
 
 
-def assert_polygons(component, n_polygons, layer=LAYER.WG):
+def assert_polygons(
+    component: gf.Component, n_polygons: int, layer: Layer = LAYER.WG
+) -> int:
     result = len(component.get_polygons()[layer])
     assert result == n_polygons, result
     assert len(component.insts) == n_polygons, len(component.insts)

--- a/tests/gds/alphabet.py
+++ b/tests/gds/alphabet.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory.typings import Delta
 
 characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#()+,-./:;<=>?@[{|}~_"
 
 
 @gf.cell
-def alphabet(dx=10):
+def alphabet(dx: Delta = 10) -> gf.Component:
     c = gf.Component()
     x = 0
     for s in characters:

--- a/tests/labels/write_test_manifest.py
+++ b/tests/labels/write_test_manifest.py
@@ -4,7 +4,7 @@ import gdsfactory as gf
 from gdsfactory.samples.sample_reticle import sample_reticle
 
 
-def test_write_test_manifest():
+def test_write_test_manifest() -> None:
     c = sample_reticle()
     gdspath = c.write_gds()
     csvpath = gdspath.with_suffix(".csv")

--- a/tests/read/test_import_gds.py
+++ b/tests/read/test_import_gds.py
@@ -4,6 +4,7 @@ import json
 
 import jsondiff
 import pandas as pd
+from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
 from gdsfactory.generic_tech import LAYER
@@ -31,7 +32,7 @@ def test_import_gds_hierarchy() -> None:
     assert c.name == c0.name, c.name
 
 
-def test_import_json_label(data_regression) -> None:
+def test_import_json_label(data_regression: DataRegressionFixture) -> None:
     """Import ports from GDS."""
     c = gf.components.straight()
     c1 = gf.labels.add_label_json(c)
@@ -55,7 +56,7 @@ def test_import_gds_array() -> None:
     assert len(c1.get_polygons()[LAYER.WG]) == 4, len(c1.get_polygons()[LAYER.WG])
 
 
-def test_import_gds_ports(data_regression) -> None:
+def test_import_gds_ports(data_regression: DataRegressionFixture) -> None:
     """Import the ports."""
     c0 = gf.components.straight()
     gdspath = c0.write_gds()

--- a/tests/routing/test_add_fiber_array.py
+++ b/tests/routing/test_add_fiber_array.py
@@ -30,7 +30,7 @@ components = [sample_fiber_array, sample_fiber_single, sample_excluded_ports]
 
 
 @pytest.fixture(params=components, scope="function")
-def component(request) -> Component:
+def component(request: pytest.FixtureRequest) -> Component:
     return request.param()
 
 

--- a/tests/routing/test_add_pads.py
+++ b/tests/routing/test_add_pads.py
@@ -21,7 +21,7 @@ components = [add_pads0]
 
 
 @pytest.fixture(params=components, scope="function")
-def component(request) -> Component:
+def component(request: pytest.FixtureRequest) -> Component:
     return request.param()
 
 

--- a/tests/routing/test_routing_route_bundle.py
+++ b/tests/routing/test_routing_route_bundle.py
@@ -9,6 +9,7 @@ from gdsfactory import Port
 from gdsfactory.component import Component
 from gdsfactory.difftest import difftest
 from gdsfactory.routing.route_bundle import route_bundle
+from gdsfactory.typings import AngleInDegrees, Delta
 
 
 def test_route_bundle(
@@ -60,7 +61,7 @@ def test_route_bundle(
 
 @pytest.mark.parametrize("config", ["A", "C"])
 def test_connect_corner(
-    config: str, data_regression: DataRegressionFixture, check: bool = True, N=6
+    config: str, data_regression: DataRegressionFixture, check: bool = True, n: int = 6
 ) -> None:
     d = 10.0
     sep = 5.0
@@ -77,7 +78,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_TL = [
@@ -88,7 +89,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BR = [
@@ -99,7 +100,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BL = [
@@ -110,7 +111,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A = [ports_A_TR, ports_A_TL, ports_A_BR, ports_A_BL]
@@ -123,7 +124,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_TL = [
@@ -134,7 +135,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BR = [
@@ -145,7 +146,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BL = [
@@ -156,13 +157,13 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B = [ports_B_TR, ports_B_TL, ports_B_BR, ports_B_BL]
 
     elif config in {"C", "D"}:
-        a = N * sep + 2 * d
+        a = n * sep + 2 * d
         ports_A_TR = [
             Port(
                 f"A_TR_{i}",
@@ -171,7 +172,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_TL = [
@@ -182,7 +183,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BR = [
@@ -193,7 +194,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BL = [
@@ -204,7 +205,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A = [ports_A_TR, ports_A_TL, ports_A_BR, ports_A_BL]
@@ -217,7 +218,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_TL = [
@@ -228,7 +229,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BR = [
@@ -239,7 +240,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BL = [
@@ -250,7 +251,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B = [ports_B_TR, ports_B_TL, ports_B_BR, ports_B_BL]
@@ -278,7 +279,7 @@ def test_connect_corner(
 def test_route_bundle_udirect(
     data_regression: DataRegressionFixture,
     check: bool = True,
-    dy: float = 200,
+    dy: Delta = 200,
     angle: float = 270,
 ) -> None:
     xs1 = [-100, -90, -80, -55, -35, 24, 0] + [200, 210, 240]
@@ -352,7 +353,10 @@ def test_route_bundle_udirect(
 
 @pytest.mark.parametrize("angle", [0, 90, 180, 270])
 def test_route_bundle_u_indirect(
-    data_regression: DataRegressionFixture, angle: int, check: bool = True, dy=-200
+    data_regression: DataRegressionFixture,
+    angle: AngleInDegrees,
+    check: bool = True,
+    dy: Delta = -200,
 ) -> None:
     xs1 = [-100, -90, -80, -55, -35] + [200, 210, 240]
 

--- a/tests/routing/test_routing_route_bundle_corner.py
+++ b/tests/routing/test_routing_route_bundle_corner.py
@@ -5,13 +5,13 @@ from gdsfactory import Port
 
 
 def test_connect_corner(
-    data_regression: DataRegressionFixture | None, N=6, config="A"
+    data_regression: DataRegressionFixture | None, n: int = 6, config: str = "A"
 ) -> None:
     """Test connecting two bundles of ports in a corner.
 
     Args:
         data_regression: regression test data
-        N: number of ports
+        n: number of ports
         config: configuration of the ports
     """
     d = 10.0
@@ -29,7 +29,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_TL = [
@@ -40,7 +40,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BR = [
@@ -51,7 +51,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BL = [
@@ -62,7 +62,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A = [ports_A_TR, ports_A_TL, ports_A_BR, ports_A_BL]
@@ -75,7 +75,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_TL = [
@@ -86,7 +86,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BR = [
@@ -97,7 +97,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BL = [
@@ -108,13 +108,13 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B = [ports_B_TR, ports_B_TL, ports_B_BR, ports_B_BL]
 
     elif config in ["C", "D"]:
-        a = N * sep + 2 * d
+        a = n * sep + 2 * d
         ports_A_TR = [
             Port(
                 f"A_TR_{i}",
@@ -123,7 +123,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_TL = [
@@ -134,7 +134,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BR = [
@@ -145,7 +145,7 @@ def test_connect_corner(
                 orientation=0,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A_BL = [
@@ -156,7 +156,7 @@ def test_connect_corner(
                 orientation=180,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_A = [ports_A_TR, ports_A_TL, ports_A_BR, ports_A_BL]
@@ -169,7 +169,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_TL = [
@@ -180,7 +180,7 @@ def test_connect_corner(
                 orientation=90,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BR = [
@@ -191,7 +191,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B_BL = [
@@ -202,7 +202,7 @@ def test_connect_corner(
                 orientation=270,
                 layer=layer,
             )
-            for i in range(N)
+            for i in range(n)
         ]
 
         ports_B = [ports_B_TR, ports_B_TL, ports_B_BR, ports_B_BL]

--- a/tests/routing/test_routing_route_bundle_udirect.py
+++ b/tests/routing/test_routing_route_bundle_udirect.py
@@ -7,6 +7,7 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
 from gdsfactory import Component, Port
+from gdsfactory.typings import AngleInDegrees, Delta, Layer
 
 
 def test_route_bundle_udirect_pads(
@@ -44,9 +45,9 @@ def test_route_bundle_udirect_pads(
 def test_route_connect_bundle_udirect(
     data_regression: DataRegressionFixture,
     check: bool = True,
-    dy=200,
-    orientation=270,
-    layer=(1, 0),
+    dy: Delta = 200,
+    orientation: AngleInDegrees = 270,
+    layer: Layer = (1, 0),
 ) -> None:
     xs1 = [-100, -90, -80, -55, -35, 24, 0] + [200, 210, 240]
     axis = "X" if orientation in [0, 180] else "Y"

--- a/tests/routing/test_routing_route_bundle_uindirect.py
+++ b/tests/routing/test_routing_route_bundle_uindirect.py
@@ -4,13 +4,14 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
 from gdsfactory import Component, Port
+from gdsfactory.typings import AngleInDegrees, Delta, Layer
 
 
 def test_connect_bundle_u_indirect(
     data_regression: DataRegressionFixture,
-    dy=-200,
-    orientation=180,
-    layer=(1, 0),
+    dy: Delta = -200,
+    orientation: AngleInDegrees = 180,
+    layer: Layer = (1, 0),
     check: bool = True,
 ) -> None:
     """Test routing a bundle of ports with indirect connection.

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -25,21 +25,21 @@ def c2() -> gf.Component:
     )
 
 
-def test_boolean_not(c1, c2) -> None:
+def test_boolean_not(c1: gf.Component, c2: gf.Component) -> None:
     c4 = gf.boolean(c1, c2, operation="not", layer=layer)
     assert int(c4.area(layer=layer)) == 87
 
 
-def test_boolean_or(c1, c2) -> None:
+def test_boolean_or(c1: gf.Component, c2: gf.Component) -> None:
     c4 = gf.boolean(c1, c2, operation="or", layer=layer)
     assert int(c4.area(layer=layer)) == 225
 
 
-def test_boolean_xor(c1, c2) -> None:
+def test_boolean_xor(c1: gf.Component, c2: gf.Component) -> None:
     c4 = gf.boolean(c1, c2, operation="xor", layer=layer)
     assert int(c4.area(layer=layer)) == 111
 
 
-def test_boolean_and(c1, c2) -> None:
+def test_boolean_and(c1: gf.Component, c2: gf.Component) -> None:
     c4 = gf.boolean(c1, c2, operation="and", layer=layer)
     assert int(c4.area(layer=layer)) == 113

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -3,14 +3,14 @@ from gdsfactory import partial
 
 
 @gf.cell
-def inner(a=1) -> gf.Component:
+def inner(a: int = 1) -> gf.Component:
     c = gf.Component()
     c.add_ref(gf.components.rectangle(size=(a, a)))
     return c
 
 
 @gf.cell
-def outer(b=1) -> gf.Component:
+def outer(b: int = 1) -> gf.Component:
     return inner(b)
 
 

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -73,7 +73,7 @@ xc_sin_ec = partial(xc_sin, width=0.2)
 
 
 @gf.cell
-def demo_taper_cladding_offsets():
+def demo_taper_cladding_offsets() -> gf.Component:
     taper_length = 10
 
     in_stub_length = 10
@@ -97,7 +97,7 @@ def demo_taper_cladding_offsets():
     return c
 
 
-def test_taper_cladding_offets():
+def test_taper_cladding_offets() -> None:
     c = demo_taper_cladding_offsets()
     n = len(c.get_polygons()[LAYER.WG])
     assert n == 3, n

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,9 +1,18 @@
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from gdsfactory.difftest import diff
 
 
-def assert_xor_fails(ref_gds, run_gds, test_name, capsys, layers_with_xor) -> None:
+def assert_xor_fails(
+    ref_gds: Path,
+    run_gds: Path,
+    test_name: str,
+    capsys: pytest.CaptureFixture[Any],
+    layers_with_xor: list[str],
+) -> None:
     assert diff(ref_gds, run_gds, xor=True, test_name=test_name) is True
     captured = capsys.readouterr()
     for layer in layers_with_xor:
@@ -14,7 +23,7 @@ def assert_xor_fails(ref_gds, run_gds, test_name, capsys, layers_with_xor) -> No
 _gds_dir = Path(__file__).parent / "gds"
 
 
-def test_xor1(capsys) -> None:
+def test_xor1(capsys: pytest.CaptureFixture[Any]) -> None:
     """Assert that the XOR flags the layer with A not B differences."""
     ref_gds = _gds_dir / "big_rect.gds"
     run_gds = _gds_dir / "small_rect.gds"
@@ -27,7 +36,7 @@ def test_xor1(capsys) -> None:
     )
 
 
-def test_xor2(capsys) -> None:
+def test_xor2(capsys: pytest.CaptureFixture[Any]) -> None:
     """Assert that the XOR flags the layer with B not A differences."""
     ref_gds = _gds_dir / "small_rect.gds"
     run_gds = _gds_dir / "big_rect.gds"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,7 +2,7 @@ import gdsfactory as gf
 from gdsfactory.generic_tech import LAYER
 
 
-def test_get_polygons():
+def test_get_polygons() -> None:
     c = gf.c.rectangle(size=(10, 10), centered=True)
 
     p = c.get_polygons(layers=("WG",), by="tuple")

--- a/tests/test_get_netlist.py
+++ b/tests/test_get_netlist.py
@@ -58,7 +58,7 @@ def test_get_netlist_cell_array() -> None:
     ), f"Expected {n_ports_expected} ports in netlist. Got {len(n['ports'])}"
     for ib in range(rows):
         for port in component_to_array.ports:
-            expected_port_name = f"{port.name}_{ib+1}_1"
+            expected_port_name = f"{port.name}_{ib + 1}_1"
             expected_lower_port_name = f"{inst_name}<0.{ib}>,{port.name}"
             assert expected_port_name in n["ports"]
             assert n["ports"][expected_port_name] == expected_lower_port_name

--- a/tests/test_get_netlist_recursive.py
+++ b/tests/test_get_netlist_recursive.py
@@ -7,7 +7,7 @@ import gdsfactory as gf
 from gdsfactory.get_netlist import get_netlist_recursive
 
 
-def test_no_effect_on_original_components():
+def test_no_effect_on_original_components() -> None:
     passive_mzi = gf.components.mzi2x2_2x2()
     passive_mzi_phase_shifter_netlist_electrical = get_netlist_recursive(
         passive_mzi, exclude_port_types="optical"
@@ -16,14 +16,14 @@ def test_no_effect_on_original_components():
 
 
 @gf.cell
-def hcomponent_top():
+def hcomponent_top() -> gf.Component:
     c = gf.Component()
     c << hcomponent_l2()
     return c
 
 
 @gf.cell
-def hcomponent_l2():
+def hcomponent_l2() -> gf.Component:
     c = gf.Component()
     c << hcomponent_l3()
     c << hcomponent_l3()
@@ -31,12 +31,12 @@ def hcomponent_l2():
 
 
 @gf.cell
-def hcomponent_l3():
+def hcomponent_l3() -> gf.Component:
     c = gf.Component()
     return c
 
 
-def test_n_netlists():
+def test_n_netlists() -> None:
     c = hcomponent_top()
     netlists = get_netlist_recursive(c)
     # only netlists with hierarchy should be reported

--- a/tests/test_get_netlist_yaml2.py
+++ b/tests/test_get_netlist_yaml2.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import gdsfactory as gf
+from gdsfactory.component import Component
 from gdsfactory.config import PATH
 
 
 @gf.cell
-def straight_with_bend(radius: float = 10):
+def straight_with_bend(radius: float = 10) -> Component:
     """Returns straight_with_bend interferometer with bend."""
     c = gf.Component()
     s = c.add_ref(gf.components.straight())

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -2,11 +2,11 @@ import gdsfactory as gf
 
 
 @gf.cell
-def swatch(index) -> gf.Component:
+def swatch(index: int) -> gf.Component:
     return gf.components.rectangle(size=(1, 1), layer=(index + 1, 0))
 
 
-def test_grid_with_None_ports(rows=3, columns=4) -> None:
+def test_grid_with_None_ports(rows: int = 3, columns: int = 4) -> None:
     swatches = [swatch(index) for index in range(11)]
     c = gf.grid(
         components=swatches,
@@ -18,12 +18,10 @@ def test_grid_with_None_ports(rows=3, columns=4) -> None:
     assert c
 
 
-def test_grid_with_ports(rows=3, columns=4) -> None:
+def test_grid_with_ports(rows: int = 3, columns: int = 4) -> None:
     n = 3
     components = [gf.c.rectangle(size=(1, 1)) for _ in range(3)]
-    c = gf.grid(
-        components=components,
-    )
+    c = gf.grid(components=components)
     assert len(c.ports) == n * 4, len(c.ports)
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
@@ -35,7 +38,7 @@ def test_path_append() -> None:
     assert np.round(P.length(), 3) == 107.697, P.length()
 
 
-def looploop(num_pts=1000):
+def looploop(num_pts: int = 1000) -> npt.NDArray[np.signedinteger[Any]]:
     """Simple limacon looping curve."""
     t = np.linspace(-np.pi, 0, num_pts)
     r = 20 + 25 * np.sin(t)
@@ -111,7 +114,7 @@ component_names = component_factory.keys()
 
 
 @pytest.fixture(params=component_names, scope="function")
-def component(request) -> Component:
+def component(request: pytest.FixtureRequest) -> Component:
     return component_factory[request.param]()
 
 

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import gdsfactory as gf
 from gdsfactory import Section
+from gdsfactory.cross_section import CrossSection
 from gdsfactory.generic_tech import LAYER
+from gdsfactory.typings import LayerSpec
 
 
 def test_path_near_collinear() -> None:
@@ -65,7 +67,13 @@ def test_transition_cross_section() -> None:
     assert c.ports["o2"].width == w2
 
 
-def dummy_cladded_wg_cs(intent_layer, core_layer, core_width, clad_layer, clad_width):
+def dummy_cladded_wg_cs(
+    intent_layer: LayerSpec,
+    core_layer: LayerSpec,
+    core_width: float,
+    clad_layer: LayerSpec,
+    clad_width: float,
+) -> CrossSection:
     sections = (
         Section(width=core_width, offset=0, layer=core_layer, name="core"),
         Section(width=clad_width, offset=0, layer=clad_layer, name="clad"),
@@ -137,7 +145,7 @@ def test_extrude_port_centers() -> None:
     assert s.ports["e2"].dcenter[1] == s.ports["o2"].dcenter[1] - s1_offset
 
 
-def test_extrude_component_along_path():
+def test_extrude_component_along_path() -> None:
     p = gf.path.straight()
     p += gf.path.arc(10)
     p += gf.path.straight()

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -12,7 +12,7 @@ def test_get_cross_section() -> None:
     assert xs.sections[0].width == 1
 
 
-def test_get_layer():
+def test_get_layer() -> None:
     assert gf.get_layer(1) == LAYER.WG
     assert gf.get_layer((1, 0)) == LAYER.WG
     assert gf.get_layer("WG") == LAYER.WG

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -59,7 +59,7 @@ def test_get_ports_sort_counter_clockwise() -> None:
 
 
 @pytest.mark.parametrize("port_type", ["electrical", "optical", "placement"])
-def test_rename_ports(port_type, data_regression: DataRegressionFixture):
+def test_rename_ports(port_type: str, data_regression: DataRegressionFixture) -> None:
     c = gf.components.nxn(port_type=port_type)
     data_regression.check(c.to_dict())
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -44,7 +44,7 @@ def test_clean_value_json() -> None:
 
 
 def test_clean_value_partial() -> None:
-    def sample_func(a, b=2) -> None:
+    def sample_func(a: float, b: float = 2) -> float:
         return a + b
 
     partial_func = functools.partial(sample_func, 1)


### PR DESCRIPTION
## Summary by Sourcery

Fix type hints across multiple functions by specifying 'Any' for '**kwargs' and refactor routing strategy definitions to use type aliases for improved code clarity.

Bug Fixes:
- Correct type hints for various functions by specifying 'Any' for '**kwargs' to ensure proper type checking and avoid potential runtime errors.

Enhancements:
- Add more ruff linting rules

Design Choices:
- Add more TypeAlias like 'Size', 'Delta' and 'Spacing' for widely used types to improve readability and maintainability.