### PR TITLE
Make ComponentAlongPath accessible

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -27,7 +27,12 @@ from gdsfactory.component import (
 from gdsfactory.config import CONF, PATH
 from gdsfactory.port import Port
 from gdsfactory.read.import_gds import import_gds
-from gdsfactory.cross_section import CrossSection, Section, xsection
+from gdsfactory.cross_section import (
+    ComponentAlongPath,
+    CrossSection,
+    Section,
+    xsection,
+)
 from gdsfactory.difftest import difftest, diff
 from gdsfactory.boolean import boolean
 
@@ -81,6 +86,7 @@ __all__ = (
     "CONF",
     "Component",
     "ComponentAllAngle",
+    "ComponentAlongPath",
     "ComponentBase",
     "ComponentReference",
     "CrossSection",


### PR DESCRIPTION
Makes `ComponentAlongPath` accessible as `gf.ComponentAlongPath`.

Currently mypy does not recognize either of the following annotations:
```python
import gdsfactory as gf
foo: gf.cross_section.ComponentAlongPath
```
```python
import gdsfactory.cross_section as gf_xs
foo: gf_xs.ComponentAlongPath
```

After this PR, the following works:
```python
import gdsfactory as gf
foo: gf.ComponentAlongPath
```

## Summary by Sourcery

New Features:
- Expose `ComponentAlongPath` as `gf.ComponentAlongPath` for easier access and type annotation.