### PR TITLE
fix grid docs

### DIFF
--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -40,7 +40,7 @@ def grid(
     Args:
         components: Iterable to be placed onto a grid. (can be 1D or 2D).
         spacing: between adjacent elements on the grid, can be a tuple for \
-                different distances in height and width.
+                different distances in height and width or a single float.
         shape: x, y shape of the grid (see np.reshape). \
                 If no shape and the list is 1D, if np.reshape were run with (1, -1).
         align_x: x alignment along (origin, xmin, xmax, center).

--- a/notebooks/04_components_pack.ipynb
+++ b/notebooks/04_components_pack.ipynb
@@ -17,10 +17,10 @@
     "\n",
     "\n",
     "The ``gf.grid()`` function can take a list (or 2D array) of objects and arrange them along a grid. This is often useful for making parameter sweeps.\n",
-    "If the `separation` argument is true, grid is arranged such that the elements are guaranteed not to touch, with a `spacing` distance between them.\n",
-    "If `separation` is false, elements are spaced evenly along a grid.\n",
-    "The `align_x`/`align_y` arguments specify intra-row/intra-column alignment. \n",
-    "The `edge_x`/`edge_y` arguments specify inter-row/inter-column alignment (unused if `separation = True`)."
+    "The grid is arranged such that the elements are guaranteed not to touch, with a `spacing` distance between them.\n",
+    "Spacing can be a scalar or a tuple of two values, for different spacing in the x and y directions.\n",
+    "\n",
+    "The `align_x`/`align_y` arguments specify intra-row/intra-column alignment. Available options are `origin`, `xmin`, `xmax`, and `center`."
    ]
   },
   {
@@ -40,7 +40,7 @@
     "\n",
     "c = gf.grid(\n",
     "    tuple(components_list),\n",
-    "    spacing=(5, 1),\n",
+    "    spacing=(1, 1),\n",
     "    shape=(3, 4),\n",
     "    align_x=\"x\",\n",
     "    align_y=\"y\",\n",
@@ -55,10 +55,13 @@
    "source": [
     "## Pack\n",
     "\n",
+    "The `gf.pack()` function packs geometries together into rectangular bins. If a `max_size` is specified, the function will create as many bins as necessary to pack all the geometries and then return a list of the filled-bin Components.\n",
     "\n",
-    "The ``gf.pack()`` function packs geometries together into rectangular bins. If a ``max_size`` is specified, the function will create as many bins as is necessary to pack all the geometries and then return a list of the filled-bin Components.\n",
+    "> ⚠️ **Warning:** Unlike `gf.grid()`, which returns a single Component, `gf.pack()` returns a **list of Components** (one for each filled bin). Ensure your workflow accounts for this difference.\n",
     "\n",
-    "Here we generate several random shapes then pack them together automatically. We allow the bin to be as large as needed to fit all the Components by specifying ``max_size = (None, None)``.  By setting ``aspect_ratio = (2,1)``, we specify the rectangular bin it tries to pack them into should be twice as wide as it is tall:"
+    "Here we generate several random shapes and pack them together automatically.\n",
+    "We allow the bin to be as large as needed to fit all the Components by specifying `max_size = (None, None)`.\n",
+    "By setting `aspect_ratio = (2,1)`, we specify that the rectangular bin it tries to pack them into should be twice as wide as it is tall:\n"
    ]
   },
   {
@@ -158,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3442


Thanks to Manuel

@Arka-noid

## Summary

Fix the documentation for the `gf.grid()` and `gf.pack()` functions to accurately describe their parameters and behavior, including a warning about the return type of `gf.pack()`. Update the Python version in the notebook metadata.

Bug Fixes:
- Correct the documentation for the `gf.grid()` function to accurately describe the behavior of the `spacing` parameter and alignment options.

Documentation:
- Update the `gf.grid()` function documentation to clarify the behavior of the `spacing` parameter and alignment options. Add a warning to the `gf.pack()` function documentation about its return type.