### PR TITLE
Fix mirror flag

### DIFF
--- a/notebooks/10_yaml_component.ipynb
+++ b/notebooks/10_yaml_component.ipynb
@@ -478,7 +478,7 @@
    "source": [
     "## Arrays\n",
     "\n",
-    "You can also define arrays and connect to the array ports."
+    "You can also define arrays and connect to the array ports using the `instance<column,row>,port_name` syntax:"
    ]
   },
   {
@@ -523,6 +523,49 @@
    "id": "40",
    "metadata": {},
    "source": [
+    "## Arrays with routes\n",
+    "\n",
+    "You can also define groups of route ports in a group using the `instance_name,port_base:index_start:index_end` syntax:\n",
+    "\n",
+    "For example, if you have an instance `a` with `o3` and `o4` ports, you can define a group of ports `a,o:3:4`  to connect the `o3` and `o4` ports of the instance `a` to the same port of another instance `b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "port_array_optical = \"\"\"\n",
+    "instances:\n",
+    "  a:\n",
+    "    component: nxn\n",
+    "  b:\n",
+    "    component: nxn\n",
+    "\n",
+    "placements:\n",
+    "  b:\n",
+    "    x: 50\n",
+    "    y: 50\n",
+    "    mirror: True\n",
+    "\n",
+    "routes:\n",
+    "  optical:\n",
+    "    settings:\n",
+    "        cross_section: strip\n",
+    "    links:\n",
+    "      a,o:3:4: b,o:4:3\n",
+    "\"\"\"\n",
+    "\n",
+    "gf.read.from_yaml(port_array_optical)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42",
+   "metadata": {},
+   "source": [
     "## Jinja Pcells\n",
     "\n",
     "You use jinja templates in YAML cells to define Pcells."
@@ -531,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,28 +625,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
-   "metadata": {},
-   "source": [
-    "You'll see that this generated a python function, with a real signature, default arguments, docstring and all!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "43",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(pic_cell)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "44",
    "metadata": {},
    "source": [
-    "You can invoke this cell without arguments to see the default implementation"
+    "You'll see that this generated a python function, with a real signature, default arguments, docstring and all!"
    ]
   },
   {
@@ -613,13 +638,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "help(pic_cell)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46",
+   "metadata": {},
+   "source": [
+    "You can invoke this cell without arguments to see the default implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "c = pic_cell()\n",
     "c.plot()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "48",
    "metadata": {},
    "source": [
     "Or you can provide arguments explicitly, like a normal cell. Note however that yaml-based cells **only accept keyword arguments**, since yaml dictionaries are inherently unordered."
@@ -628,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary by Sourcery

Fix the mirror flag functionality by updating the transformation logic and enhance documentation to clarify array and routing syntax with examples.

Bug Fixes:
- Fix the mirror flag functionality by replacing the transformation logic with a call to the dmirror_x method.

Documentation:
- Update documentation to clarify the syntax for defining arrays and connecting to array ports, including examples for arrays with routes.