### PR TITLE
Fix spiral

### DIFF
--- a/gdsfactory/components/spiral.py
+++ b/gdsfactory/components/spiral.py
@@ -25,9 +25,15 @@ def spiral(
     """
     c = gf.Component()
     b = gf.get_component(bend, cross_section=cross_section)
-    if "radius" not in b.info:
-        raise ValueError(f"bend component {b} must have a radius info field")
-    radius = b.info["radius"]
+
+    o1 = b["o1"]
+    o2 = b["o2"]
+    dx = abs(o2.dx - o1.dx)
+    dy = abs(o2.dy - o1.dy)
+
+    if dx != dy:
+        raise ValueError(f"bend component {b} must have dx == dy")
+    radius = dx
     _length = length
 
     b_inners = [c << b for _ in range(4)]

--- a/gdsfactory/components/spiral.py
+++ b/gdsfactory/components/spiral.py
@@ -24,10 +24,10 @@ def spiral(
         n_loops: number of loops.
     """
     c = gf.Component()
-    xs = gf.get_cross_section(cross_section)
-
     b = gf.get_component(bend, cross_section=cross_section)
-    radius = xs.radius
+    if "radius" not in b.info:
+        raise ValueError(f"bend component {b} must have a radius info field")
+    radius = b.info["radius"]
     _length = length
 
     b_inners = [c << b for _ in range(4)]

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -958,9 +958,12 @@ class LayerViews(BaseModel):
         scale = size / 100
         num_layers = len(self.get_layer_views())
         matrix_size = int(np.ceil(np.sqrt(num_layers)))
-        sorted_layers = sorted(
-            self.get_layer_views().values(), key=lambda x: (x.layer[0], x.layer[1])
-        )
+        layer_views = self.get_layer_views()
+
+        non_empty_layers = [v for v in layer_views.values() if v.layer is not None]
+
+        sorted_layers = sorted(non_empty_layers, key=lambda x: (x.layer[0], x.layer[1]))
+
         for n, layer in enumerate(sorted_layers):
             layer_tuple = layer.layer
             rectangle = gf.components.rectangle(

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -50,6 +50,15 @@ def get_layer_stack_faba(
     )
 
 
+def test_preview_layerset() -> None:
+    from gdsfactory.generic_tech import get_generic_pdk
+
+    PDK = get_generic_pdk()
+    LAYER_VIEWS = PDK.layer_views
+    c = LAYER_VIEWS.preview_layerset()
+    assert c
+
+
 if __name__ == "__main__":
     LAYER_STACK = get_layer_stack_faba()
     WIDTH = 2


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3394

thank you Manuel!

@Arka-noid

## Summary

Fix the spiral component by ensuring the bend component has equal dx and dy, and improve layer view sorting by excluding layers with None values. Add a test for the preview_layerset function.

Bug Fixes:
- Fix the spiral component to ensure the bend component has equal dx and dy, raising a ValueError if not.

Enhancements:
- Improve the sorting of layer views by filtering out layers with None values before sorting.

Tests:
- Add a test for the preview_layerset function to ensure it returns a valid component.