### PR TITLE
Fix return typing for get_boxes()

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -751,7 +751,7 @@ class ComponentBase:
             )
         return paths
 
-    def get_boxes(self, layer: LayerSpec, recursive: bool = True) -> list[kf.kdb.Box]:
+    def get_boxes(self, layer: LayerSpec, recursive: bool = True) -> list[kf.kdb.DBox]:
         """Returns a list of boxes.
 
         Args:


### PR DESCRIPTION
## Summary
- get_boxes() actually returns a list[kf.kdb.DBox], but was typed as returning a list[kf.kdb.Box].

## Testing
- Tests passed locally for me!

## Summary by Sourcery

Bug Fixes:
- Correct the return type annotation of the get_boxes() method to accurately reflect that it returns a list of kf.kdb.DBox instead of kf.kdb.Box.