### PR TITLE
remove Transition inheritance

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -417,7 +417,7 @@ ConductorViaConductorName = tuple[str, str, str] | tuple[str, str]
 ConnectivitySpec = ConductorConductorName | ConductorViaConductorName
 
 
-class Transition(CrossSection):
+class Transition(BaseModel):
     """Waveguide information to extrude a path between two CrossSection.
 
     cladding_layers follow path shape
@@ -444,17 +444,6 @@ class Transition(CrossSection):
         return ",".join(
             [str(round(width, 3)) for width in width_type(t_values, *self.width)]
         )
-
-    @property
-    def width(self) -> tuple[float, float]:
-        return (
-            self.cross_section1.sections[0].width,
-            self.cross_section2.sections[0].width,
-        )
-
-    @property
-    def layer(self) -> LayerSpec:
-        return self.cross_section1.sections[0].layer
 
 
 cross_sections = {}

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -852,6 +852,10 @@ def extrude(
     x = get_cross_section(cross_section)
 
     if isinstance(x, Transition):
+        warnings.warn(
+            "Use extrude_transition() instead of extrude() for Transition cross-sections",
+            stacklevel=2,
+        )
         return extrude_transition(
             p,
             transition=x,
@@ -1734,12 +1738,21 @@ if __name__ == "__main__":
     via = gf.cross_section.ComponentAlongPath(
         component=gf.c.rectangle(size=(1, 1), centered=True), spacing=5, padding=2
     )
-    s = gf.Section(width=0.5, offset=0, layer=(1, 0), port_names=("in", "out"))
+    s = gf.Section(
+        width=0.5, offset=0, layer=(1, 0), port_names=("in", "out"), name="core"
+    )
     x = gf.CrossSection(sections=[s], components_along_path=[via])
 
     # Combine the path with the cross-section
-    c = gf.path.extrude(p, cross_section=x)
-    assert c
+    # c = gf.path.extrude(p, cross_section=x)
+    # assert c
+
+    s = gf.Section(
+        width=2, offset=0, layer=(1, 0), port_names=("in", "out"), name="core"
+    )
+    x2 = gf.CrossSection(sections=[s], components_along_path=[via])
+    t = gf.path.transition(x, x2, width_type="linear")
+    c = gf.path.extrude_transition(p, t)
 
     # c = gf.path.extrude(P, x1)
     # print(hash(P))

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -170,9 +170,7 @@ CellSpec: TypeAlias = (
 )
 
 ComponentSpecDict: TypeAlias = dict[str, ComponentSpec]
-CrossSectionSpec: TypeAlias = (
-    CrossSectionFactory | CrossSection | dict[str, Any] | str | Transition
-)
+CrossSectionSpec: TypeAlias = CrossSectionFactory | CrossSection | dict[str, Any] | str
 CrossSectionSpecs: TypeAlias = tuple[CrossSectionSpec, ...]
 
 MultiCrossSectionAngleSpec: TypeAlias = list[tuple[CrossSectionSpec, tuple[int, ...]]]
@@ -261,5 +259,6 @@ __all__ = (
     "Size",
     "Spacing",
     "Strs",
+    "Transition",
     "WidthTypes",
 )

--- a/notebooks/03_Path_CrossSection.ipynb
+++ b/notebooks/03_Path_CrossSection.ipynb
@@ -987,9 +987,7 @@
    "id": "65",
    "metadata": {},
    "source": [
-    "Since a Transition inherits from CrossSection you can also extrude an arbitrary Transition.\n",
-    "\n",
-    "1. Extruding a Path"
+    "You can also extrude an arbitrary Transition:"
    ]
   },
   {
@@ -1005,38 +1003,13 @@
     "x2 = gf.get_cross_section(\"strip\", width=w2)\n",
     "transition = gf.path.transition(x1, x2)\n",
     "p = gf.path.arc(radius=10)\n",
-    "c = gf.path.extrude(p, transition)\n",
+    "c = gf.path.extrude_transition(p, transition)\n",
     "c.plot()"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "67",
-   "metadata": {},
-   "source": [
-    "2. Or as a CrossSection for a component"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "w1 = 1\n",
-    "w2 = 5\n",
-    "length = 10\n",
-    "x1 = gf.get_cross_section(\"strip\", width=w1)\n",
-    "x2 = gf.get_cross_section(\"strip\", width=w2)\n",
-    "transition = gf.path.transition(x1, x2)\n",
-    "c = gf.components.bend_euler(radius=10, cross_section=transition)\n",
-    "c.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "69",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1055,7 +1028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "68",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1088,7 +1061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "69",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1099,7 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "70",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1132,7 +1105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "71",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1148,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,7 +1152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1217,7 +1190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1228,7 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1272,7 +1245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1284,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1300,7 +1273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "82",
    "metadata": {},
    "source": [
     "## Creating new cross_sections\n",
@@ -1317,7 +1290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1327,7 +1300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1368,7 +1341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1379,7 +1352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1390,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,7 +1373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "88",
    "metadata": {},
    "source": [
     "finally, you can also pass most components Dict that define the cross-section"
@@ -1409,7 +1382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1448,7 +1421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1467,7 +1440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1484,7 +1457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1494,7 +1467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95",
+   "id": "93",
    "metadata": {},
    "source": [
     "The port location, width and orientation remains the same for a sheared component. However, an additional property, `shear_angle` is set to the value of the shear angle. In general, shear ports can be safely connected together."
@@ -1502,7 +1475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "94",
    "metadata": {},
    "source": [
     "## bbox_layers vs cladding_layers\n",
@@ -1516,7 +1489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1528,7 +1501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1539,7 +1512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99",
+   "id": "97",
    "metadata": {},
    "source": [
     "## Insets\n",
@@ -1550,7 +1523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1580,7 +1553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1609,7 +1582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1636,7 +1609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary 

Refactor the Transition class to inherit from BaseModel instead of CrossSection, and update the related documentation and code to use the new extrude_transition function for handling Transition cross-sections.

Enhancements:
- Refactor the Transition class to inherit from BaseModel instead of CrossSection, simplifying the class structure.

Documentation:
- Update the documentation in the notebook to reflect the changes in the Transition class and its usage.


@MatthewMckee4