### PR TITLE
Move Section to cross_section functions in api docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,7 @@ Classes and functions for construction and manipulation of geometric objects.
 
    CrossSection
    Transition
+   Section
    cross_section
    strip
    heater_metal
@@ -108,7 +109,6 @@ Classes and functions for construction and manipulation of geometric objects.
    MaterialSpec
    MultiCrossSectionAngleSpec
    PathType
-   Section
    Step
 
 


### PR DESCRIPTION
Fixes #3455

## Summary by Sourcery

Documentation:
- Relocate the 'Section' to the 'cross_section' functions in the API documentation.