### PR TITLE
bump kfactory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]==0.21.7",
+  "kfactory[ipy]==0.21.10",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update kfactory dependency version from 0.21.7 to 0.21.10 in pyproject.toml.