### PR TITLE
add offset

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1127,8 +1127,8 @@ class ComponentBase:
             nets=netlist["nets"],
         )
 
-    def over_under(self, layer: LayerSpec, distance: float = 0.001) -> Component:
-        """Returns a new Component over-under on a layer in the Component.
+    def over_under(self, layer: LayerSpec, distance: float = 0.001) -> None:
+        """Returns a Component over-under on a layer in the Component.
 
         For big components use tiled version.
 
@@ -1140,15 +1140,14 @@ class ComponentBase:
 
         distance_dbu = self.kcl.to_dbu(distance)
 
-        c = Component()
         layer_index = get_layer(layer)
         region = kdb.Region(self.begin_shapes_rec(layer_index))
         region.size(+distance_dbu).size(-distance_dbu)
-        c.shapes(layer_index).insert(region)
-        return c
+        self.remove_layers([layer])
+        self.shapes(layer_index).insert(region)
 
-    def offset(self, layer: LayerSpec, distance: float) -> Component:
-        """Offsets a Component layer by a distance in um and returns a new Component.
+    def offset(self, layer: LayerSpec, distance: float) -> None:
+        """Offsets a Component layer by a distance in um.
 
         Args:
             layer: layer to offset the Component on.
@@ -1158,12 +1157,11 @@ class ComponentBase:
 
         distance_dbu = self.kcl.to_dbu(distance)
 
-        c = Component()
         layer_index = get_layer(layer)
         region = kdb.Region(self.begin_shapes_rec(layer_index))
         region.size(+distance_dbu)
-        c.shapes(layer_index).insert(region)
-        return c
+        self.remove_layers([layer])
+        self.shapes(layer_index).insert(region)
 
     def to_dict(self, with_ports: bool = False) -> dict[str, Any]:
         """Returns a dictionary representation of the Component."""
@@ -1372,8 +1370,8 @@ if __name__ == "__main__":
     import gdsfactory as gf
 
     c = gf.c.mzi()
-    # c = c.offset("WG", 0.2)
-    c = c.over_under("WG", 0.2)
+    c.offset("WG", -0.2)
+    # c.over_under("WG", 0.2)
     # n = c.to_graphviz()
 
     # plot_graphviz(n)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1138,17 +1138,17 @@ class ComponentBase:
         """
         from gdsfactory import get_layer
 
-        distance = self.kcl.to_dbu(distance)
+        distance_dbu = self.kcl.to_dbu(distance)
 
         c = Component()
-        layer = get_layer(layer)
-        region = kdb.Region(self.begin_shapes_rec(layer))
-        region.size(+distance).size(-distance)
-        c.shapes(layer).insert(region)
+        layer_index = get_layer(layer)
+        region = kdb.Region(self.begin_shapes_rec(layer_index))
+        region.size(+distance_dbu).size(-distance_dbu)
+        c.shapes(layer_index).insert(region)
         return c
 
-    def offset(self, layer: LayerSpec, distance: float) -> None:
-        """Offsets the Component by a distance.
+    def offset(self, layer: LayerSpec, distance: float) -> Component:
+        """Offsets a Component layer by a distance in um and returns a new Component.
 
         Args:
             layer: layer to offset the Component on.
@@ -1156,13 +1156,13 @@ class ComponentBase:
         """
         from gdsfactory import get_layer
 
-        distance = self.kcl.to_dbu(distance)
+        distance_dbu = self.kcl.to_dbu(distance)
 
         c = Component()
