### PR TITLE
fix docs

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -119,8 +119,6 @@ def route_single(
                 layer=layer, width=route_width
             )
 
-    assert cross_section is not None, "cross_section or radius is required"
-
     port_type = port_type or p1.port_type
     xs = gf.get_cross_section(cross_section)
     width = route_width or xs.width

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -114,7 +114,12 @@ def route_single(
             raise ValueError(
                 f"Either {cross_section=} or {layer=} and route_width must be provided"
             )
-        elif radius is not None:
+
+        elif radius:
+            cross_section = gf.cross_section.cross_section(
+                layer=layer, width=route_width, radius=radius
+            )
+        else:
             cross_section = gf.cross_section.cross_section(
                 layer=layer, width=route_width
             )

--- a/gdsfactory/technology/layer_map.py
+++ b/gdsfactory/technology/layer_map.py
@@ -27,7 +27,10 @@ class LayerMapFab(LayerMap):
 """
     lys = LayerViews.from_lyp(filepathin)
     for layer_name, layer in sorted(lys.get_layer_views().items()):
-        script += f"    {layer_name}: Layer = ({layer.layer[0]}, {layer.layer[1]})\n"
+        if layer.layer is not None:
+            script += (
+                f"    {layer_name}: Layer = ({layer.layer[0]}, {layer.layer[1]})\n"
+            )
 
     script += """
 

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -958,9 +958,12 @@ class LayerViews(BaseModel):
         scale = size / 100
         num_layers = len(self.get_layer_views())
         matrix_size = int(np.ceil(np.sqrt(num_layers)))
-        sorted_layers = sorted(
-            self.get_layer_views().values(), key=lambda x: (x.layer[0], x.layer[1])
-        )
+        layer_views = self.get_layer_views()
+
+        non_empty_layers = [v for v in layer_views.values() if v.layer is not None]
+
+        sorted_layers = sorted(non_empty_layers, key=lambda x: (x.layer[0], x.layer[1]))
+
         for n, layer in enumerate(sorted_layers):
             layer_tuple = layer.layer
             rectangle = gf.components.rectangle(

--- a/notebooks/09_pdk_import.ipynb
+++ b/notebooks/09_pdk_import.ipynb
@@ -443,7 +443,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -50,6 +50,15 @@ def get_layer_stack_faba(
     )
 
 
+def test_preview_layerset() -> None:
+    from gdsfactory.generic_tech import get_generic_pdk
+
+    PDK = get_generic_pdk()
+    LAYER_VIEWS = PDK.layer_views
+    c = LAYER_VIEWS.preview_layerset()
+    assert c
+
+
 if __name__ == "__main__":
     LAYER_STACK = get_layer_stack_faba()
     WIDTH = 2


### PR DESCRIPTION
For some reason the typing improvements PR broke the docs

This PR trying to fix them

## Summary by Sourcery

Fix the documentation generation issue by modifying the layer sorting logic to exclude empty layers and add a test for the preview_layerset function.

Bug Fixes:
- Fix the documentation generation issue caused by the typing improvements by ensuring only non-empty layers are processed.

Tests:
- Add a test for the preview_layerset function to ensure it generates a valid component.