### PR TITLE
add uv-precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.0"
+    rev: "v0.8.1"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -45,9 +45,16 @@ repos:
     rev: v1.7.4
     hooks:
       - id: actionlint
-# - repo: https://github.com/pre-commit/mirrors-mypy
-#   rev: v1.13.0
-#   hooks:
-#     - id: mypy
-#       stages: [pre-commit]
-#       args: [--strict, --ignore-missing-imports, --config-file=pyproject.toml]
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # - repo: https://github.com/pre-commit/mirrors-mypy
+    #   rev: v1.13.0
+    #   hooks:
+    #     - id: mypy
+    #       stages: [pre-commit]
+    #       args: [--strict, --ignore-missing-imports, --config-file=pyproject.toml]
+
+    # uv version.
+    rev: 0.5.5
+    hooks:
+      # Update the uv lockfile
+      - id: uv-lock

--- a/uv.lock
+++ b/uv.lock
@@ -996,7 +996,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "8.20.0"
+version = "8.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -1104,7 +1104,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "plotly", marker = "extra == 'docs'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pydantic", specifier = ">=2.6,<2.10" },
+    { name = "pydantic", specifier = ">=2.6,<2.11" },
     { name = "pydantic-extra-types", specifier = "<3" },
     { name = "pydantic-settings", specifier = "<3" },
     { name = "pyglet", specifier = "<2" },


### PR DESCRIPTION
## Summary by Sourcery

Update the pre-commit configuration by upgrading the ruff-pre-commit hook to version 0.8.1 and adding a new uv-precommit hook with version 0.5.5.

Build:
- Update ruff-pre-commit hook to version 0.8.1.
- Add uv-precommit hook with version 0.5.5 to the pre-commit configuration.