-        layer = get_layer(layer)
-        region = kdb.Region(self.begin_shapes_rec(layer))
-        region.size(+distance)
-        c.shapes(layer).insert(region)
+        layer_index = get_layer(layer)
+        region = kdb.Region(self.begin_shapes_rec(layer_index))
+        region.size(+distance_dbu)
+        c.shapes(layer_index).insert(region)
         return c
 
     def to_dict(self, with_ports: bool = False) -> dict[str, Any]:

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -309,7 +309,6 @@ def crossing45(
     c.add_port("o3", port=b_tr.ports["o1"])
     c.add_port("o4", port=b_br.ports["o1"])
 
-    c.over_under(layer=bend.ports[0].layer)  # type: ignore
     xs = gf.get_cross_section(cross_section)
     xs.add_bbox(c)
     return c

--- a/gdsfactory/components/crossing_waveguide.py
+++ b/gdsfactory/components/crossing_waveguide.py
@@ -219,7 +219,7 @@ def crossing_etched(
     return c
 
 
-@gf.cell
+@gf.cell(check_instances=False)
 def crossing45(
     crossing: ComponentSpec = crossing,
     port_spacing: float = 40.0,
@@ -316,5 +316,5 @@ def crossing45(
 
 
 if __name__ == "__main__":
-    c = crossing45()
+    c = crossing()
     c.show()

--- a/test-data-regression/test_netlists_crossing45_.yml
+++ b/test-data-regression/test_netlists_crossing45_.yml
@@ -1,5 +1,190 @@
-instances: {}
+instances:
+  bezier_CP2p828427124746_e6b6928c_45255_16971:
+    component: bezier
+    info:
+      end_angle: 0
+      length: 42.085
+      min_bend_radius: 44.312
+      route_info_length: 42.085
+      route_info_min_bend_radius: 44.312
+      route_info_n_bend_s: 1
+      route_info_strip_length: 42.085
+      route_info_type: strip
+      route_info_weight: 42.085
+      start_angle: 45
+    settings:
+      allow_min_radius_violation: false
+      bend_radius_error_type: null
+      control_points:
+      - - 2.828
+        - 2.828
+      - - 17.256
+        - 17.366
+      - - 30.858
+        - 20.027
+      - - 40
+        - 20
+      cross_section: strip
+      end_angle: 0
+      npoints: 101
+      start_angle: 45
+      with_manhattan_facing_angles: true
+  bezier_CP2p828427124746_e6b6928c_45255_m16971:
+    component: bezier
+    info:
+      end_angle: 0
+      length: 42.085
+      min_bend_radius: 44.312
+      route_info_length: 42.085
+      route_info_min_bend_radius: 44.312
+      route_info_n_bend_s: 1
+      route_info_strip_length: 42.085
+      route_info_type: strip
+      route_info_weight: 42.085
+      start_angle: 45
+    settings:
+      allow_min_radius_violation: false
+      bend_radius_error_type: null
+      control_points:
+      - - 2.828
+        - 2.828
+      - - 17.256
+        - 17.366
+      - - 30.858
+        - 20.027
+      - - 40
+        - 20
+      cross_section: strip
+      end_angle: 0
+      npoints: 101
+      start_angle: 45
+      with_manhattan_facing_angles: true
+  bezier_CP2p828427124746_e6b6928c_m45255_16971:
+    component: bezier
+    info:
+      end_angle: 0
+      length: 42.085
+      min_bend_radius: 44.312
+      route_info_length: 42.085
+      route_info_min_bend_radius: 44.312
+      route_info_n_bend_s: 1
+      route_info_strip_length: 42.085
+      route_info_type: strip
+      route_info_weight: 42.085
+      start_angle: 45
+    settings:
+      allow_min_radius_violation: false
+      bend_radius_error_type: null
+      control_points:
+      - - 2.828
+        - 2.828
+      - - 17.256
+        - 17.366
+      - - 30.858
+        - 20.027
+      - - 40
+        - 20
+      cross_section: strip
+      end_angle: 0
+      npoints: 101
+      start_angle: 45
+      with_manhattan_facing_angles: true
+  bezier_CP2p828427124746_e6b6928c_m45255_m16971:
+    component: bezier
+    info:
+      end_angle: 0
+      length: 42.085
+      min_bend_radius: 44.312
+      route_info_length: 42.085
+      route_info_min_bend_radius: 44.312
+      route_info_n_bend_s: 1
+      route_info_strip_length: 42.085
+      route_info_type: strip
+      route_info_weight: 42.085
+      start_angle: 45
+    settings:
+      allow_min_radius_violation: false
+      bend_radius_error_type: null
+      control_points:
+      - - 2.828
+        - 2.828
+      - - 17.256
+        - 17.366
+      - - 30.858
+        - 20.027
+      - - 40
+        - 20
+      cross_section: strip
+      end_angle: 0
+      npoints: 101
+      start_angle: 45
+      with_manhattan_facing_angles: true
+  crossing_Acrossing_arm_CSstrip_0_0:
+    component: crossing
+    info: {}
+    settings:
+      arm: crossing_arm
+      cross_section: strip
 name: crossing45_Ccrossing_PS_3d8d9fd2
 nets: []
-placements: {}
-ports: {}
+placements:
+  bezier_CP2p828427124746_e6b6928c_45255_16971:
+    mirror: true
+    rotation: 225
+    x: 45.255
+    y: 16.971
+  bezier_CP2p828427124746_e6b6928c_45255_m16971:
+    mirror: false
+    rotation: 135
+    x: 45.255
+    y: -16.971
+  bezier_CP2p828427124746_e6b6928c_m45255_16971:
+    mirror: false
+    rotation: 315
+    x: -45.255
+    y: 16.971
+  bezier_CP2p828427124746_e6b6928c_m45255_m16971:
+    mirror: true
+    rotation: 45
+    x: -45.255
+    y: -16.971
+  crossing_Acrossing_arm_CSstrip_0_0:
+    mirror: false
+    rotation: 45
+    x: 0
+    y: 0
+ports:
+  o1: bezier_CP2p828427124746_e6b6928c_45255_m16971,o1
+  o2: bezier_CP2p828427124746_e6b6928c_m45255_m16971,o1
+  o3: bezier_CP2p828427124746_e6b6928c_45255_16971,o1
+  o4: bezier_CP2p828427124746_e6b6928c_m45255_16971,o1
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 8 unconnected optical ports!
+      ports:
+      - crossing_Acrossing_arm_CSstrip_0_0,o1
+      - crossing_Acrossing_arm_CSstrip_0_0,o3
+      - crossing_Acrossing_arm_CSstrip_0_0,o4
+      - crossing_Acrossing_arm_CSstrip_0_0,o2
+      - bezier_CP2p828427124746_e6b6928c_45255_16971,o2
+      - bezier_CP2p828427124746_e6b6928c_m45255_m16971,o2
+      - bezier_CP2p828427124746_e6b6928c_45255_m16971,o2
+      - bezier_CP2p828427124746_e6b6928c_m45255_16971,o2
+      values:
+      - - -2828
+        - -2828
+      - - 2828
+        - 2828
+      - - 2828
+        - -2828
+      - - -2828
+        - 2828
+      - - 2829
+        - 2829
+      - - -2829
+        - -2829
+      - - 2829
+        - -2829
+      - - -2829
+        - 2829

--- a/tests/components/test_netlists.py
+++ b/tests/components/test_netlists.py
@@ -27,6 +27,7 @@ skip_test = {
     "spiral_racetrack",
     "spiral_racetrack_heater_metal",
     "text_freetype",
+    "crossing45",
 }
 cells_to_test = set(cells.keys()) - skip_test
 

--- a/tests/routing/test_routing_route_bundle_west_to_north.py
+++ b/tests/routing/test_routing_route_bundle_west_to_north.py
@@ -15,10 +15,10 @@ def test_route_bundle_west_to_north(
     pad = gf.components.pad
     c = gf.Component()
     pad_south = gf.components.pad_array(
-        port_orientation=270, spacing=(15.0, 0.0), pad=pad, size=(10, 10)
+        port_orientation=270, pad=pad, size=(10, 10), column_pitch=15
     )
     pad_north = gf.components.pad_array(
-        port_orientation=90, spacing=(15.0, 0.0), pad=pad, size=(10, 10)
+        port_orientation=90, pad=pad, size=(10, 10), column_pitch=15
     )
     pl = c << pad_south
     pb = c << pad_north


### PR DESCRIPTION
- add offset
- make over_under to use um and make it recursive

@thomasdorch

## Summary by Sourcery

Add an 'offset' method to the component class and enhance the 'over_under' method to use micrometers for distance measurement and return a new component.

New Features:
- Introduce an 'offset' method to offset a component by a specified distance on a given layer.

Enhancements:
- Modify the 'over_under' method to return a new component and use micrometers (um) for distance measurement instead of database units (DBU).