### PR TITLE
rename via_spacing to pitch and add via_circular

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -278,7 +278,7 @@ from gdsfactory.components.text_rectangular import (
 from gdsfactory.components.triangles import triangle, triangle2, triangle4
 from gdsfactory.components.verniers import verniers
 from gdsfactory.components.version_stamp import pixel, qrcode, version_stamp
-from gdsfactory.components.via import via, via1, via2, viac
+from gdsfactory.components.via import via, via1, via2, via_circular, viac
 from gdsfactory.components.via_chain import via_chain
 from gdsfactory.components.via_corner import via_corner
 from gdsfactory.components.via_stack import (
@@ -546,6 +546,7 @@ __all__ = [
     "via1",
     "via2",
     "via_chain",
+    "via_circular",
     "via_corner",
     "via_stack",
     "via_stack_corner45",

--- a/gdsfactory/components/via_corner.py
+++ b/gdsfactory/components/via_corner.py
@@ -47,14 +47,11 @@ def via_corner(
     b = min_height / 2
 
     c = gf.Component()
-    c.height = max_height
     c.info["size"] = (float(max_width), float(max_height))
     c.info["length"] = max(max_width, max_height)
 
-    n = len(layers)
-
+    port_type = "electrical"
     for i, layer in enumerate(layers):
-        port_type = "electrical" if i == n - 1 else "electrical"
         ref = c << compass(
             size=(widths[i], heights[i]), layer=layer, port_type=port_type
         )
@@ -73,12 +70,23 @@ def via_corner(
 
     for via in vias:
         via = gf.get_component(via)
+        if "xsize" not in via.info:
+            raise ValueError(f"Via {via.name!r} does not have xsize in info")
+
+        if "ysize" not in via.info:
+            raise ValueError(f"Via {via.name!r} does not have ysize in info")
+
+        if "enclosure" not in via.info:
+            raise ValueError(f"Via {via.name!r} does not have enclosure in info")
+
+        if "pitch" not in via.info:
+            raise ValueError(f"Via {via.name!r} does not have pitch in info")
 
         w = via.info["xsize"]
         h = via.info["ysize"]
         g = via.info["enclosure"]
-        pitch_x = via.info["xspacing"]
-        pitch_y = via.info["yspacing"]
+        pitch = via.info["pitch"]
+        pitch_x = pitch_y = pitch
 
         nb_vias_x = (min_width - w - 2 * g) / pitch_x + 1
         nb_vias_y = (min_height - h - 2 * g) / pitch_y + 1

--- a/gdsfactory/components/via_stack.py
+++ b/gdsfactory/components/via_stack.py
@@ -34,9 +34,6 @@ def via_stack(
     also know as Via array
     http://www.vlsi-expert.com/2017/12/vias.html
 
-    spacing = via.info['spacing']
-    enclosure = via.info['enclosure']
-
     Args:
         size: of the layers.
         layers: layers on which to draw rectangles.
@@ -110,9 +107,25 @@ def via_stack(
             width += 2 * offset
             height += 2 * offset
             _via = gf.get_component(via)
-            w, h = _via.info["xsize"], _via.info["ysize"]
+
+            if "xsize" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'xsize' key in info"
+                )
+            if "ysize" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'ysize' key in info"
+                )
+
+            if "pitch" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'pitch' key in info"
+                )
+
+            w, h = _via.dxsize, _via.dysize
             enclosure = _via.info["enclosure"]
-            pitch_x, pitch_y = _via.info["xspacing"], _via.info["yspacing"]
+            pitch = _via.info["pitch"]
+            pitch_x, pitch_y = pitch, pitch
 
             min_width = w + enclosure
             min_height = h + enclosure
@@ -180,9 +193,6 @@ def via_stack_corner45(
 ) -> Component:
     """Rectangular via array stack at a 45 degree angle.
 
-    spacing = via.info['spacing']
-    enclosure = via.info['enclosure']
-
     Args:
         width: of the corner45.
         layers: layers on which to draw rectangles.
@@ -235,9 +245,23 @@ def via_stack_corner45(
                 2 * (width_corner + 2 * offset) * np.cos(np.deg2rad(45))
             )  # Width in the x direction
             _via = gf.get_component(via)
+            if "xsize" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'xsize' key in info"
+                )
+            if "ysize" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'ysize' key in info"
+                )
+
+            if "pitch" not in _via.info:
+                raise ValueError(
+                    f"Component {_via.name!r} does not have a 'pitch' key in info"
+                )
+
             w, h = _via.info["xsize"], _via.info["ysize"]
             enclosure = _via.info["enclosure"]
-            pitch_x, pitch_y = _via.info["xspacing"], _via.info["yspacing"]
+            pitch_x, pitch_y = _via.info["pitch"], _via.info["pitch"]
 
             via = _via
 

--- a/gdsfactory/components/via_stack_with_offset.py
+++ b/gdsfactory/components/via_stack_with_offset.py
@@ -120,9 +120,19 @@ def via_stack_with_offset(
 
         if via:
             via = gf.get_component(via)
+            if "xsize" not in via.info:
+                raise ValueError(f"via {via.name!r} is missing xsize info")
+            if "ysize" not in via.info:
+                raise ValueError(f"via {via.name!r} is missing ysize info")
+            if "enclosure" not in via.info:
+                raise ValueError(f"via {via.name!r} is missing enclosure info")
+            if "pitch" not in via.info:
+                raise ValueError(f"via {via.name!r} is missing pitch info")
+
             w, h = via.info["xsize"], via.info["ysize"]
             enclosure = via.info["enclosure"]
-            pitch_x, pitch_y = via.info["xspacing"], via.info["yspacing"]
+            pitch = via.info["pitch"]
+            pitch_x, pitch_y = pitch, pitch
 
             nb_vias_x = (width - w - 2 * enclosure) / pitch_x + 1
             nb_vias_y = (height - h - 2 * enclosure) / pitch_y + 1

--- a/test-data-regression/test_netlists_via1_.yml
+++ b/test-data-regression/test_netlists_via1_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_bcb63a01
+name: via_S0p7_0p7_SNone_GNon_c3f5c6aa
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via2_.yml
+++ b/test-data-regression/test_netlists_via2_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_c1ab00a8
+name: via_S0p7_0p7_SNone_GNon_e14245b6
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via_.yml
+++ b/test-data-regression/test_netlists_via_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_8696e860
+name: via_S0p7_0p7_SNone_GNon_372ed4f2
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_via_chain_.yml
+++ b/test-data-regression/test_netlists_via_chain_.yml
@@ -69,16 +69,15 @@ instances:
       size:
       - 6.4
       - 2.7
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_4050_350:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_4050_350:
     column_pitch: 3.7
     columns: 10
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 3.7
     rows: 10
     settings:
@@ -88,12 +87,11 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
   via_stack_S11_11_LM2_MT_ff6eecb9_m6500_37800:
     component: via_stack
     info:
@@ -169,7 +167,7 @@ placements:
     rotation: 0
     x: 2.2
     y: 0.35
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_4050_350:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_4050_350:
     mirror: false
     rotation: 0
     x: 4.05

--- a/test-data-regression/test_netlists_via_circular_.yml
+++ b/test-data-regression/test_netlists_via_circular_.yml
@@ -1,0 +1,17 @@
+instances:
+  circle_R0p35_AR2p5_LVIAC_0_0:
+    component: circle
+    info: {}
+    settings:
+      angle_resolution: 2.5
+      layer: VIAC
+      radius: 0.35
+name: via_circular_R0p35_E1_LVIAC_P2
+nets: []
+placements:
+  circle_R0p35_AR2p5_LVIAC_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+ports: {}

--- a/test-data-regression/test_netlists_via_stack_.yml
+++ b/test-data-regression/test_netlists_via_stack_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -66,22 +65,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -91,12 +88,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LM1_M2_e0ab0502
 nets: []
 placements:
@@ -115,12 +111,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_m3_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -66,22 +65,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -91,12 +88,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LHEATE_faf52e81
 nets: []
 placements:
@@ -115,12 +111,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -66,22 +65,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -91,12 +88,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LHEATE_faf52e81
 nets: []
 placements:
@@ -115,12 +111,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_heater_mtop_mini_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_mtop_mini_.yml
@@ -47,14 +47,13 @@ instances:
       size:
       - 4
       - 4
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_0_0:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_0_0:
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -62,20 +61,18 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_0_0:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_0_0:
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -83,12 +80,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S4_4_LHEATER__371e9067
 nets: []
 placements:
@@ -107,12 +103,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_0_0:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_0_0:
+  via_S0p7_0p7_SNone_GNon_e14245b6_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -66,22 +65,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -91,12 +88,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LM1_M2_e0ab0502
 nets: []
 placements:
@@ -115,12 +111,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_npp_m1_.yml
+++ b/test-data-regression/test_netlists_via_stack_npp_m1_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -66,12 +65,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIAC
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LWG_NP_2419ac71
 nets: []
 placements:
@@ -90,7 +88,7 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
@@ -31,16 +31,15 @@ instances:
       size:
       - 11
       - 11
-  via_S7_0p7_S2_2_GNone_E_7483948b_0_m3000:
+  via_S7_0p70000000000000_6ce51dbf_0_m3000:
     column_pitch: 2
     columns: 1
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -50,22 +49,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S9_0p7_S2_2_GNone_E_f82cd750_0_m4000:
+      spacing: null
+  via_S9_0p70000000000000_a6f786c9_0_m4000:
     column_pitch: 2
     columns: 1
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 9
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -75,12 +72,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIAC
+      pitch: 2
       size:
       - 9
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LSLAB9_138d3e37
 nets: []
 placements:
@@ -94,12 +90,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S7_0p7_S2_2_GNone_E_7483948b_0_m3000:
+  via_S7_0p70000000000000_6ce51dbf_0_m3000:
     mirror: false
     rotation: 0
     x: 0
     y: -3
-  via_S9_0p7_S2_2_GNone_E_f82cd750_0_m4000:
+  via_S9_0p70000000000000_a6f786c9_0_m4000:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m3_.yml
@@ -63,16 +63,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -82,22 +81,20 @@ instances:
       enclosure: 1
       gap: null
       layer: VIAC
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 2
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -107,22 +104,20 @@ instances:
       enclosure: 2
       gap: null
       layer: VIA1
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+      spacing: null
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -132,12 +127,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIA2
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LSLAB9_a891ac05
 nets: []
 placements:
@@ -161,17 +155,17 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4
     y: -4
-  via_S0p7_0p7_S2_2_GNone_bcb63a01_m3000_m3000:
+  via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
     mirror: false
     rotation: 0
     x: -3
     y: -3
-  via_S0p7_0p7_S2_2_GNone_c1ab00a8_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
@@ -47,16 +47,15 @@ instances:
       size:
       - 11
       - 11
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     column_pitch: 2
     columns: 5
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 5
     settings:
@@ -66,12 +65,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIAC
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_S11_11_LSLAB9_faa7856f
 nets: []
 placements:
@@ -90,7 +88,7 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  via_S0p7_0p7_S2_2_GNone_8696e860_m4000_m4000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
     mirror: false
     rotation: 0
     x: -4

--- a/test-data-regression/test_netlists_via_stack_with_offset_.yml
+++ b/test-data-regression/test_netlists_via_stack_with_offset_.yml
@@ -59,16 +59,15 @@ instances:
       size:
       - 10
       - 10
-  via_S0p7_0p7_S2_2_GNone_8696e860_m3000_2000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m3000_2000:
     column_pitch: 2
     columns: 4
     component: via
     info:
       enclosure: 1
+      pitch: 2
       xsize: 0.7
-      xspacing: 2
       ysize: 0.7
-      yspacing: 2
     row_pitch: 2
     rows: 4
     settings:
@@ -78,12 +77,11 @@ instances:
       enclosure: 1
       gap: null
       layer: VIAC
+      pitch: 2
       size:
       - 0.7
       - 0.7
-      spacing:
-      - 2
-      - 2
+      spacing: null
 name: via_stack_with_offset_L_d2f39f70
 nets: []
 placements:
@@ -107,7 +105,7 @@ placements:
     rotation: 0
     x: 0
     y: 5
-  via_S0p7_0p7_S2_2_GNone_8696e860_m3000_2000:
+  via_S0p7_0p7_SNone_GNon_372ed4f2_m3000_2000:
     mirror: false
     rotation: 0
     x: -3

--- a/test-data-regression/test_netlists_viac_.yml
+++ b/test-data-regression/test_netlists_viac_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: via_S0p7_0p7_S2_2_GNone_8696e860
+name: via_S0p7_0p7_SNone_GNon_372ed4f2
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_via1_.yml
+++ b/test-data-regression/test_settings_via1_.yml
@@ -1,17 +1,14 @@
 info:
   enclosure: 2
+  pitch: 2
   xsize: 0.7
-  xspacing: 2
   ysize: 0.7
-  yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_bcb63a01
+name: via_S0p7_0p7_SNone_GNon_c3f5c6aa
 settings:
   bbox_offset: 0
   enclosure: 2
   layer: VIA1
+  pitch: 2
   size:
   - 0.7
   - 0.7
-  spacing:
-  - 2
-  - 2

--- a/test-data-regression/test_settings_via_.yml
+++ b/test-data-regression/test_settings_via_.yml
@@ -1,17 +1,14 @@
 info:
   enclosure: 1
+  pitch: 2
   xsize: 0.7
-  xspacing: 2
   ysize: 0.7
-  yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_8696e860
+name: via_S0p7_0p7_SNone_GNon_372ed4f2
 settings:
   bbox_offset: 0
   enclosure: 1
   layer: VIAC
+  pitch: 2
   size:
   - 0.7
   - 0.7
-  spacing:
-  - 2
-  - 2

--- a/test-data-regression/test_settings_via_circular_.yml
+++ b/test-data-regression/test_settings_via_circular_.yml
@@ -1,14 +1,12 @@
 info:
   enclosure: 1
   pitch: 2
+  radius: 0.35
   xsize: 0.7
   ysize: 0.7
-name: via_S0p7_0p7_SNone_GNon_e14245b6
+name: via_circular_R0p35_E1_LVIAC_P2
 settings:
-  bbox_offset: 0
   enclosure: 1
-  layer: VIA2
+  layer: VIAC
   pitch: 2
-  size:
-  - 0.7
-  - 0.7
+  radius: 0.35

--- a/test-data-regression/test_settings_viac_.yml
+++ b/test-data-regression/test_settings_viac_.yml
@@ -1,17 +1,14 @@
 info:
   enclosure: 1
+  pitch: 2
   xsize: 0.7
-  xspacing: 2
   ysize: 0.7
-  yspacing: 2
-name: via_S0p7_0p7_S2_2_GNone_8696e860
+name: via_S0p7_0p7_SNone_GNon_372ed4f2
 settings:
   bbox_offset: 0
   enclosure: 1
   layer: VIAC
+  pitch: 2
   size:
   - 0.7
   - 0.7
-  spacing:
-  - 2
-  - 2


### PR DESCRIPTION
- rename via_spacing to pitch, spacing implies gap and is misleading
- add via_circular

## Summary by Sourcery

Rename 'spacing' to 'pitch' in via components to clarify its meaning and introduce a new 'via_circular' component. Update test data to align with these changes and ensure compatibility.

New Features:
- Introduce a new 'via_circular' component for creating circular vias.

Enhancements:
- Deprecate 'spacing' and 'gap' parameters in favor of a new 'pitch' parameter for defining the distance between vias.

Tests:
- Update test data to reflect the changes in via component naming and the introduction of the 'pitch' parameter.