### PR TITLE
Fix remove layers

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -889,15 +889,13 @@ class ComponentBase:
 
         layers = [get_layer(layer) for layer in layers]
         for layer_index in layers:
+            self.shapes(layer_index).clear()
             if recursive:
                 [
                     self.kcl[ci].shapes(layer).clear()
                     for ci in self.called_cells()
                     for layer in layers
                 ]
-
-            else:
-                self.shapes(layer_index).clear()
         return self
 
     def remap_layers(

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -890,7 +890,6 @@ class ComponentBase:
         layers = [get_layer(layer) for layer in layers]
         for layer_index in layers:
             if recursive:
-                print(f"removing layer {layer_index}")
                 [
                     self.kcl[ci].shapes(layer).clear()
                     for ci in self.called_cells()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -890,7 +890,13 @@ class ComponentBase:
         layers = [get_layer(layer) for layer in layers]
         for layer_index in layers:
             if recursive:
-                self.kcl.clear_layer(layer_index)
+                print(f"removing layer {layer_index}")
+                [
+                    self.kcl[ci].shapes(layer).clear()
+                    for ci in self.called_cells()
+                    for layer in layers
+                ]
+
             else:
                 self.shapes(layer_index).clear()
         return self

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -61,7 +61,7 @@ def test_from_kcell() -> None:
     gf.Component.from_kcell(kf.cells.straight.straight(1, 1, gf.kcl.get_info(LAYER.WG)))
 
 
-def test_remove_layers() -> None:
+def test_remove_layers_recursive() -> None:
     comp = gf.Component()
     r1 = gf.components.rectangle(size=(1, 15), layer=(1, 0), centered=True)
     _ = comp << r1
@@ -74,3 +74,13 @@ def test_remove_layers() -> None:
 
     assert comp.area((1, 0)) == 15, f"{comp.area((1, 0))}"
     assert comp.area((2, 0)) == 60, f"{comp.area((2, 0))}"
+
+
+def test_remove_layers_flat() -> None:
+    comp = gf.Component()
+    comp.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(2, 0))
+
+    copy = comp.dup()
+    copy.remove_layers(layers=[(2, 0)])
+    assert comp.area((2, 0)) == 0, f"{comp.area((2, 0))}"
+    assert copy.area((2, 0)) == 100, f"{copy.area((2, 0))}"

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -59,3 +59,18 @@ def test_trim() -> None:
 def test_from_kcell() -> None:
     kf.kcl.infos = kf.LayerInfos(WG=kf.kdb.LayerInfo(1, 0))
     gf.Component.from_kcell(kf.cells.straight.straight(1, 1, gf.kcl.get_info(LAYER.WG)))
+
+
+def test_remove_layers() -> None:
+    comp = gf.Component()
+    r1 = gf.components.rectangle(size=(1, 15), layer=(1, 0), centered=True)
+    _ = comp << r1
+    r2 = gf.components.rectangle(size=(2, 30), layer=(2, 0), centered=True)
+    _ = comp << r2
+    comp.flatten()
+
+    copy = comp.dup()
+    copy.remove_layers(layers=[(2, 0)])
+
+    assert comp.area((1, 0)) == 15, f"{comp.area((1, 0))}"
+    assert comp.area((2, 0)) == 60, f"{comp.area((2, 0))}"

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -77,10 +77,10 @@ def test_remove_layers_recursive() -> None:
 
 
 def test_remove_layers_flat() -> None:
-    comp = gf.Component()
-    comp.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(2, 0))
+    c = gf.Component()
+    c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(2, 0))
 
-    copy = comp.dup()
-    copy.remove_layers(layers=[(2, 0)])
-    assert comp.area((2, 0)) == 0, f"{comp.area((2, 0))}"
-    assert copy.area((2, 0)) == 100, f"{copy.area((2, 0))}"
+    empty = c.dup()
+    empty.remove_layers(layers=[(2, 0)])
+    assert c.area((2, 0)) == 100, f"{c.area((2, 0))}"
+    assert empty.area((2, 0)) == 0, f"{empty.area((2, 0))}"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -53,6 +53,17 @@ def test_clean_value_partial() -> None:
 
 
 def test_clean_value_name() -> None:
-    assert clean_value_name(1) == "1"
-    assert clean_value_name(1.23456) == "1.235"
-    assert clean_value_name([1, 2, 3]) == "(1, 2, 3)"
+    assert clean_value_name("with space") == "with_space"
+    assert clean_value_name("with-dash") == "withdash", clean_value_name("with-dash")
+    assert clean_value_name("with_underscore") == "with_underscore"
+    assert clean_value_name("with.dot") == "withdot"
+    assert clean_value_name("with:colon") == "withcolon"
+    assert clean_value_name("with/forwardslash") == "withforwardslash"
+    assert clean_value_name("with\\backslash") == "withbackslash"
+    assert clean_value_name("with*asterisk") == "withasterisk"
+    assert clean_value_name("with?questionmark") == "withquestionmark"
+    assert clean_value_name("with!exclamationmark") == "withexclamationmark"
+
+
+if __name__ == "__main__":
+    test_clean_value_name()


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3433

@sebastian-goeldi 
@rgiroud

## Summary by Sourcery

Fix the remove_layers function to handle layer removal correctly in recursive mode and add a corresponding test to validate the fix.

Bug Fixes:
- Fix the remove_layers function to correctly clear layers in both the current and called cells when the recursive option is enabled.

Tests:
- Add a test case to verify the functionality of the remove_layers method, ensuring it correctly removes specified layers and maintains the expected area calculations.