### PR TITLE
rename_fiber_spacing_to_pitch

### DIFF
--- a/gdsfactory/components/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/add_fiber_array_optical_south_electrical_north.py
@@ -12,7 +12,7 @@ def add_fiber_array_optical_south_electrical_north(
     cross_section_metal: CrossSectionSpec,
     with_loopback: bool = True,
     pad_pitch: float = 100.0,
-    fiber_spacing: float = 127.0,
+    pitch: float = 127.0,
     pad_gc_spacing: float = 250.0,
     electrical_port_names: list[str] | None = None,
     electrical_port_orientation: AngleInDegrees | None = 90,
@@ -32,7 +32,7 @@ def add_fiber_array_optical_south_electrical_north(
         cross_section_metal: metal cross section.
         with_loopback: whether to add a loopback port.
         pad_pitch: spacing between pads.
-        fiber_spacing: spacing between grating couplers.
+        pitch: spacing between grating couplers.
         pad_gc_spacing: spacing between pads and grating couplers.
         electrical_port_names: list of electrical port names. Defaults to all.
         electrical_port_orientation: orientation of electrical ports. Defaults to 90.
@@ -90,7 +90,7 @@ def add_fiber_array_optical_south_electrical_north(
         component=component,
         grating_coupler=grating_coupler,
         with_loopback=with_loopback,
-        fiber_spacing=fiber_spacing,
+        pitch=pitch,
         **kwargs,
     )
     port_types_grating_couplers = (

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -44,8 +44,6 @@ component_settings = ["function", "component", "settings"]
 cross_section_settings = ["function", "cross_section", "settings"]
 
 constants = {
-    "fiber_array_spacing": 127.0,
-    "fiber_spacing": 50.0,
     "fiber_input_to_output_spacing": 200.0,
     "metal_spacing": 10.0,
     "pad_pitch": 100.0,

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -55,7 +55,7 @@ def add_fiber_array(
         routing_method: route_single.
         gc_rotation: fiber coupler rotation in degrees. Defaults to -90.
         input_port_indexes: to connect.
-        fiber_spacing: in um.
+        pitch: in um.
         radius: optional radius of the bend. Defaults to the cross_section.
         radius_loopback: optional radius of the loopback bend. Defaults to the cross_section.
         start_straight_length: length of the start straight.

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -26,7 +26,7 @@ def add_fiber_single(
     select_ports: SelectPorts = select_ports_optical,
     cross_section: CrossSectionSpec = "strip",
     input_port_names: Sequence[str] | None = None,
-    fiber_spacing: float = 70,
+    pitch: float = 70,
     with_loopback: bool = True,
     loopback_spacing: float = 100.0,
     straight: ComponentFactory = straight_function,
@@ -44,7 +44,7 @@ def add_fiber_single(
         select_ports: function to select ports.
         cross_section: cross_section function.
         input_port_names: list of input port names to connect to grating couplers.
-        fiber_spacing: spacing between fibers.
+        pitch: spacing between fibers.
         with_loopback: adds loopback structures.
         loopback_spacing: spacing between loopback and test structure.
         straight: straight spec.
@@ -139,7 +139,7 @@ def add_fiber_single(
         select_ports=select_ports,
         with_loopback=False,
         port_names=input_port_names,
-        fiber_spacing=fiber_spacing,
+        pitch=pitch,
         **kwargs,
     )
 
@@ -155,7 +155,7 @@ def add_fiber_single(
         select_ports=select_ports,
         with_loopback=False,
         port_names=output_port_names,
-        fiber_spacing=fiber_spacing,
+        pitch=pitch,
         **kwargs,
     )
     c2.copy_child_info(component)

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -143,7 +143,7 @@ def add_pads_bot(
         bend=bend,
         straight_separation=straight_separation,
         port_names=port_names,
-        fiber_spacing=pad_pitch,  # type: ignore
+        pitch=pad_pitch,  # type: ignore
         port_type=port_type,
         gc_port_name_fiber=pad_port_name,
         allow_width_mismatch=allow_width_mismatch,

--- a/gdsfactory/samples/01_component_pcell_with_parameters.py
+++ b/gdsfactory/samples/01_component_pcell_with_parameters.py
@@ -14,5 +14,5 @@ def mzi_with_bend(radius: float = 10) -> gf.Component:
 
 if __name__ == "__main__":
     c = mzi_with_bend(radius=100)
-    c = gf.routing.add_fiber_array(c, fiber_spacing=250, fanout_length=100)
+    c = gf.routing.add_fiber_array(c, pitch=250, fanout_length=100)
     c.show()

--- a/test-data-regression/test_settings_add_fiber_array_optical_south_electrical_north_.yml
+++ b/test-data-regression/test_settings_add_fiber_array_optical_south_electrical_north_.yml
@@ -11,7 +11,7 @@ settings:
       straight_x_top: straight_heater_metal
   electrical_port_names: null
   electrical_port_orientation: 90
-  fiber_spacing: 127.0
+  pitch: 127.0
   grating_coupler:
     function: grating_coupler_elliptical
   npads: null


### PR DESCRIPTION
## Summary

spacing is confusing, because it could be interpreted as gap,

pitch is a better name


Enhancements:
- Rename 'fiber_spacing' parameter to 'pitch' across multiple functions for consistency.