### PR TITLE
less kwargs

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -929,7 +929,7 @@ class ComponentBase:
         """Remaps a list of layers and returns the same Component.
 
         Args:
-            layer_map: dictionary of layers to remap.
+            layer_map: dictionary of layers to copy.
             recursive: if True, remaps layers recursively.
         """
         from gdsfactory import get_layer

--- a/gdsfactory/components/bend_euler.py
+++ b/gdsfactory/components/bend_euler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Literal, overload
+from typing import Literal, overload
 
 import numpy as np
 
@@ -132,24 +132,32 @@ def _bend_euler(
 
 
 @gf.cell
-def bend_euler_s(port1: str = "o1", port2: str = "o2", **kwargs: Any) -> Component:
+def bend_euler_s(
+    radius: float | None = None,
+    p: float = 0.5,
+    with_arc_floorplan: bool = True,
+    npoints: int | None = None,
+    layer: LayerSpec | None = None,
+    width: float | None = None,
+    cross_section: CrossSectionSpec = "strip",
+    allow_min_radius_violation: bool = False,
+    port1: str = "o1",
+    port2: str = "o2",
+) -> Component:
     r"""Sbend made of 2 euler bends.
 
     Args:
+        radius: in um. Defaults to cross_section_radius.
+        p: Proportion of the curve that is an Euler curve.
+        with_arc_floorplan: If False: `radius` is the minimum radius of curvature.
+        npoints: Number of points used per 360 degrees.
+        layer: layer to use. Defaults to cross_section.layer.
+        width: width to use. Defaults to cross_section.width.
+        cross_section: specification (CrossSection, string, CrossSectionFactory dict).
+        allow_min_radius_violation: if True allows radius to be smaller than cross_section radius.
         port1: input port name.
         port2: output port name.
 
-    Keyword Args:
-        angle: total angle of the curve.
-        p: Proportion of the curve that is an Euler curve.
-        with_arc_floorplan: If False: `radius` is the minimum radius of curvature
-          If True: The curve scales such that the endpoints match a bend_circular
-          with parameters `radius` and `angle`.
-        npoints: Number of points used per 360 degrees.
-        direction: cw (clock-wise) or ccw (counter clock-wise).
-        with_bbox: add bbox_layers and bbox_offsets to avoid DRC sharp edges.
-        cross_section: specification (CrossSection, string, CrossSectionFactory dict).
-        kwargs: cross_section settings.
 
     .. code::
 
@@ -166,7 +174,16 @@ def bend_euler_s(port1: str = "o1", port2: str = "o2", **kwargs: Any) -> Compone
 
     """
     c = Component()
-    b = bend_euler(**kwargs)
+    b = bend_euler(
+        radius=radius,
+        p=p,
+        with_arc_floorplan=with_arc_floorplan,
+        npoints=npoints,
+        layer=layer,
+        width=width,
+        cross_section=cross_section,
+        allow_min_radius_violation=allow_min_radius_violation,
+    )
     b1 = c.add_ref(b)
     b2 = c.add_ref(b)
     b2.connect(port1, b1[port2], mirror=True)

--- a/gdsfactory/components/bend_s.py
+++ b/gdsfactory/components/bend_s.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any
 
 import numpy as np
 
@@ -18,7 +17,6 @@ def bend_s(
     npoints: int = 99,
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
-    **kwargs: Any,
 ) -> Component:
     """Return S bend with bezier curve.
 
@@ -30,20 +28,18 @@ def bend_s(
         npoints: number of points.
         cross_section: spec.
         allow_min_radius_violation: bool.
-        kwargs: cross_section settings.
 
     """
     dx, dy = size
 
     if dy == 0:
-        return gf.components.straight(length=dx, cross_section=cross_section, **kwargs)
+        return gf.components.straight(length=dx, cross_section=cross_section)
 
     return bezier(
         control_points=((0, 0), (dx / 2, 0), (dx / 2, dy), (dx, dy)),
         npoints=npoints,
         cross_section=cross_section,
         allow_min_radius_violation=allow_min_radius_violation,
-        **kwargs,
     )
 
 
@@ -51,7 +47,6 @@ def get_min_sbend_size(
     size: tuple[float | None, float | None] = (None, 10.0),
     cross_section: CrossSectionSpec = "strip",
     num_points: int = 100,
-    **kwargs: Any,
 ) -> float:
     """Returns the minimum sbend size to comply with bend radius requirements.
 
@@ -59,10 +54,9 @@ def get_min_sbend_size(
         size: in x and y direction. One of them is None, which is the size we need to figure out.
         cross_section: spec.
         num_points: number of points to iterate over between max_size and 0.1 * max_size.
-        kwargs: cross_section settings.
     """
     size_list = list(size)
-    cross_section_f = gf.get_cross_section(cross_section, **kwargs)
+    cross_section_f = gf.get_cross_section(cross_section)
 
     if size_list[0] is None:
         ind = 0

--- a/gdsfactory/components/dbr_tapered.py
+++ b/gdsfactory/components/dbr_tapered.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.snap import snap_to_grid2x
@@ -71,7 +69,6 @@ def dbr_tapered(
     fins: bool = False,
     fin_size: Size = (0.2, 0.05),
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
 ) -> Component:
     """Distributed Bragg Reflector Cell class.
 
@@ -88,10 +85,6 @@ def dbr_tapered(
        fins: If `True`, adds fins to the input/output straights.
        fin_size: Specifies the x- and y-size of the `fins`. Defaults to 200 nm x 50 nm
        cross_section: cross_section spec.
-       kwargs: cross_section settings.
-
-    Keyword Args:
-        cross_section kwargs.
 
     .. code::
 
@@ -106,7 +99,7 @@ def dbr_tapered(
     """
     c = gf.Component()
 
-    xs = gf.get_cross_section(cross_section=cross_section, width=w2, **kwargs)
+    xs = gf.get_cross_section(cross_section=cross_section, width=w2)
 
     input_taper = c << gf.components.taper(
         length=taper_length,

--- a/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_coupler_elliptical_arbitrary.py
@@ -33,7 +33,6 @@ def grating_coupler_elliptical_arbitrary(
     spiked: bool = True,
     bias_gap: float = 0,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
 ) -> Component:
     r"""Grating coupler with parametrization based on Lumerical FDTD simulation.
 
@@ -58,7 +57,6 @@ def grating_coupler_elliptical_arbitrary(
         bias_gap: etch gap (um).
             Positive bias increases gap and reduces width to keep period constant.
         cross_section: cross_section spec for waveguide port.
-        kwargs: cross_section settings.
 
     https://en.wikipedia.org/wiki/Ellipse
     c = (a1 ** 2 - b1 ** 2) ** 0.5
@@ -77,7 +75,7 @@ def grating_coupler_elliptical_arbitrary(
             o1  ______________|
 
     """
-    xs = gf.get_cross_section(cross_section, **kwargs)
+    xs = gf.get_cross_section(cross_section)
     wg_width = xs.width
     layer_wg = gf.get_layer(xs.layer)
 

--- a/gdsfactory/components/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_coupler_elliptical_lumerical.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from gdsfactory.components.grating_coupler_elliptical_arbitrary import (
     grating_coupler_elliptical_arbitrary,
 )
-from gdsfactory.typings import Floats, LayerSpec
+from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
 parameters = (
     -2.4298362615732447,
@@ -67,14 +67,13 @@ parameters = (
 @gf.cell
 def grating_coupler_elliptical_lumerical(
     parameters: Floats = parameters,
-    layer: LayerSpec = "WG",
     layer_slab: LayerSpec | None = "SLAB150",
     taper_angle: float = 55,
     taper_length: float = 12.24 + 0.36,
     fiber_angle: float = 5,
     info: dict[str, Any] | None = None,
     bias_gap: float = 0,
-    **kwargs: Any,
+    cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Returns a grating coupler from lumerical inverse design 3D optimization.
 
@@ -105,7 +104,6 @@ def grating_coupler_elliptical_lumerical(
         fiber_angle: used to compute ellipticity.
         info: optional simulation settings.
         bias_gap: gap/trenches bias (um) to compensate for etching bias.
-        kwargs: cross_section settings.
 
     Keyword Args:
         taper_length: taper length from input in um.
@@ -131,10 +129,9 @@ def grating_coupler_elliptical_lumerical(
         widths=widths,
         taper_angle=taper_angle,
         taper_length=taper_length,
-        layer=layer,
         layer_slab=layer_slab,
         fiber_angle=fiber_angle,
-        **kwargs,
+        cross_section=cross_section,
     )
     c.info.update(info)
     c.info["xinput"] = xinput
@@ -154,6 +151,6 @@ grating_coupler_elliptical_lumerical_etch70 = partial(
 )
 
 if __name__ == "__main__":
-    # c = grating_coupler_elliptical_lumerical_etch70()
-    c = grating_coupler_elliptical_lumerical()
+    c = grating_coupler_elliptical_lumerical_etch70()
+    # c = grating_coupler_elliptical_lumerical()
     c.show()

--- a/gdsfactory/components/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_coupler_elliptical_trenches.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
 
 import numpy as np
 
@@ -30,7 +29,6 @@ def grating_coupler_elliptical_trenches(
     end_straight_length: float = 0.2,
     taper: ComponentSpec = taper_function,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
 ) -> Component:
     r"""Returns Grating coupler with defined trenches.
 
@@ -53,7 +51,6 @@ def grating_coupler_elliptical_trenches(
         end_straight_length: at the end of straight.
         taper: taper function.
         cross_section: cross_section spec.
-        kwargs: cross_section settings.
 
 
     .. code::
@@ -66,7 +63,7 @@ def grating_coupler_elliptical_trenches(
         WG  o1  ______________|
 
     """
-    xs = gf.get_cross_section(cross_section, **kwargs)
+    xs = gf.get_cross_section(cross_section)
     wg_width = xs.width
     layer = xs.layer
 

--- a/gdsfactory/components/grating_coupler_loss.py
+++ b/gdsfactory/components/grating_coupler_loss.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.grating_coupler_elliptical_trenches import grating_coupler_te
@@ -17,7 +15,6 @@ def loss_deembedding_ch13_24(
     port_name: str = "o1",
     rotation: float = -90,
     yspacing: float | None = None,
-    **kwargs: Any,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -30,7 +27,6 @@ def loss_deembedding_ch13_24(
         port_name: for the grating_coupler port.
         rotation: degrees.
         yspacing: um.
-        kwargs: cross_section settings.
     """
     gc = gf.get_component(grating_coupler)
     c = gf.Component()
@@ -49,10 +45,9 @@ def loss_deembedding_ch13_24(
         gc_ports[2],
         start_straight_length=40.0,
         cross_section=cross_section,
-        **kwargs,
     )
 
-    x = gf.get_cross_section(cross_section, **kwargs)
+    x = gf.get_cross_section(cross_section)
     radius = x.radius
 
     if radius is None:
@@ -61,7 +56,7 @@ def loss_deembedding_ch13_24(
     p1 = gc_ports[1]
     p3 = gc_ports[3]
     yspacing = yspacing or gc.dysize + 2 * radius
-    bend90 = gf.components.bend_euler(cross_section=cross_section, **kwargs)
+    bend90 = gf.components.bend_euler(cross_section=cross_section)
     points = gf.kf.routing.optical.route_loopback(
         p1,
         p3,
@@ -76,7 +71,6 @@ def loss_deembedding_ch13_24(
         bend=bend90,
         straight=gf.components.straight,
         cross_section=cross_section,
-        **kwargs,
     )
 
     return c
@@ -89,7 +83,6 @@ def loss_deembedding_ch12_34(
     port_name: str = "o1",
     cross_section: CrossSectionSpec = "strip",
     rotation: float = -90,
-    **kwargs: Any,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -101,10 +94,6 @@ def loss_deembedding_ch12_34(
         port_name: for the grating_coupler port.
         cross_section: spec.
         rotation: degrees.
-        kwargs: cross_section settings.
-
-    Keyword Args:
-        kwargs: cross_section settings.
     """
     gc = gf.get_component(grating_coupler)
 
@@ -125,7 +114,6 @@ def loss_deembedding_ch12_34(
         gc_ports[1],
         start_straight_length=40.0,
         cross_section=cross_section,
-        **kwargs,
     )
     route_single(
         c,
@@ -133,7 +121,6 @@ def loss_deembedding_ch12_34(
         gc_ports[3],
         start_straight_length=40.0,
         cross_section=cross_section,
-        **kwargs,
     )
     return c
 
@@ -145,7 +132,6 @@ def loss_deembedding_ch14_23(
     cross_section: CrossSectionSpec = "strip",
     port_name: str = "o1",
     rotation: float = -90,
-    **kwargs: Any,
 ) -> Component:
     """Grating coupler test structure for fiber array.
 
@@ -157,10 +143,7 @@ def loss_deembedding_ch14_23(
         cross_section: spec.
         port_name: for the grating_coupler port.
         rotation: degrees.
-        kwargs: cross_section settings.
 
-    Keyword Args:
-        kwargs: cross_section settings.
     """
     gc = gf.get_component(grating_coupler)
 
@@ -180,7 +163,6 @@ def loss_deembedding_ch14_23(
         gc_ports[3],
         start_straight_length=40.0,
         cross_section=cross_section,
-        **kwargs,
     )
     route_single(
         c,
@@ -188,7 +170,6 @@ def loss_deembedding_ch14_23(
         gc_ports[2],
         start_straight_length=30.0,
         cross_section=cross_section,
-        **kwargs,
     )
     return c
 
@@ -200,7 +181,6 @@ def grating_coupler_loss_fiber_array(
     port_name: str = "o1",
     cross_section: CrossSectionSpec = "strip",
     rotation: float = -90,
-    **kwargs: Any,
 ) -> Component:
     """Returns Grating coupler fiber array loopback.
 
@@ -210,10 +190,6 @@ def grating_coupler_loss_fiber_array(
         port_name: for the grating_coupler port.
         cross_section: spec.
         rotation: degrees.
-        kwargs: cross_section settings.
-
-    Keyword Args:
-        kwargs: cross_section settings.
     """
     gc = gf.get_component(grating_coupler)
 
@@ -233,7 +209,6 @@ def grating_coupler_loss_fiber_array(
         gc_ports[1],
         start_straight_length=40.0,
         cross_section=cross_section,
-        **kwargs,
     )
     return c
 
@@ -242,7 +217,6 @@ def grating_coupler_loss_fiber_array(
 def grating_coupler_loss_fiber_array4(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = grating_coupler_te,
-    **kwargs: Any,
 ) -> Component:
     """Returns a grating coupler test structure for fiber array.
 
@@ -255,12 +229,11 @@ def grating_coupler_loss_fiber_array4(
     Args:
         pitch: grating_coupler_pitch.
         grating_coupler: function.
-        kwargs: cross_section settings.
     """
     c = gf.Component()
-    c1 = loss_deembedding_ch13_24(grating_coupler=grating_coupler, **kwargs)
-    c2 = loss_deembedding_ch14_23(grating_coupler=grating_coupler, **kwargs)
-    c3 = loss_deembedding_ch12_34(grating_coupler=grating_coupler, **kwargs)
+    c1 = loss_deembedding_ch13_24(grating_coupler=grating_coupler)
+    c2 = loss_deembedding_ch14_23(grating_coupler=grating_coupler)
+    c3 = loss_deembedding_ch12_34(grating_coupler=grating_coupler)
     c.add_ref(c1)
     c2_ref = c.add_ref(c2)
     c3_ref = c.add_ref(c3)

--- a/gdsfactory/components/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_coupler_rectangular.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import numpy as np
 
 import gdsfactory as gf
@@ -27,7 +25,6 @@ def grating_coupler_rectangular(
     slab_xmin: float = -1.0,
     slab_offset: float = 1.0,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
 ) -> Component:
     r"""Grating coupler with rectangular shapes (not elliptical).
 
@@ -50,7 +47,6 @@ def grating_coupler_rectangular(
         slab_xmin: where 0 is at the start of the taper.
         slab_offset: from edge of grating to edge of the slab.
         cross_section: for input waveguide port.
-        kwargs: cross_section settings.
 
     .. code::
 
@@ -78,7 +74,7 @@ def grating_coupler_rectangular(
                  <-->
                 taper_length
     """
-    xs = gf.get_cross_section(cross_section, **kwargs)
+    xs = gf.get_cross_section(cross_section)
     wg_width = xs.width
     layer = layer_grating or xs.layer
 

--- a/gdsfactory/components/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_coupler_tree.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.grating_coupler_elliptical import (
@@ -19,7 +17,6 @@ def grating_coupler_tree(
     with_loopback: bool = False,
     bend: ComponentSpec = "bend_euler",
     fanout_length: float = 0.0,
-    **kwargs: Any,
 ) -> Component:
     """Array of straights connected with grating couplers.
 
@@ -32,12 +29,10 @@ def grating_coupler_tree(
         with_loopback: adds loopback.
         bend: bend spec.
         fanout_length: in um.
-        kwargs: cross_section settings.
     """
     c = straight_array(
         n=n,
         spacing=straight_spacing,
-        **kwargs,
     )
 
     return gf.routing.add_fiber_array(
@@ -46,7 +41,6 @@ def grating_coupler_tree(
         grating_coupler=grating_coupler,
         fanout_length=fanout_length,
         bend=bend,
-        **kwargs,
     )
 
 

--- a/gdsfactory/components/straight.py
+++ b/gdsfactory/components/straight.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.typings import CrossSectionSpec
@@ -14,7 +12,7 @@ def straight(
     length: float = 10.0,
     npoints: int = 2,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
+    width: float | None = None,
 ) -> Component:
     """Returns a Straight waveguide.
 
@@ -22,14 +20,14 @@ def straight(
         length: straight length (um).
         npoints: number of points.
         cross_section: specification (CrossSection, string or dict).
-        kwargs: additional cross_section arguments.
+        width: width of the waveguide. If None, it will use the width of the cross_section.
 
     .. code::
 
         o1 -------------- o2
                 length
     """
-    x = gf.get_cross_section(cross_section, **kwargs)
+    x = gf.get_cross_section(cross_section, width=width)
     p = gf.path.straight(length=length, npoints=npoints)
     c = p.extrude(x)
     x.add_bbox(c)
@@ -45,7 +43,7 @@ def straight_all_angle(
     length: float = 10.0,
     npoints: int = 2,
     cross_section: CrossSectionSpec = "strip",
-    **kwargs: Any,
+    width: float | None = None,
 ) -> ComponentAllAngle:
     """Returns a Straight waveguide with offgrid ports.
 
@@ -53,14 +51,14 @@ def straight_all_angle(
         length: straight length (um).
         npoints: number of points.
         cross_section: specification (CrossSection, string or dict).
-        kwargs: additional cross_section arguments.
+        width: width of the waveguide. If None, it will use the width of the cross_section.
 
     .. code::
 
         o1 -------------- o2
                 length
     """
-    x = gf.get_cross_section(cross_section, **kwargs)
+    x = gf.get_cross_section(cross_section, width=width)
     p = gf.path.straight(length=length, npoints=npoints)
     c = p.extrude(x, all_angle=True)
     x.add_bbox(c)
@@ -77,7 +75,7 @@ if __name__ == "__main__":
     # c = gf.Component()
     c = straight(
         length=10,
-        width=2,
+        # width=2,
         # cross_section="rib_bbox",
     )
     # ref = c << w

--- a/gdsfactory/components/taper_adiabatic.py
+++ b/gdsfactory/components/taper_adiabatic.py
@@ -37,7 +37,7 @@ def neff_TE1550SOI_220nm(w: float) -> float:
         w: width in um.
 
     Returns:
-        effective index
+        effective index.
     """
     return np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w)  # type: ignore
 

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
 
 import numpy as np
 
@@ -21,7 +20,7 @@ def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing",
     port_names: "PortNames" = port_names_electrical,
     port_types: "PortTypes" = port_types_electrical,
-    **kwargs: Any,
+    width: float | None = None,
 ) -> Component:
     """Returns 45 degrees electrical corner wire.
 
@@ -29,9 +28,9 @@ def wire_corner(
         cross_section: spec.
         port_names: port names.
         port_types: port types.
-        kwargs: cross_section parameters.
+        width: optional width. Defaults to cross_section width.
     """
-    x = gf.get_cross_section(cross_section, **kwargs)
+    x = gf.get_cross_section(cross_section, width=width)
     layer = x.layer
     width = x.width
 

--- a/gdsfactory/components/wire.py
+++ b/gdsfactory/components/wire.py
@@ -10,19 +10,25 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components.straight import straight
-from gdsfactory.typings import CrossSectionSpec, LayerSpec
+from gdsfactory.cross_section import port_names_electrical, port_types_electrical
+from gdsfactory.typings import CrossSectionSpec, LayerSpec, PortNames, PortTypes
 
 wire_straight = partial(straight, cross_section="metal_routing")
 
 
 @gf.cell
 def wire_corner(
-    cross_section: CrossSectionSpec = "metal_routing", **kwargs: Any
+    cross_section: CrossSectionSpec = "metal_routing",
+    port_names: "PortNames" = port_names_electrical,
+    port_types: "PortTypes" = port_types_electrical,
+    **kwargs: Any,
 ) -> Component:
     """Returns 45 degrees electrical corner wire.
 
     Args:
         cross_section: spec.
+        port_names: port names.
+        port_types: port types.
         kwargs: cross_section parameters.
     """
     x = gf.get_cross_section(cross_section, **kwargs)
@@ -35,20 +41,20 @@ def wire_corner(
     ypts = [-a, -a, a, a]
     c.add_polygon(list(zip(xpts, ypts)), layer=layer)
     c.add_port(
-        name="e1",
+        name=port_names[0],
         center=(-a, 0),
         width=width,
         orientation=180,
         layer=layer,
-        port_type="electrical",
+        port_type=port_types[0],
     )
     c.add_port(
-        name="e2",
+        name=port_names[1],
         center=(0, a),
         width=width,
         orientation=90,
         layer=layer,
-        port_type="electrical",
+        port_type=port_types[1],
     )
     c.info["length"] = width
     c.info["dy"] = width
@@ -84,8 +90,6 @@ def wire_corner45(
     ypts = [-a, radius, radius + np.sqrt(2) * width, -a]
     c.add_polygon(list(zip(xpts, ypts)), layer=layer)
 
-    w = float(np.round(width * np.sqrt(2), 3))  # type: ignore
-
     if with_corner90_ports:
         c.add_port(
             name="e1",
@@ -105,6 +109,8 @@ def wire_corner45(
         )
 
     else:
+        w = float(np.round(width * np.sqrt(2), 3))  # type: ignore
+
         c.add_port(
             name="e1",
             center=(-w / 2, -a),

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -623,7 +623,8 @@ def get_material_index(material: MaterialSpec, *args: Any, **kwargs: Any) -> Com
 def get_component(
     component: ComponentSpec, settings: dict[str, Any] | None = None, **kwargs: Any
 ) -> Component:
-    return get_active_pdk().get_component(component, settings=settings, **kwargs)
+    kwargs_clean = {k: v for k, v in kwargs.items() if v is not None}
+    return get_active_pdk().get_component(component, settings=settings, **kwargs_clean)
 
 
 def get_cell(cell: CellSpec, **kwargs: Any) -> ComponentFactory:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -631,7 +631,8 @@ def get_cell(cell: CellSpec, **kwargs: Any) -> ComponentFactory:
 
 
 def get_cross_section(cross_section: CrossSectionSpec, **kwargs: Any) -> CrossSection:
-    return get_active_pdk().get_cross_section(cross_section, **kwargs)
+    kwargs_clean = {k: v for k, v in kwargs.items() if v is not None}
+    return get_active_pdk().get_cross_section(cross_section, **kwargs_clean)
 
 
 def get_layer(layer: LayerSpec) -> LayerEnum:

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 import gdsfactory as gf
 from gdsfactory.boolean import boolean
 from gdsfactory.component import Component
+from gdsfactory.typings import PathType
 
 
 def compute_area_signed(pr: npt.NDArray[np.floating[Any]]) -> float:
@@ -66,7 +67,7 @@ def from_np(
 
 
 @gf.cell
-def from_image(image_path: str, **kwargs: Any) -> Component:
+def from_image(image_path: PathType, **kwargs: Any) -> Component:
     """Returns Component from a png image.
 
     Args:

--- a/gdsfactory/samples/06_remapping_layers.py
+++ b/gdsfactory/samples/06_remapping_layers.py
@@ -11,9 +11,9 @@ def remap_layers() -> Component:
     c = gf.Component()
     straight = gf.components.straight
 
-    wg1 = c << straight(length=11, width=1, layer=(1, 0))
-    wg2 = c << straight(length=11, width=1, layer=(1, 0))
-    wg3 = c << straight(length=11, width=1, layer=(1, 0))
+    wg1 = c << straight(length=11, width=1)
+    wg2 = c << straight(length=11, width=1)
+    wg3 = c << straight(length=11, width=1)
 
     wg2.connect("o1", wg1.ports["o2"])
     wg3.connect("o1", wg2.ports["o2"])

--- a/notebooks/00_geometry.ipynb
+++ b/notebooks/00_geometry.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "# Now that the geometry has been added to \"c\", we can move everything around:\n",
     "text1.movey(25)\n",
-    "text2.move([5, 30])\n",
+    "text2.move((5, 30))\n",
     "text2.drotate(45)\n",
     "r.movex(-15)\n",
     "\n",
@@ -165,14 +165,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def straight(length=10, width=1, layer=(1, 0)):\n",
+    "def straight(length=10, width: float = 1, layer=(1, 0)):\n",
     "    c = gf.Component()\n",
     "    c.add_polygon([(0, 0), (length, 0), (length, width), (0, width)], layer=layer)\n",
     "    c.add_port(\n",
-    "        name=\"o1\", center=[0, width / 2], width=width, orientation=180, layer=layer\n",
+    "        name=\"o1\", center=(0, width / 2), width=width, orientation=180, layer=layer\n",
     "    )\n",
     "    c.add_port(\n",
-    "        name=\"o2\", center=[length, width / 2], width=width, orientation=0, layer=layer\n",
+    "        name=\"o2\", center=(length, width / 2), width=width, orientation=0, layer=layer\n",
     "    )\n",
     "    return c\n",
     "\n",
@@ -308,7 +308,7 @@
     "wg3 = c << straight(length=3, layer=(3, 0))\n",
     "\n",
     "# Shift the second straight we created over by dx = 2, dy = 2 um. D stands for Decimal\n",
-    "wg2.move([2.0, 2.0])\n",
+    "wg2.move((2.0, 2.0))\n",
     "\n",
     "# Then, move again the third straight by 3um\n",
     "wg3.movex(3)  # equivalent to wg3.move(3)\n",
@@ -376,14 +376,14 @@
     "import gdsfactory as gf\n",
     "\n",
     "\n",
-    "def straight(length=10, width=1, layer=(1, 0)):\n",
+    "def straight(length: float = 10, width: float = 1, layer=(1, 0)):\n",
     "    c = gf.Component()\n",
     "    c.add_polygon([(0, 0), (length, 0), (length, width), (0, width)], layer=layer)\n",
     "    c.add_port(\n",
-    "        name=\"o1\", center=[0, width / 2], width=width, orientation=180, layer=layer\n",
+    "        name=\"o1\", center=(0, width / 2), width=width, orientation=180, layer=layer\n",
     "    )\n",
     "    c.add_port(\n",
-    "        name=\"o2\", center=[length, width / 2], width=width, orientation=0, layer=layer\n",
+    "        name=\"o2\", center=(length, width / 2), width=width, orientation=0, layer=layer\n",
     "    )\n",
     "    return c"
    ]
@@ -396,22 +396,14 @@
    "outputs": [],
    "source": [
     "s = straight(length=10)\n",
-    "s.ports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s.pprint_ports()"
+    "s.draw_ports()\n",
+    "s.pprint_ports()\n",
+    "s"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "27",
    "metadata": {},
    "source": [
     "## References\n",
@@ -422,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Labels\n",
@@ -463,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "32",
    "metadata": {},
    "source": [
     "Another simple example"
@@ -490,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "34",
    "metadata": {},
    "source": [
     "## Boolean shapes\n",
@@ -525,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Move Reference by port"
@@ -558,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Mirror reference\n",
@@ -592,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "42",
    "metadata": {},
    "source": [
     "## Write\n",
@@ -622,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "44",
    "metadata": {},
    "source": [
     "You can see the GDS file in Klayout viewer.\n",
@@ -646,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "46",
    "metadata": {},
    "source": [
     "OASIS is a newer format that can store CAD files and that reduces the size."
@@ -664,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "48",
    "metadata": {},
    "source": [
     "You can also save it as STL for 3D printing or for device level simulations. For that you need to extrude the polygons using the information in the LayerStack."
@@ -682,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/03_layer_stack.ipynb
+++ b/notebooks/03_layer_stack.ipynb
@@ -209,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = gf.components.straight(layer=(2, 0))\n",
+    "c = gf.components.rectangle(layer=(2, 0))\n",
     "c.plot()"
    ]
   },
@@ -884,7 +884,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -898,7 +898,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -117,8 +117,8 @@
     "e = c << gf.components.ellipse(\n",
     "    radii=(10, 5), layer=(1, 0)\n",
     ")  # Ellipse. equivalent to c.add_ref(gf.components.ellipse(radii=(10, 5), layer=(1, 0))\n",
-    "r = (\n",
-    "    c << gf.components.rectangle(size=(15, 5), layer=(2, 0))\n",
+    "r = c << gf.components.rectangle(\n",
+    "    size=(15, 5), layer=(2, 0)\n",
     ")  # Rectangle. equivalent to c.add_ref(gf.components.rectangle(size=(15, 5), layer=(2, 0))\n",
     "print(len(c.insts))  # 2 component instances\n",
     "c.flatten()\n",
@@ -177,8 +177,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c2 = c.copy()\n",
-    "r = r.sized(2000)\n",
+    "c2 = c.dup()\n",
+    "r = r.sized(2000)  # Note that the region is sized in DB units (1nm)\n",
     "c2.add_polygon(r, layer=LAYER.SLAB90)\n",
     "c2"
    ]
@@ -198,9 +198,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c2 = c.copy()\n",
+    "c2 = c.dup()\n",
     "\n",
-    "d = 800\n",
+    "d = 800  # DB units\n",
     "r = gf.kdb.Region(polygons)\n",
     "r = r.sized(+d + 2000)\n",
     "r = r.sized(-d)\n",
@@ -213,13 +213,52 @@
    "id": "16",
    "metadata": {},
    "source": [
-    "## Outline"
+    "You can also apply it to a component directly."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "core = gf.components.coupler_ring()\n",
+    "\n",
+    "clad = core.dup()\n",
+    "clad.offset(layer=\"WG\", distance=1)\n",
+    "clad.remap_layers({\"WG\": \"SLAB90\"})\n",
+    "\n",
+    "c.add_ref(core)\n",
+    "c.add_ref(clad)\n",
+    "\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.over_under(layer=\"SLAB90\", distance=0.2)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Outline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Round corners"
@@ -245,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Union"
@@ -310,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +392,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "28",
    "metadata": {},
    "source": [
     "## Importing GDS files"
@@ -361,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "29",
    "metadata": {},
    "source": [
     "`gf.import_gds()` allows you to easily import external GDSII files.  It imports a single cell from the external GDS file and converts it into a gdsfactory component."
@@ -370,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Copying and extracting geometry"
@@ -391,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,19 +457,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
-    "c_copied_layers = gf.components.copy_layers(\n",
-    "    gf.components.straight, layers=((1, 0), (2, 0))\n",
-    ")\n",
-    "c_copied_layers.plot()"
+    "c = gf.c.straight()\n",
+    "c.copy_layers(dict(WG=(2, 0)))\n",
+    "c"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Import Images into GDS\n",
@@ -441,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Dummy Fill / Tiling\n",
@@ -483,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -992,7 +992,7 @@
    "outputs": [],
    "source": [
     "c = gf.Component()\n",
-    "w = gf.components.array(gf.c.straight, columns=1, rows=3, spacing=(3, 3))\n",
+    "w = gf.components.array(gf.c.straight, columns=1, rows=3, row_pitch=3)\n",
     "left = c << w\n",
     "right = c << w\n",
     "right.move((100, 100))\n",
@@ -1136,8 +1136,8 @@
     "c = gf.Component()\n",
     "rows = 3\n",
     "straight = gf.c.straight\n",
-    "w1 = c << gf.c.array(straight, spacing=(0, 10), rows=rows, columns=1)\n",
-    "w2 = c << gf.c.array(straight, spacing=(0, 10), rows=rows, columns=1)\n",
+    "w1 = c << gf.c.array(straight, rows=rows, columns=1, row_pitch=10)\n",
+    "w2 = c << gf.c.array(straight, rows=rows, columns=1, row_pitch=10)\n",
     "w2.drotate(-30)\n",
     "w2.movex(140)\n",
     "p1 = list(w1.ports.filter(orientation=0))\n",
@@ -1211,8 +1211,8 @@
     "c = gf.Component()\n",
     "\n",
     "# Create two straight waveguides with different orientations\n",
-    "wg1 = c << gf.components.straight(length=100, width=3.2, layer=(30, 0))\n",
-    "wg2 = c << gf.components.straight(length=100, width=3.2, layer=(30, 0))\n",
+    "wg1 = c << gf.components.straight(length=100, width=3.2)\n",
+    "wg2 = c << gf.components.straight(length=100, width=3.2)\n",
     "\n",
     "# Move and rotate the second waveguide\n",
     "wg2.move((300, 50))\n",
@@ -1223,7 +1223,7 @@
     "    c,\n",
     "    port1=wg1.ports[\"o2\"],\n",
     "    port2=wg2.ports[\"o1\"],\n",
-    "    cross_section=gf.cross_section.strip(width=3.2, layer=(30, 0), radius=100),\n",
+    "    cross_section=gf.cross_section.strip(width=3.2, radius=100),\n",
     ")\n",
     "c"
    ]
@@ -1238,12 +1238,8 @@
     "c = gf.Component()\n",
     "\n",
     "# Create two multi-port components\n",
-    "comp1 = c << gf.components.nxn(\n",
-    "    west=0, east=10, xsize=10, ysize=100, layer=(30, 0), wg_width=3.2\n",
-    ")\n",
-    "comp2 = c << gf.components.nxn(\n",
-    "    west=0, east=10, xsize=10, ysize=100, layer=(30, 0), wg_width=3.2\n",
-    ")\n",
+    "comp1 = c << gf.components.nxn(west=0, east=10, xsize=10, ysize=100, wg_width=3.2)\n",
+    "comp2 = c << gf.components.nxn(west=0, east=10, xsize=10, ysize=100, wg_width=3.2)\n",
     "\n",
     "# Position second component\n",
     "comp2.drotate(30)\n",
@@ -1257,9 +1253,7 @@
     "        c,\n",
     "        port1=comp1.ports[port1_name],\n",
     "        port2=comp2.ports[port2_name],\n",
-    "        cross_section=gf.cross_section.strip(\n",
-    "            width=3.2, layer=(30, 0), radius=100 + i * 10\n",
-    "        ),\n",
+    "        cross_section=gf.cross_section.strip(width=3.2, radius=100 + i * 10),\n",
     "    )\n",
     "c"
    ]
@@ -1362,14 +1356,6 @@
     "c = silicon_nitride_strip(width_nitride=4)\n",
     "c"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/test-data-regression/test_import_gds_ports.yml
+++ b/test-data-regression/test_import_gds_ports.yml
@@ -5,7 +5,7 @@ info:
   route_info_type: strip
   route_info_weight: 10
   width: 0.5
-name: straight_L10_N2_CSstrip
+name: straight_L10_N2_CSstrip_WNone
 settings:
   cross_section: strip
   length: 10

--- a/test-data-regression/test_import_json_label.yml
+++ b/test-data-regression/test_import_json_label.yml
@@ -3,10 +3,11 @@ analysis_settings:
   cross_section: strip
   length: 10.0
   npoints: 2
+  width: null
 doe: null
 measurement: null
 measurement_settings: {}
-name: straight_L10_N2_CSstrip
+name: straight_L10_N2_CSstrip_WNone
 xelec: []
 xopt:
 - 0

--- a/test-data-regression/test_netlists_add_termination_.yml
+++ b/test-data-regression/test_netlists_add_termination_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 10
@@ -12,7 +12,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  taper_L10_W0p5_W0p1_PNo_5b99c220_0_0:
+      width: null
+  taper_L10_W0p5_W0p1_LNo_81147eb0_0_0:
     component: taper
     info:
       length: 10
@@ -20,6 +21,7 @@ instances:
       width2: 0.1
     settings:
       cross_section: strip
+      layer: null
       length: 10
       port: null
       port_names:
@@ -32,7 +34,7 @@ instances:
       width2: 0.1
       with_bbox: true
       with_two_ports: true
-  taper_L10_W0p5_W0p1_PNo_5b99c220_10000_0:
+  taper_L10_W0p5_W0p1_LNo_81147eb0_10000_0:
     component: taper
     info:
       length: 10
@@ -40,6 +42,7 @@ instances:
       width2: 0.1
     settings:
       cross_section: strip
+      layer: null
       length: 10
       port: null
       port_names:
@@ -54,22 +57,22 @@ instances:
       with_two_ports: true
 name: add_termination_Cstraig_a456518a
 nets:
-- p1: straight_L10_N2_CSstrip_0_0,o1
-  p2: taper_L10_W0p5_W0p1_PNo_5b99c220_0_0,o1
-- p1: straight_L10_N2_CSstrip_0_0,o2
-  p2: taper_L10_W0p5_W0p1_PNo_5b99c220_10000_0,o1
+- p1: straight_L10_N2_CSstrip_WNone_0_0,o1
+  p2: taper_L10_W0p5_W0p1_LNo_81147eb0_0_0,o1
+- p1: straight_L10_N2_CSstrip_WNone_0_0,o2
+  p2: taper_L10_W0p5_W0p1_LNo_81147eb0_10000_0,o1
 placements:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  taper_L10_W0p5_W0p1_PNo_5b99c220_0_0:
+  taper_L10_W0p5_W0p1_LNo_81147eb0_0_0:
     mirror: false
     rotation: 180
     x: 0
     y: 0
-  taper_L10_W0p5_W0p1_PNo_5b99c220_10000_0:
+  taper_L10_W0p5_W0p1_LNo_81147eb0_10000_0:
     mirror: false
     rotation: 0
     x: 10
@@ -80,8 +83,8 @@ warnings:
     unconnected_ports:
     - message: 2 unconnected optical ports!
       ports:
-      - taper_L10_W0p5_W0p1_PNo_5b99c220_0_0,o2
-      - taper_L10_W0p5_W0p1_PNo_5b99c220_10000_0,o2
+      - taper_L10_W0p5_W0p1_LNo_81147eb0_0_0,o2
+      - taper_L10_W0p5_W0p1_LNo_81147eb0_10000_0,o2
       values:
       - - -10000
         - 0

--- a/test-data-regression/test_netlists_awg_.yml
+++ b/test-data-regression/test_netlists_awg_.yml
@@ -507,7 +507,7 @@ instances:
       wg_width: 0.5
       width1: 10
       width2: 20
-  straight_L10p5_N2_CSstrip_19750_30000:
+  straight_L10p5_N2_CSstrip_WNone_19750_30000:
     component: straight
     info:
       length: 10.5
@@ -520,7 +520,8 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-  straight_L10p5_N2_CSstrip_55417_30500:
+      width: null
+  straight_L10p5_N2_CSstrip_WNone_55417_30500:
     component: straight
     info:
       length: 10.5
@@ -533,7 +534,8 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-  straight_L10p5_N2_CSstrip_m5417_30500:
+      width: null
+  straight_L10p5_N2_CSstrip_WNone_m5417_30500:
     component: straight
     info:
       length: 10.5
@@ -546,7 +548,8 @@ instances:
       cross_section: strip
       length: 10.5
       npoints: 2
-  straight_L12_N2_CSstrip_57583_32000:
+      width: null
+  straight_L12_N2_CSstrip_WNone_57583_32000:
     component: straight
     info:
       length: 12
@@ -559,7 +562,8 @@ instances:
       cross_section: strip
       length: 12
       npoints: 2
-  straight_L12_N2_CSstrip_m7583_32000:
+      width: null
+  straight_L12_N2_CSstrip_WNone_m7583_32000:
     component: straight
     info:
       length: 12
@@ -572,7 +576,8 @@ instances:
       cross_section: strip
       length: 12
       npoints: 2
-  straight_L13p5_N2_CSstrip_59750_33500:
+      width: null
+  straight_L13p5_N2_CSstrip_WNone_59750_33500:
     component: straight
     info:
       length: 13.5
@@ -585,7 +590,8 @@ instances:
       cross_section: strip
       length: 13.5
       npoints: 2
-  straight_L13p5_N2_CSstrip_m9750_33500:
+      width: null
+  straight_L13p5_N2_CSstrip_WNone_m9750_33500:
     component: straight
     info:
       length: 13.5
@@ -598,7 +604,8 @@ instances:
       cross_section: strip
       length: 13.5
       npoints: 2
-  straight_L14p834_N2_CSstrip_17583_31500:
+      width: null
+  straight_L14p834_N2_CSs_1c3891c0_17583_31500:
     component: straight
     info:
       length: 14.834
@@ -611,7 +618,8 @@ instances:
       cross_section: strip
       length: 14.834
       npoints: 2
-  straight_L19p166_N2_CSstrip_15417_33000:
+      width: null
+  straight_L19p166_N2_CSs_b7981645_15417_33000:
     component: straight
     info:
       length: 19.166
@@ -624,7 +632,8 @@ instances:
       cross_section: strip
       length: 19.166
       npoints: 2
-  straight_L1p5_N2_CSstrip_42417_21500:
+      width: null
+  straight_L1p5_N2_CSstrip_WNone_42417_21500:
     component: straight
     info:
       length: 1.5
@@ -637,7 +646,8 @@ instances:
       cross_section: strip
       length: 1.5
       npoints: 2
-  straight_L1p5_N2_CSstrip_7583_21500:
+      width: null
+  straight_L1p5_N2_CSstrip_WNone_7583_21500:
     component: straight
     info:
       length: 1.5
@@ -650,7 +660,8 @@ instances:
       cross_section: strip
       length: 1.5
       npoints: 2
-  straight_L23p5_N2_CSstrip_13250_34500:
+      width: null
+  straight_L23p5_N2_CSstrip_WNone_13250_34500:
     component: straight
     info:
       length: 23.5
@@ -663,7 +674,8 @@ instances:
       cross_section: strip
       length: 23.5
       npoints: 2
-  straight_L27p834_N2_CSstrip_11083_36000:
+      width: null
+  straight_L27p834_N2_CSs_5d181985_11083_36000:
     component: straight
     info:
       length: 27.834
@@ -676,7 +688,8 @@ instances:
       cross_section: strip
       length: 27.834
       npoints: 2
-  straight_L32p1660000000_643231bb_8917_37500:
+      width: null
+  straight_L32p1660000000_37974347_8917_37500:
     component: straight
     info:
       length: 32.166
@@ -689,7 +702,8 @@ instances:
       cross_section: strip
       length: 32.166
       npoints: 2
-  straight_L36p5_N2_CSstrip_6750_39000:
+      width: null
+  straight_L36p5_N2_CSstrip_WNone_6750_39000:
     component: straight
     info:
       length: 36.5
@@ -702,7 +716,8 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-  straight_L3_N2_CSstrip_44583_23000:
+      width: null
+  straight_L3_N2_CSstrip_WNone_44583_23000:
     component: straight
     info:
       length: 3
@@ -715,7 +730,8 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-  straight_L3_N2_CSstrip_5417_23000:
+      width: null
+  straight_L3_N2_CSstrip_WNone_5417_23000:
     component: straight
     info:
       length: 3
@@ -728,7 +744,8 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-  straight_L40p834_N2_CSstrip_4583_40500:
+      width: null
+  straight_L40p834_N2_CSs_fb3a91b2_4583_40500:
     component: straight
     info:
       length: 40.834
@@ -741,7 +758,8 @@ instances:
       cross_section: strip
       length: 40.834
       npoints: 2
-  straight_L45p1660000000_4d1de147_2417_42000:
+      width: null
+  straight_L45p1660000000_67f54d0c_2417_42000:
     component: straight
     info:
       length: 45.166
@@ -754,7 +772,8 @@ instances:
       cross_section: strip
       length: 45.166
       npoints: 2
-  straight_L49p5_N2_CSstrip_250_43500:
+      width: null
+  straight_L49p5_N2_CSstrip_WNone_250_43500:
     component: straight
     info:
       length: 49.5
@@ -767,7 +786,8 @@ instances:
       cross_section: strip
       length: 49.5
       npoints: 2
-  straight_L4p5_N2_CSstrip_3250_24500:
+      width: null
+  straight_L4p5_N2_CSstrip_WNone_3250_24500:
     component: straight
     info:
       length: 4.5
@@ -780,7 +800,8 @@ instances:
       cross_section: strip
       length: 4.5
       npoints: 2
-  straight_L4p5_N2_CSstrip_46750_24500:
+      width: null
+  straight_L4p5_N2_CSstrip_WNone_46750_24500:
     component: straight
     info:
       length: 4.5
@@ -793,7 +814,8 @@ instances:
       cross_section: strip
       length: 4.5
       npoints: 2
-  straight_L6_N2_CSstrip_1083_26000:
+      width: null
+  straight_L6_N2_CSstrip_WNone_1083_26000:
     component: straight
     info:
       length: 6
@@ -806,7 +828,8 @@ instances:
       cross_section: strip
       length: 6
       npoints: 2
-  straight_L6_N2_CSstrip_48917_26000:
+      width: null
+  straight_L6_N2_CSstrip_WNone_48917_26000:
     component: straight
     info:
       length: 6
@@ -819,7 +842,8 @@ instances:
       cross_section: strip
       length: 6
       npoints: 2
-  straight_L7p5_N2_CSstrip_51083_27500:
+      width: null
+  straight_L7p5_N2_CSstrip_WNone_51083_27500:
     component: straight
     info:
       length: 7.5
@@ -832,7 +856,8 @@ instances:
       cross_section: strip
       length: 7.5
       npoints: 2
-  straight_L7p5_N2_CSstrip_m1083_27500:
+      width: null
+  straight_L7p5_N2_CSstrip_WNone_m1083_27500:
     component: straight
     info:
       length: 7.5
@@ -845,7 +870,8 @@ instances:
       cross_section: strip
       length: 7.5
       npoints: 2
-  straight_L9_N2_CSstrip_53250_29000:
+      width: null
+  straight_L9_N2_CSstrip_WNone_53250_29000:
     component: straight
     info:
       length: 9
@@ -858,7 +884,8 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
-  straight_L9_N2_CSstrip_m3250_29000:
+      width: null
+  straight_L9_N2_CSstrip_WNone_m3250_29000:
     component: straight
     info:
       length: 9
@@ -871,124 +898,125 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
+      width: null
 name: awg_A10_O3_FPRIFFfree_p_a3247b17
 nets:
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000,o1
-  p2: straight_L6_N2_CSstrip_1083_26000,o1
+  p2: straight_L6_N2_CSstrip_WNone_1083_26000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000,o2
-  p2: straight_L27p834_N2_CSstrip_11083_36000,o1
+  p2: straight_L27p834_N2_CSs_5d181985_11083_36000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000,o1
-  p2: straight_L10p5_N2_CSstrip_19750_30000,o2
+  p2: straight_L10p5_N2_CSstrip_WNone_19750_30000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_30250_30000,o2
   p2: free_propagation_region_b76b91f7_50000_0,E9
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500,o1
-  p2: straight_L14p834_N2_CSstrip_17583_31500,o2
+  p2: straight_L14p834_N2_CSs_1c3891c0_17583_31500,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_32417_31500,o2
-  p2: straight_L1p5_N2_CSstrip_42417_21500,o1
+  p2: straight_L1p5_N2_CSstrip_WNone_42417_21500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500,o1
-  p2: straight_L4p5_N2_CSstrip_3250_24500,o1
+  p2: straight_L4p5_N2_CSstrip_WNone_3250_24500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_3250_24500,o2
-  p2: straight_L23p5_N2_CSstrip_13250_34500,o1
+  p2: straight_L23p5_N2_CSstrip_WNone_13250_34500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000,o1
-  p2: straight_L19p166_N2_CSstrip_15417_33000,o2
+  p2: straight_L19p166_N2_CSs_b7981645_15417_33000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_34583_33000,o2
-  p2: straight_L3_N2_CSstrip_44583_23000,o1
+  p2: straight_L3_N2_CSstrip_WNone_44583_23000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500,o1
-  p2: straight_L23p5_N2_CSstrip_13250_34500,o2
+  p2: straight_L23p5_N2_CSstrip_WNone_13250_34500,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_36750_34500,o2
-  p2: straight_L4p5_N2_CSstrip_46750_24500,o1
+  p2: straight_L4p5_N2_CSstrip_WNone_46750_24500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000,o1
-  p2: straight_L27p834_N2_CSstrip_11083_36000,o2
+  p2: straight_L27p834_N2_CSs_5d181985_11083_36000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_38917_36000,o2
-  p2: straight_L6_N2_CSstrip_48917_26000,o1
+  p2: straight_L6_N2_CSstrip_WNone_48917_26000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500,o1
-  p2: straight_L32p1660000000_643231bb_8917_37500,o2
+  p2: straight_L32p1660000000_37974347_8917_37500,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_41083_37500,o2
-  p2: straight_L7p5_N2_CSstrip_51083_27500,o1
+  p2: straight_L7p5_N2_CSstrip_WNone_51083_27500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000,o1
-  p2: straight_L36p5_N2_CSstrip_6750_39000,o2
+  p2: straight_L36p5_N2_CSstrip_WNone_6750_39000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_43250_39000,o2
-  p2: straight_L9_N2_CSstrip_53250_29000,o1
+  p2: straight_L9_N2_CSstrip_WNone_53250_29000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500,o1
-  p2: straight_L40p834_N2_CSstrip_4583_40500,o2
+  p2: straight_L40p834_N2_CSs_fb3a91b2_4583_40500,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_45417_40500,o2
-  p2: straight_L10p5_N2_CSstrip_55417_30500,o1
+  p2: straight_L10p5_N2_CSstrip_WNone_55417_30500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000,o1
-  p2: straight_L45p1660000000_4d1de147_2417_42000,o2
+  p2: straight_L45p1660000000_67f54d0c_2417_42000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_47583_42000,o2
-  p2: straight_L12_N2_CSstrip_57583_32000,o1
+  p2: straight_L12_N2_CSstrip_WNone_57583_32000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500,o1
-  p2: straight_L49p5_N2_CSstrip_250_43500,o2
+  p2: straight_L49p5_N2_CSstrip_WNone_250_43500,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_49750_43500,o2
-  p2: straight_L13p5_N2_CSstrip_59750_33500,o1
+  p2: straight_L13p5_N2_CSstrip_WNone_59750_33500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000,o1
-  p2: straight_L3_N2_CSstrip_5417_23000,o1
+  p2: straight_L3_N2_CSstrip_WNone_5417_23000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_5417_23000,o2
-  p2: straight_L19p166_N2_CSstrip_15417_33000,o1
+  p2: straight_L19p166_N2_CSs_b7981645_15417_33000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500,o1
-  p2: straight_L1p5_N2_CSstrip_7583_21500,o1
+  p2: straight_L1p5_N2_CSstrip_WNone_7583_21500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_7583_21500,o2
-  p2: straight_L14p834_N2_CSstrip_17583_31500,o1
+  p2: straight_L14p834_N2_CSs_1c3891c0_17583_31500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000,o1
   p2: free_propagation_region_17623e49_0_0,E0
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_9750_20000,o2
-  p2: straight_L10p5_N2_CSstrip_19750_30000,o1
+  p2: straight_L10p5_N2_CSstrip_WNone_19750_30000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500,o1
-  p2: straight_L7p5_N2_CSstrip_m1083_27500,o1
+  p2: straight_L7p5_N2_CSstrip_WNone_m1083_27500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m1083_27500,o2
-  p2: straight_L32p1660000000_643231bb_8917_37500,o1
+  p2: straight_L32p1660000000_37974347_8917_37500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000,o1
-  p2: straight_L9_N2_CSstrip_m3250_29000,o1
+  p2: straight_L9_N2_CSstrip_WNone_m3250_29000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m3250_29000,o2
-  p2: straight_L36p5_N2_CSstrip_6750_39000,o1
+  p2: straight_L36p5_N2_CSstrip_WNone_6750_39000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500,o1
-  p2: straight_L10p5_N2_CSstrip_m5417_30500,o1
+  p2: straight_L10p5_N2_CSstrip_WNone_m5417_30500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m5417_30500,o2
-  p2: straight_L40p834_N2_CSstrip_4583_40500,o1
+  p2: straight_L40p834_N2_CSs_fb3a91b2_4583_40500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000,o1
-  p2: straight_L12_N2_CSstrip_m7583_32000,o1
+  p2: straight_L12_N2_CSstrip_WNone_m7583_32000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m7583_32000,o2
-  p2: straight_L45p1660000000_4d1de147_2417_42000,o1
+  p2: straight_L45p1660000000_67f54d0c_2417_42000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500,o1
-  p2: straight_L13p5_N2_CSstrip_m9750_33500,o1
+  p2: straight_L13p5_N2_CSstrip_WNone_m9750_33500,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_m9750_33500,o2
-  p2: straight_L49p5_N2_CSstrip_250_43500,o1
+  p2: straight_L49p5_N2_CSstrip_WNone_250_43500,o1
 - p1: free_propagation_region_17623e49_0_0,E1
-  p2: straight_L1p5_N2_CSstrip_7583_21500,o2
+  p2: straight_L1p5_N2_CSstrip_WNone_7583_21500,o2
 - p1: free_propagation_region_17623e49_0_0,E2
-  p2: straight_L3_N2_CSstrip_5417_23000,o2
+  p2: straight_L3_N2_CSstrip_WNone_5417_23000,o2
 - p1: free_propagation_region_17623e49_0_0,E3
-  p2: straight_L4p5_N2_CSstrip_3250_24500,o2
+  p2: straight_L4p5_N2_CSstrip_WNone_3250_24500,o2
 - p1: free_propagation_region_17623e49_0_0,E4
-  p2: straight_L6_N2_CSstrip_1083_26000,o2
+  p2: straight_L6_N2_CSstrip_WNone_1083_26000,o2
 - p1: free_propagation_region_17623e49_0_0,E5
-  p2: straight_L7p5_N2_CSstrip_m1083_27500,o2
+  p2: straight_L7p5_N2_CSstrip_WNone_m1083_27500,o2
 - p1: free_propagation_region_17623e49_0_0,E6
-  p2: straight_L9_N2_CSstrip_m3250_29000,o2
+  p2: straight_L9_N2_CSstrip_WNone_m3250_29000,o2
 - p1: free_propagation_region_17623e49_0_0,E7
-  p2: straight_L10p5_N2_CSstrip_m5417_30500,o2
+  p2: straight_L10p5_N2_CSstrip_WNone_m5417_30500,o2
 - p1: free_propagation_region_17623e49_0_0,E8
-  p2: straight_L12_N2_CSstrip_m7583_32000,o2
+  p2: straight_L12_N2_CSstrip_WNone_m7583_32000,o2
 - p1: free_propagation_region_17623e49_0_0,E9
-  p2: straight_L13p5_N2_CSstrip_m9750_33500,o2
+  p2: straight_L13p5_N2_CSstrip_WNone_m9750_33500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E0
-  p2: straight_L13p5_N2_CSstrip_59750_33500,o2
+  p2: straight_L13p5_N2_CSstrip_WNone_59750_33500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E1
-  p2: straight_L12_N2_CSstrip_57583_32000,o2
+  p2: straight_L12_N2_CSstrip_WNone_57583_32000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E2
-  p2: straight_L10p5_N2_CSstrip_55417_30500,o2
+  p2: straight_L10p5_N2_CSstrip_WNone_55417_30500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E3
-  p2: straight_L9_N2_CSstrip_53250_29000,o2
+  p2: straight_L9_N2_CSstrip_WNone_53250_29000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E4
-  p2: straight_L7p5_N2_CSstrip_51083_27500,o2
+  p2: straight_L7p5_N2_CSstrip_WNone_51083_27500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E5
-  p2: straight_L6_N2_CSstrip_48917_26000,o2
+  p2: straight_L6_N2_CSstrip_WNone_48917_26000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E6
-  p2: straight_L4p5_N2_CSstrip_46750_24500,o2
+  p2: straight_L4p5_N2_CSstrip_WNone_46750_24500,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E7
-  p2: straight_L3_N2_CSstrip_44583_23000,o2
+  p2: straight_L3_N2_CSstrip_WNone_44583_23000,o2
 - p1: free_propagation_region_b76b91f7_50000_0,E8
-  p2: straight_L1p5_N2_CSstrip_42417_21500,o2
+  p2: straight_L1p5_N2_CSstrip_WNone_42417_21500,o2
 placements:
   bend_euler_R10_A90_P0p5_f9fcb00b_1083_26000:
     mirror: true
@@ -1100,142 +1128,142 @@ placements:
     rotation: 90
     x: 50
     y: 0
-  straight_L10p5_N2_CSstrip_19750_30000:
+  straight_L10p5_N2_CSstrip_WNone_19750_30000:
     mirror: false
     rotation: 0
     x: 19.75
     y: 30
-  straight_L10p5_N2_CSstrip_55417_30500:
+  straight_L10p5_N2_CSstrip_WNone_55417_30500:
     mirror: false
     rotation: 270
     x: 55.417
     y: 30.5
-  straight_L10p5_N2_CSstrip_m5417_30500:
+  straight_L10p5_N2_CSstrip_WNone_m5417_30500:
     mirror: false
     rotation: 270
     x: -5.417
     y: 30.5
-  straight_L12_N2_CSstrip_57583_32000:
+  straight_L12_N2_CSstrip_WNone_57583_32000:
     mirror: false
     rotation: 270
     x: 57.583
     y: 32
-  straight_L12_N2_CSstrip_m7583_32000:
+  straight_L12_N2_CSstrip_WNone_m7583_32000:
     mirror: false
     rotation: 270
     x: -7.583
     y: 32
-  straight_L13p5_N2_CSstrip_59750_33500:
+  straight_L13p5_N2_CSstrip_WNone_59750_33500:
     mirror: false
     rotation: 270
     x: 59.75
     y: 33.5
-  straight_L13p5_N2_CSstrip_m9750_33500:
+  straight_L13p5_N2_CSstrip_WNone_m9750_33500:
     mirror: false
     rotation: 270
     x: -9.75
     y: 33.5
-  straight_L14p834_N2_CSstrip_17583_31500:
+  straight_L14p834_N2_CSs_1c3891c0_17583_31500:
     mirror: false
     rotation: 0
     x: 17.583
     y: 31.5
-  straight_L19p166_N2_CSstrip_15417_33000:
+  straight_L19p166_N2_CSs_b7981645_15417_33000:
     mirror: false
     rotation: 0
     x: 15.417
     y: 33
-  straight_L1p5_N2_CSstrip_42417_21500:
+  straight_L1p5_N2_CSstrip_WNone_42417_21500:
     mirror: false
     rotation: 270
     x: 42.417
     y: 21.5
-  straight_L1p5_N2_CSstrip_7583_21500:
+  straight_L1p5_N2_CSstrip_WNone_7583_21500:
     mirror: false
     rotation: 270
     x: 7.583
     y: 21.5
-  straight_L23p5_N2_CSstrip_13250_34500:
+  straight_L23p5_N2_CSstrip_WNone_13250_34500:
     mirror: false
     rotation: 0
     x: 13.25
     y: 34.5
-  straight_L27p834_N2_CSstrip_11083_36000:
+  straight_L27p834_N2_CSs_5d181985_11083_36000:
     mirror: false
     rotation: 0
     x: 11.083
     y: 36
-  straight_L32p1660000000_643231bb_8917_37500:
+  straight_L32p1660000000_37974347_8917_37500:
     mirror: false
     rotation: 0
     x: 8.917
     y: 37.5
-  straight_L36p5_N2_CSstrip_6750_39000:
+  straight_L36p5_N2_CSstrip_WNone_6750_39000:
     mirror: false
     rotation: 0
     x: 6.75
     y: 39
-  straight_L3_N2_CSstrip_44583_23000:
+  straight_L3_N2_CSstrip_WNone_44583_23000:
     mirror: false
     rotation: 270
     x: 44.583
     y: 23
-  straight_L3_N2_CSstrip_5417_23000:
+  straight_L3_N2_CSstrip_WNone_5417_23000:
     mirror: false
     rotation: 270
     x: 5.417
     y: 23
-  straight_L40p834_N2_CSstrip_4583_40500:
+  straight_L40p834_N2_CSs_fb3a91b2_4583_40500:
     mirror: false
     rotation: 0
     x: 4.583
     y: 40.5
-  straight_L45p1660000000_4d1de147_2417_42000:
+  straight_L45p1660000000_67f54d0c_2417_42000:
     mirror: false
     rotation: 0
     x: 2.417
     y: 42
-  straight_L49p5_N2_CSstrip_250_43500:
+  straight_L49p5_N2_CSstrip_WNone_250_43500:
     mirror: false
     rotation: 0
     x: 0.25
     y: 43.5
-  straight_L4p5_N2_CSstrip_3250_24500:
+  straight_L4p5_N2_CSstrip_WNone_3250_24500:
     mirror: false
     rotation: 270
     x: 3.25
     y: 24.5
-  straight_L4p5_N2_CSstrip_46750_24500:
+  straight_L4p5_N2_CSstrip_WNone_46750_24500:
     mirror: false
     rotation: 270
     x: 46.75
     y: 24.5
-  straight_L6_N2_CSstrip_1083_26000:
+  straight_L6_N2_CSstrip_WNone_1083_26000:
     mirror: false
     rotation: 270
     x: 1.083
     y: 26
-  straight_L6_N2_CSstrip_48917_26000:
+  straight_L6_N2_CSstrip_WNone_48917_26000:
     mirror: false
     rotation: 270
     x: 48.917
     y: 26
-  straight_L7p5_N2_CSstrip_51083_27500:
+  straight_L7p5_N2_CSstrip_WNone_51083_27500:
     mirror: false
     rotation: 270
     x: 51.083
     y: 27.5
-  straight_L7p5_N2_CSstrip_m1083_27500:
+  straight_L7p5_N2_CSstrip_WNone_m1083_27500:
     mirror: false
     rotation: 270
     x: -1.083
     y: 27.5
-  straight_L9_N2_CSstrip_53250_29000:
+  straight_L9_N2_CSstrip_WNone_53250_29000:
     mirror: false
     rotation: 270
     x: 53.25
     y: 29
-  straight_L9_N2_CSstrip_m3250_29000:
+  straight_L9_N2_CSstrip_WNone_m3250_29000:
     mirror: false
     rotation: 270
     x: -3.25

--- a/test-data-regression/test_netlists_bend_euler_s_.yml
+++ b/test-data-regression/test_netlists_bend_euler_s_.yml
@@ -47,7 +47,7 @@ instances:
       radius: null
       width: null
       with_arc_floorplan: true
-name: bend_euler_s_Po1_Po2
+name: bend_euler_s_RNone_P0p5_a75130fe
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_0_0,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_10000_10000,o1

--- a/test-data-regression/test_netlists_coh_rx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_rx_single_pol_.yml
@@ -255,7 +255,7 @@ instances:
       width: 0.5
       width_mmi: 10
       width_taper: 1.7
-  straight_L20_N2_CSstrip_m60000_3750:
+  straight_L20_N2_CSstrip_WNone_m60000_3750:
     component: straight
     info:
       length: 20
@@ -268,7 +268,8 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-  straight_L20_N2_CSstrip_m60000_m1250:
+      width: null
+  straight_L20_N2_CSstrip_WNone_m60000_m1250:
     component: straight
     info:
       length: 20
@@ -281,7 +282,8 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-  straight_L36p5_N2_CSstrip_238500_25000:
+      width: null
+  straight_L36p5_N2_CSstrip_WNone_238500_25000:
     component: straight
     info:
       length: 36.5
@@ -294,7 +296,8 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-  straight_L36p5_N2_CSstrip_238500_m25000:
+      width: null
+  straight_L36p5_N2_CSstrip_WNone_238500_m25000:
     component: straight
     info:
       length: 36.5
@@ -307,7 +310,8 @@ instances:
       cross_section: strip
       length: 36.5
       npoints: 2
-  straight_L3p5_N2_CSstrip_218500_1250:
+      width: null
+  straight_L3p5_N2_CSstrip_WNone_218500_1250:
     component: straight
     info:
       length: 3.5
@@ -320,7 +324,8 @@ instances:
       cross_section: strip
       length: 3.5
       npoints: 2
-  straight_L3p5_N2_CSstrip_218500_m1250:
+      width: null
+  straight_L3p5_N2_CSstrip_WNone_218500_m1250:
     component: straight
     info:
       length: 3.5
@@ -333,7 +338,8 @@ instances:
       cross_section: strip
       length: 3.5
       npoints: 2
-  straight_L3p75_N2_CSstrip_228500_15000:
+      width: null
+  straight_L3p75_N2_CSstrip_WNone_228500_15000:
     component: straight
     info:
       length: 3.75
@@ -346,7 +352,8 @@ instances:
       cross_section: strip
       length: 3.75
       npoints: 2
-  straight_L3p75_N2_CSstrip_228500_m15000:
+      width: null
+  straight_L3p75_N2_CSstrip_WNone_228500_m15000:
     component: straight
     info:
       length: 3.75
@@ -359,7 +366,8 @@ instances:
       cross_section: strip
       length: 3.75
       npoints: 2
-  straight_L40_N2_CSstrip_235000_75000:
+      width: null
+  straight_L40_N2_CSstrip_WNone_235000_75000:
     component: straight
     info:
       length: 40
@@ -372,7 +380,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_235000_m75000:
+      width: null
+  straight_L40_N2_CSstrip_WNone_235000_m75000:
     component: straight
     info:
       length: 40
@@ -385,7 +394,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L51p25_N2_CSstrip_225000_65000:
+      width: null
+  straight_L51p25_N2_CSstrip_WNone_225000_65000:
     component: straight
     info:
       length: 51.25
@@ -398,7 +408,8 @@ instances:
       cross_section: strip
       length: 51.25
       npoints: 2
-  straight_L51p25_N2_CSstrip_225000_m65000:
+      width: null
+  straight_L51p25_N2_CSstrip_WNone_225000_m65000:
     component: straight
     info:
       length: 51.25
@@ -411,56 +422,57 @@ instances:
       cross_section: strip
       length: 51.25
       npoints: 2
+      width: null
 name: coh_rx_single_pol_Bbend_352b2c0b
 nets:
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750,o1
-  p2: straight_L51p25_N2_CSstrip_225000_65000,o2
+  p2: straight_L51p25_N2_CSstrip_WNone_225000_65000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750,o2
   p2: mmi_90degree_hybrid_W0p_80ee73a1_0_0,I_out1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750,o1
-  p2: straight_L51p25_N2_CSstrip_225000_m65000,o2
+  p2: straight_L51p25_N2_CSstrip_WNone_225000_m65000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_225000_m13750,o2
   p2: mmi_90degree_hybrid_W0p_80ee73a1_0_0,I_out2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250,o1
-  p2: straight_L3p75_N2_CSstrip_228500_15000,o2
+  p2: straight_L3p75_N2_CSstrip_WNone_228500_15000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_11250,o2
-  p2: straight_L3p5_N2_CSstrip_218500_1250,o1
+  p2: straight_L3p5_N2_CSstrip_WNone_218500_1250,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250,o1
-  p2: straight_L3p75_N2_CSstrip_228500_m15000,o2
+  p2: straight_L3p75_N2_CSstrip_WNone_228500_m15000,o2
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_228500_m11250,o2
-  p2: straight_L3p5_N2_CSstrip_218500_m1250,o1
+  p2: straight_L3p5_N2_CSstrip_WNone_218500_m1250,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000,o1
-  p2: straight_L40_N2_CSstrip_235000_75000,o1
+  p2: straight_L40_N2_CSstrip_WNone_235000_75000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_75000,o2
-  p2: straight_L51p25_N2_CSstrip_225000_65000,o1
+  p2: straight_L51p25_N2_CSstrip_WNone_225000_65000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000,o1
-  p2: straight_L40_N2_CSstrip_235000_m75000,o1
+  p2: straight_L40_N2_CSstrip_WNone_235000_m75000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_235000_m75000,o2
-  p2: straight_L51p25_N2_CSstrip_225000_m65000,o1
+  p2: straight_L51p25_N2_CSstrip_WNone_225000_m65000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000,o1
-  p2: straight_L36p5_N2_CSstrip_238500_25000,o1
+  p2: straight_L36p5_N2_CSstrip_WNone_238500_25000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_25000,o2
-  p2: straight_L3p75_N2_CSstrip_228500_15000,o1
+  p2: straight_L3p75_N2_CSstrip_WNone_228500_15000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000,o1
-  p2: straight_L36p5_N2_CSstrip_238500_m25000,o1
+  p2: straight_L36p5_N2_CSstrip_WNone_238500_m25000,o1
 - p1: bend_euler_R10_A90_P0p5_f9fcb00b_238500_m25000,o2
-  p2: straight_L3p75_N2_CSstrip_228500_m15000,o1
+  p2: straight_L3p75_N2_CSstrip_WNone_228500_m15000,o1
 - p1: ge_detector_straight_si_857c1c1e_295000_25000,o1
-  p2: straight_L36p5_N2_CSstrip_238500_25000,o2
+  p2: straight_L36p5_N2_CSstrip_WNone_238500_25000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_75000,o1
-  p2: straight_L40_N2_CSstrip_235000_75000,o2
+  p2: straight_L40_N2_CSstrip_WNone_235000_75000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_m25000,o1
-  p2: straight_L36p5_N2_CSstrip_238500_m25000,o2
+  p2: straight_L36p5_N2_CSstrip_WNone_238500_m25000,o2
 - p1: ge_detector_straight_si_857c1c1e_295000_m75000,o1
-  p2: straight_L40_N2_CSstrip_235000_m75000,o2
+  p2: straight_L40_N2_CSstrip_WNone_235000_m75000,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,LO_in
-  p2: straight_L20_N2_CSstrip_m60000_m1250,o2
+  p2: straight_L20_N2_CSstrip_WNone_m60000_m1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,Q_out1
-  p2: straight_L3p5_N2_CSstrip_218500_1250,o2
+  p2: straight_L3p5_N2_CSstrip_WNone_218500_1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,Q_out2
-  p2: straight_L3p5_N2_CSstrip_218500_m1250,o2
+  p2: straight_L3p5_N2_CSstrip_WNone_218500_m1250,o2
 - p1: mmi_90degree_hybrid_W0p_80ee73a1_0_0,signal_in
-  p2: straight_L20_N2_CSstrip_m60000_3750,o2
+  p2: straight_L20_N2_CSstrip_WNone_m60000_3750,o2
 placements:
   bend_euler_R10_A90_P0p5_f9fcb00b_225000_13750:
     mirror: true
@@ -527,68 +539,68 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L20_N2_CSstrip_m60000_3750:
+  straight_L20_N2_CSstrip_WNone_m60000_3750:
     mirror: false
     rotation: 0
     x: -60
     y: 3.75
-  straight_L20_N2_CSstrip_m60000_m1250:
+  straight_L20_N2_CSstrip_WNone_m60000_m1250:
     mirror: false
     rotation: 0
     x: -60
     y: -1.25
-  straight_L36p5_N2_CSstrip_238500_25000:
+  straight_L36p5_N2_CSstrip_WNone_238500_25000:
     mirror: false
     rotation: 0
     x: 238.5
     y: 25
-  straight_L36p5_N2_CSstrip_238500_m25000:
+  straight_L36p5_N2_CSstrip_WNone_238500_m25000:
     mirror: false
     rotation: 0
     x: 238.5
     y: -25
-  straight_L3p5_N2_CSstrip_218500_1250:
+  straight_L3p5_N2_CSstrip_WNone_218500_1250:
     mirror: false
     rotation: 180
     x: 218.5
     y: 1.25
-  straight_L3p5_N2_CSstrip_218500_m1250:
+  straight_L3p5_N2_CSstrip_WNone_218500_m1250:
     mirror: false
     rotation: 180
     x: 218.5
     y: -1.25
-  straight_L3p75_N2_CSstrip_228500_15000:
+  straight_L3p75_N2_CSstrip_WNone_228500_15000:
     mirror: false
     rotation: 270
     x: 228.5
     y: 15
-  straight_L3p75_N2_CSstrip_228500_m15000:
+  straight_L3p75_N2_CSstrip_WNone_228500_m15000:
     mirror: false
     rotation: 90
     x: 228.5
     y: -15
-  straight_L40_N2_CSstrip_235000_75000:
+  straight_L40_N2_CSstrip_WNone_235000_75000:
     mirror: false
     rotation: 0
     x: 235
     y: 75
-  straight_L40_N2_CSstrip_235000_m75000:
+  straight_L40_N2_CSstrip_WNone_235000_m75000:
     mirror: false
     rotation: 0
     x: 235
     y: -75
-  straight_L51p25_N2_CSstrip_225000_65000:
+  straight_L51p25_N2_CSstrip_WNone_225000_65000:
     mirror: false
     rotation: 270
     x: 225
     y: 65
-  straight_L51p25_N2_CSstrip_225000_m65000:
+  straight_L51p25_N2_CSstrip_WNone_225000_m65000:
     mirror: false
     rotation: 90
     x: 225
     y: -65
 ports:
-  LO_in: straight_L20_N2_CSstrip_m60000_m1250,o1
+  LO_in: straight_L20_N2_CSstrip_WNone_m60000_m1250,o1
   i1vminustop_e1: ge_detector_straight_si_857c1c1e_295000_75000,top_e1
   i1vminustop_e2: ge_detector_straight_si_857c1c1e_295000_75000,top_e2
   i1vminustop_e3: ge_detector_straight_si_857c1c1e_295000_75000,top_e3
@@ -605,7 +617,7 @@ ports:
   q2vplusbot_e2: ge_detector_straight_si_857c1c1e_295000_m25000,bot_e2
   q2vplusbot_e3: ge_detector_straight_si_857c1c1e_295000_m25000,bot_e3
   q2vplusbot_e4: ge_detector_straight_si_857c1c1e_295000_m25000,bot_e4
-  signal_in: straight_L20_N2_CSstrip_m60000_3750,o1
+  signal_in: straight_L20_N2_CSstrip_WNone_m60000_3750,o1
 warnings:
   electrical:
     unconnected_ports:

--- a/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_dual_pol_.yml
@@ -144,7 +144,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L65p875_N2_CSstrip_m80000_m216250:
+  straight_L65p875_N2_CSs_aab2ae3d_m80000_m216250:
     component: straight
     info:
       length: 65.875
@@ -157,7 +157,8 @@ instances:
       cross_section: strip
       length: 65.875
       npoints: 2
-  straight_L65p875_N2_CSstrip_m80000_m63250:
+      width: null
+  straight_L65p875_N2_CSs_aab2ae3d_m80000_m63250:
     component: straight
     info:
       length: 65.875
@@ -170,7 +171,8 @@ instances:
       cross_section: strip
       length: 65.875
       npoints: 2
-  straight_L7p25_N2_CSstrip_m70000_m226250:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_m70000_m226250:
     component: straight
     info:
       length: 7.25
@@ -183,7 +185,8 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-  straight_L7p25_N2_CSstrip_m70000_m53250:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_m70000_m53250:
     component: straight
     info:
       length: 7.25
@@ -196,28 +199,29 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
+      width: null
 name: coh_tx_dual_pol_Smmi1x2_a3c36516
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250,o1
-  p2: straight_L7p25_N2_CSstrip_m70000_m226250,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_m70000_m226250,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250,o2
-  p2: straight_L65p875_N2_CSstrip_m80000_m216250,o1
+  p2: straight_L65p875_N2_CSs_aab2ae3d_m80000_m216250,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250,o1
-  p2: straight_L7p25_N2_CSstrip_m70000_m53250,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_m70000_m53250,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m53250,o2
-  p2: straight_L65p875_N2_CSstrip_m80000_m63250,o1
+  p2: straight_L65p875_N2_CSs_aab2ae3d_m80000_m63250,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125,o1
-  p2: straight_L65p875_N2_CSstrip_m80000_m63250,o2
+  p2: straight_L65p875_N2_CSs_aab2ae3d_m80000_m63250,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m129125,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m105500_m139750,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375,o1
-  p2: straight_L65p875_N2_CSstrip_m80000_m216250,o2
+  p2: straight_L65p875_N2_CSs_aab2ae3d_m80000_m216250,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m80000_m150375,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m105500_m139750,o3
 - p1: coh_tx_single_pol_BPSFa_4ee171aa_0_0,o1
-  p2: straight_L7p25_N2_CSstrip_m70000_m53250,o2
+  p2: straight_L7p25_N2_CSstrip_WNone_m70000_m53250,o2
 - p1: coh_tx_single_pol_BPSFa_4ee171aa_0_m173000,o1
-  p2: straight_L7p25_N2_CSstrip_m70000_m226250,o2
+  p2: straight_L7p25_N2_CSstrip_WNone_m70000_m226250,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_m70000_m226250:
     mirror: true
@@ -254,22 +258,22 @@ placements:
     rotation: 0
     x: -105.5
     y: -139.75
-  straight_L65p875_N2_CSstrip_m80000_m216250:
+  straight_L65p875_N2_CSs_aab2ae3d_m80000_m216250:
     mirror: false
     rotation: 90
     x: -80
     y: -216.25
-  straight_L65p875_N2_CSstrip_m80000_m63250:
+  straight_L65p875_N2_CSs_aab2ae3d_m80000_m63250:
     mirror: false
     rotation: 270
     x: -80
     y: -63.25
-  straight_L7p25_N2_CSstrip_m70000_m226250:
+  straight_L7p25_N2_CSstrip_WNone_m70000_m226250:
     mirror: false
     rotation: 0
     x: -70
     y: -226.25
-  straight_L7p25_N2_CSstrip_m70000_m53250:
+  straight_L7p25_N2_CSstrip_WNone_m70000_m53250:
     mirror: false
     rotation: 0
     x: -70

--- a/test-data-regression/test_netlists_coh_tx_single_pol_.yml
+++ b/test-data-regression/test_netlists_coh_tx_single_pol_.yml
@@ -275,7 +275,7 @@ instances:
       straight_x_top: straight_pin
       straight_y: null
       with_splitter: true
-  straight_L100_N2_CSstrip_321000_0:
+  straight_L100_N2_CSstrip_WNone_321000_0:
     component: straight
     info:
       length: 100
@@ -288,7 +288,8 @@ instances:
       cross_section: strip
       length: 100
       npoints: 2
-  straight_L32p625_N2_CSstrip_438250_m10000:
+      width: null
+  straight_L32p625_N2_CSs_fe6a8d7e_438250_m10000:
     component: straight
     info:
       length: 32.625
@@ -301,7 +302,8 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-  straight_L32p625_N2_CSstrip_438250_m96500:
+      width: null
+  straight_L32p625_N2_CSs_fe6a8d7e_438250_m96500:
     component: straight
     info:
       length: 32.625
@@ -314,7 +316,8 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-  straight_L32p625_N2_CSstrip_m27250_m10000:
+      width: null
+  straight_L32p625_N2_CSs_fe6a8d7e_m27250_m10000:
     component: straight
     info:
       length: 32.625
@@ -327,7 +330,8 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-  straight_L32p625_N2_CSstrip_m27250_m96500:
+      width: null
+  straight_L32p625_N2_CSs_fe6a8d7e_m27250_m96500:
     component: straight
     info:
       length: 32.625
@@ -340,7 +344,8 @@ instances:
       cross_section: strip
       length: 32.625
       npoints: 2
-  straight_L40_N2_CSstrip_281000_0:
+      width: null
+  straight_L40_N2_CSstrip_WNone_281000_0:
     component: straight
     info:
       length: 40
@@ -353,7 +358,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_281000_m106500:
+      width: null
+  straight_L40_N2_CSstrip_WNone_281000_m106500:
     component: straight
     info:
       length: 40
@@ -366,7 +372,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L7p25_N2_CSstrip_428250_0:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_428250_0:
     component: straight
     info:
       length: 7.25
@@ -379,7 +386,8 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-  straight_L7p25_N2_CSstrip_428250_m106500:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_428250_m106500:
     component: straight
     info:
       length: 7.25
@@ -392,7 +400,8 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-  straight_L7p25_N2_CSstrip_m17250_0:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_m17250_0:
     component: straight
     info:
       length: 7.25
@@ -405,7 +414,8 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
-  straight_L7p25_N2_CSstrip_m17250_m106500:
+      width: null
+  straight_L7p25_N2_CSstrip_WNone_m17250_m106500:
     component: straight
     info:
       length: 7.25
@@ -418,6 +428,7 @@ instances:
       cross_section: strip
       length: 7.25
       npoints: 2
+      width: null
   straight_pin_L100_CSpin_f2ba7e88_331000_m106500:
     component: straight_pin
     info: {}
@@ -431,52 +442,52 @@ instances:
 name: coh_tx_single_pol_BPSFa_4ee171aa
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0,o1
-  p2: straight_L7p25_N2_CSstrip_428250_0,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_428250_0,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0,o2
-  p2: straight_L32p625_N2_CSstrip_438250_m10000,o1
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_438250_m10000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_428250_m106500,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_428250_m106500,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_428250_m106500,o2
-  p2: straight_L32p625_N2_CSstrip_438250_m96500,o1
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_438250_m96500,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625,o1
-  p2: straight_L32p625_N2_CSstrip_438250_m10000,o2
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_438250_m10000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m42625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_463750_m53250,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875,o1
-  p2: straight_L32p625_N2_CSstrip_438250_m96500,o2
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_438250_m96500,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_438250_m63875,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_463750_m53250,o3
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0,o1
-  p2: straight_L7p25_N2_CSstrip_m17250_0,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_m17250_0,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_0,o2
-  p2: straight_L32p625_N2_CSstrip_m27250_m10000,o1
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_m27250_m10000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_m17250_m106500,o1
+  p2: straight_L7p25_N2_CSstrip_WNone_m17250_m106500,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m17250_m106500,o2
-  p2: straight_L32p625_N2_CSstrip_m27250_m96500,o1
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_m27250_m96500,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625,o1
-  p2: straight_L32p625_N2_CSstrip_m27250_m10000,o2
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_m27250_m10000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m42625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m52750_m53250,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875,o1
-  p2: straight_L32p625_N2_CSstrip_m27250_m96500,o2
+  p2: straight_L32p625_N2_CSs_fe6a8d7e_m27250_m96500,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m27250_m63875,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_m52750_m53250,o3
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_0,o1
-  p2: straight_L7p25_N2_CSstrip_m17250_0,o2
+  p2: straight_L7p25_N2_CSstrip_WNone_m17250_0,o2
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_0,o2
-  p2: straight_L40_N2_CSstrip_281000_0,o1
+  p2: straight_L40_N2_CSstrip_WNone_281000_0,o1
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_m106500,o1
-  p2: straight_L7p25_N2_CSstrip_m17250_m106500,o2
+  p2: straight_L7p25_N2_CSstrip_WNone_m17250_m106500,o2
 - p1: mzi_DL0_LY2_LX200_Bbend_31a2f4c6_0_m106500,o2
-  p2: straight_L40_N2_CSstrip_281000_m106500,o1
-- p1: straight_L100_N2_CSstrip_321000_0,o1
-  p2: straight_L40_N2_CSstrip_281000_0,o2
-- p1: straight_L100_N2_CSstrip_321000_0,o2
-  p2: straight_L7p25_N2_CSstrip_428250_0,o2
-- p1: straight_L40_N2_CSstrip_281000_m106500,o2
+  p2: straight_L40_N2_CSstrip_WNone_281000_m106500,o1
+- p1: straight_L100_N2_CSstrip_WNone_321000_0,o1
+  p2: straight_L40_N2_CSstrip_WNone_281000_0,o2
+- p1: straight_L100_N2_CSstrip_WNone_321000_0,o2
+  p2: straight_L7p25_N2_CSstrip_WNone_428250_0,o2
+- p1: straight_L40_N2_CSstrip_WNone_281000_m106500,o2
   p2: straight_pin_L100_CSpin_f2ba7e88_331000_m106500,o1
-- p1: straight_L7p25_N2_CSstrip_428250_m106500,o2
+- p1: straight_L7p25_N2_CSstrip_WNone_428250_m106500,o2
   p2: straight_pin_L100_CSpin_f2ba7e88_331000_m106500,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_428250_0:
@@ -539,57 +550,57 @@ placements:
     rotation: 0
     x: 0
     y: -106.5
-  straight_L100_N2_CSstrip_321000_0:
+  straight_L100_N2_CSstrip_WNone_321000_0:
     mirror: false
     rotation: 0
     x: 321
     y: 0
-  straight_L32p625_N2_CSstrip_438250_m10000:
+  straight_L32p625_N2_CSs_fe6a8d7e_438250_m10000:
     mirror: false
     rotation: 270
     x: 438.25
     y: -10
-  straight_L32p625_N2_CSstrip_438250_m96500:
+  straight_L32p625_N2_CSs_fe6a8d7e_438250_m96500:
     mirror: false
     rotation: 90
     x: 438.25
     y: -96.5
-  straight_L32p625_N2_CSstrip_m27250_m10000:
+  straight_L32p625_N2_CSs_fe6a8d7e_m27250_m10000:
     mirror: false
     rotation: 270
     x: -27.25
     y: -10
-  straight_L32p625_N2_CSstrip_m27250_m96500:
+  straight_L32p625_N2_CSs_fe6a8d7e_m27250_m96500:
     mirror: false
     rotation: 90
     x: -27.25
     y: -96.5
-  straight_L40_N2_CSstrip_281000_0:
+  straight_L40_N2_CSstrip_WNone_281000_0:
     mirror: false
     rotation: 0
     x: 281
     y: 0
-  straight_L40_N2_CSstrip_281000_m106500:
+  straight_L40_N2_CSstrip_WNone_281000_m106500:
     mirror: false
     rotation: 0
     x: 281
     y: -106.5
-  straight_L7p25_N2_CSstrip_428250_0:
+  straight_L7p25_N2_CSstrip_WNone_428250_0:
     mirror: false
     rotation: 180
     x: 428.25
     y: 0
-  straight_L7p25_N2_CSstrip_428250_m106500:
+  straight_L7p25_N2_CSstrip_WNone_428250_m106500:
     mirror: false
     rotation: 180
     x: 428.25
     y: -106.5
-  straight_L7p25_N2_CSstrip_m17250_0:
+  straight_L7p25_N2_CSstrip_WNone_m17250_0:
     mirror: false
     rotation: 0
     x: -17.25
     y: 0
-  straight_L7p25_N2_CSstrip_m17250_m106500:
+  straight_L7p25_N2_CSstrip_WNone_m17250_m106500:
     mirror: false
     rotation: 0
     x: -17.25

--- a/test-data-regression/test_netlists_coupler90_.yml
+++ b/test-data-regression/test_netlists_coupler90_.yml
@@ -23,7 +23,7 @@ instances:
       radius: 10
       width: null
       with_arc_floorplan: true
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 10
@@ -36,6 +36,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
 name: coupler90_G0p2_R10_Bben_11d57add
 nets: []
 placements:
@@ -44,13 +45,13 @@ placements:
     rotation: 0
     x: 0
     y: 0.7
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: straight_L10_N2_CSstrip_0_0,o1
+  o1: straight_L10_N2_CSstrip_WNone_0_0,o1
   o2: bend_euler_R10_A90_P0p5_2f1f5c6d_0_700,o1
   o3: bend_euler_R10_A90_P0p5_2f1f5c6d_0_700,o2
-  o4: straight_L10_N2_CSstrip_0_0,o2
+  o4: straight_L10_N2_CSstrip_WNone_0_0,o2

--- a/test-data-regression/test_netlists_coupler90circular_.yml
+++ b/test-data-regression/test_netlists_coupler90circular_.yml
@@ -20,7 +20,7 @@ instances:
       npoints: null
       radius: 10
       width: null
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 10
@@ -33,6 +33,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
 name: coupler90_G0p2_R10_Bben_0c9734ee
 nets: []
 placements:
@@ -41,13 +42,13 @@ placements:
     rotation: 0
     x: 0
     y: 0.7
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: straight_L10_N2_CSstrip_0_0,o1
+  o1: straight_L10_N2_CSstrip_WNone_0_0,o1
   o2: bend_circular_R10_A90_N_aaec1a70_0_700,o1
   o3: bend_circular_R10_A90_N_aaec1a70_0_700,o2
-  o4: straight_L10_N2_CSstrip_0_0,o2
+  o4: straight_L10_N2_CSstrip_WNone_0_0,o2

--- a/test-data-regression/test_netlists_coupler_adiabatic_.yml
+++ b/test-data-regression/test_netlists_coupler_adiabatic_.yml
@@ -126,7 +126,7 @@ instances:
       cross_section: strip
       gap: 0.27
       length: 50
-  taper_L10_W0p5_W0p4_PNo_a87d0813_0_0:
+  taper_L10_W0p5_W0p4_LNo_789cfae8_0_0:
     component: taper
     info:
       length: 10
@@ -134,6 +134,7 @@ instances:
       width2: 0.4
     settings:
       cross_section: strip
+      layer: null
       length: 10
       port: null
       port_names:
@@ -146,7 +147,7 @@ instances:
       width2: 0.4
       with_bbox: true
       with_two_ports: true
-  taper_L10_W0p5_W0p6_PNo_23934efe_0_770:
+  taper_L10_W0p5_W0p6_LNo_372c593e_0_770:
     component: taper
     info:
       length: 10
@@ -154,6 +155,7 @@ instances:
       width2: 0.6
     settings:
       cross_section: strip
+      layer: null
       length: 10
       port: null
       port_names:
@@ -169,17 +171,17 @@ instances:
 name: coupler_adiabatic_L20_L_6807e123
 nets:
 - p1: bezier_CP0_0_10_0_10_m1_8e7e82ff_m30000_1770,o2
-  p2: taper_L10_W0p5_W0p6_PNo_23934efe_0_770,o2
+  p2: taper_L10_W0p5_W0p6_LNo_372c593e_0_770,o2
 - p1: bezier_CP0_m3_10_m3_10__aaf3b4a4_m30000_2000,o2
-  p2: taper_L10_W0p5_W0p4_PNo_a87d0813_0_0,o2
+  p2: taper_L10_W0p5_W0p4_LNo_789cfae8_0_0,o2
 - p1: bezier_CP70_m1_85_m1_85_c9a8926c_m20000_1770,o1
   p2: coupler_straight_L50_G0_e5e3337b_0_0,o3
 - p1: bezier_CP70_m1_85_m1_85_c9a8926c_m20000_m1000,o1
   p2: coupler_straight_L50_G0_e5e3337b_0_0,o4
 - p1: coupler_straight_L50_G0_e5e3337b_0_0,o1
-  p2: taper_L10_W0p5_W0p4_PNo_a87d0813_0_0,o1
+  p2: taper_L10_W0p5_W0p4_LNo_789cfae8_0_0,o1
 - p1: coupler_straight_L50_G0_e5e3337b_0_0,o2
-  p2: taper_L10_W0p5_W0p6_PNo_23934efe_0_770,o1
+  p2: taper_L10_W0p5_W0p6_LNo_372c593e_0_770,o1
 placements:
   bezier_CP0_0_10_0_10_m1_8e7e82ff_m30000_1770:
     mirror: false
@@ -206,12 +208,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  taper_L10_W0p5_W0p4_PNo_a87d0813_0_0:
+  taper_L10_W0p5_W0p4_LNo_789cfae8_0_0:
     mirror: false
     rotation: 180
     x: 0
     y: 0
-  taper_L10_W0p5_W0p6_PNo_23934efe_0_770:
+  taper_L10_W0p5_W0p6_LNo_372c593e_0_770:
     mirror: false
     rotation: 180
     x: 0

--- a/test-data-regression/test_netlists_coupler_straight_.yml
+++ b/test-data-regression/test_netlists_coupler_straight_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 10
@@ -12,7 +12,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  straight_L10_N2_CSstrip_0_770:
+      width: null
+  straight_L10_N2_CSstrip_WNone_0_770:
     component: straight
     info:
       length: 10
@@ -25,21 +26,22 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
 name: coupler_straight_L10_G0_ec65877d
 nets: []
 placements:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_L10_N2_CSstrip_0_770:
+  straight_L10_N2_CSstrip_WNone_0_770:
     mirror: false
     rotation: 0
     x: 0
     y: 0.77
 ports:
-  o1: straight_L10_N2_CSstrip_0_0,o1
-  o2: straight_L10_N2_CSstrip_0_770,o1
-  o3: straight_L10_N2_CSstrip_0_770,o2
-  o4: straight_L10_N2_CSstrip_0_0,o2
+  o1: straight_L10_N2_CSstrip_WNone_0_0,o1
+  o2: straight_L10_N2_CSstrip_WNone_0_770,o1
+  o3: straight_L10_N2_CSstrip_WNone_0_770,o2
+  o4: straight_L10_N2_CSstrip_WNone_0_0,o2

--- a/test-data-regression/test_netlists_cutback_bend180_.yml
+++ b/test-data-regression/test_netlists_cutback_bend180_.yml
@@ -12,6 +12,7 @@ instances:
       cross_section: strip
       length: 40.656
       npoints: 2
+      width: null
   '2':
     component: straight
     info:
@@ -25,6 +26,7 @@ instances:
       cross_section: strip
       length: 40.656
       npoints: 2
+      width: null
   '3':
     component: straight
     info:
@@ -38,6 +40,7 @@ instances:
       cross_section: strip
       length: 40.656
       npoints: 2
+      width: null
   '4':
     component: straight
     info:
@@ -51,6 +54,7 @@ instances:
       cross_section: strip
       length: 40.656
       npoints: 2
+      width: null
   '5':
     component: straight
     info:
@@ -64,6 +68,7 @@ instances:
       cross_section: strip
       length: 40.656
       npoints: 2
+      width: null
   C1:
     component: bend_euler
     info:
@@ -1805,6 +1810,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m10:
     component: straight
     info:
@@ -1818,6 +1824,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m11:
     component: straight
     info:
@@ -1831,6 +1838,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m12:
     component: straight
     info:
@@ -1844,6 +1852,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m13:
     component: straight
     info:
@@ -1857,6 +1866,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m14:
     component: straight
     info:
@@ -1870,6 +1880,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m15:
     component: straight
     info:
@@ -1883,6 +1894,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m16:
     component: straight
     info:
@@ -1896,6 +1908,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m17:
     component: straight
     info:
@@ -1909,6 +1922,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m18:
     component: straight
     info:
@@ -1922,6 +1936,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m19:
     component: straight
     info:
@@ -1935,6 +1950,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m2:
     component: straight
     info:
@@ -1948,6 +1964,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m20:
     component: straight
     info:
@@ -1961,6 +1978,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m21:
     component: straight
     info:
@@ -1974,6 +1992,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m22:
     component: straight
     info:
@@ -1987,6 +2006,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m23:
     component: straight
     info:
@@ -2000,6 +2020,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m24:
     component: straight
     info:
@@ -2013,6 +2034,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m25:
     component: straight
     info:
@@ -2026,6 +2048,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m26:
     component: straight
     info:
@@ -2039,6 +2062,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m27:
     component: straight
     info:
@@ -2052,6 +2076,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m28:
     component: straight
     info:
@@ -2065,6 +2090,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m29:
     component: straight
     info:
@@ -2078,6 +2104,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m3:
     component: straight
     info:
@@ -2091,6 +2118,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m30:
     component: straight
     info:
@@ -2104,6 +2132,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m31:
     component: straight
     info:
@@ -2117,6 +2146,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m32:
     component: straight
     info:
@@ -2130,6 +2160,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m33:
     component: straight
     info:
@@ -2143,6 +2174,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m34:
     component: straight
     info:
@@ -2156,6 +2188,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m35:
     component: straight
     info:
@@ -2169,6 +2202,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m36:
     component: straight
     info:
@@ -2182,6 +2216,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m37:
     component: straight
     info:
@@ -2195,6 +2230,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m38:
     component: straight
     info:
@@ -2208,6 +2244,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m39:
     component: straight
     info:
@@ -2221,6 +2258,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m4:
     component: straight
     info:
@@ -2234,6 +2272,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m40:
     component: straight
     info:
@@ -2247,6 +2286,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m41:
     component: straight
     info:
@@ -2260,6 +2300,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m42:
     component: straight
     info:
@@ -2273,6 +2314,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m43:
     component: straight
     info:
@@ -2286,6 +2328,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m44:
     component: straight
     info:
@@ -2299,6 +2342,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m45:
     component: straight
     info:
@@ -2312,6 +2356,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m46:
     component: straight
     info:
@@ -2325,6 +2370,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m47:
     component: straight
     info:
@@ -2338,6 +2384,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m48:
     component: straight
     info:
@@ -2351,6 +2398,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m49:
     component: straight
     info:
@@ -2364,6 +2412,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m5:
     component: straight
     info:
@@ -2377,6 +2426,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m50:
     component: straight
     info:
@@ -2390,6 +2440,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m51:
     component: straight
     info:
@@ -2403,6 +2454,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m52:
     component: straight
     info:
@@ -2416,6 +2468,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m53:
     component: straight
     info:
@@ -2429,6 +2482,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m54:
     component: straight
     info:
@@ -2442,6 +2496,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m55:
     component: straight
     info:
@@ -2455,6 +2510,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m56:
     component: straight
     info:
@@ -2468,6 +2524,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m57:
     component: straight
     info:
@@ -2481,6 +2538,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m58:
     component: straight
     info:
@@ -2494,6 +2552,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m59:
     component: straight
     info:
@@ -2507,6 +2566,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m6:
     component: straight
     info:
@@ -2520,6 +2580,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m60:
     component: straight
     info:
@@ -2533,6 +2594,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m61:
     component: straight
     info:
@@ -2546,6 +2608,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m62:
     component: straight
     info:
@@ -2559,6 +2622,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m63:
     component: straight
     info:
@@ -2572,6 +2636,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m64:
     component: straight
     info:
@@ -2585,6 +2650,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m65:
     component: straight
     info:
@@ -2598,6 +2664,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m66:
     component: straight
     info:
@@ -2611,6 +2678,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m67:
     component: straight
     info:
@@ -2624,6 +2692,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m68:
     component: straight
     info:
@@ -2637,6 +2706,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m69:
     component: straight
     info:
@@ -2650,6 +2720,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m7:
     component: straight
     info:
@@ -2663,6 +2734,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m70:
     component: straight
     info:
@@ -2676,6 +2748,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m71:
     component: straight
     info:
@@ -2689,6 +2762,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m72:
     component: straight
     info:
@@ -2702,6 +2776,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m8:
     component: straight
     info:
@@ -2715,6 +2790,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m9:
     component: straight
     info:
@@ -2728,6 +2804,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: cutback_bend180_CFbend__5a8124e5
 nets:
 - p1: 1,o1

--- a/test-data-regression/test_netlists_cutback_bend90_.yml
+++ b/test-data-regression/test_netlists_cutback_bend90_.yml
@@ -12,6 +12,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '2':
     component: straight
     info:
@@ -25,6 +26,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '3':
     component: straight
     info:
@@ -38,6 +40,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '4':
     component: straight
     info:
@@ -51,6 +54,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '5':
     component: straight
     info:
@@ -64,6 +68,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   A1:
     component: bend_euler
     info:
@@ -3533,6 +3538,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m10:
     component: straight
     info:
@@ -3546,6 +3552,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m100:
     component: straight
     info:
@@ -3559,6 +3566,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m101:
     component: straight
     info:
@@ -3572,6 +3580,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m102:
     component: straight
     info:
@@ -3585,6 +3594,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m103:
     component: straight
     info:
@@ -3598,6 +3608,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m104:
     component: straight
     info:
@@ -3611,6 +3622,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m105:
     component: straight
     info:
@@ -3624,6 +3636,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m106:
     component: straight
     info:
@@ -3637,6 +3650,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m107:
     component: straight
     info:
@@ -3650,6 +3664,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m108:
     component: straight
     info:
@@ -3663,6 +3678,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m109:
     component: straight
     info:
@@ -3676,6 +3692,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m11:
     component: straight
     info:
@@ -3689,6 +3706,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m110:
     component: straight
     info:
@@ -3702,6 +3720,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m111:
     component: straight
     info:
@@ -3715,6 +3734,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m112:
     component: straight
     info:
@@ -3728,6 +3748,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m113:
     component: straight
     info:
@@ -3741,6 +3762,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m114:
     component: straight
     info:
@@ -3754,6 +3776,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m115:
     component: straight
     info:
@@ -3767,6 +3790,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m116:
     component: straight
     info:
@@ -3780,6 +3804,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m117:
     component: straight
     info:
@@ -3793,6 +3818,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m118:
     component: straight
     info:
@@ -3806,6 +3832,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m119:
     component: straight
     info:
@@ -3819,6 +3846,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m12:
     component: straight
     info:
@@ -3832,6 +3860,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m120:
     component: straight
     info:
@@ -3845,6 +3874,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m121:
     component: straight
     info:
@@ -3858,6 +3888,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m122:
     component: straight
     info:
@@ -3871,6 +3902,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m123:
     component: straight
     info:
@@ -3884,6 +3916,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m124:
     component: straight
     info:
@@ -3897,6 +3930,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m125:
     component: straight
     info:
@@ -3910,6 +3944,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m126:
     component: straight
     info:
@@ -3923,6 +3958,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m127:
     component: straight
     info:
@@ -3936,6 +3972,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m128:
     component: straight
     info:
@@ -3949,6 +3986,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m129:
     component: straight
     info:
@@ -3962,6 +4000,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m13:
     component: straight
     info:
@@ -3975,6 +4014,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m130:
     component: straight
     info:
@@ -3988,6 +4028,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m131:
     component: straight
     info:
@@ -4001,6 +4042,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m132:
     component: straight
     info:
@@ -4014,6 +4056,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m133:
     component: straight
     info:
@@ -4027,6 +4070,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m134:
     component: straight
     info:
@@ -4040,6 +4084,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m135:
     component: straight
     info:
@@ -4053,6 +4098,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m136:
     component: straight
     info:
@@ -4066,6 +4112,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m137:
     component: straight
     info:
@@ -4079,6 +4126,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m138:
     component: straight
     info:
@@ -4092,6 +4140,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m139:
     component: straight
     info:
@@ -4105,6 +4154,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m14:
     component: straight
     info:
@@ -4118,6 +4168,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m140:
     component: straight
     info:
@@ -4131,6 +4182,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m141:
     component: straight
     info:
@@ -4144,6 +4196,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m142:
     component: straight
     info:
@@ -4157,6 +4210,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m143:
     component: straight
     info:
@@ -4170,6 +4224,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m144:
     component: straight
     info:
@@ -4183,6 +4238,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m15:
     component: straight
     info:
@@ -4196,6 +4252,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m16:
     component: straight
     info:
@@ -4209,6 +4266,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m17:
     component: straight
     info:
@@ -4222,6 +4280,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m18:
     component: straight
     info:
@@ -4235,6 +4294,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m19:
     component: straight
     info:
@@ -4248,6 +4308,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m2:
     component: straight
     info:
@@ -4261,6 +4322,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m20:
     component: straight
     info:
@@ -4274,6 +4336,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m21:
     component: straight
     info:
@@ -4287,6 +4350,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m22:
     component: straight
     info:
@@ -4300,6 +4364,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m23:
     component: straight
     info:
@@ -4313,6 +4378,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m24:
     component: straight
     info:
@@ -4326,6 +4392,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m25:
     component: straight
     info:
@@ -4339,6 +4406,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m26:
     component: straight
     info:
@@ -4352,6 +4420,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m27:
     component: straight
     info:
@@ -4365,6 +4434,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m28:
     component: straight
     info:
@@ -4378,6 +4448,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m29:
     component: straight
     info:
@@ -4391,6 +4462,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m3:
     component: straight
     info:
@@ -4404,6 +4476,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m30:
     component: straight
     info:
@@ -4417,6 +4490,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m31:
     component: straight
     info:
@@ -4430,6 +4504,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m32:
     component: straight
     info:
@@ -4443,6 +4518,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m33:
     component: straight
     info:
@@ -4456,6 +4532,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m34:
     component: straight
     info:
@@ -4469,6 +4546,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m35:
     component: straight
     info:
@@ -4482,6 +4560,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m36:
     component: straight
     info:
@@ -4495,6 +4574,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m37:
     component: straight
     info:
@@ -4508,6 +4588,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m38:
     component: straight
     info:
@@ -4521,6 +4602,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m39:
     component: straight
     info:
@@ -4534,6 +4616,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m4:
     component: straight
     info:
@@ -4547,6 +4630,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m40:
     component: straight
     info:
@@ -4560,6 +4644,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m41:
     component: straight
     info:
@@ -4573,6 +4658,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m42:
     component: straight
     info:
@@ -4586,6 +4672,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m43:
     component: straight
     info:
@@ -4599,6 +4686,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m44:
     component: straight
     info:
@@ -4612,6 +4700,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m45:
     component: straight
     info:
@@ -4625,6 +4714,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m46:
     component: straight
     info:
@@ -4638,6 +4728,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m47:
     component: straight
     info:
@@ -4651,6 +4742,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m48:
     component: straight
     info:
@@ -4664,6 +4756,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m49:
     component: straight
     info:
@@ -4677,6 +4770,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m5:
     component: straight
     info:
@@ -4690,6 +4784,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m50:
     component: straight
     info:
@@ -4703,6 +4798,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m51:
     component: straight
     info:
@@ -4716,6 +4812,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m52:
     component: straight
     info:
@@ -4729,6 +4826,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m53:
     component: straight
     info:
@@ -4742,6 +4840,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m54:
     component: straight
     info:
@@ -4755,6 +4854,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m55:
     component: straight
     info:
@@ -4768,6 +4868,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m56:
     component: straight
     info:
@@ -4781,6 +4882,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m57:
     component: straight
     info:
@@ -4794,6 +4896,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m58:
     component: straight
     info:
@@ -4807,6 +4910,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m59:
     component: straight
     info:
@@ -4820,6 +4924,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m6:
     component: straight
     info:
@@ -4833,6 +4938,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m60:
     component: straight
     info:
@@ -4846,6 +4952,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m61:
     component: straight
     info:
@@ -4859,6 +4966,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m62:
     component: straight
     info:
@@ -4872,6 +4980,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m63:
     component: straight
     info:
@@ -4885,6 +4994,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m64:
     component: straight
     info:
@@ -4898,6 +5008,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m65:
     component: straight
     info:
@@ -4911,6 +5022,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m66:
     component: straight
     info:
@@ -4924,6 +5036,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m67:
     component: straight
     info:
@@ -4937,6 +5050,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m68:
     component: straight
     info:
@@ -4950,6 +5064,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m69:
     component: straight
     info:
@@ -4963,6 +5078,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m7:
     component: straight
     info:
@@ -4976,6 +5092,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m70:
     component: straight
     info:
@@ -4989,6 +5106,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m71:
     component: straight
     info:
@@ -5002,6 +5120,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m72:
     component: straight
     info:
@@ -5015,6 +5134,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m73:
     component: straight
     info:
@@ -5028,6 +5148,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m74:
     component: straight
     info:
@@ -5041,6 +5162,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m75:
     component: straight
     info:
@@ -5054,6 +5176,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m76:
     component: straight
     info:
@@ -5067,6 +5190,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m77:
     component: straight
     info:
@@ -5080,6 +5204,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m78:
     component: straight
     info:
@@ -5093,6 +5218,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m79:
     component: straight
     info:
@@ -5106,6 +5232,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m8:
     component: straight
     info:
@@ -5119,6 +5246,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m80:
     component: straight
     info:
@@ -5132,6 +5260,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m81:
     component: straight
     info:
@@ -5145,6 +5274,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m82:
     component: straight
     info:
@@ -5158,6 +5288,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m83:
     component: straight
     info:
@@ -5171,6 +5302,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m84:
     component: straight
     info:
@@ -5184,6 +5316,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m85:
     component: straight
     info:
@@ -5197,6 +5330,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m86:
     component: straight
     info:
@@ -5210,6 +5344,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m87:
     component: straight
     info:
@@ -5223,6 +5358,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m88:
     component: straight
     info:
@@ -5236,6 +5372,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m89:
     component: straight
     info:
@@ -5249,6 +5386,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m9:
     component: straight
     info:
@@ -5262,6 +5400,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m90:
     component: straight
     info:
@@ -5275,6 +5414,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m91:
     component: straight
     info:
@@ -5288,6 +5428,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m92:
     component: straight
     info:
@@ -5301,6 +5442,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m93:
     component: straight
     info:
@@ -5314,6 +5456,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m94:
     component: straight
     info:
@@ -5327,6 +5470,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m95:
     component: straight
     info:
@@ -5340,6 +5484,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m96:
     component: straight
     info:
@@ -5353,6 +5498,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m97:
     component: straight
     info:
@@ -5366,6 +5512,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m98:
     component: straight
     info:
@@ -5379,6 +5526,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m99:
     component: straight
     info:
@@ -5392,6 +5540,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: cutback_bend90_Cbend_eu_378c1fb8
 nets:
 - p1: 1,o1

--- a/test-data-regression/test_netlists_cutback_bend90circular_.yml
+++ b/test-data-regression/test_netlists_cutback_bend90circular_.yml
@@ -12,6 +12,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '2':
     component: straight
     info:
@@ -25,6 +26,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '3':
     component: straight
     info:
@@ -38,6 +40,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '4':
     component: straight
     info:
@@ -51,6 +54,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   '5':
     component: straight
     info:
@@ -64,6 +68,7 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
+      width: null
   A1:
     component: bend_circular
     info:
@@ -3101,6 +3106,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m10:
     component: straight
     info:
@@ -3114,6 +3120,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m100:
     component: straight
     info:
@@ -3127,6 +3134,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m101:
     component: straight
     info:
@@ -3140,6 +3148,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m102:
     component: straight
     info:
@@ -3153,6 +3162,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m103:
     component: straight
     info:
@@ -3166,6 +3176,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m104:
     component: straight
     info:
@@ -3179,6 +3190,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m105:
     component: straight
     info:
@@ -3192,6 +3204,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m106:
     component: straight
     info:
@@ -3205,6 +3218,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m107:
     component: straight
     info:
@@ -3218,6 +3232,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m108:
     component: straight
     info:
@@ -3231,6 +3246,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m109:
     component: straight
     info:
@@ -3244,6 +3260,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m11:
     component: straight
     info:
@@ -3257,6 +3274,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m110:
     component: straight
     info:
@@ -3270,6 +3288,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m111:
     component: straight
     info:
@@ -3283,6 +3302,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m112:
     component: straight
     info:
@@ -3296,6 +3316,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m113:
     component: straight
     info:
@@ -3309,6 +3330,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m114:
     component: straight
     info:
@@ -3322,6 +3344,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m115:
     component: straight
     info:
@@ -3335,6 +3358,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m116:
     component: straight
     info:
@@ -3348,6 +3372,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m117:
     component: straight
     info:
@@ -3361,6 +3386,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m118:
     component: straight
     info:
@@ -3374,6 +3400,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m119:
     component: straight
     info:
@@ -3387,6 +3414,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m12:
     component: straight
     info:
@@ -3400,6 +3428,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m120:
     component: straight
     info:
@@ -3413,6 +3442,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m121:
     component: straight
     info:
@@ -3426,6 +3456,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m122:
     component: straight
     info:
@@ -3439,6 +3470,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m123:
     component: straight
     info:
@@ -3452,6 +3484,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m124:
     component: straight
     info:
@@ -3465,6 +3498,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m125:
     component: straight
     info:
@@ -3478,6 +3512,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m126:
     component: straight
     info:
@@ -3491,6 +3526,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m127:
     component: straight
     info:
@@ -3504,6 +3540,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m128:
     component: straight
     info:
@@ -3517,6 +3554,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m129:
     component: straight
     info:
@@ -3530,6 +3568,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m13:
     component: straight
     info:
@@ -3543,6 +3582,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m130:
     component: straight
     info:
@@ -3556,6 +3596,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m131:
     component: straight
     info:
@@ -3569,6 +3610,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m132:
     component: straight
     info:
@@ -3582,6 +3624,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m133:
     component: straight
     info:
@@ -3595,6 +3638,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m134:
     component: straight
     info:
@@ -3608,6 +3652,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m135:
     component: straight
     info:
@@ -3621,6 +3666,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m136:
     component: straight
     info:
@@ -3634,6 +3680,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m137:
     component: straight
     info:
@@ -3647,6 +3694,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m138:
     component: straight
     info:
@@ -3660,6 +3708,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m139:
     component: straight
     info:
@@ -3673,6 +3722,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m14:
     component: straight
     info:
@@ -3686,6 +3736,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m140:
     component: straight
     info:
@@ -3699,6 +3750,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m141:
     component: straight
     info:
@@ -3712,6 +3764,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m142:
     component: straight
     info:
@@ -3725,6 +3778,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m143:
     component: straight
     info:
@@ -3738,6 +3792,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m144:
     component: straight
     info:
@@ -3751,6 +3806,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m15:
     component: straight
     info:
@@ -3764,6 +3820,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m16:
     component: straight
     info:
@@ -3777,6 +3834,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m17:
     component: straight
     info:
@@ -3790,6 +3848,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m18:
     component: straight
     info:
@@ -3803,6 +3862,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m19:
     component: straight
     info:
@@ -3816,6 +3876,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m2:
     component: straight
     info:
@@ -3829,6 +3890,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m20:
     component: straight
     info:
@@ -3842,6 +3904,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m21:
     component: straight
     info:
@@ -3855,6 +3918,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m22:
     component: straight
     info:
@@ -3868,6 +3932,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m23:
     component: straight
     info:
@@ -3881,6 +3946,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m24:
     component: straight
     info:
@@ -3894,6 +3960,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m25:
     component: straight
     info:
@@ -3907,6 +3974,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m26:
     component: straight
     info:
@@ -3920,6 +3988,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m27:
     component: straight
     info:
@@ -3933,6 +4002,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m28:
     component: straight
     info:
@@ -3946,6 +4016,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m29:
     component: straight
     info:
@@ -3959,6 +4030,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m3:
     component: straight
     info:
@@ -3972,6 +4044,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m30:
     component: straight
     info:
@@ -3985,6 +4058,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m31:
     component: straight
     info:
@@ -3998,6 +4072,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m32:
     component: straight
     info:
@@ -4011,6 +4086,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m33:
     component: straight
     info:
@@ -4024,6 +4100,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m34:
     component: straight
     info:
@@ -4037,6 +4114,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m35:
     component: straight
     info:
@@ -4050,6 +4128,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m36:
     component: straight
     info:
@@ -4063,6 +4142,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m37:
     component: straight
     info:
@@ -4076,6 +4156,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m38:
     component: straight
     info:
@@ -4089,6 +4170,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m39:
     component: straight
     info:
@@ -4102,6 +4184,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m4:
     component: straight
     info:
@@ -4115,6 +4198,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m40:
     component: straight
     info:
@@ -4128,6 +4212,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m41:
     component: straight
     info:
@@ -4141,6 +4226,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m42:
     component: straight
     info:
@@ -4154,6 +4240,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m43:
     component: straight
     info:
@@ -4167,6 +4254,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m44:
     component: straight
     info:
@@ -4180,6 +4268,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m45:
     component: straight
     info:
@@ -4193,6 +4282,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m46:
     component: straight
     info:
@@ -4206,6 +4296,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m47:
     component: straight
     info:
@@ -4219,6 +4310,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m48:
     component: straight
     info:
@@ -4232,6 +4324,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m49:
     component: straight
     info:
@@ -4245,6 +4338,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m5:
     component: straight
     info:
@@ -4258,6 +4352,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m50:
     component: straight
     info:
@@ -4271,6 +4366,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m51:
     component: straight
     info:
@@ -4284,6 +4380,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m52:
     component: straight
     info:
@@ -4297,6 +4394,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m53:
     component: straight
     info:
@@ -4310,6 +4408,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m54:
     component: straight
     info:
@@ -4323,6 +4422,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m55:
     component: straight
     info:
@@ -4336,6 +4436,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m56:
     component: straight
     info:
@@ -4349,6 +4450,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m57:
     component: straight
     info:
@@ -4362,6 +4464,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m58:
     component: straight
     info:
@@ -4375,6 +4478,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m59:
     component: straight
     info:
@@ -4388,6 +4492,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m6:
     component: straight
     info:
@@ -4401,6 +4506,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m60:
     component: straight
     info:
@@ -4414,6 +4520,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m61:
     component: straight
     info:
@@ -4427,6 +4534,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m62:
     component: straight
     info:
@@ -4440,6 +4548,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m63:
     component: straight
     info:
@@ -4453,6 +4562,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m64:
     component: straight
     info:
@@ -4466,6 +4576,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m65:
     component: straight
     info:
@@ -4479,6 +4590,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m66:
     component: straight
     info:
@@ -4492,6 +4604,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m67:
     component: straight
     info:
@@ -4505,6 +4618,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m68:
     component: straight
     info:
@@ -4518,6 +4632,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m69:
     component: straight
     info:
@@ -4531,6 +4646,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m7:
     component: straight
     info:
@@ -4544,6 +4660,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m70:
     component: straight
     info:
@@ -4557,6 +4674,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m71:
     component: straight
     info:
@@ -4570,6 +4688,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m72:
     component: straight
     info:
@@ -4583,6 +4702,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m73:
     component: straight
     info:
@@ -4596,6 +4716,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m74:
     component: straight
     info:
@@ -4609,6 +4730,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m75:
     component: straight
     info:
@@ -4622,6 +4744,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m76:
     component: straight
     info:
@@ -4635,6 +4758,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m77:
     component: straight
     info:
@@ -4648,6 +4772,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m78:
     component: straight
     info:
@@ -4661,6 +4786,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m79:
     component: straight
     info:
@@ -4674,6 +4800,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m8:
     component: straight
     info:
@@ -4687,6 +4814,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m80:
     component: straight
     info:
@@ -4700,6 +4828,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m81:
     component: straight
     info:
@@ -4713,6 +4842,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m82:
     component: straight
     info:
@@ -4726,6 +4856,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m83:
     component: straight
     info:
@@ -4739,6 +4870,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m84:
     component: straight
     info:
@@ -4752,6 +4884,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m85:
     component: straight
     info:
@@ -4765,6 +4898,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m86:
     component: straight
     info:
@@ -4778,6 +4912,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m87:
     component: straight
     info:
@@ -4791,6 +4926,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m88:
     component: straight
     info:
@@ -4804,6 +4940,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m89:
     component: straight
     info:
@@ -4817,6 +4954,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m9:
     component: straight
     info:
@@ -4830,6 +4968,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m90:
     component: straight
     info:
@@ -4843,6 +4982,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m91:
     component: straight
     info:
@@ -4856,6 +4996,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m92:
     component: straight
     info:
@@ -4869,6 +5010,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m93:
     component: straight
     info:
@@ -4882,6 +5024,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m94:
     component: straight
     info:
@@ -4895,6 +5038,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m95:
     component: straight
     info:
@@ -4908,6 +5052,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m96:
     component: straight
     info:
@@ -4921,6 +5066,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m97:
     component: straight
     info:
@@ -4934,6 +5080,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m98:
     component: straight
     info:
@@ -4947,6 +5094,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m99:
     component: straight
     info:
@@ -4960,6 +5108,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: cutback_bend90_Cbend_ci_790928a7
 nets:
 - p1: 1,o1

--- a/test-data-regression/test_netlists_cutback_bend_.yml
+++ b/test-data-regression/test_netlists_cutback_bend_.yml
@@ -1644,6 +1644,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S10:
     component: straight
     info:
@@ -1657,6 +1658,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S11:
     component: straight
     info:
@@ -1670,6 +1672,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S12:
     component: straight
     info:
@@ -1683,6 +1686,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S13:
     component: straight
     info:
@@ -1696,6 +1700,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S14:
     component: straight
     info:
@@ -1709,6 +1714,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S15:
     component: straight
     info:
@@ -1722,6 +1728,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S16:
     component: straight
     info:
@@ -1735,6 +1742,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S17:
     component: straight
     info:
@@ -1748,6 +1756,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S18:
     component: straight
     info:
@@ -1761,6 +1770,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S19:
     component: straight
     info:
@@ -1774,6 +1784,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S2:
     component: straight
     info:
@@ -1787,6 +1798,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S20:
     component: straight
     info:
@@ -1800,6 +1812,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S21:
     component: straight
     info:
@@ -1813,6 +1826,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S22:
     component: straight
     info:
@@ -1826,6 +1840,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S23:
     component: straight
     info:
@@ -1839,6 +1854,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S24:
     component: straight
     info:
@@ -1852,6 +1868,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S25:
     component: straight
     info:
@@ -1865,6 +1882,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S26:
     component: straight
     info:
@@ -1878,6 +1896,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S27:
     component: straight
     info:
@@ -1891,6 +1910,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S28:
     component: straight
     info:
@@ -1904,6 +1924,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S29:
     component: straight
     info:
@@ -1917,6 +1938,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S3:
     component: straight
     info:
@@ -1930,6 +1952,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S30:
     component: straight
     info:
@@ -1943,6 +1966,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S31:
     component: straight
     info:
@@ -1956,6 +1980,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S32:
     component: straight
     info:
@@ -1969,6 +1994,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S33:
     component: straight
     info:
@@ -1982,6 +2008,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S34:
     component: straight
     info:
@@ -1995,6 +2022,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S35:
     component: straight
     info:
@@ -2008,6 +2036,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S36:
     component: straight
     info:
@@ -2021,6 +2050,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S37:
     component: straight
     info:
@@ -2034,6 +2064,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S38:
     component: straight
     info:
@@ -2047,6 +2078,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S39:
     component: straight
     info:
@@ -2060,6 +2092,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S4:
     component: straight
     info:
@@ -2073,6 +2106,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S40:
     component: straight
     info:
@@ -2086,6 +2120,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S41:
     component: straight
     info:
@@ -2099,6 +2134,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S42:
     component: straight
     info:
@@ -2112,6 +2148,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S43:
     component: straight
     info:
@@ -2125,6 +2162,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S44:
     component: straight
     info:
@@ -2138,6 +2176,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S45:
     component: straight
     info:
@@ -2151,6 +2190,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S46:
     component: straight
     info:
@@ -2164,6 +2204,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S47:
     component: straight
     info:
@@ -2177,6 +2218,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S48:
     component: straight
     info:
@@ -2190,6 +2232,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S49:
     component: straight
     info:
@@ -2203,6 +2246,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S5:
     component: straight
     info:
@@ -2216,6 +2260,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S50:
     component: straight
     info:
@@ -2229,6 +2274,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S51:
     component: straight
     info:
@@ -2242,6 +2288,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S52:
     component: straight
     info:
@@ -2255,6 +2302,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S53:
     component: straight
     info:
@@ -2268,6 +2316,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S54:
     component: straight
     info:
@@ -2281,6 +2330,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S55:
     component: straight
     info:
@@ -2294,6 +2344,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S56:
     component: straight
     info:
@@ -2307,6 +2358,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S57:
     component: straight
     info:
@@ -2320,6 +2372,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S58:
     component: straight
     info:
@@ -2333,6 +2386,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S59:
     component: straight
     info:
@@ -2346,6 +2400,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S6:
     component: straight
     info:
@@ -2359,6 +2414,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S60:
     component: straight
     info:
@@ -2372,6 +2428,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S61:
     component: straight
     info:
@@ -2385,6 +2442,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S62:
     component: straight
     info:
@@ -2398,6 +2456,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S63:
     component: straight
     info:
@@ -2411,6 +2470,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S64:
     component: straight
     info:
@@ -2424,6 +2484,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S65:
     component: straight
     info:
@@ -2437,6 +2498,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S66:
     component: straight
     info:
@@ -2450,6 +2512,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S67:
     component: straight
     info:
@@ -2463,6 +2526,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S68:
     component: straight
     info:
@@ -2476,6 +2540,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S7:
     component: straight
     info:
@@ -2489,6 +2554,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S8:
     component: straight
     info:
@@ -2502,6 +2568,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   S9:
     component: straight
     info:
@@ -2515,6 +2582,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: cutback_bend_Cbend_eule_117ca8a7
 nets:
 - p1: A1,o2

--- a/test-data-regression/test_netlists_cutback_component_mirror_.yml
+++ b/test-data-regression/test_netlists_cutback_component_mirror_.yml
@@ -684,6 +684,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
   m1:
     component: straight
     info:
@@ -697,6 +698,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
 name: cutback_component_CFtap_4bce6c9a
 nets:
 - p1: A1,o2

--- a/test-data-regression/test_netlists_cutback_splitter_.yml
+++ b/test-data-regression/test_netlists_cutback_splitter_.yml
@@ -1244,6 +1244,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
   m1:
     component: straight
     info:
@@ -1257,6 +1258,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
 name: cutback_splitter_Cmmi1x_5fd4c12d
 nets:
 - p1: A1,o2

--- a/test-data-regression/test_netlists_dbr_.yml
+++ b/test-data-regression/test_netlists_dbr_.yml
@@ -12,7 +12,7 @@ instances:
       l2: 0.159
       w1: 0.45
       w2: 0.55
-  straight_L0p01_N2_CSstrip_0_0:
+  straight_L0p01_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 0.01
@@ -25,7 +25,8 @@ instances:
       cross_section: strip
       length: 0.01
       npoints: 2
-  straight_L0p01_N2_CSstrip_3180_0:
+      width: null
+  straight_L0p01_N2_CSstrip_WNone_3180_0:
     component: straight
     info:
       length: 0.01
@@ -38,10 +39,11 @@ instances:
       cross_section: strip
       length: 0.01
       npoints: 2
+      width: null
 name: dbr_W0p45_W0p55_L0p159__efcfb70c
 nets:
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<0.0>,o1
-  p2: straight_L0p01_N2_CSstrip_0_0,o1
+  p2: straight_L0p01_N2_CSstrip_WNone_0_0,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<0.0>,o2
   p2: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<1.0>,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<1.0>,o2
@@ -61,47 +63,47 @@ nets:
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<8.0>,o2
   p2: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<9.0>,o1
 - p1: dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<9.0>,o2
-  p2: straight_L0p01_N2_CSstrip_3180_0,o1
+  p2: straight_L0p01_N2_CSstrip_WNone_3180_0,o1
 placements:
   dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_L0p01_N2_CSstrip_0_0:
+  straight_L0p01_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 180
     x: 0
     y: 0
-  straight_L0p01_N2_CSstrip_3180_0:
+  straight_L0p01_N2_CSstrip_WNone_3180_0:
     mirror: false
     rotation: 0
     x: 3.18
     y: 0
 ports:
-  o1: straight_L0p01_N2_CSstrip_0_0,o2
+  o1: straight_L0p01_N2_CSstrip_WNone_0_0,o2
 warnings:
   optical:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - straight_L0p01_N2_CSstrip_3180_0,o2
+      - straight_L0p01_N2_CSstrip_WNone_3180_0,o2
       values:
       - - 3190
         - 0
     width_mismatch:
-    - message: Widths of ports straight_L0p01_N2_CSstrip_0_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<0.0>,o1
+    - message: Widths of ports straight_L0p01_N2_CSstrip_WNone_0_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<0.0>,o1
         not equal. Difference of 50 um
       ports:
-      - straight_L0p01_N2_CSstrip_0_0,o1
+      - straight_L0p01_N2_CSstrip_WNone_0_0,o1
       - dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<0.0>,o1
       values:
       - 500
       - 450
-    - message: Widths of ports straight_L0p01_N2_CSstrip_3180_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<9.0>,o2
+    - message: Widths of ports straight_L0p01_N2_CSstrip_WNone_3180_0,o1 and dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<9.0>,o2
         not equal. Difference of 50 um
       ports:
-      - straight_L0p01_N2_CSstrip_3180_0,o1
+      - straight_L0p01_N2_CSstrip_WNone_3180_0,o1
       - dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0<9.0>,o2
       values:
       - 500

--- a/test-data-regression/test_netlists_dbr_tapered_.yml
+++ b/test-data-regression/test_netlists_dbr_tapered_.yml
@@ -28,7 +28,7 @@ instances:
       length: 10
       npoints: 2
       width: 0.4
-  taper_L20_W0p4_W1_PNone_0f93cfde_5000_0:
+  taper_L20_W0p4_W1_LNone_1073290e_5000_0:
     component: taper
     info:
       length: 20
@@ -36,6 +36,7 @@ instances:
       width2: 1
     settings:
       cross_section: strip
+      layer: null
       length: 20
       port: null
       port_names:
@@ -48,7 +49,7 @@ instances:
       width2: 1
       with_bbox: true
       with_two_ports: true
-  taper_L20_W1_W0p4_PNone_92d96627_m25000_0:
+  taper_L20_W1_W0p4_LNone_ebd83a58_m25000_0:
     component: taper
     info:
       length: 20
@@ -56,6 +57,7 @@ instances:
       width2: 0.4
     settings:
       cross_section: strip
+      layer: null
       length: 20
       port: null
       port_names:
@@ -71,9 +73,9 @@ instances:
 name: dbr_tapered_L10_P0p85_D_9872475d
 nets:
 - p1: straight_L10_N2_CSstrip_W0p4_m5000_0,o1
-  p2: taper_L20_W1_W0p4_PNone_92d96627_m25000_0,o2
+  p2: taper_L20_W1_W0p4_LNone_ebd83a58_m25000_0,o2
 - p1: straight_L10_N2_CSstrip_W0p4_m5000_0,o2
-  p2: taper_L20_W0p4_W1_PNone_0f93cfde_5000_0,o1
+  p2: taper_L20_W0p4_W1_LNone_1073290e_5000_0,o1
 placements:
   array_Crectangle_S0p424_fb9b4fef_m24437_m500:
     mirror: false
@@ -85,19 +87,19 @@ placements:
     rotation: 0
     x: -5
     y: 0
-  taper_L20_W0p4_W1_PNone_0f93cfde_5000_0:
+  taper_L20_W0p4_W1_LNone_1073290e_5000_0:
     mirror: false
     rotation: 0
     x: 5
     y: 0
-  taper_L20_W1_W0p4_PNone_92d96627_m25000_0:
+  taper_L20_W1_W0p4_LNone_ebd83a58_m25000_0:
     mirror: false
     rotation: 0
     x: -25
     y: 0
 ports:
-  o1: taper_L20_W1_W0p4_PNone_92d96627_m25000_0,o1
-  o2: taper_L20_W0p4_W1_PNone_0f93cfde_5000_0,o2
+  o1: taper_L20_W1_W0p4_LNone_ebd83a58_m25000_0,o1
+  o2: taper_L20_W0p4_W1_LNone_1073290e_5000_0,o2
 warnings:
   electrical:
     unconnected_ports:

--- a/test-data-regression/test_netlists_delay_snake_sbend_.yml
+++ b/test-data-regression/test_netlists_delay_snake_sbend_.yml
@@ -80,6 +80,7 @@ instances:
       cross_section: strip
       length: 78.681
       npoints: 2
+      width: null
   s3:
     component: straight
     info:
@@ -93,6 +94,7 @@ instances:
       cross_section: strip
       length: 78.681
       npoints: 2
+      width: null
 name: delay_snake_sbend_L100__a249e5b3
 nets:
 - p1: bend_euler_R5_A180_P0p5_7f7c6f20_0_m10000,o1

--- a/test-data-regression/test_netlists_edge_coupler_array_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_.yml
@@ -7,6 +7,7 @@ instances:
       width2: 0.2
     settings:
       cross_section: strip
+      layer: null
       length: 100
       port: null
       port_names:
@@ -27,6 +28,7 @@ instances:
       width2: 0.2
     settings:
       cross_section: strip
+      layer: null
       length: 100
       port: null
       port_names:
@@ -47,6 +49,7 @@ instances:
       width2: 0.2
     settings:
       cross_section: strip
+      layer: null
       length: 100
       port: null
       port_names:
@@ -67,6 +70,7 @@ instances:
       width2: 0.2
     settings:
       cross_section: strip
+      layer: null
       length: 100
       port: null
       port_names:
@@ -87,6 +91,7 @@ instances:
       width2: 0.2
     settings:
       cross_section: strip
+      layer: null
       length: 100
       port: null
       port_names:

--- a/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -113,7 +113,7 @@ instances:
       - o1
       - o2
       port_type: optical
-  straight_L67_N2_CSstrip_m30000_859000:
+  straight_L67_N2_CSstrip_WNone_m30000_859000:
     component: straight
     info:
       length: 67
@@ -126,7 +126,8 @@ instances:
       cross_section: strip
       length: 67
       npoints: 2
-  straight_L67_N2_CSstrip_m31000_97000:
+      width: null
+  straight_L67_N2_CSstrip_WNone_m31000_97000:
     component: straight
     info:
       length: 67
@@ -139,22 +140,23 @@ instances:
       cross_section: strip
       length: 67
       npoints: 2
+      width: null
 name: edge_coupler_array_with_0e29eb5f
 nets:
 - p1: bend_euler_R30_A90_P0p5_6f642382_0_889000,o1
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o8
 - p1: bend_euler_R30_A90_P0p5_6f642382_0_889000,o2
-  p2: straight_L67_N2_CSstrip_m30000_859000,o1
+  p2: straight_L67_N2_CSstrip_WNone_m30000_859000,o1
 - p1: bend_euler_R30_A90_P0p5_6f642382_m1000_127000,o1
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o2
 - p1: bend_euler_R30_A90_P0p5_6f642382_m1000_127000,o2
-  p2: straight_L67_N2_CSstrip_m31000_97000,o1
+  p2: straight_L67_N2_CSstrip_WNone_m31000_97000,o1
 - p1: bend_euler_R30_A90_P0p5_6f642382_m30000_792000,o1
-  p2: straight_L67_N2_CSstrip_m30000_859000,o2
+  p2: straight_L67_N2_CSstrip_WNone_m30000_859000,o2
 - p1: bend_euler_R30_A90_P0p5_6f642382_m30000_792000,o2
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o7
 - p1: bend_euler_R30_A90_P0p5_6f642382_m31000_30000,o1
-  p2: straight_L67_N2_CSstrip_m31000_97000,o2
+  p2: straight_L67_N2_CSstrip_WNone_m31000_97000,o2
 - p1: bend_euler_R30_A90_P0p5_6f642382_m31000_30000,o2
   p2: extend_ports_Cedge_coup_a17a8c07_0_0,o1
 placements:
@@ -183,12 +185,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L67_N2_CSstrip_m30000_859000:
+  straight_L67_N2_CSstrip_WNone_m30000_859000:
     mirror: false
     rotation: 270
     x: -30
     y: 859
-  straight_L67_N2_CSstrip_m31000_97000:
+  straight_L67_N2_CSstrip_WNone_m31000_97000:
     mirror: false
     rotation: 270
     x: -31

--- a/test-data-regression/test_netlists_edge_coupler_silicon_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_silicon_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: taper_L100_W0p5_W0p2_PN_82884949
+name: taper_L100_W0p5_W0p2_LN_b7de9566
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_extend_ports_.yml
+++ b/test-data-regression/test_netlists_extend_ports_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L5_N2_CSxs_9400d77f_15500_625:
+  straight_L5_N2_CSxs_940_9241d340_15500_625:
     component: straight
     info:
       length: 5
@@ -12,7 +12,8 @@ instances:
       cross_section: xs_9400d77f
       length: 5
       npoints: 2
-  straight_L5_N2_CSxs_9400d77f_15500_m625:
+      width: null
+  straight_L5_N2_CSxs_940_9241d340_15500_m625:
     component: straight
     info:
       length: 5
@@ -25,7 +26,8 @@ instances:
       cross_section: xs_9400d77f
       length: 5
       npoints: 2
-  straight_L5_N2_CSxs_9400d77f_m10000_0:
+      width: null
+  straight_L5_N2_CSxs_940_9241d340_m10000_0:
     component: straight
     info:
       length: 5
@@ -38,36 +40,37 @@ instances:
       cross_section: xs_9400d77f
       length: 5
       npoints: 2
+      width: null
 name: extend_ports_Cmmi1x2_PN_b9f68e2a
 nets: []
 placements:
-  straight_L5_N2_CSxs_9400d77f_15500_625:
+  straight_L5_N2_CSxs_940_9241d340_15500_625:
     mirror: false
     rotation: 0
     x: 15.5
     y: 0.625
-  straight_L5_N2_CSxs_9400d77f_15500_m625:
+  straight_L5_N2_CSxs_940_9241d340_15500_m625:
     mirror: false
     rotation: 0
     x: 15.5
     y: -0.625
-  straight_L5_N2_CSxs_9400d77f_m10000_0:
+  straight_L5_N2_CSxs_940_9241d340_m10000_0:
     mirror: false
     rotation: 180
     x: -10
     y: 0
 ports:
-  o1: straight_L5_N2_CSxs_9400d77f_m10000_0,o2
-  o2: straight_L5_N2_CSxs_9400d77f_15500_625,o2
-  o3: straight_L5_N2_CSxs_9400d77f_15500_m625,o2
+  o1: straight_L5_N2_CSxs_940_9241d340_m10000_0,o2
+  o2: straight_L5_N2_CSxs_940_9241d340_15500_625,o2
+  o3: straight_L5_N2_CSxs_940_9241d340_15500_m625,o2
 warnings:
   optical:
     unconnected_ports:
     - message: 3 unconnected optical ports!
       ports:
-      - straight_L5_N2_CSxs_9400d77f_m10000_0,o1
-      - straight_L5_N2_CSxs_9400d77f_15500_625,o1
-      - straight_L5_N2_CSxs_9400d77f_15500_m625,o1
+      - straight_L5_N2_CSxs_940_9241d340_m10000_0,o1
+      - straight_L5_N2_CSxs_940_9241d340_15500_625,o1
+      - straight_L5_N2_CSxs_940_9241d340_15500_m625,o1
       values:
       - - -10000
         - 0

--- a/test-data-regression/test_netlists_ge_detector_straight_si_contacts_.yml
+++ b/test-data-regression/test_netlists_ge_detector_straight_si_contacts_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L40_N2_CSpn_ge_ef2cc18e_0_0:
+  straight_L40_N2_CSpn_ge_a66790e3_0_0:
     component: straight
     info:
       length: 40
@@ -12,7 +12,8 @@ instances:
       cross_section: pn_ge_detector_si_contacts
       length: 40
       npoints: 2
-  taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0:
+      width: null
+  taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0:
     component: taper
     info:
       length: 20
@@ -20,6 +21,7 @@ instances:
       width2: 0.8
     settings:
       cross_section: strip
+      layer: null
       length: 20
       port: null
       port_names:
@@ -94,15 +96,15 @@ instances:
       - null
 name: ge_detector_straight_si_857c1c1e
 nets:
-- p1: straight_L40_N2_CSpn_ge_ef2cc18e_0_0,o1
-  p2: taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0,o2
+- p1: straight_L40_N2_CSpn_ge_a66790e3_0_0,o1
+  p2: taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0,o2
 placements:
-  straight_L40_N2_CSpn_ge_ef2cc18e_0_0:
+  straight_L40_N2_CSpn_ge_a66790e3_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0:
+  taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0:
     mirror: false
     rotation: 0
     x: -20
@@ -122,7 +124,7 @@ ports:
   bot_e2: via_stack_S40_10_LSLAB9_7a3de302_20000_m7500,e2
   bot_e3: via_stack_S40_10_LSLAB9_7a3de302_20000_m7500,e3
   bot_e4: via_stack_S40_10_LSLAB9_7a3de302_20000_m7500,e4
-  o1: taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0,o1
+  o1: taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0,o1
   top_e1: via_stack_S40_10_LSLAB9_7a3de302_20000_7500,e1
   top_e2: via_stack_S40_10_LSLAB9_7a3de302_20000_7500,e2
   top_e3: via_stack_S40_10_LSLAB9_7a3de302_20000_7500,e3
@@ -132,16 +134,16 @@ warnings:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - straight_L40_N2_CSpn_ge_ef2cc18e_0_0,o2
+      - straight_L40_N2_CSpn_ge_a66790e3_0_0,o2
       values:
       - - 40000
         - 0
     width_mismatch:
-    - message: Widths of ports straight_L40_N2_CSpn_ge_ef2cc18e_0_0,o1 and taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0,o2
+    - message: Widths of ports straight_L40_N2_CSpn_ge_a66790e3_0_0,o1 and taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0,o2
         not equal. Difference of 5200 um
       ports:
-      - straight_L40_N2_CSpn_ge_ef2cc18e_0_0,o1
-      - taper_L20_W0p5_W0p8_PNo_1374d3b8_m20000_0,o2
+      - straight_L40_N2_CSpn_ge_a66790e3_0_0,o1
+      - taper_L20_W0p5_W0p8_LNo_b621feeb_m20000_0,o2
       values:
       - 6000
       - 800

--- a/test-data-regression/test_netlists_grating_coupler_dual_pol_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_dual_pol_.yml
@@ -33,7 +33,7 @@ instances:
       size:
       - 11
       - 11
-  taper_L150_W0p5_W10_PNo_6147a3d5_0_m155500:
+  taper_L150_W0p5_W10_LNo_29b81de7_0_m155500:
     component: taper
     info:
       length: 150
@@ -41,6 +41,7 @@ instances:
       width2: 10
     settings:
       cross_section: strip
+      layer: null
       length: 150
       port: null
       port_names:
@@ -53,7 +54,7 @@ instances:
       width2: 10
       with_bbox: true
       with_two_ports: true
-  taper_L150_W0p5_W10_PNo_6147a3d5_m155500_0:
+  taper_L150_W0p5_W10_LNo_29b81de7_m155500_0:
     component: taper
     info:
       length: 150
@@ -61,6 +62,7 @@ instances:
       width2: 10
     settings:
       cross_section: strip
+      layer: null
       length: 150
       port: null
       port_names:
@@ -86,26 +88,26 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  taper_L150_W0p5_W10_PNo_6147a3d5_0_m155500:
+  taper_L150_W0p5_W10_LNo_29b81de7_0_m155500:
     mirror: false
     rotation: 90
     x: 0
     y: -155.5
-  taper_L150_W0p5_W10_PNo_6147a3d5_m155500_0:
+  taper_L150_W0p5_W10_LNo_29b81de7_m155500_0:
     mirror: false
     rotation: 0
     x: -155.5
     y: 0
 ports:
-  o1: taper_L150_W0p5_W10_PNo_6147a3d5_m155500_0,o1
-  o2: taper_L150_W0p5_W10_PNo_6147a3d5_0_m155500,o1
+  o1: taper_L150_W0p5_W10_LNo_29b81de7_m155500_0,o1
+  o2: taper_L150_W0p5_W10_LNo_29b81de7_0_m155500,o1
 warnings:
   optical:
     unconnected_ports:
     - message: 2 unconnected optical ports!
       ports:
-      - taper_L150_W0p5_W10_PNo_6147a3d5_m155500_0,o2
-      - taper_L150_W0p5_W10_PNo_6147a3d5_0_m155500,o2
+      - taper_L150_W0p5_W10_LNo_29b81de7_m155500_0,o2
+      - taper_L150_W0p5_W10_LNo_29b81de7_0_m155500,o2
       values:
       - - -5500
         - 0

--- a/test-data-regression/test_netlists_grating_coupler_elliptical_lumerical_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_elliptical_lumerical_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: grating_coupler_ellipti_b2b21f8a
+name: grating_coupler_ellipti_4c46b398
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_grating_coupler_loss_fiber_array_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_loss_fiber_array_.yml
@@ -91,7 +91,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_117000_49529:
+  straight_L107_N2_CSstrip_WNone_117000_49529:
     component: straight
     info:
       length: 107
@@ -104,7 +104,8 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-  straight_L40_N2_CSstrip_0_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_0_39529:
     component: straight
     info:
       length: 40
@@ -117,7 +118,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_127000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_127000_39529:
     component: straight
     info:
       length: 40
@@ -130,20 +132,21 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
+      width: null
 name: grating_coupler_loss_fi_1149cf5f
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
-  p2: straight_L107_N2_CSstrip_117000_49529,o2
+  p2: straight_L107_N2_CSstrip_WNone_117000_49529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_0_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o1
-  p2: straight_L40_N2_CSstrip_127000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_127000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o2
-  p2: straight_L107_N2_CSstrip_117000_49529,o1
+  p2: straight_L107_N2_CSstrip_WNone_117000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_0_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L40_N2_CSstrip_127000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_127000_39529,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
@@ -165,17 +168,17 @@ placements:
     rotation: 270
     x: 127
     y: 0
-  straight_L107_N2_CSstrip_117000_49529:
+  straight_L107_N2_CSstrip_WNone_117000_49529:
     mirror: false
     rotation: 180
     x: 117
     y: 49.529
-  straight_L40_N2_CSstrip_0_39529:
+  straight_L40_N2_CSstrip_WNone_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_127000_39529:
+  straight_L40_N2_CSstrip_WNone_127000_39529:
     mirror: false
     rotation: 270
     x: 127

--- a/test-data-regression/test_netlists_grating_coupler_rectangular_arbitrary_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_rectangular_arbitrary_.yml
@@ -1,5 +1,5 @@
 instances:
-  taper_L150_W0p5_W11_PNo_497f27e7_0_0:
+  taper_L150_W0p5_W11_LNo_935c804f_0_0:
     component: taper
     info:
       length: 150
@@ -7,6 +7,7 @@ instances:
       width2: 11
     settings:
       cross_section: strip
+      layer: null
       length: 150
       port: null
       port_names:
@@ -22,19 +23,19 @@ instances:
 name: grating_coupler_rectang_484ead2a
 nets: []
 placements:
-  taper_L150_W0p5_W11_PNo_497f27e7_0_0:
+  taper_L150_W0p5_W11_LNo_935c804f_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: taper_L150_W0p5_W11_PNo_497f27e7_0_0,o1
+  o1: taper_L150_W0p5_W11_LNo_935c804f_0_0,o1
 warnings:
   optical:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - taper_L150_W0p5_W11_PNo_497f27e7_0_0,o2
+      - taper_L150_W0p5_W11_LNo_935c804f_0_0,o2
       values:
       - - 150000
         - 0

--- a/test-data-regression/test_netlists_grating_coupler_tree_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_tree_.yml
@@ -359,7 +359,7 @@ instances:
       taper_angle: 40
       taper_length: 16.6
       wavelength: 1.554
-  straight_L175p5_N2_CSstrip_185500_4500:
+  straight_L175p5_N2_CSstrip_WNone_185500_4500:
     component: straight
     info:
       length: 175.5
@@ -372,7 +372,8 @@ instances:
       cross_section: strip
       length: 175.5
       npoints: 2
-  straight_L175p5_N2_CSstrip_m175500_4500:
+      width: null
+  straight_L175p5_N2_CSstrip_WNone_m175500_4500:
     component: straight
     info:
       length: 175.5
@@ -385,7 +386,8 @@ instances:
       cross_section: strip
       length: 175.5
       npoints: 2
-  straight_L302p5_N2_CSstrip_312500_9000:
+      width: null
+  straight_L302p5_N2_CSstrip_WNone_312500_9000:
     component: straight
     info:
       length: 302.5
@@ -398,7 +400,8 @@ instances:
       cross_section: strip
       length: 302.5
       npoints: 2
-  straight_L302p5_N2_CSstrip_m302500_9000:
+      width: null
+  straight_L302p5_N2_CSstrip_WNone_m302500_9000:
     component: straight
     info:
       length: 302.5
@@ -411,7 +414,8 @@ instances:
       cross_section: strip
       length: 302.5
       npoints: 2
-  straight_L429p5_N2_CSstrip_439500_13500:
+      width: null
+  straight_L429p5_N2_CSstrip_WNone_439500_13500:
     component: straight
     info:
       length: 429.5
@@ -424,7 +428,8 @@ instances:
       cross_section: strip
       length: 429.5
       npoints: 2
-  straight_L429p5_N2_CSstrip_m429500_13500:
+      width: null
+  straight_L429p5_N2_CSstrip_WNone_m429500_13500:
     component: straight
     info:
       length: 429.5
@@ -437,7 +442,8 @@ instances:
       cross_section: strip
       length: 429.5
       npoints: 2
-  straight_L48p5_N2_CSstrip_58500_0:
+      width: null
+  straight_L48p5_N2_CSstrip_WNone_58500_0:
     component: straight
     info:
       length: 48.5
@@ -450,7 +456,8 @@ instances:
       cross_section: strip
       length: 48.5
       npoints: 2
-  straight_L48p5_N2_CSstrip_m48500_0:
+      width: null
+  straight_L48p5_N2_CSstrip_WNone_m48500_0:
     component: straight
     info:
       length: 48.5
@@ -463,7 +470,8 @@ instances:
       cross_section: strip
       length: 48.5
       npoints: 2
-  straight_L59p5_N2_CSstrip_68500_m10000:
+      width: null
+  straight_L59p5_N2_CSstrip_WNone_68500_m10000:
     component: straight
     info:
       length: 59.5
@@ -476,7 +484,8 @@ instances:
       cross_section: strip
       length: 59.5
       npoints: 2
-  straight_L59p5_N2_CSstrip_m58500_m10000:
+      width: null
+  straight_L59p5_N2_CSstrip_WNone_m58500_m10000:
     component: straight
     info:
       length: 59.5
@@ -489,7 +498,8 @@ instances:
       cross_section: strip
       length: 59.5
       npoints: 2
-  straight_L64_N2_CSstrip_195500_m5500:
+      width: null
+  straight_L64_N2_CSstrip_WNone_195500_m5500:
     component: straight
     info:
       length: 64
@@ -502,7 +512,8 @@ instances:
       cross_section: strip
       length: 64
       npoints: 2
-  straight_L64_N2_CSstrip_m185500_m5500:
+      width: null
+  straight_L64_N2_CSstrip_WNone_m185500_m5500:
     component: straight
     info:
       length: 64
@@ -515,7 +526,8 @@ instances:
       cross_section: strip
       length: 64
       npoints: 2
-  straight_L68p5_N2_CSstrip_322500_m1000:
+      width: null
+  straight_L68p5_N2_CSstrip_WNone_322500_m1000:
     component: straight
     info:
       length: 68.5
@@ -528,7 +540,8 @@ instances:
       cross_section: strip
       length: 68.5
       npoints: 2
-  straight_L68p5_N2_CSstrip_m312500_m1000:
+      width: null
+  straight_L68p5_N2_CSstrip_WNone_m312500_m1000:
     component: straight
     info:
       length: 68.5
@@ -541,7 +554,8 @@ instances:
       cross_section: strip
       length: 68.5
       npoints: 2
-  straight_L73_N2_CSstrip_449500_3500:
+      width: null
+  straight_L73_N2_CSstrip_WNone_449500_3500:
     component: straight
     info:
       length: 73
@@ -554,7 +568,8 @@ instances:
       cross_section: strip
       length: 73
       npoints: 2
-  straight_L73_N2_CSstrip_m439500_3500:
+      width: null
+  straight_L73_N2_CSstrip_WNone_m439500_3500:
     component: straight
     info:
       length: 73
@@ -567,6 +582,7 @@ instances:
       cross_section: strip
       length: 73
       npoints: 2
+      width: null
   straight_array_N4_S4_L10_CSstrip_0_0:
     component: straight_array
     info: {}
@@ -578,68 +594,68 @@ instances:
 name: grating_coupler_tree_N4_2a7d2c50
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500,o1
-  p2: straight_L64_N2_CSstrip_195500_m5500,o1
+  p2: straight_L64_N2_CSstrip_WNone_195500_m5500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500,o2
-  p2: straight_L175p5_N2_CSstrip_185500_4500,o1
+  p2: straight_L175p5_N2_CSstrip_WNone_185500_4500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_322500_m1000,o1
-  p2: straight_L68p5_N2_CSstrip_322500_m1000,o1
+  p2: straight_L68p5_N2_CSstrip_WNone_322500_m1000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_322500_m1000,o2
-  p2: straight_L302p5_N2_CSstrip_312500_9000,o1
+  p2: straight_L302p5_N2_CSstrip_WNone_312500_9000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_449500_3500,o1
-  p2: straight_L73_N2_CSstrip_449500_3500,o1
+  p2: straight_L73_N2_CSstrip_WNone_449500_3500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_449500_3500,o2
-  p2: straight_L429p5_N2_CSstrip_439500_13500,o1
+  p2: straight_L429p5_N2_CSstrip_WNone_439500_13500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o1
-  p2: straight_L59p5_N2_CSstrip_68500_m10000,o1
+  p2: straight_L59p5_N2_CSstrip_WNone_68500_m10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_68500_m10000,o2
-  p2: straight_L48p5_N2_CSstrip_58500_0,o1
+  p2: straight_L48p5_N2_CSstrip_WNone_58500_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m185500_m5500,o1
-  p2: straight_L64_N2_CSstrip_m185500_m5500,o1
+  p2: straight_L64_N2_CSstrip_WNone_m185500_m5500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m185500_m5500,o2
-  p2: straight_L175p5_N2_CSstrip_m175500_4500,o1
+  p2: straight_L175p5_N2_CSstrip_WNone_m175500_4500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m312500_m1000,o1
-  p2: straight_L68p5_N2_CSstrip_m312500_m1000,o1
+  p2: straight_L68p5_N2_CSstrip_WNone_m312500_m1000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m312500_m1000,o2
-  p2: straight_L302p5_N2_CSstrip_m302500_9000,o1
+  p2: straight_L302p5_N2_CSstrip_WNone_m302500_9000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m439500_3500,o1
-  p2: straight_L73_N2_CSstrip_m439500_3500,o1
+  p2: straight_L73_N2_CSstrip_WNone_m439500_3500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m439500_3500,o2
-  p2: straight_L429p5_N2_CSstrip_m429500_13500,o1
+  p2: straight_L429p5_N2_CSstrip_WNone_m429500_13500,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o1
-  p2: straight_L59p5_N2_CSstrip_m58500_m10000,o1
+  p2: straight_L59p5_N2_CSstrip_WNone_m58500_m10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m58500_m10000,o2
-  p2: straight_L48p5_N2_CSstrip_m48500_0,o1
+  p2: straight_L48p5_N2_CSstrip_WNone_m48500_0,o1
 - p1: grating_coupler_ellipti_07e69d9a_195500_m69500,o1
-  p2: straight_L64_N2_CSstrip_195500_m5500,o2
+  p2: straight_L64_N2_CSstrip_WNone_195500_m5500,o2
 - p1: grating_coupler_ellipti_07e69d9a_322500_m69500,o1
-  p2: straight_L68p5_N2_CSstrip_322500_m1000,o2
+  p2: straight_L68p5_N2_CSstrip_WNone_322500_m1000,o2
 - p1: grating_coupler_ellipti_07e69d9a_449500_m69500,o1
-  p2: straight_L73_N2_CSstrip_449500_3500,o2
+  p2: straight_L73_N2_CSstrip_WNone_449500_3500,o2
 - p1: grating_coupler_ellipti_07e69d9a_68500_m69500,o1
-  p2: straight_L59p5_N2_CSstrip_68500_m10000,o2
+  p2: straight_L59p5_N2_CSstrip_WNone_68500_m10000,o2
 - p1: grating_coupler_ellipti_07e69d9a_m185500_m69500,o1
-  p2: straight_L64_N2_CSstrip_m185500_m5500,o2
+  p2: straight_L64_N2_CSstrip_WNone_m185500_m5500,o2
 - p1: grating_coupler_ellipti_07e69d9a_m312500_m69500,o1
-  p2: straight_L68p5_N2_CSstrip_m312500_m1000,o2
+  p2: straight_L68p5_N2_CSstrip_WNone_m312500_m1000,o2
 - p1: grating_coupler_ellipti_07e69d9a_m439500_m69500,o1
-  p2: straight_L73_N2_CSstrip_m439500_3500,o2
+  p2: straight_L73_N2_CSstrip_WNone_m439500_3500,o2
 - p1: grating_coupler_ellipti_07e69d9a_m58500_m69500,o1
-  p2: straight_L59p5_N2_CSstrip_m58500_m10000,o2
-- p1: straight_L175p5_N2_CSstrip_185500_4500,o2
+  p2: straight_L59p5_N2_CSstrip_WNone_m58500_m10000,o2
+- p1: straight_L175p5_N2_CSstrip_WNone_185500_4500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o7
-- p1: straight_L175p5_N2_CSstrip_m175500_4500,o2
+- p1: straight_L175p5_N2_CSstrip_WNone_m175500_4500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o2
-- p1: straight_L302p5_N2_CSstrip_312500_9000,o2
+- p1: straight_L302p5_N2_CSstrip_WNone_312500_9000,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o6
-- p1: straight_L302p5_N2_CSstrip_m302500_9000,o2
+- p1: straight_L302p5_N2_CSstrip_WNone_m302500_9000,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o3
-- p1: straight_L429p5_N2_CSstrip_439500_13500,o2
+- p1: straight_L429p5_N2_CSstrip_WNone_439500_13500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o5
-- p1: straight_L429p5_N2_CSstrip_m429500_13500,o2
+- p1: straight_L429p5_N2_CSstrip_WNone_m429500_13500,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o4
-- p1: straight_L48p5_N2_CSstrip_58500_0,o2
+- p1: straight_L48p5_N2_CSstrip_WNone_58500_0,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o8
-- p1: straight_L48p5_N2_CSstrip_m48500_0,o2
+- p1: straight_L48p5_N2_CSstrip_WNone_m48500_0,o2
   p2: straight_array_N4_S4_L10_CSstrip_0_0,o1
 placements:
   bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500:
@@ -722,82 +738,82 @@ placements:
     rotation: 270
     x: -58.5
     y: -69.5
-  straight_L175p5_N2_CSstrip_185500_4500:
+  straight_L175p5_N2_CSstrip_WNone_185500_4500:
     mirror: false
     rotation: 180
     x: 185.5
     y: 4.5
-  straight_L175p5_N2_CSstrip_m175500_4500:
+  straight_L175p5_N2_CSstrip_WNone_m175500_4500:
     mirror: false
     rotation: 0
     x: -175.5
     y: 4.5
-  straight_L302p5_N2_CSstrip_312500_9000:
+  straight_L302p5_N2_CSstrip_WNone_312500_9000:
     mirror: false
     rotation: 180
     x: 312.5
     y: 9
-  straight_L302p5_N2_CSstrip_m302500_9000:
+  straight_L302p5_N2_CSstrip_WNone_m302500_9000:
     mirror: false
     rotation: 0
     x: -302.5
     y: 9
-  straight_L429p5_N2_CSstrip_439500_13500:
+  straight_L429p5_N2_CSstrip_WNone_439500_13500:
     mirror: false
     rotation: 180
     x: 439.5
     y: 13.5
-  straight_L429p5_N2_CSstrip_m429500_13500:
+  straight_L429p5_N2_CSstrip_WNone_m429500_13500:
     mirror: false
     rotation: 0
     x: -429.5
     y: 13.5
-  straight_L48p5_N2_CSstrip_58500_0:
+  straight_L48p5_N2_CSstrip_WNone_58500_0:
     mirror: false
     rotation: 180
     x: 58.5
     y: 0
-  straight_L48p5_N2_CSstrip_m48500_0:
+  straight_L48p5_N2_CSstrip_WNone_m48500_0:
     mirror: false
     rotation: 0
     x: -48.5
     y: 0
-  straight_L59p5_N2_CSstrip_68500_m10000:
+  straight_L59p5_N2_CSstrip_WNone_68500_m10000:
     mirror: false
     rotation: 270
     x: 68.5
     y: -10
-  straight_L59p5_N2_CSstrip_m58500_m10000:
+  straight_L59p5_N2_CSstrip_WNone_m58500_m10000:
     mirror: false
     rotation: 270
     x: -58.5
     y: -10
-  straight_L64_N2_CSstrip_195500_m5500:
+  straight_L64_N2_CSstrip_WNone_195500_m5500:
     mirror: false
     rotation: 270
     x: 195.5
     y: -5.5
-  straight_L64_N2_CSstrip_m185500_m5500:
+  straight_L64_N2_CSstrip_WNone_m185500_m5500:
     mirror: false
     rotation: 270
     x: -185.5
     y: -5.5
-  straight_L68p5_N2_CSstrip_322500_m1000:
+  straight_L68p5_N2_CSstrip_WNone_322500_m1000:
     mirror: false
     rotation: 270
     x: 322.5
     y: -1
-  straight_L68p5_N2_CSstrip_m312500_m1000:
+  straight_L68p5_N2_CSstrip_WNone_m312500_m1000:
     mirror: false
     rotation: 270
     x: -312.5
     y: -1
-  straight_L73_N2_CSstrip_449500_3500:
+  straight_L73_N2_CSstrip_WNone_449500_3500:
     mirror: false
     rotation: 270
     x: 449.5
     y: 3.5
-  straight_L73_N2_CSstrip_m439500_3500:
+  straight_L73_N2_CSstrip_WNone_m439500_3500:
     mirror: false
     rotation: 270
     x: -439.5

--- a/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/test-data-regression/test_netlists_loop_mirror_.yml
@@ -108,7 +108,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L1p25_N2_CSstrip_45500_m9375:
+  straight_L1p25_N2_CSstrip_WNone_45500_m9375:
     component: straight
     info:
       length: 1.25
@@ -121,7 +121,8 @@ instances:
       cross_section: strip
       length: 1.25
       npoints: 2
-  straight_L20_N2_CSstrip_35500_625:
+      width: null
+  straight_L20_N2_CSstrip_WNone_35500_625:
     component: straight
     info:
       length: 20
@@ -134,6 +135,7 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
 name: loop_mirror_Cmmi1x2_Bbe_15330a29
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625,o1
@@ -141,15 +143,15 @@ nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625,o2
   p2: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o3
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_625,o1
-  p2: straight_L20_N2_CSstrip_35500_625,o1
+  p2: straight_L20_N2_CSstrip_WNone_35500_625,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_625,o2
-  p2: straight_L1p25_N2_CSstrip_45500_m9375,o1
+  p2: straight_L1p25_N2_CSstrip_WNone_45500_m9375,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_35500_m20625,o1
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_45500_m10625,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_45500_m10625,o1
-  p2: straight_L1p25_N2_CSstrip_45500_m9375,o2
+  p2: straight_L1p25_N2_CSstrip_WNone_45500_m9375,o2
 - p1: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o2
-  p2: straight_L20_N2_CSstrip_35500_625,o2
+  p2: straight_L20_N2_CSstrip_WNone_35500_625,o2
 placements:
   bend_euler_RNone_A90_P0_d7c3a5a9_25500_m10625:
     mirror: false
@@ -176,12 +178,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L1p25_N2_CSstrip_45500_m9375:
+  straight_L1p25_N2_CSstrip_WNone_45500_m9375:
     mirror: false
     rotation: 270
     x: 45.5
     y: -9.375
-  straight_L20_N2_CSstrip_35500_625:
+  straight_L20_N2_CSstrip_WNone_35500_625:
     mirror: false
     rotation: 180
     x: 35.5

--- a/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch12_34_.yml
@@ -183,7 +183,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_117000_49529:
+  straight_L107_N2_CSstrip_WNone_117000_49529:
     component: straight
     info:
       length: 107
@@ -196,7 +196,8 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-  straight_L107_N2_CSstrip_371000_49529:
+      width: null
+  straight_L107_N2_CSstrip_WNone_371000_49529:
     component: straight
     info:
       length: 107
@@ -209,7 +210,8 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-  straight_L40_N2_CSstrip_0_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_0_39529:
     component: straight
     info:
       length: 40
@@ -222,7 +224,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_127000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_127000_39529:
     component: straight
     info:
       length: 40
@@ -235,7 +238,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_254000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_254000_39529:
     component: straight
     info:
       length: 40
@@ -248,7 +252,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_381000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_381000_39529:
     component: straight
     info:
       length: 40
@@ -261,32 +266,33 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
+      width: null
 name: loss_deembedding_ch12_3_0220c4ef
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
-  p2: straight_L107_N2_CSstrip_117000_49529,o2
+  p2: straight_L107_N2_CSstrip_WNone_117000_49529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_0_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o1
-  p2: straight_L40_N2_CSstrip_127000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_127000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_127000_39529,o2
-  p2: straight_L107_N2_CSstrip_117000_49529,o1
+  p2: straight_L107_N2_CSstrip_WNone_117000_49529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529,o1
-  p2: straight_L107_N2_CSstrip_371000_49529,o2
+  p2: straight_L107_N2_CSstrip_WNone_371000_49529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_264000_49529,o2
-  p2: straight_L40_N2_CSstrip_254000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_254000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o1
-  p2: straight_L40_N2_CSstrip_381000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_381000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o2
-  p2: straight_L107_N2_CSstrip_371000_49529,o1
+  p2: straight_L107_N2_CSstrip_WNone_371000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_0_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L40_N2_CSstrip_127000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_127000_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L40_N2_CSstrip_254000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_254000_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_381000_0,o1
-  p2: straight_L40_N2_CSstrip_381000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_381000_39529,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
@@ -328,32 +334,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L107_N2_CSstrip_117000_49529:
+  straight_L107_N2_CSstrip_WNone_117000_49529:
     mirror: false
     rotation: 180
     x: 117
     y: 49.529
-  straight_L107_N2_CSstrip_371000_49529:
+  straight_L107_N2_CSstrip_WNone_371000_49529:
     mirror: false
     rotation: 180
     x: 371
     y: 49.529
-  straight_L40_N2_CSstrip_0_39529:
+  straight_L40_N2_CSstrip_WNone_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_127000_39529:
+  straight_L40_N2_CSstrip_WNone_127000_39529:
     mirror: false
     rotation: 270
     x: 127
     y: 39.529
-  straight_L40_N2_CSstrip_254000_39529:
+  straight_L40_N2_CSstrip_WNone_254000_39529:
     mirror: false
     rotation: 270
     x: 254
     y: 39.529
-  straight_L40_N2_CSstrip_381000_39529:
+  straight_L40_N2_CSstrip_WNone_381000_39529:
     mirror: false
     rotation: 270
     x: 381

--- a/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch13_24_.yml
@@ -279,7 +279,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L234_N2_CSstrip_244000_49529:
+  straight_L234_N2_CSstrip_WNone_244000_49529:
     component: straight
     info:
       length: 234
@@ -292,7 +292,8 @@ instances:
       cross_section: strip
       length: 234
       npoints: 2
-  straight_L274_N2_CSstrip_391000_m46417:
+      width: null
+  straight_L274_N2_CSstrip_WNone_391000_m46417:
     component: straight
     info:
       length: 274
@@ -305,7 +306,8 @@ instances:
       cross_section: strip
       length: 274
       npoints: 2
-  straight_L35p946_N2_CSstrip_107000_m36417:
+      width: null
+  straight_L35p946_N2_CSs_919240e7_107000_m36417:
     component: straight
     info:
       length: 35.946
@@ -318,7 +320,8 @@ instances:
       cross_section: strip
       length: 35.946
       npoints: 2
-  straight_L35p946_N2_CSstrip_401000_m471:
+      width: null
+  straight_L35p946_N2_CSs_919240e7_401000_m471:
     component: straight
     info:
       length: 35.946
@@ -331,7 +334,8 @@ instances:
       cross_section: strip
       length: 35.946
       npoints: 2
-  straight_L40_N2_CSstrip_0_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_0_39529:
     component: straight
     info:
       length: 40
@@ -344,7 +348,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_254000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_254000_39529:
     component: straight
     info:
       length: 40
@@ -357,40 +362,41 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
+      width: null
 name: loss_deembedding_ch13_2_f0d5a16c
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
-  p2: straight_L234_N2_CSstrip_244000_49529,o2
+  p2: straight_L234_N2_CSstrip_WNone_244000_49529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_0_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529,o1
-  p2: straight_L40_N2_CSstrip_254000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_254000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_39529,o2
-  p2: straight_L234_N2_CSstrip_244000_49529,o1
+  p2: straight_L234_N2_CSstrip_WNone_244000_49529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_107000_m471,o1
-  p2: straight_L35p946_N2_CSstrip_107000_m36417,o2
+  p2: straight_L35p946_N2_CSs_919240e7_107000_m36417,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_107000_m471,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_117000_9529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_9529,o2
   p2: grating_coupler_ellipti_7b8aa449_127000_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_m46417,o1
-  p2: straight_L274_N2_CSstrip_391000_m46417,o2
+  p2: straight_L274_N2_CSstrip_WNone_391000_m46417,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_117000_m46417,o2
-  p2: straight_L35p946_N2_CSstrip_107000_m36417,o1
+  p2: straight_L35p946_N2_CSs_919240e7_107000_m36417,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_381000_m471,o1
   p2: grating_coupler_ellipti_7b8aa449_381000_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_381000_m471,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_391000_9529,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_391000_9529,o2
-  p2: straight_L35p946_N2_CSstrip_401000_m471,o1
+  p2: straight_L35p946_N2_CSs_919240e7_401000_m471,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_401000_m36417,o1
-  p2: straight_L35p946_N2_CSstrip_401000_m471,o2
+  p2: straight_L35p946_N2_CSs_919240e7_401000_m471,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_401000_m36417,o2
-  p2: straight_L274_N2_CSstrip_391000_m46417,o1
+  p2: straight_L274_N2_CSstrip_WNone_391000_m46417,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_0_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L40_N2_CSstrip_254000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_254000_39529,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
@@ -452,32 +458,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L234_N2_CSstrip_244000_49529:
+  straight_L234_N2_CSstrip_WNone_244000_49529:
     mirror: false
     rotation: 180
     x: 244
     y: 49.529
-  straight_L274_N2_CSstrip_391000_m46417:
+  straight_L274_N2_CSstrip_WNone_391000_m46417:
     mirror: false
     rotation: 180
     x: 391
     y: -46.417
-  straight_L35p946_N2_CSstrip_107000_m36417:
+  straight_L35p946_N2_CSs_919240e7_107000_m36417:
     mirror: false
     rotation: 90
     x: 107
     y: -36.417
-  straight_L35p946_N2_CSstrip_401000_m471:
+  straight_L35p946_N2_CSs_919240e7_401000_m471:
     mirror: false
     rotation: 270
     x: 401
     y: -0.471
-  straight_L40_N2_CSstrip_0_39529:
+  straight_L40_N2_CSstrip_WNone_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_254000_39529:
+  straight_L40_N2_CSstrip_WNone_254000_39529:
     mirror: false
     rotation: 270
     x: 254

--- a/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
+++ b/test-data-regression/test_netlists_loss_deembedding_ch14_23_.yml
@@ -183,7 +183,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_L107_N2_CSstrip_244000_39529:
+  straight_L107_N2_CSstrip_WNone_244000_39529:
     component: straight
     info:
       length: 107
@@ -196,7 +196,8 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-  straight_L30_N2_CSstrip_127000_29529:
+      width: null
+  straight_L30_N2_CSstrip_WNone_127000_29529:
     component: straight
     info:
       length: 30
@@ -209,7 +210,8 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
-  straight_L30_N2_CSstrip_254000_29529:
+      width: null
+  straight_L30_N2_CSstrip_WNone_254000_29529:
     component: straight
     info:
       length: 30
@@ -222,7 +224,8 @@ instances:
       cross_section: strip
       length: 30
       npoints: 2
-  straight_L361_N2_CSstrip_371000_49529:
+      width: null
+  straight_L361_N2_CSstrip_WNone_371000_49529:
     component: straight
     info:
       length: 361
@@ -235,7 +238,8 @@ instances:
       cross_section: strip
       length: 361
       npoints: 2
-  straight_L40_N2_CSstrip_0_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_0_39529:
     component: straight
     info:
       length: 40
@@ -248,7 +252,8 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
-  straight_L40_N2_CSstrip_381000_39529:
+      width: null
+  straight_L40_N2_CSstrip_WNone_381000_39529:
     component: straight
     info:
       length: 40
@@ -261,32 +266,33 @@ instances:
       cross_section: strip
       length: 40
       npoints: 2
+      width: null
 name: loss_deembedding_ch14_2_d0b63223
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o1
-  p2: straight_L361_N2_CSstrip_371000_49529,o2
+  p2: straight_L361_N2_CSstrip_WNone_371000_49529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529,o2
-  p2: straight_L40_N2_CSstrip_0_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529,o1
-  p2: straight_L107_N2_CSstrip_244000_39529,o2
+  p2: straight_L107_N2_CSstrip_WNone_244000_39529,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_137000_39529,o2
-  p2: straight_L30_N2_CSstrip_127000_29529,o1
+  p2: straight_L30_N2_CSstrip_WNone_127000_29529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529,o1
-  p2: straight_L30_N2_CSstrip_254000_29529,o1
+  p2: straight_L30_N2_CSstrip_WNone_254000_29529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_254000_29529,o2
-  p2: straight_L107_N2_CSstrip_244000_39529,o1
+  p2: straight_L107_N2_CSstrip_WNone_244000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o1
-  p2: straight_L40_N2_CSstrip_381000_39529,o1
+  p2: straight_L40_N2_CSstrip_WNone_381000_39529,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_381000_39529,o2
-  p2: straight_L361_N2_CSstrip_371000_49529,o1
+  p2: straight_L361_N2_CSstrip_WNone_371000_49529,o1
 - p1: grating_coupler_ellipti_7b8aa449_0_0,o1
-  p2: straight_L40_N2_CSstrip_0_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_0_39529,o2
 - p1: grating_coupler_ellipti_7b8aa449_127000_0,o1
-  p2: straight_L30_N2_CSstrip_127000_29529,o2
+  p2: straight_L30_N2_CSstrip_WNone_127000_29529,o2
 - p1: grating_coupler_ellipti_7b8aa449_254000_0,o1
-  p2: straight_L30_N2_CSstrip_254000_29529,o2
+  p2: straight_L30_N2_CSstrip_WNone_254000_29529,o2
 - p1: grating_coupler_ellipti_7b8aa449_381000_0,o1
-  p2: straight_L40_N2_CSstrip_381000_39529,o2
+  p2: straight_L40_N2_CSstrip_WNone_381000_39529,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_10000_49529:
     mirror: false
@@ -328,32 +334,32 @@ placements:
     rotation: 270
     x: 381
     y: 0
-  straight_L107_N2_CSstrip_244000_39529:
+  straight_L107_N2_CSstrip_WNone_244000_39529:
     mirror: false
     rotation: 180
     x: 244
     y: 39.529
-  straight_L30_N2_CSstrip_127000_29529:
+  straight_L30_N2_CSstrip_WNone_127000_29529:
     mirror: false
     rotation: 270
     x: 127
     y: 29.529
-  straight_L30_N2_CSstrip_254000_29529:
+  straight_L30_N2_CSstrip_WNone_254000_29529:
     mirror: false
     rotation: 270
     x: 254
     y: 29.529
-  straight_L361_N2_CSstrip_371000_49529:
+  straight_L361_N2_CSstrip_WNone_371000_49529:
     mirror: false
     rotation: 180
     x: 371
     y: 49.529
-  straight_L40_N2_CSstrip_0_39529:
+  straight_L40_N2_CSstrip_WNone_0_39529:
     mirror: false
     rotation: 270
     x: 0
     y: 39.529
-  straight_L40_N2_CSstrip_381000_39529:
+  straight_L40_N2_CSstrip_WNone_381000_39529:
     mirror: false
     rotation: 270
     x: 381

--- a/test-data-regression/test_netlists_mode_converter_.yml
+++ b/test-data-regression/test_netlists_mode_converter_.yml
@@ -48,7 +48,7 @@ instances:
       length: 10
       width_bot: 1
       width_top: 0.5
-  taper_L25_W1_W1p2_PNone_c47a90e6_0_0:
+  taper_L25_W1_W1p2_LNone_38ef62c2_0_0:
     component: taper
     info:
       length: 25
@@ -56,6 +56,7 @@ instances:
       width2: 1.2
     settings:
       cross_section: strip
+      layer: null
       length: 25
       port: null
       port_names:
@@ -68,7 +69,7 @@ instances:
       width2: 1.2
       with_bbox: true
       with_two_ports: true
-  taper_L25_W1_W1p2_PNone_c47a90e6_10000_0:
+  taper_L25_W1_W1p2_LNone_38ef62c2_10000_0:
     component: taper
     info:
       length: 25
@@ -76,6 +77,7 @@ instances:
       width2: 1.2
     settings:
       cross_section: strip
+      layer: null
       length: 25
       port: null
       port_names:
@@ -95,9 +97,9 @@ nets:
 - p1: bend_s_S25_3_N99_CSstri_7865203f_10000_1050,o1
   p2: coupler_straight_asymme_d7b83f37_0_0,o3
 - p1: coupler_straight_asymme_d7b83f37_0_0,o1
-  p2: taper_L25_W1_W1p2_PNone_c47a90e6_0_0,o1
+  p2: taper_L25_W1_W1p2_LNone_38ef62c2_0_0,o1
 - p1: coupler_straight_asymme_d7b83f37_0_0,o4
-  p2: taper_L25_W1_W1p2_PNone_c47a90e6_10000_0,o1
+  p2: taper_L25_W1_W1p2_LNone_38ef62c2_10000_0,o1
 placements:
   bend_s_S25_3_N99_CSstri_7865203f_0_1050:
     mirror: true
@@ -114,18 +116,18 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  taper_L25_W1_W1p2_PNone_c47a90e6_0_0:
+  taper_L25_W1_W1p2_LNone_38ef62c2_0_0:
     mirror: false
     rotation: 180
     x: 0
     y: 0
-  taper_L25_W1_W1p2_PNone_c47a90e6_10000_0:
+  taper_L25_W1_W1p2_LNone_38ef62c2_10000_0:
     mirror: false
     rotation: 0
     x: 10
     y: 0
 ports:
-  o1: taper_L25_W1_W1p2_PNone_c47a90e6_0_0,o2
+  o1: taper_L25_W1_W1p2_LNone_38ef62c2_0_0,o2
   o2: bend_s_S25_3_N99_CSstri_7865203f_0_1050,o2
-  o3: taper_L25_W1_W1p2_PNone_c47a90e6_10000_0,o2
+  o3: taper_L25_W1_W1p2_LNone_38ef62c2_10000_0,o2
   o4: bend_s_S25_3_N99_CSstri_7865203f_10000_1050,o2

--- a/test-data-regression/test_netlists_mzi1x2_2x2_.yml
+++ b/test-data-regression/test_netlists_mzi1x2_2x2_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 0.1
       npoints: 2
+      width: null
   sxt:
     component: straight
     info:
@@ -243,6 +244,7 @@ instances:
       cross_section: strip
       length: 0.1
       npoints: 2
+      width: null
   sybr:
     component: straight
     info:
@@ -256,6 +258,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -269,6 +272,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -282,6 +286,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -295,6 +300,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX0p1_Bben_50da3b81
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi2x2_2x2_.yml
+++ b/test-data-regression/test_netlists_mzi2x2_2x2_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
   sxt:
     component: straight
     info:
@@ -243,6 +244,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
   sybr:
     component: straight
     info:
@@ -256,6 +258,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -269,6 +272,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -282,6 +286,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -295,6 +300,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LXNone_Bbe_845a7ade
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 200
       npoints: 2
+      width: null
   sxt:
     component: straight_heater_metal_undercut
     info:
@@ -263,6 +264,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -276,6 +278,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -289,6 +292,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -302,6 +306,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX200_Bben_45028f49
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi_.yml
+++ b/test-data-regression/test_netlists_mzi_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 0.1
       npoints: 2
+      width: null
   sxt:
     component: straight
     info:
@@ -243,6 +244,7 @@ instances:
       cross_section: strip
       length: 0.1
       npoints: 2
+      width: null
   sybr:
     component: straight
     info:
@@ -256,6 +258,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -269,6 +272,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -282,6 +286,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -295,6 +300,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX0p1_Bben_4daac747
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi_arm_.yml
+++ b/test-data-regression/test_netlists_mzi_arm_.yml
@@ -60,6 +60,7 @@ instances:
       cross_section: strip
       length: 0.8
       npoints: 2
+      width: null
   R1:
     component: straight
     info:
@@ -73,6 +74,7 @@ instances:
       cross_section: strip
       length: 0.8
       npoints: 2
+      width: null
   b1:
     component: bend_euler
     info:
@@ -134,6 +136,7 @@ instances:
       cross_section: strip
       length: 0.1
       npoints: 2
+      width: null
 name: mzi_arm_LYL0p8_LYR0p8_L_1bd36bcd
 nets:
 - p1: B1,o1

--- a/test-data-regression/test_netlists_mzi_coupler_.yml
+++ b/test-data-regression/test_netlists_mzi_coupler_.yml
@@ -228,6 +228,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
   sxt:
     component: straight
     info:
@@ -241,6 +242,7 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
   sybr:
     component: straight
     info:
@@ -254,6 +256,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -267,6 +270,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -280,6 +284,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -293,6 +298,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LXNone_Bbe_2f449048
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 200
       npoints: 2
+      width: null
   sxt:
     component: straight_heater_metal_undercut
     info:
@@ -263,6 +264,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -276,6 +278,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -289,6 +292,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -302,6 +306,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX200_Bben_6e9f3e3b
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 200
       npoints: 2
+      width: null
   sxt:
     component: straight_heater_metal_undercut
     info:
@@ -263,6 +264,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -276,6 +278,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -289,6 +292,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -302,6 +306,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX200_Bben_f0fe831d
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzi_pin_.yml
+++ b/test-data-regression/test_netlists_mzi_pin_.yml
@@ -230,6 +230,7 @@ instances:
       cross_section: strip
       length: 100
       npoints: 2
+      width: null
   sxt:
     component: straight_pin
     info: {}
@@ -253,6 +254,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -266,6 +268,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -279,6 +282,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -292,6 +296,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL0_LY2_LX100_Bbend_f9c88a9b
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -189,7 +189,7 @@ instances:
       length: 4
       npoints: 2
       width: 0.55
-  taper_L5_W0p45_W0p55_PN_f55f7d5c_25000_21400:
+  taper_L5_W0p45_W0p55_LN_265d0d8a_25000_21400:
     component: taper
     info:
       length: 5
@@ -197,6 +197,7 @@ instances:
       width2: 0.55
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -209,7 +210,7 @@ instances:
       width2: 0.55
       with_bbox: true
       with_two_ports: true
-  taper_L5_W0p45_W0p5_PNo_4080dc7e_19000_23400:
+  taper_L5_W0p45_W0p5_LNo_018a50c4_19000_23400:
     component: taper
     info:
       length: 5
@@ -217,6 +218,7 @@ instances:
       width2: 0.5
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -229,7 +231,7 @@ instances:
       width2: 0.5
       with_bbox: true
       with_two_ports: true
-  taper_L5_W0p55_W0p45_PN_df1360bc_25000_23400:
+  taper_L5_W0p55_W0p45_LN_836f292d_25000_23400:
     component: taper
     info:
       length: 5
@@ -237,6 +239,7 @@ instances:
       width2: 0.45
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -249,7 +252,7 @@ instances:
       width2: 0.45
       with_bbox: true
       with_two_ports: true
-  taper_L5_W0p55_W0p5_PNo_438ce168_19000_21400:
+  taper_L5_W0p55_W0p5_LNo_61376476_19000_21400:
     component: taper
     info:
       length: 5
@@ -257,6 +260,7 @@ instances:
       width2: 0.5
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -269,7 +273,7 @@ instances:
       width2: 0.5
       with_bbox: true
       with_two_ports: true
-  taper_L5_W0p5_W0p45_PNo_b650d75a_20000_1400:
+  taper_L5_W0p5_W0p45_LNo_e894c800_20000_1400:
     component: taper
     info:
       length: 5
@@ -277,6 +281,7 @@ instances:
       width2: 0.45
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -289,7 +294,7 @@ instances:
       width2: 0.45
       with_bbox: true
       with_two_ports: true
-  taper_L5_W0p5_W0p55_PNo_839c49ab_20000_m600:
+  taper_L5_W0p5_W0p55_LNo_4599d000_20000_m600:
     component: taper
     info:
       length: 5
@@ -297,6 +302,7 @@ instances:
       width2: 0.55
     settings:
       cross_section: strip
+      layer: null
       length: 5
       port: null
       port_names:
@@ -312,11 +318,11 @@ instances:
 name: mzit_W0p5_W0p45_W0p55_D_a253119c
 nets:
 - p1: bend_euler_RNone_A90_P0_2aa8c47e_25000_1400,o1
-  p2: taper_L5_W0p5_W0p45_PNo_b650d75a_20000_1400,o2
+  p2: taper_L5_W0p5_W0p45_LNo_e894c800_20000_1400,o2
 - p1: bend_euler_RNone_A90_P0_2aa8c47e_25000_1400,o2
   p2: bend_euler_RNone_A90_P0_2aa8c47e_35000_11400,o1
 - p1: bend_euler_RNone_A90_P0_2aa8c47e_35000_11400,o2
-  p2: taper_L5_W0p45_W0p55_PN_f55f7d5c_25000_21400,o1
+  p2: taper_L5_W0p45_W0p55_LN_265d0d8a_25000_21400,o1
 - p1: bend_euler_RNone_A90_P0_903f8d22_28000_m600,o1
   p2: straight_L3_N2_CSstrip_W0p55_25000_m600,o2
 - p1: bend_euler_RNone_A90_P0_903f8d22_28000_m600,o2
@@ -326,25 +332,25 @@ nets:
 - p1: bend_euler_RNone_A90_P0_903f8d22_38000_13400,o2
   p2: straight_L3_N2_CSstrip_W0p55_28000_23400,o1
 - p1: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o3
-  p2: taper_L5_W0p45_W0p5_PNo_4080dc7e_19000_23400,o2
+  p2: taper_L5_W0p45_W0p5_LNo_018a50c4_19000_23400,o2
 - p1: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o4
-  p2: taper_L5_W0p55_W0p5_PNo_438ce168_19000_21400,o2
+  p2: taper_L5_W0p55_W0p5_LNo_61376476_19000_21400,o2
 - p1: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o3
-  p2: taper_L5_W0p5_W0p45_PNo_b650d75a_20000_1400,o1
+  p2: taper_L5_W0p5_W0p45_LNo_e894c800_20000_1400,o1
 - p1: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o4
-  p2: taper_L5_W0p5_W0p55_PNo_839c49ab_20000_m600,o1
+  p2: taper_L5_W0p5_W0p55_LNo_4599d000_20000_m600,o1
 - p1: straight_L1_N2_CSstrip_W0p45_20000_23400,o1
-  p2: taper_L5_W0p55_W0p45_PN_df1360bc_25000_23400,o2
+  p2: taper_L5_W0p55_W0p45_LN_836f292d_25000_23400,o2
 - p1: straight_L1_N2_CSstrip_W0p45_20000_23400,o2
-  p2: taper_L5_W0p45_W0p5_PNo_4080dc7e_19000_23400,o1
+  p2: taper_L5_W0p45_W0p5_LNo_018a50c4_19000_23400,o1
 - p1: straight_L1_N2_CSstrip_W0p55_20000_21400,o1
-  p2: taper_L5_W0p45_W0p55_PN_f55f7d5c_25000_21400,o2
+  p2: taper_L5_W0p45_W0p55_LN_265d0d8a_25000_21400,o2
 - p1: straight_L1_N2_CSstrip_W0p55_20000_21400,o2
-  p2: taper_L5_W0p55_W0p5_PNo_438ce168_19000_21400,o1
+  p2: taper_L5_W0p55_W0p5_LNo_61376476_19000_21400,o1
 - p1: straight_L3_N2_CSstrip_W0p55_25000_m600,o1
-  p2: taper_L5_W0p5_W0p55_PNo_839c49ab_20000_m600,o2
+  p2: taper_L5_W0p5_W0p55_LNo_4599d000_20000_m600,o2
 - p1: straight_L3_N2_CSstrip_W0p55_28000_23400,o2
-  p2: taper_L5_W0p55_W0p45_PN_df1360bc_25000_23400,o1
+  p2: taper_L5_W0p55_W0p45_LN_836f292d_25000_23400,o1
 placements:
   bend_euler_RNone_A90_P0_2aa8c47e_25000_1400:
     mirror: false
@@ -401,32 +407,32 @@ placements:
     rotation: 90
     x: 38
     y: 9.4
-  taper_L5_W0p45_W0p55_PN_f55f7d5c_25000_21400:
+  taper_L5_W0p45_W0p55_LN_265d0d8a_25000_21400:
     mirror: false
     rotation: 180
     x: 25
     y: 21.4
-  taper_L5_W0p45_W0p5_PNo_4080dc7e_19000_23400:
+  taper_L5_W0p45_W0p5_LNo_018a50c4_19000_23400:
     mirror: false
     rotation: 180
     x: 19
     y: 23.4
-  taper_L5_W0p55_W0p45_PN_df1360bc_25000_23400:
+  taper_L5_W0p55_W0p45_LN_836f292d_25000_23400:
     mirror: false
     rotation: 180
     x: 25
     y: 23.4
-  taper_L5_W0p55_W0p5_PNo_438ce168_19000_21400:
+  taper_L5_W0p55_W0p5_LNo_61376476_19000_21400:
     mirror: false
     rotation: 180
     x: 19
     y: 21.4
-  taper_L5_W0p5_W0p45_PNo_b650d75a_20000_1400:
+  taper_L5_W0p5_W0p45_LNo_e894c800_20000_1400:
     mirror: false
     rotation: 0
     x: 20
     y: 1.4
-  taper_L5_W0p5_W0p55_PNo_839c49ab_20000_m600:
+  taper_L5_W0p5_W0p55_LNo_4599d000_20000_m600:
     mirror: false
     rotation: 0
     x: 20

--- a/test-data-regression/test_netlists_mzm_.yml
+++ b/test-data-regression/test_netlists_mzm_.yml
@@ -250,6 +250,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   syl:
     component: straight
     info:
@@ -263,6 +264,7 @@ instances:
       cross_section: strip
       length: 7
       npoints: 2
+      width: null
   sytl:
     component: straight
     info:
@@ -276,6 +278,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
   sytr:
     component: straight
     info:
@@ -289,6 +292,7 @@ instances:
       cross_section: strip
       length: 2
       npoints: 2
+      width: null
 name: mzi_DL10_LY2_LX200_Bben_ff43f7ce
 nets:
 - p1: b1,o1

--- a/test-data-regression/test_netlists_pad_array0_.yml
+++ b/test-data-regression/test_netlists_pad_array0_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     column_pitch: 150
     columns: 1
     component: pad
@@ -16,8 +16,12 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
-      port_orientations: null
+      port_orientation: 0
+      port_orientations:
+      - 180
+      - 90
+      - 0
+      - -90
       port_type: pad
       size:
       - 100
@@ -25,9 +29,45 @@ instances:
 name: pad_array_Ppad_SNone_C1_79b1e858
 nets: []
 placements:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e3
+  e21: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e3
+  e31: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e3
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 9 unconnected electrical ports!
+      ports:
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e4
+      values:
+      - - -50000
+        - 0
+      - - 0
+        - 50000
+      - - 0
+        - -50000
+      - - -50000
+        - 150000
+      - - 0
+        - 200000
+      - - 0
+        - 100000
+      - - -50000
+        - 300000
+      - - 0
+        - 350000
+      - - 0
+        - 250000

--- a/test-data-regression/test_netlists_pad_array180_.yml
+++ b/test-data-regression/test_netlists_pad_array180_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     column_pitch: 150
     columns: 1
     component: pad
@@ -16,8 +16,12 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
-      port_orientations: null
+      port_orientation: 0
+      port_orientations:
+      - 180
+      - 90
+      - 0
+      - -90
       port_type: pad
       size:
       - 100
@@ -25,9 +29,45 @@ instances:
 name: pad_array_Ppad_SNone_C1_024a62db
 nets: []
 placements:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e1
+  e21: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e1
+  e31: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e1
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 9 unconnected electrical ports!
+      ports:
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.1>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.2>,e4
+      values:
+      - - 0
+        - 50000
+      - - 50000
+        - 0
+      - - 0
+        - -50000
+      - - 0
+        - 200000
+      - - 50000
+        - 150000
+      - - 0
+        - 100000
+      - - 0
+        - 350000
+      - - 50000
+        - 300000
+      - - 0
+        - 250000

--- a/test-data-regression/test_netlists_pad_array270_.yml
+++ b/test-data-regression/test_netlists_pad_array270_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     column_pitch: 150
     columns: 6
     component: pad
@@ -16,8 +16,12 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
-      port_orientations: null
+      port_orientation: 0
+      port_orientations:
+      - 180
+      - 90
+      - 0
+      - -90
       port_type: pad
       size:
       - 100
@@ -25,9 +29,75 @@ instances:
 name: pad_array_Ppad_SNone_C6_fa910346
 nets: []
 placements:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e4
+  e12: pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e4
+  e13: pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e4
+  e14: pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e4
+  e15: pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e4
+  e16: pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e4
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 18 unconnected electrical ports!
+      ports:
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e3
+      values:
+      - - -50000
+        - 0
+      - - 0
+        - 50000
+      - - 50000
+        - 0
+      - - 100000
+        - 0
+      - - 150000
+        - 50000
+      - - 200000
+        - 0
+      - - 250000
+        - 0
+      - - 300000
+        - 50000
+      - - 350000
+        - 0
+      - - 400000
+        - 0
+      - - 450000
+        - 50000
+      - - 500000
+        - 0
+      - - 550000
+        - 0
+      - - 600000
+        - 50000
+      - - 650000
+        - 0
+      - - 700000
+        - 0
+      - - 750000
+        - 50000
+      - - 800000
+        - 0

--- a/test-data-regression/test_netlists_pad_array90_.yml
+++ b/test-data-regression/test_netlists_pad_array90_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     column_pitch: 150
     columns: 6
     component: pad
@@ -16,8 +16,12 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
-      port_orientations: null
+      port_orientation: 0
+      port_orientations:
+      - 180
+      - 90
+      - 0
+      - -90
       port_type: pad
       size:
       - 100
@@ -25,9 +29,75 @@ instances:
 name: pad_array_Ppad_SNone_C6_e5788292
 nets: []
 placements:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e2
+  e12: pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e2
+  e13: pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e2
+  e14: pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e2
+  e15: pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e2
+  e16: pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e2
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 18 unconnected electrical ports!
+      ports:
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e3
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e4
+      values:
+      - - -50000
+        - 0
+      - - 50000
+        - 0
+      - - 0
+        - -50000
+      - - 100000
+        - 0
+      - - 200000
+        - 0
+      - - 150000
+        - -50000
+      - - 250000
+        - 0
+      - - 350000
+        - 0
+      - - 300000
+        - -50000
+      - - 400000
+        - 0
+      - - 500000
+        - 0
+      - - 450000
+        - -50000
+      - - 550000
+        - 0
+      - - 650000
+        - 0
+      - - 600000
+        - -50000
+      - - 700000
+        - 0
+      - - 800000
+        - 0
+      - - 750000
+        - -50000

--- a/test-data-regression/test_netlists_pad_array_.yml
+++ b/test-data-regression/test_netlists_pad_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     column_pitch: 150
     columns: 6
     component: pad
@@ -16,8 +16,12 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
-      port_orientations: null
+      port_orientation: 0
+      port_orientations:
+      - 180
+      - 90
+      - 0
+      - -90
       port_type: pad
       size:
       - 100
@@ -25,9 +29,75 @@ instances:
 name: pad_array_Ppad_SNone_C6_e4b6a67c
 nets: []
 placements:
-  pad_S100_100_LMTOP_BLNo_23f16118_0_0:
+  pad_S100_100_LMTOP_BLNo_163fd346_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e3
+  e12: pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e3
+  e13: pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e3
+  e14: pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e3
+  e15: pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e3
+  e16: pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e3
+warnings:
+  electrical:
+    unconnected_ports:
+    - message: 18 unconnected electrical ports!
+      ports:
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<0.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<1.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<2.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<3.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<4.0>,e4
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e1
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e2
+      - pad_S100_100_LMTOP_BLNo_163fd346_0_0<5.0>,e4
+      values:
+      - - -50000
+        - 0
+      - - 0
+        - 50000
+      - - 0
+        - -50000
+      - - 100000
+        - 0
+      - - 150000
+        - 50000
+      - - 150000
+        - -50000
+      - - 250000
+        - 0
+      - - 300000
+        - 50000
+      - - 300000
+        - -50000
+      - - 400000
+        - 0
+      - - 450000
+        - 50000
+      - - 450000
+        - -50000
+      - - 550000
+        - 0
+      - - 600000
+        - 50000
+      - - 600000
+        - -50000
+      - - 700000
+        - 0
+      - - 750000
+        - 50000
+      - - 750000
+        - -50000

--- a/test-data-regression/test_netlists_ring_crow_.yml
+++ b/test-data-regression/test_netlists_ring_crow_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L20_N2_CSstrip_m10000_0:
+  straight_L20_N2_CSstrip_WNone_m10000_0:
     component: straight
     info:
       length: 20
@@ -12,7 +12,8 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-  straight_L20_N2_CSstrip_m10000_62800:
+      width: null
+  straight_L20_N2_CSstrip_WNone_m10000_62800:
     component: straight
     info:
       length: 20
@@ -25,21 +26,22 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
+      width: null
 name: ring_crow_G0p2_0p2_0p2__5abcdbba
 nets: []
 placements:
-  straight_L20_N2_CSstrip_m10000_0:
+  straight_L20_N2_CSstrip_WNone_m10000_0:
     mirror: false
     rotation: 0
     x: -10
     y: 0
-  straight_L20_N2_CSstrip_m10000_62800:
+  straight_L20_N2_CSstrip_WNone_m10000_62800:
     mirror: false
     rotation: 0
     x: -10
     y: 62.8
 ports:
-  o1: straight_L20_N2_CSstrip_m10000_0,o1
-  o2: straight_L20_N2_CSstrip_m10000_0,o2
-  o3: straight_L20_N2_CSstrip_m10000_62800,o1
-  o4: straight_L20_N2_CSstrip_m10000_62800,o2
+  o1: straight_L20_N2_CSstrip_WNone_m10000_0,o1
+  o2: straight_L20_N2_CSstrip_WNone_m10000_0,o2
+  o3: straight_L20_N2_CSstrip_WNone_m10000_62800,o1
+  o4: straight_L20_N2_CSstrip_WNone_m10000_62800,o2

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -23,7 +23,7 @@ instances:
       length_x: 0.01
       radius: 10
       straight: straight
-  straight_L0p01_N2_CSstrip_10000_10710:
+  straight_L0p01_N2_CSstrip_WNone_10000_10710:
     component: straight
     info:
       length: 0.01
@@ -36,7 +36,8 @@ instances:
       cross_section: strip
       length: 0.01
       npoints: 2
-  straight_L0p01_N2_CSstrip_m10010_10700:
+      width: null
+  straight_L0p01_N2_CSstrip_WNone_m10010_10700:
     component: straight
     info:
       length: 0.01
@@ -49,16 +50,17 @@ instances:
       cross_section: strip
       length: 0.01
       npoints: 2
+      width: null
 name: ring_double_G0p2_R10_LX_07be0fa3
 nets:
 - p1: coupler_ring_G0p2_R10_L_f700a51f_0_0,o2
-  p2: straight_L0p01_N2_CSstrip_m10010_10700,o1
+  p2: straight_L0p01_N2_CSstrip_WNone_m10010_10700,o1
 - p1: coupler_ring_G0p2_R10_L_f700a51f_0_0,o3
-  p2: straight_L0p01_N2_CSstrip_10000_10710,o2
+  p2: straight_L0p01_N2_CSstrip_WNone_10000_10710,o2
 - p1: coupler_ring_G0p2_R10_L_f700a51f_m10_21410,o2
-  p2: straight_L0p01_N2_CSstrip_10000_10710,o1
+  p2: straight_L0p01_N2_CSstrip_WNone_10000_10710,o1
 - p1: coupler_ring_G0p2_R10_L_f700a51f_m10_21410,o3
-  p2: straight_L0p01_N2_CSstrip_m10010_10700,o2
+  p2: straight_L0p01_N2_CSstrip_WNone_m10010_10700,o2
 placements:
   coupler_ring_G0p2_R10_L_f700a51f_0_0:
     mirror: false
@@ -70,12 +72,12 @@ placements:
     rotation: 180
     x: -0.01
     y: 21.41
-  straight_L0p01_N2_CSstrip_10000_10710:
+  straight_L0p01_N2_CSstrip_WNone_10000_10710:
     mirror: false
     rotation: 270
     x: 10
     y: 10.71
-  straight_L0p01_N2_CSstrip_m10010_10700:
+  straight_L0p01_N2_CSstrip_WNone_m10010_10700:
     mirror: false
     rotation: 90
     x: -10.01

--- a/test-data-regression/test_netlists_ring_double_heater_.yml
+++ b/test-data-regression/test_netlists_ring_double_heater_.yml
@@ -23,7 +23,7 @@ instances:
       length_x: 1
       radius: 10
       straight: straight
-  straight_L0p01_N2_CSstr_b7a6e359_10000_10700:
+  straight_L0p01_N2_CSstr_99fbf211_10000_10700:
     component: straight
     info:
       length: 0.01
@@ -36,7 +36,8 @@ instances:
       cross_section: strip_heater_metal
       length: 0.01
       npoints: 2
-  straight_L0p01_N2_CSstr_b7a6e359_m11000_10700:
+      width: null
+  straight_L0p01_N2_CSstr_99fbf211_m11000_10700:
     component: straight
     info:
       length: 0.01
@@ -49,7 +50,8 @@ instances:
       cross_section: strip_heater_metal
       length: 0.01
       npoints: 2
-  straight_L1_N2_CSheater_metal_m1000_20710:
+      width: null
+  straight_L1_N2_CSheater_7547f2a1_m1000_20710:
     component: straight
     info:
       length: 1
@@ -62,6 +64,7 @@ instances:
       cross_section: heater_metal
       length: 1
       npoints: 2
+      width: null
   via_stack_S4_4_LHEATER__371e9067_3000_0:
     component: via_stack
     info:
@@ -121,25 +124,25 @@ instances:
 name: ring_double_heater_G0p2_26d47ff1
 nets:
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,e2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,e1
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,e1
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,e3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10700,e1
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10700,e1
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,o2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,o1
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,o1
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,o3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10700,o1
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10700,o1
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,e1
-  p2: straight_L1_N2_CSheater_metal_m1000_20710,e1
+  p2: straight_L1_N2_CSheater_7547f2a1_m1000_20710,e1
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,e2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10700,e2
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10700,e2
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,e3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,e2
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,e2
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,e4
-  p2: straight_L1_N2_CSheater_metal_m1000_20710,e2
+  p2: straight_L1_N2_CSheater_7547f2a1_m1000_20710,e2
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,o2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10700,o2
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10700,o2
 - p1: coupler_ring_G0p2_R10_L_ca129826_m1000_21410,o3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,o2
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,o2
 placements:
   coupler_ring_G0p2_R10_L_ca129826_0_0:
     mirror: false
@@ -151,17 +154,17 @@ placements:
     rotation: 180
     x: -1
     y: 21.41
-  straight_L0p01_N2_CSstr_b7a6e359_10000_10700:
+  straight_L0p01_N2_CSstr_99fbf211_10000_10700:
     mirror: false
     rotation: 90
     x: 10
     y: 10.7
-  straight_L0p01_N2_CSstr_b7a6e359_m11000_10700:
+  straight_L0p01_N2_CSstr_99fbf211_m11000_10700:
     mirror: false
     rotation: 90
     x: -11
     y: 10.7
-  straight_L1_N2_CSheater_metal_m1000_20710:
+  straight_L1_N2_CSheater_7547f2a1_m1000_20710:
     mirror: false
     rotation: 0
     x: -1

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -59,7 +59,7 @@ instances:
       length_x: 4
       radius: 10
       straight: straight
-  straight_L0p6_N2_CSstrip_10000_11300:
+  straight_L0p6_N2_CSstrip_WNone_10000_11300:
     component: straight
     info:
       length: 0.6
@@ -72,7 +72,8 @@ instances:
       cross_section: strip
       length: 0.6
       npoints: 2
-  straight_L0p6_N2_CSstrip_m14000_10700:
+      width: null
+  straight_L0p6_N2_CSstrip_WNone_m14000_10700:
     component: straight
     info:
       length: 0.6
@@ -85,7 +86,8 @@ instances:
       cross_section: strip
       length: 0.6
       npoints: 2
-  straight_L4_N2_CSstrip_0_21300:
+      width: null
+  straight_L4_N2_CSstrip_WNone_0_21300:
     component: straight
     info:
       length: 4
@@ -98,20 +100,21 @@ instances:
       cross_section: strip
       length: 4
       npoints: 2
+      width: null
 name: ring_single_G0p2_R10_LX_1ab45a89
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_11300,o1
-  p2: straight_L0p6_N2_CSstrip_10000_11300,o1
+  p2: straight_L0p6_N2_CSstrip_WNone_10000_11300,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_10000_11300,o2
-  p2: straight_L4_N2_CSstrip_0_21300,o1
+  p2: straight_L4_N2_CSstrip_WNone_0_21300,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m4000_21300,o1
-  p2: straight_L4_N2_CSstrip_0_21300,o2
+  p2: straight_L4_N2_CSstrip_WNone_0_21300,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_m4000_21300,o2
-  p2: straight_L0p6_N2_CSstrip_m14000_10700,o2
+  p2: straight_L0p6_N2_CSstrip_WNone_m14000_10700,o2
 - p1: coupler_ring_G0p2_R10_L_9871ac59_0_0,o2
-  p2: straight_L0p6_N2_CSstrip_m14000_10700,o1
+  p2: straight_L0p6_N2_CSstrip_WNone_m14000_10700,o1
 - p1: coupler_ring_G0p2_R10_L_9871ac59_0_0,o3
-  p2: straight_L0p6_N2_CSstrip_10000_11300,o2
+  p2: straight_L0p6_N2_CSstrip_WNone_10000_11300,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_10000_11300:
     mirror: false
@@ -128,17 +131,17 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L0p6_N2_CSstrip_10000_11300:
+  straight_L0p6_N2_CSstrip_WNone_10000_11300:
     mirror: false
     rotation: 270
     x: 10
     y: 11.3
-  straight_L0p6_N2_CSstrip_m14000_10700:
+  straight_L0p6_N2_CSstrip_WNone_m14000_10700:
     mirror: false
     rotation: 90
     x: -14
     y: 10.7
-  straight_L4_N2_CSstrip_0_21300:
+  straight_L4_N2_CSstrip_WNone_0_21300:
     mirror: false
     rotation: 180
     x: 0

--- a/test-data-regression/test_netlists_ring_single_array_.yml
+++ b/test-data-regression/test_netlists_ring_single_array_.yml
@@ -23,7 +23,7 @@ instances:
       length_y: 0.6
       radius: 5
       straight: straight
-  straight_L5_N2_CSstrip_8000_0:
+  straight_L5_N2_CSstrip_WNone_8000_0:
     component: straight
     info:
       length: 5
@@ -36,12 +36,13 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: ring_single_array_Rring_c44178b9
 nets:
 - p1: ring_single_G0p2_R10_LX_756584a5_46000_0,o1
-  p2: straight_L5_N2_CSstrip_8000_0,o2
+  p2: straight_L5_N2_CSstrip_WNone_8000_0,o2
 - p1: ring_single_G0p2_R5_LX1_7dcbd653_0_0,o2
-  p2: straight_L5_N2_CSstrip_8000_0,o1
+  p2: straight_L5_N2_CSstrip_WNone_8000_0,o1
 placements:
   ring_single_G0p2_R10_LX_756584a5_46000_0:
     mirror: false
@@ -53,7 +54,7 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L5_N2_CSstrip_8000_0:
+  straight_L5_N2_CSstrip_WNone_8000_0:
     mirror: false
     rotation: 0
     x: 8

--- a/test-data-regression/test_netlists_ring_single_dut_.yml
+++ b/test-data-regression/test_netlists_ring_single_dut_.yml
@@ -59,7 +59,7 @@ instances:
       length_x: 4
       radius: 5
       straight: straight
-  straight_L10_N2_CSstrip_m9000_15700:
+  straight_L10_N2_CSstrip_WNone_m9000_15700:
     component: straight
     info:
       length: 10
@@ -72,7 +72,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  straight_L4_N2_CSstrip_m4000_20700:
+      width: null
+  straight_L4_N2_CSstrip_WNone_m4000_20700:
     component: straight
     info:
       length: 4
@@ -85,7 +86,8 @@ instances:
       cross_section: strip
       length: 4
       npoints: 2
-  taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700:
+      width: null
+  taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700:
     component: taper
     info:
       length: 10
@@ -93,6 +95,7 @@ instances:
       width2: 3
     settings:
       cross_section: strip
+      layer: null
       length: 10
       port: null
       port_names:
@@ -108,17 +111,17 @@ instances:
 name: ring_single_dut_CFtaper_ab2e96a5
 nets:
 - p1: bend_euler_R5_A90_P0p5__c7bd5c45_5000_15700,o1
-  p2: taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700,o1
+  p2: taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700,o1
 - p1: bend_euler_R5_A90_P0p5__c7bd5c45_5000_15700,o2
-  p2: straight_L4_N2_CSstrip_m4000_20700,o2
+  p2: straight_L4_N2_CSstrip_WNone_m4000_20700,o2
 - p1: bend_euler_R5_A90_P0p5__c7bd5c45_m4000_20700,o1
-  p2: straight_L4_N2_CSstrip_m4000_20700,o1
+  p2: straight_L4_N2_CSstrip_WNone_m4000_20700,o1
 - p1: bend_euler_R5_A90_P0p5__c7bd5c45_m4000_20700,o2
-  p2: straight_L10_N2_CSstrip_m9000_15700,o1
+  p2: straight_L10_N2_CSstrip_WNone_m9000_15700,o1
 - p1: coupler_ring_G0p2_R5_LX_ba10ec54_0_0,o2
-  p2: straight_L10_N2_CSstrip_m9000_15700,o2
+  p2: straight_L10_N2_CSstrip_WNone_m9000_15700,o2
 - p1: coupler_ring_G0p2_R5_LX_ba10ec54_0_0,o3
-  p2: taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700,o2
+  p2: taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700,o2
 placements:
   bend_euler_R5_A90_P0p5__c7bd5c45_5000_15700:
     mirror: false
@@ -135,17 +138,17 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L10_N2_CSstrip_m9000_15700:
+  straight_L10_N2_CSstrip_WNone_m9000_15700:
     mirror: false
     rotation: 270
     x: -9
     y: 15.7
-  straight_L4_N2_CSstrip_m4000_20700:
+  straight_L4_N2_CSstrip_WNone_m4000_20700:
     mirror: false
     rotation: 0
     x: -4
     y: 20.7
-  taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700:
+  taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700:
     mirror: false
     rotation: 270
     x: 5
@@ -156,11 +159,11 @@ ports:
 warnings:
   optical:
     width_mismatch:
-    - message: Widths of ports coupler_ring_G0p2_R5_LX_ba10ec54_0_0,o3 and taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700,o2
+    - message: Widths of ports coupler_ring_G0p2_R5_LX_ba10ec54_0_0,o3 and taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700,o2
         not equal. Difference of 2500 um
       ports:
       - coupler_ring_G0p2_R5_LX_ba10ec54_0_0,o3
-      - taper_L10_W0p5_W3_PNone_8fb8efc8_5000_15700,o2
+      - taper_L10_W0p5_W3_LNone_5e3a56c5_5000_15700,o2
       values:
       - 500
       - 3000

--- a/test-data-regression/test_netlists_ring_single_heater_.yml
+++ b/test-data-regression/test_netlists_ring_single_heater_.yml
@@ -59,7 +59,7 @@ instances:
       length_x: 1
       radius: 10
       straight: straight
-  straight_L0p01_N2_CSstr_b7a6e359_10000_10710:
+  straight_L0p01_N2_CSstr_99fbf211_10000_10710:
     component: straight
     info:
       length: 0.01
@@ -72,7 +72,8 @@ instances:
       cross_section: strip_heater_metal
       length: 0.01
       npoints: 2
-  straight_L0p01_N2_CSstr_b7a6e359_m11000_10700:
+      width: null
+  straight_L0p01_N2_CSstr_99fbf211_m11000_10700:
     component: straight
     info:
       length: 0.01
@@ -85,7 +86,8 @@ instances:
       cross_section: strip_heater_metal
       length: 0.01
       npoints: 2
-  straight_L1_N2_CSstrip__f1c4f592_0_20710:
+      width: null
+  straight_L1_N2_CSstrip__a1f45d7c_0_20710:
     component: straight
     info:
       length: 1
@@ -98,6 +100,7 @@ instances:
       cross_section: strip_heater_metal
       length: 1
       npoints: 2
+      width: null
   via_stack_S4_4_LHEATER__371e9067_3000_0:
     component: via_stack
     info:
@@ -157,29 +160,29 @@ instances:
 name: ring_double_heater_G0p2_113fb173
 nets:
 - p1: bend_euler_R10_A90_P0p5_8747be7e_10000_10710,e1
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10710,e1
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10710,e1
 - p1: bend_euler_R10_A90_P0p5_8747be7e_10000_10710,e2
-  p2: straight_L1_N2_CSstrip__f1c4f592_0_20710,e1
+  p2: straight_L1_N2_CSstrip__a1f45d7c_0_20710,e1
 - p1: bend_euler_R10_A90_P0p5_8747be7e_10000_10710,o1
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10710,o1
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10710,o1
 - p1: bend_euler_R10_A90_P0p5_8747be7e_10000_10710,o2
-  p2: straight_L1_N2_CSstrip__f1c4f592_0_20710,o1
+  p2: straight_L1_N2_CSstrip__a1f45d7c_0_20710,o1
 - p1: bend_euler_R10_A90_P0p5_8747be7e_m1000_20710,e1
-  p2: straight_L1_N2_CSstrip__f1c4f592_0_20710,e2
+  p2: straight_L1_N2_CSstrip__a1f45d7c_0_20710,e2
 - p1: bend_euler_R10_A90_P0p5_8747be7e_m1000_20710,e2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,e2
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,e2
 - p1: bend_euler_R10_A90_P0p5_8747be7e_m1000_20710,o1
-  p2: straight_L1_N2_CSstrip__f1c4f592_0_20710,o2
+  p2: straight_L1_N2_CSstrip__a1f45d7c_0_20710,o2
 - p1: bend_euler_R10_A90_P0p5_8747be7e_m1000_20710,o2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,o2
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,o2
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,e2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,e1
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,e1
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,e3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10710,e2
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10710,e2
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,o2
-  p2: straight_L0p01_N2_CSstr_b7a6e359_m11000_10700,o1
+  p2: straight_L0p01_N2_CSstr_99fbf211_m11000_10700,o1
 - p1: coupler_ring_G0p2_R10_L_ca129826_0_0,o3
-  p2: straight_L0p01_N2_CSstr_b7a6e359_10000_10710,o2
+  p2: straight_L0p01_N2_CSstr_99fbf211_10000_10710,o2
 placements:
   bend_euler_R10_A90_P0p5_8747be7e_10000_10710:
     mirror: false
@@ -196,17 +199,17 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L0p01_N2_CSstr_b7a6e359_10000_10710:
+  straight_L0p01_N2_CSstr_99fbf211_10000_10710:
     mirror: false
     rotation: 270
     x: 10
     y: 10.71
-  straight_L0p01_N2_CSstr_b7a6e359_m11000_10700:
+  straight_L0p01_N2_CSstr_99fbf211_m11000_10700:
     mirror: false
     rotation: 90
     x: -11
     y: 10.7
-  straight_L1_N2_CSstrip__f1c4f592_0_20710:
+  straight_L1_N2_CSstrip__a1f45d7c_0_20710:
     mirror: false
     rotation: 180
     x: 0

--- a/test-data-regression/test_netlists_spiral_.yml
+++ b/test-data-regression/test_netlists_spiral_.yml
@@ -671,7 +671,7 @@ instances:
       radius: null
       width: null
       with_arc_floorplan: true
-  straight_L100_N2_CSstrip_0_0:
+  straight_L100_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 100
@@ -684,7 +684,8 @@ instances:
       cross_section: strip
       length: 100
       npoints: 2
-  straight_L123_N2_CSstrip_100000_23000:
+      width: null
+  straight_L123_N2_CSstrip_WNone_100000_23000:
     component: straight
     info:
       length: 123
@@ -697,7 +698,8 @@ instances:
       cross_section: strip
       length: 123
       npoints: 2
-  straight_L123_N2_CSstrip_m20000_m3000:
+      width: null
+  straight_L123_N2_CSstrip_WNone_m20000_m3000:
     component: straight
     info:
       length: 123
@@ -710,7 +712,8 @@ instances:
       cross_section: strip
       length: 123
       npoints: 2
-  straight_L129_N2_CSstrip_103000_26000:
+      width: null
+  straight_L129_N2_CSstrip_WNone_103000_26000:
     component: straight
     info:
       length: 129
@@ -723,7 +726,8 @@ instances:
       cross_section: strip
       length: 129
       npoints: 2
-  straight_L129_N2_CSstrip_m23000_m6000:
+      width: null
+  straight_L129_N2_CSstrip_WNone_m23000_m6000:
     component: straight
     info:
       length: 129
@@ -736,7 +740,8 @@ instances:
       cross_section: strip
       length: 129
       npoints: 2
-  straight_L135_N2_CSstrip_106000_29000:
+      width: null
+  straight_L135_N2_CSstrip_WNone_106000_29000:
     component: straight
     info:
       length: 135
@@ -749,7 +754,8 @@ instances:
       cross_section: strip
       length: 135
       npoints: 2
-  straight_L135_N2_CSstrip_m26000_m9000:
+      width: null
+  straight_L135_N2_CSstrip_WNone_m26000_m9000:
     component: straight
     info:
       length: 135
@@ -762,7 +768,8 @@ instances:
       cross_section: strip
       length: 135
       npoints: 2
-  straight_L141_N2_CSstrip_109000_32000:
+      width: null
+  straight_L141_N2_CSstrip_WNone_109000_32000:
     component: straight
     info:
       length: 141
@@ -775,7 +782,8 @@ instances:
       cross_section: strip
       length: 141
       npoints: 2
-  straight_L141_N2_CSstrip_m29000_m12000:
+      width: null
+  straight_L141_N2_CSstrip_WNone_m29000_m12000:
     component: straight
     info:
       length: 141
@@ -788,7 +796,8 @@ instances:
       cross_section: strip
       length: 141
       npoints: 2
-  straight_L147_N2_CSstrip_112000_35000:
+      width: null
+  straight_L147_N2_CSstrip_WNone_112000_35000:
     component: straight
     info:
       length: 147
@@ -801,7 +810,8 @@ instances:
       cross_section: strip
       length: 147
       npoints: 2
-  straight_L147_N2_CSstrip_m32000_m15000:
+      width: null
+  straight_L147_N2_CSstrip_WNone_m32000_m15000:
     component: straight
     info:
       length: 147
@@ -814,7 +824,8 @@ instances:
       cross_section: strip
       length: 147
       npoints: 2
-  straight_L153_N2_CSstrip_115000_38000:
+      width: null
+  straight_L153_N2_CSstrip_WNone_115000_38000:
     component: straight
     info:
       length: 153
@@ -827,7 +838,8 @@ instances:
       cross_section: strip
       length: 153
       npoints: 2
-  straight_L153_N2_CSstrip_m35000_m18000:
+      width: null
+  straight_L153_N2_CSstrip_WNone_m35000_m18000:
     component: straight
     info:
       length: 153
@@ -840,7 +852,8 @@ instances:
       cross_section: strip
       length: 153
       npoints: 2
-  straight_L159_N2_CSstrip_m38000_m21000:
+      width: null
+  straight_L159_N2_CSstrip_WNone_m38000_m21000:
     component: straight
     info:
       length: 159
@@ -853,7 +866,8 @@ instances:
       cross_section: strip
       length: 159
       npoints: 2
-  straight_L15_N2_CSstrip_116000_4000:
+      width: null
+  straight_L15_N2_CSstrip_WNone_116000_4000:
     component: straight
     info:
       length: 15
@@ -866,7 +880,8 @@ instances:
       cross_section: strip
       length: 15
       npoints: 2
-  straight_L15_N2_CSstrip_m36000_16000:
+      width: null
+  straight_L15_N2_CSstrip_WNone_m36000_16000:
     component: straight
     info:
       length: 15
@@ -879,7 +894,8 @@ instances:
       cross_section: strip
       length: 15
       npoints: 2
-  straight_L21_N2_CSstrip_119000_1000:
+      width: null
+  straight_L21_N2_CSstrip_WNone_119000_1000:
     component: straight
     info:
       length: 21
@@ -892,7 +908,8 @@ instances:
       cross_section: strip
       length: 21
       npoints: 2
-  straight_L21_N2_CSstrip_m39000_19000:
+      width: null
+  straight_L21_N2_CSstrip_WNone_m39000_19000:
     component: straight
     info:
       length: 21
@@ -905,7 +922,8 @@ instances:
       cross_section: strip
       length: 21
       npoints: 2
-  straight_L27_N2_CSstrip_122000_m2000:
+      width: null
+  straight_L27_N2_CSstrip_WNone_122000_m2000:
     component: straight
     info:
       length: 27
@@ -918,7 +936,8 @@ instances:
       cross_section: strip
       length: 27
       npoints: 2
-  straight_L27_N2_CSstrip_m42000_22000:
+      width: null
+  straight_L27_N2_CSstrip_WNone_m42000_22000:
     component: straight
     info:
       length: 27
@@ -931,7 +950,8 @@ instances:
       cross_section: strip
       length: 27
       npoints: 2
-  straight_L33_N2_CSstrip_125000_m5000:
+      width: null
+  straight_L33_N2_CSstrip_WNone_125000_m5000:
     component: straight
     info:
       length: 33
@@ -944,7 +964,8 @@ instances:
       cross_section: strip
       length: 33
       npoints: 2
-  straight_L33_N2_CSstrip_m45000_25000:
+      width: null
+  straight_L33_N2_CSstrip_WNone_m45000_25000:
     component: straight
     info:
       length: 33
@@ -957,7 +978,8 @@ instances:
       cross_section: strip
       length: 33
       npoints: 2
-  straight_L39_N2_CSstrip_m48000_28000:
+      width: null
+  straight_L39_N2_CSstrip_WNone_m48000_28000:
     component: straight
     info:
       length: 39
@@ -970,7 +992,8 @@ instances:
       cross_section: strip
       length: 39
       npoints: 2
-  straight_L3_N2_CSstrip_110000_10000:
+      width: null
+  straight_L3_N2_CSstrip_WNone_110000_10000:
     component: straight
     info:
       length: 3
@@ -983,7 +1006,8 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-  straight_L3_N2_CSstrip_m30000_10000:
+      width: null
+  straight_L3_N2_CSstrip_WNone_m30000_10000:
     component: straight
     info:
       length: 3
@@ -996,7 +1020,8 @@ instances:
       cross_section: strip
       length: 3
       npoints: 2
-  straight_L9_N2_CSstrip_113000_7000:
+      width: null
+  straight_L9_N2_CSstrip_WNone_113000_7000:
     component: straight
     info:
       length: 9
@@ -1009,7 +1034,8 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
-  straight_L9_N2_CSstrip_m33000_13000:
+      width: null
+  straight_L9_N2_CSstrip_WNone_m33000_13000:
     component: straight
     info:
       length: 9
@@ -1022,116 +1048,117 @@ instances:
       cross_section: strip
       length: 9
       npoints: 2
+      width: null
 name: spiral_L100_Bbend_euler_16ec11d3
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_0_0,o1
-  p2: straight_L100_N2_CSstrip_0_0,o1
+  p2: straight_L100_N2_CSstrip_WNone_0_0,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_0_0,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_m10000_10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_100000_0,o1
-  p2: straight_L100_N2_CSstrip_0_0,o2
+  p2: straight_L100_N2_CSstrip_WNone_0_0,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_100000_0,o2
-  p2: straight_L3_N2_CSstrip_110000_10000,o1
+  p2: straight_L3_N2_CSstrip_WNone_110000_10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_103000_m3000,o1
-  p2: straight_L123_N2_CSstrip_m20000_m3000,o2
+  p2: straight_L123_N2_CSstrip_WNone_m20000_m3000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_103000_m3000,o2
-  p2: straight_L9_N2_CSstrip_113000_7000,o1
+  p2: straight_L9_N2_CSstrip_WNone_113000_7000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_106000_m6000,o1
-  p2: straight_L129_N2_CSstrip_m23000_m6000,o2
+  p2: straight_L129_N2_CSstrip_WNone_m23000_m6000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_106000_m6000,o2
-  p2: straight_L15_N2_CSstrip_116000_4000,o1
+  p2: straight_L15_N2_CSstrip_WNone_116000_4000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_109000_m9000,o1
-  p2: straight_L135_N2_CSstrip_m26000_m9000,o2
+  p2: straight_L135_N2_CSstrip_WNone_m26000_m9000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_109000_m9000,o2
-  p2: straight_L21_N2_CSstrip_119000_1000,o1
+  p2: straight_L21_N2_CSstrip_WNone_119000_1000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_110000_13000,o1
-  p2: straight_L3_N2_CSstrip_110000_10000,o2
+  p2: straight_L3_N2_CSstrip_WNone_110000_10000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_110000_13000,o2
-  p2: straight_L123_N2_CSstrip_100000_23000,o1
+  p2: straight_L123_N2_CSstrip_WNone_100000_23000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_112000_m12000,o1
-  p2: straight_L141_N2_CSstrip_m29000_m12000,o2
+  p2: straight_L141_N2_CSstrip_WNone_m29000_m12000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_112000_m12000,o2
-  p2: straight_L27_N2_CSstrip_122000_m2000,o1
+  p2: straight_L27_N2_CSstrip_WNone_122000_m2000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_113000_16000,o1
-  p2: straight_L9_N2_CSstrip_113000_7000,o2
+  p2: straight_L9_N2_CSstrip_WNone_113000_7000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_113000_16000,o2
-  p2: straight_L129_N2_CSstrip_103000_26000,o1
+  p2: straight_L129_N2_CSstrip_WNone_103000_26000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_115000_m15000,o1
-  p2: straight_L147_N2_CSstrip_m32000_m15000,o2
+  p2: straight_L147_N2_CSstrip_WNone_m32000_m15000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_115000_m15000,o2
-  p2: straight_L33_N2_CSstrip_125000_m5000,o1
+  p2: straight_L33_N2_CSstrip_WNone_125000_m5000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_116000_19000,o1
-  p2: straight_L15_N2_CSstrip_116000_4000,o2
+  p2: straight_L15_N2_CSstrip_WNone_116000_4000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_116000_19000,o2
-  p2: straight_L135_N2_CSstrip_106000_29000,o1
+  p2: straight_L135_N2_CSstrip_WNone_106000_29000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_119000_22000,o1
-  p2: straight_L21_N2_CSstrip_119000_1000,o2
+  p2: straight_L21_N2_CSstrip_WNone_119000_1000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_119000_22000,o2
-  p2: straight_L141_N2_CSstrip_109000_32000,o1
+  p2: straight_L141_N2_CSstrip_WNone_109000_32000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_122000_25000,o1
-  p2: straight_L27_N2_CSstrip_122000_m2000,o2
+  p2: straight_L27_N2_CSstrip_WNone_122000_m2000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_122000_25000,o2
-  p2: straight_L147_N2_CSstrip_112000_35000,o1
+  p2: straight_L147_N2_CSstrip_WNone_112000_35000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_125000_28000,o1
-  p2: straight_L33_N2_CSstrip_125000_m5000,o2
+  p2: straight_L33_N2_CSstrip_WNone_125000_m5000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_125000_28000,o2
-  p2: straight_L153_N2_CSstrip_115000_38000,o1
+  p2: straight_L153_N2_CSstrip_WNone_115000_38000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m10000_10000,o2
   p2: bend_euler_RNone_A90_P0_d7c3a5a9_m20000_20000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m20000_20000,o2
-  p2: straight_L3_N2_CSstrip_m30000_10000,o1
+  p2: straight_L3_N2_CSstrip_WNone_m30000_10000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m23000_23000,o1
-  p2: straight_L123_N2_CSstrip_100000_23000,o2
+  p2: straight_L123_N2_CSstrip_WNone_100000_23000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m23000_23000,o2
-  p2: straight_L9_N2_CSstrip_m33000_13000,o1
+  p2: straight_L9_N2_CSstrip_WNone_m33000_13000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m26000_26000,o1
-  p2: straight_L129_N2_CSstrip_103000_26000,o2
+  p2: straight_L129_N2_CSstrip_WNone_103000_26000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m26000_26000,o2
-  p2: straight_L15_N2_CSstrip_m36000_16000,o1
+  p2: straight_L15_N2_CSstrip_WNone_m36000_16000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m29000_29000,o1
-  p2: straight_L135_N2_CSstrip_106000_29000,o2
+  p2: straight_L135_N2_CSstrip_WNone_106000_29000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m29000_29000,o2
-  p2: straight_L21_N2_CSstrip_m39000_19000,o1
+  p2: straight_L21_N2_CSstrip_WNone_m39000_19000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m30000_7000,o1
-  p2: straight_L3_N2_CSstrip_m30000_10000,o2
+  p2: straight_L3_N2_CSstrip_WNone_m30000_10000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m30000_7000,o2
-  p2: straight_L123_N2_CSstrip_m20000_m3000,o1
+  p2: straight_L123_N2_CSstrip_WNone_m20000_m3000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m32000_32000,o1
-  p2: straight_L141_N2_CSstrip_109000_32000,o2
+  p2: straight_L141_N2_CSstrip_WNone_109000_32000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m32000_32000,o2
-  p2: straight_L27_N2_CSstrip_m42000_22000,o1
+  p2: straight_L27_N2_CSstrip_WNone_m42000_22000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m33000_4000,o1
-  p2: straight_L9_N2_CSstrip_m33000_13000,o2
+  p2: straight_L9_N2_CSstrip_WNone_m33000_13000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m33000_4000,o2
-  p2: straight_L129_N2_CSstrip_m23000_m6000,o1
+  p2: straight_L129_N2_CSstrip_WNone_m23000_m6000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m35000_35000,o1
-  p2: straight_L147_N2_CSstrip_112000_35000,o2
+  p2: straight_L147_N2_CSstrip_WNone_112000_35000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m35000_35000,o2
-  p2: straight_L33_N2_CSstrip_m45000_25000,o1
+  p2: straight_L33_N2_CSstrip_WNone_m45000_25000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m36000_1000,o1
-  p2: straight_L15_N2_CSstrip_m36000_16000,o2
+  p2: straight_L15_N2_CSstrip_WNone_m36000_16000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m36000_1000,o2
-  p2: straight_L135_N2_CSstrip_m26000_m9000,o1
+  p2: straight_L135_N2_CSstrip_WNone_m26000_m9000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m38000_38000,o1
-  p2: straight_L153_N2_CSstrip_115000_38000,o2
+  p2: straight_L153_N2_CSstrip_WNone_115000_38000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m38000_38000,o2
-  p2: straight_L39_N2_CSstrip_m48000_28000,o1
+  p2: straight_L39_N2_CSstrip_WNone_m48000_28000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m39000_m2000,o1
-  p2: straight_L21_N2_CSstrip_m39000_19000,o2
+  p2: straight_L21_N2_CSstrip_WNone_m39000_19000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m39000_m2000,o2
-  p2: straight_L141_N2_CSstrip_m29000_m12000,o1
+  p2: straight_L141_N2_CSstrip_WNone_m29000_m12000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m42000_m5000,o1
-  p2: straight_L27_N2_CSstrip_m42000_22000,o2
+  p2: straight_L27_N2_CSstrip_WNone_m42000_22000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m42000_m5000,o2
-  p2: straight_L147_N2_CSstrip_m32000_m15000,o1
+  p2: straight_L147_N2_CSstrip_WNone_m32000_m15000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m45000_m8000,o1
-  p2: straight_L33_N2_CSstrip_m45000_25000,o2
+  p2: straight_L33_N2_CSstrip_WNone_m45000_25000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m45000_m8000,o2
-  p2: straight_L153_N2_CSstrip_m35000_m18000,o1
+  p2: straight_L153_N2_CSstrip_WNone_m35000_m18000,o1
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m48000_m11000,o1
-  p2: straight_L39_N2_CSstrip_m48000_28000,o2
+  p2: straight_L39_N2_CSstrip_WNone_m48000_28000,o2
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_m48000_m11000,o2
-  p2: straight_L159_N2_CSstrip_m38000_m21000,o1
+  p2: straight_L159_N2_CSstrip_WNone_m38000_m21000,o1
 placements:
   bend_euler_RNone_A90_P0_d7c3a5a9_0_0:
     mirror: true
@@ -1273,141 +1300,141 @@ placements:
     rotation: 270
     x: -48
     y: -11
-  straight_L100_N2_CSstrip_0_0:
+  straight_L100_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_L123_N2_CSstrip_100000_23000:
+  straight_L123_N2_CSstrip_WNone_100000_23000:
     mirror: false
     rotation: 180
     x: 100
     y: 23
-  straight_L123_N2_CSstrip_m20000_m3000:
+  straight_L123_N2_CSstrip_WNone_m20000_m3000:
     mirror: false
     rotation: 0
     x: -20
     y: -3
-  straight_L129_N2_CSstrip_103000_26000:
+  straight_L129_N2_CSstrip_WNone_103000_26000:
     mirror: false
     rotation: 180
     x: 103
     y: 26
-  straight_L129_N2_CSstrip_m23000_m6000:
+  straight_L129_N2_CSstrip_WNone_m23000_m6000:
     mirror: false
     rotation: 0
     x: -23
     y: -6
-  straight_L135_N2_CSstrip_106000_29000:
+  straight_L135_N2_CSstrip_WNone_106000_29000:
     mirror: false
     rotation: 180
     x: 106
     y: 29
-  straight_L135_N2_CSstrip_m26000_m9000:
+  straight_L135_N2_CSstrip_WNone_m26000_m9000:
     mirror: false
     rotation: 0
     x: -26
     y: -9
-  straight_L141_N2_CSstrip_109000_32000:
+  straight_L141_N2_CSstrip_WNone_109000_32000:
     mirror: false
     rotation: 180
     x: 109
     y: 32
-  straight_L141_N2_CSstrip_m29000_m12000:
+  straight_L141_N2_CSstrip_WNone_m29000_m12000:
     mirror: false
     rotation: 0
     x: -29
     y: -12
-  straight_L147_N2_CSstrip_112000_35000:
+  straight_L147_N2_CSstrip_WNone_112000_35000:
     mirror: false
     rotation: 180
     x: 112
     y: 35
-  straight_L147_N2_CSstrip_m32000_m15000:
+  straight_L147_N2_CSstrip_WNone_m32000_m15000:
     mirror: false
     rotation: 0
     x: -32
     y: -15
-  straight_L153_N2_CSstrip_115000_38000:
+  straight_L153_N2_CSstrip_WNone_115000_38000:
     mirror: false
     rotation: 180
     x: 115
     y: 38
-  straight_L153_N2_CSstrip_m35000_m18000:
+  straight_L153_N2_CSstrip_WNone_m35000_m18000:
     mirror: false
     rotation: 0
     x: -35
     y: -18
-  straight_L159_N2_CSstrip_m38000_m21000:
+  straight_L159_N2_CSstrip_WNone_m38000_m21000:
     mirror: false
     rotation: 0
     x: -38
     y: -21
-  straight_L15_N2_CSstrip_116000_4000:
+  straight_L15_N2_CSstrip_WNone_116000_4000:
     mirror: false
     rotation: 90
     x: 116
     y: 4
-  straight_L15_N2_CSstrip_m36000_16000:
+  straight_L15_N2_CSstrip_WNone_m36000_16000:
     mirror: false
     rotation: 270
     x: -36
     y: 16
-  straight_L21_N2_CSstrip_119000_1000:
+  straight_L21_N2_CSstrip_WNone_119000_1000:
     mirror: false
     rotation: 90
     x: 119
     y: 1
-  straight_L21_N2_CSstrip_m39000_19000:
+  straight_L21_N2_CSstrip_WNone_m39000_19000:
     mirror: false
     rotation: 270
     x: -39
     y: 19
-  straight_L27_N2_CSstrip_122000_m2000:
+  straight_L27_N2_CSstrip_WNone_122000_m2000:
     mirror: false
     rotation: 90
     x: 122
     y: -2
-  straight_L27_N2_CSstrip_m42000_22000:
+  straight_L27_N2_CSstrip_WNone_m42000_22000:
     mirror: false
     rotation: 270
     x: -42
     y: 22
-  straight_L33_N2_CSstrip_125000_m5000:
+  straight_L33_N2_CSstrip_WNone_125000_m5000:
     mirror: false
     rotation: 90
     x: 125
     y: -5
-  straight_L33_N2_CSstrip_m45000_25000:
+  straight_L33_N2_CSstrip_WNone_m45000_25000:
     mirror: false
     rotation: 270
     x: -45
     y: 25
-  straight_L39_N2_CSstrip_m48000_28000:
+  straight_L39_N2_CSstrip_WNone_m48000_28000:
     mirror: false
     rotation: 270
     x: -48
     y: 28
-  straight_L3_N2_CSstrip_110000_10000:
+  straight_L3_N2_CSstrip_WNone_110000_10000:
     mirror: false
     rotation: 90
     x: 110
     y: 10
-  straight_L3_N2_CSstrip_m30000_10000:
+  straight_L3_N2_CSstrip_WNone_m30000_10000:
     mirror: false
     rotation: 270
     x: -30
     y: 10
-  straight_L9_N2_CSstrip_113000_7000:
+  straight_L9_N2_CSstrip_WNone_113000_7000:
     mirror: false
     rotation: 90
     x: 113
     y: 7
-  straight_L9_N2_CSstrip_m33000_13000:
+  straight_L9_N2_CSstrip_WNone_m33000_13000:
     mirror: false
     rotation: 270
     x: -33
     y: 13
 ports:
-  o1: straight_L153_N2_CSstrip_m35000_m18000,o2
-  o2: straight_L159_N2_CSstrip_m38000_m21000,o2
+  o1: straight_L153_N2_CSstrip_WNone_m35000_m18000,o2
+  o2: straight_L159_N2_CSstrip_WNone_m38000_m21000,o2

--- a/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
@@ -24,7 +24,7 @@ instances:
       straight_factory: straight
       straight_length: 30
       with_inner_ports: false
-  straight_L30_N2_CSnpp_0_12000:
+  straight_L30_N2_CSnpp_WNone_0_12000:
     component: straight
     info:
       length: 30
@@ -37,7 +37,8 @@ instances:
       cross_section: npp
       length: 30
       npoints: 2
-  straight_L30_N2_CSnpp_30000_m30000:
+      width: null
+  straight_L30_N2_CSnpp_WNone_30000_m30000:
     component: straight
     info:
       length: 30
@@ -50,6 +51,7 @@ instances:
       cross_section: npp
       length: 30
       npoints: 2
+      width: null
 name: spiral_racetrack_heater_b997422e
 nets: []
 placements:
@@ -58,20 +60,20 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L30_N2_CSnpp_0_12000:
+  straight_L30_N2_CSnpp_WNone_0_12000:
     mirror: false
     rotation: 0
     x: 0
     y: 12
-  straight_L30_N2_CSnpp_30000_m30000:
+  straight_L30_N2_CSnpp_WNone_30000_m30000:
     mirror: false
     rotation: 180
     x: 30
     y: -30
 ports:
-  bot_e1: straight_L30_N2_CSnpp_0_12000,e1
-  bot_e2: straight_L30_N2_CSnpp_0_12000,e2
+  bot_e1: straight_L30_N2_CSnpp_WNone_0_12000,e1
+  bot_e2: straight_L30_N2_CSnpp_WNone_0_12000,e2
   o1: spiral_racetrack_MR10_S_2cd856ae_0_0,o1
   o2: spiral_racetrack_MR10_S_2cd856ae_0_0,o2
-  top_e1: straight_L30_N2_CSnpp_30000_m30000,e1
-  top_e2: straight_L30_N2_CSnpp_30000_m30000,e2
+  top_e1: straight_L30_N2_CSnpp_WNone_30000_m30000,e1
+  top_e2: straight_L30_N2_CSnpp_WNone_30000_m30000,e2

--- a/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/test-data-regression/test_netlists_splitter_tree_.yml
@@ -214,7 +214,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_L44p5_N2_CSstrip_35500_25000:
+  straight_L44p5_N2_CSstrip_WNone_35500_25000:
     component: straight
     info:
       length: 44.5
@@ -227,7 +227,8 @@ instances:
       cross_section: strip
       length: 44.5
       npoints: 2
-  straight_L44p5_N2_CSstrip_35500_m25000:
+      width: null
+  straight_L44p5_N2_CSstrip_WNone_35500_m25000:
     component: straight
     info:
       length: 44.5
@@ -240,7 +241,8 @@ instances:
       cross_section: strip
       length: 44.5
       npoints: 2
-  straight_L4p375_N2_CSstrip_25500_15000:
+      width: null
+  straight_L4p375_N2_CSstrip_WNone_25500_15000:
     component: straight
     info:
       length: 4.375
@@ -253,7 +255,8 @@ instances:
       cross_section: strip
       length: 4.375
       npoints: 2
-  straight_L4p375_N2_CSstrip_25500_m15000:
+      width: null
+  straight_L4p375_N2_CSstrip_WNone_25500_m15000:
     component: straight
     info:
       length: 4.375
@@ -266,24 +269,25 @@ instances:
       cross_section: strip
       length: 4.375
       npoints: 2
+      width: null
 name: splitter_tree_Cmmi1x2_N_4888501b
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625,o1
-  p2: straight_L4p375_N2_CSstrip_25500_15000,o2
+  p2: straight_L4p375_N2_CSstrip_WNone_25500_15000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625,o2
   p2: coupler_0_0,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625,o1
-  p2: straight_L4p375_N2_CSstrip_25500_m15000,o2
+  p2: straight_L4p375_N2_CSstrip_WNone_25500_m15000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_25500_m10625,o2
   p2: coupler_0_0,o3
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000,o1
-  p2: straight_L44p5_N2_CSstrip_35500_25000,o1
+  p2: straight_L44p5_N2_CSstrip_WNone_35500_25000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_25000,o2
-  p2: straight_L4p375_N2_CSstrip_25500_15000,o1
+  p2: straight_L4p375_N2_CSstrip_WNone_25500_15000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000,o1
-  p2: straight_L44p5_N2_CSstrip_35500_m25000,o1
+  p2: straight_L44p5_N2_CSstrip_WNone_35500_m25000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_35500_m25000,o2
-  p2: straight_L4p375_N2_CSstrip_25500_m15000,o1
+  p2: straight_L4p375_N2_CSstrip_WNone_25500_m15000,o1
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_24375,o1
   p2: coupler_1_1,o3
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_25625,o1
@@ -293,9 +297,9 @@ nets:
 - p1: bend_s_S90_11p875_N99_C_62bc90bd_105500_m25625,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
-  p2: straight_L44p5_N2_CSstrip_35500_m25000,o2
+  p2: straight_L44p5_N2_CSstrip_WNone_35500_m25000,o2
 - p1: coupler_1_1,o1
-  p2: straight_L44p5_N2_CSstrip_35500_25000,o2
+  p2: straight_L44p5_N2_CSstrip_WNone_35500_25000,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_25500_10625:
     mirror: true
@@ -352,22 +356,22 @@ placements:
     rotation: 0
     x: 90
     y: 25
-  straight_L44p5_N2_CSstrip_35500_25000:
+  straight_L44p5_N2_CSstrip_WNone_35500_25000:
     mirror: false
     rotation: 0
     x: 35.5
     y: 25
-  straight_L44p5_N2_CSstrip_35500_m25000:
+  straight_L44p5_N2_CSstrip_WNone_35500_m25000:
     mirror: false
     rotation: 0
     x: 35.5
     y: -25
-  straight_L4p375_N2_CSstrip_25500_15000:
+  straight_L4p375_N2_CSstrip_WNone_25500_15000:
     mirror: false
     rotation: 270
     x: 25.5
     y: 15
-  straight_L4p375_N2_CSstrip_25500_m15000:
+  straight_L4p375_N2_CSstrip_WNone_25500_m15000:
     mirror: false
     rotation: 90
     x: 25.5

--- a/test-data-regression/test_netlists_staircase_.yml
+++ b/test-data-regression/test_netlists_staircase_.yml
@@ -12,6 +12,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   '2':
     component: straight
     info:
@@ -25,6 +26,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   '3':
     component: straight
     info:
@@ -38,6 +40,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   '4':
     component: straight
     info:
@@ -51,6 +54,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   A1:
     component: bend_euler
     info:
@@ -256,6 +260,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m2:
     component: straight
     info:
@@ -269,6 +274,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m3:
     component: straight
     info:
@@ -282,6 +288,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m4:
     component: straight
     info:
@@ -295,6 +302,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
   m5:
     component: straight
     info:
@@ -308,6 +316,7 @@ instances:
       cross_section: strip
       length: 5
       npoints: 2
+      width: null
 name: staircase_Cbend_euler_S_c2f7854d
 nets:
 - p1: 1,o1

--- a/test-data-regression/test_netlists_straight_.yml
+++ b/test-data-regression/test_netlists_straight_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: straight_L10_N2_CSstrip
+name: straight_L10_N2_CSstrip_WNone
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_straight_array_.yml
+++ b/test-data-regression/test_netlists_straight_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     component: straight
     info:
       length: 10
@@ -12,7 +12,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  straight_L10_N2_CSstrip_0_13500:
+      width: null
+  straight_L10_N2_CSstrip_WNone_0_13500:
     component: straight
     info:
       length: 10
@@ -25,7 +26,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  straight_L10_N2_CSstrip_0_4500:
+      width: null
+  straight_L10_N2_CSstrip_WNone_0_4500:
     component: straight
     info:
       length: 10
@@ -38,7 +40,8 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
-  straight_L10_N2_CSstrip_0_9000:
+      width: null
+  straight_L10_N2_CSstrip_WNone_0_9000:
     component: straight
     info:
       length: 10
@@ -51,35 +54,36 @@ instances:
       cross_section: strip
       length: 10
       npoints: 2
+      width: null
 name: straight_array_N4_S4_L10_CSstrip
 nets: []
 placements:
-  straight_L10_N2_CSstrip_0_0:
+  straight_L10_N2_CSstrip_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_L10_N2_CSstrip_0_13500:
+  straight_L10_N2_CSstrip_WNone_0_13500:
     mirror: false
     rotation: 0
     x: 0
     y: 13.5
-  straight_L10_N2_CSstrip_0_4500:
+  straight_L10_N2_CSstrip_WNone_0_4500:
     mirror: false
     rotation: 0
     x: 0
     y: 4.5
-  straight_L10_N2_CSstrip_0_9000:
+  straight_L10_N2_CSstrip_WNone_0_9000:
     mirror: false
     rotation: 0
     x: 0
     y: 9
 ports:
-  o1: straight_L10_N2_CSstrip_0_0,o1
-  o2: straight_L10_N2_CSstrip_0_4500,o1
-  o3: straight_L10_N2_CSstrip_0_9000,o1
-  o4: straight_L10_N2_CSstrip_0_13500,o1
-  o5: straight_L10_N2_CSstrip_0_13500,o2
-  o6: straight_L10_N2_CSstrip_0_9000,o2
-  o7: straight_L10_N2_CSstrip_0_4500,o2
-  o8: straight_L10_N2_CSstrip_0_0,o2
+  o1: straight_L10_N2_CSstrip_WNone_0_0,o1
+  o2: straight_L10_N2_CSstrip_WNone_0_4500,o1
+  o3: straight_L10_N2_CSstrip_WNone_0_9000,o1
+  o4: straight_L10_N2_CSstrip_WNone_0_13500,o1
+  o5: straight_L10_N2_CSstrip_WNone_0_13500,o2
+  o6: straight_L10_N2_CSstrip_WNone_0_9000,o2
+  o7: straight_L10_N2_CSstrip_WNone_0_4500,o2
+  o8: straight_L10_N2_CSstrip_WNone_0_0,o2

--- a/test-data-regression/test_netlists_straight_pin_.yml
+++ b/test-data-regression/test_netlists_straight_pin_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L480_N2_CSpin_0_0:
+  straight_L480_N2_CSpin_WNone_0_0:
     component: straight
     info:
       length: 480
@@ -12,6 +12,7 @@ instances:
       cross_section: pin
       length: 480
       npoints: 2
+      width: null
   taper_strip_to_ridge_L1_3a86af41_490000_0:
     component: taper_strip_to_ridge
     info:
@@ -102,12 +103,12 @@ instances:
       - null
 name: straight_pin_L500_CSpin_15abe242
 nets:
-- p1: straight_L480_N2_CSpin_0_0,o1
+- p1: straight_L480_N2_CSpin_WNone_0_0,o1
   p2: taper_strip_to_ridge_L1_3a86af41_m10000_0,o2
-- p1: straight_L480_N2_CSpin_0_0,o2
+- p1: straight_L480_N2_CSpin_WNone_0_0,o2
   p2: taper_strip_to_ridge_L1_3a86af41_490000_0,o2
 placements:
-  straight_L480_N2_CSpin_0_0:
+  straight_L480_N2_CSpin_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_straight_pin_slot_.yml
+++ b/test-data-regression/test_netlists_straight_pin_slot_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L480_N2_CSpin_0_0:
+  straight_L480_N2_CSpin_WNone_0_0:
     component: straight
     info:
       length: 480
@@ -12,6 +12,7 @@ instances:
       cross_section: pin
       length: 480
       npoints: 2
+      width: null
   taper_strip_to_ridge_L1_3a86af41_490000_0:
     component: taper_strip_to_ridge
     info:
@@ -150,12 +151,12 @@ instances:
       - via1
 name: straight_pin_slot_L500__1e9e7886
 nets:
-- p1: straight_L480_N2_CSpin_0_0,o1
+- p1: straight_L480_N2_CSpin_WNone_0_0,o1
   p2: taper_strip_to_ridge_L1_3a86af41_m10000_0,o2
-- p1: straight_L480_N2_CSpin_0_0,o2
+- p1: straight_L480_N2_CSpin_WNone_0_0,o2
   p2: taper_strip_to_ridge_L1_3a86af41_490000_0,o2
 placements:
-  straight_L480_N2_CSpin_0_0:
+  straight_L480_N2_CSpin_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_straight_pn_.yml
+++ b/test-data-regression/test_netlists_straight_pn_.yml
@@ -1,5 +1,5 @@
 instances:
-  straight_L1980_N2_CSpn_0_0:
+  straight_L1980_N2_CSpn_WNone_0_0:
     component: straight
     info:
       length: 1980
@@ -12,6 +12,7 @@ instances:
       cross_section: pn
       length: 1980
       npoints: 2
+      width: null
   taper_strip_to_ridge_L1_3a86af41_1990000_0:
     component: taper_strip_to_ridge
     info:
@@ -102,12 +103,12 @@ instances:
       - null
 name: straight_pin_L2000_CSpn_958ac331
 nets:
-- p1: straight_L1980_N2_CSpn_0_0,o1
+- p1: straight_L1980_N2_CSpn_WNone_0_0,o1
   p2: taper_strip_to_ridge_L1_3a86af41_m10000_0,o2
-- p1: straight_L1980_N2_CSpn_0_0,o2
+- p1: straight_L1980_N2_CSpn_WNone_0_0,o2
   p2: taper_strip_to_ridge_L1_3a86af41_1990000_0,o2
 placements:
-  straight_L1980_N2_CSpn_0_0:
+  straight_L1980_N2_CSpn_WNone_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_switch_tree_.yml
+++ b/test-data-regression/test_netlists_switch_tree_.yml
@@ -262,7 +262,7 @@ instances:
       straight_x_top: Fstraight_heater_metal_undercut_Mgdsfactorypcomponentspstraight_heater_metal_SWUFalse_LSI0p1_LU5_LUS0
       straight_y: null
       with_splitter: true
-  straight_L29p375_N2_CSstrip_411000_40000:
+  straight_L29p375_N2_CSs_6ed2bfdd_411000_40000:
     component: straight
     info:
       length: 29.375
@@ -275,7 +275,8 @@ instances:
       cross_section: strip
       length: 29.375
       npoints: 2
-  straight_L29p375_N2_CSstrip_411000_m40000:
+      width: null
+  straight_L29p375_N2_CSs_6ed2bfdd_411000_m40000:
     component: straight
     info:
       length: 29.375
@@ -288,7 +289,8 @@ instances:
       cross_section: strip
       length: 29.375
       npoints: 2
-  straight_L69_N2_CSstrip_421000_50000:
+      width: null
+  straight_L69_N2_CSstrip_WNone_421000_50000:
     component: straight
     info:
       length: 69
@@ -301,7 +303,8 @@ instances:
       cross_section: strip
       length: 69
       npoints: 2
-  straight_L69_N2_CSstrip_421000_m50000:
+      width: null
+  straight_L69_N2_CSstrip_WNone_421000_m50000:
     component: straight
     info:
       length: 69
@@ -314,24 +317,25 @@ instances:
       cross_section: strip
       length: 69
       npoints: 2
+      width: null
 name: splitter_tree_CFmzi_Mgd_25171b11
 nets:
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625,o1
-  p2: straight_L29p375_N2_CSstrip_411000_40000,o2
+  p2: straight_L29p375_N2_CSs_6ed2bfdd_411000_40000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625,o2
   p2: coupler_0_0,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625,o1
-  p2: straight_L29p375_N2_CSstrip_411000_m40000,o2
+  p2: straight_L29p375_N2_CSs_6ed2bfdd_411000_m40000,o2
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_411000_m10625,o2
   p2: coupler_0_0,o3
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000,o1
-  p2: straight_L69_N2_CSstrip_421000_50000,o1
+  p2: straight_L69_N2_CSstrip_WNone_421000_50000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_50000,o2
-  p2: straight_L29p375_N2_CSstrip_411000_40000,o1
+  p2: straight_L29p375_N2_CSs_6ed2bfdd_411000_40000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000,o1
-  p2: straight_L69_N2_CSstrip_421000_m50000,o1
+  p2: straight_L69_N2_CSstrip_WNone_421000_m50000,o1
 - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_421000_m50000,o2
-  p2: straight_L29p375_N2_CSstrip_411000_m40000,o1
+  p2: straight_L29p375_N2_CSs_6ed2bfdd_411000_m40000,o1
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_49375,o1
   p2: coupler_1_1,o3
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_50625,o1
@@ -341,9 +345,9 @@ nets:
 - p1: bend_s_S500_24p375_N99__7434ea4c_901000_m50625,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
-  p2: straight_L69_N2_CSstrip_421000_m50000,o2
+  p2: straight_L69_N2_CSstrip_WNone_421000_m50000,o2
 - p1: coupler_1_1,o1
-  p2: straight_L69_N2_CSstrip_421000_50000,o2
+  p2: straight_L69_N2_CSstrip_WNone_421000_50000,o2
 placements:
   bend_euler_R10_A90_P0p5_2f1f5c6d_411000_10625:
     mirror: true
@@ -400,22 +404,22 @@ placements:
     rotation: 0
     x: 500
     y: 50
-  straight_L29p375_N2_CSstrip_411000_40000:
+  straight_L29p375_N2_CSs_6ed2bfdd_411000_40000:
     mirror: false
     rotation: 270
     x: 411
     y: 40
-  straight_L29p375_N2_CSstrip_411000_m40000:
+  straight_L29p375_N2_CSs_6ed2bfdd_411000_m40000:
     mirror: false
     rotation: 90
     x: 411
     y: -40
-  straight_L69_N2_CSstrip_421000_50000:
+  straight_L69_N2_CSstrip_WNone_421000_50000:
     mirror: false
     rotation: 0
     x: 421
     y: 50
-  straight_L69_N2_CSstrip_421000_m50000:
+  straight_L69_N2_CSstrip_WNone_421000_m50000:
     mirror: false
     rotation: 0
     x: 421

--- a/test-data-regression/test_netlists_taper2_.yml
+++ b/test-data-regression/test_netlists_taper2_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: taper_L10_W0p5_W3_PNone_8fb8efc8
+name: taper_L10_W0p5_W3_LNone_5e3a56c5
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_taper_.yml
+++ b/test-data-regression/test_netlists_taper_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: taper_L10_W0p5_WNone_PN_19aa93b7
+name: taper_L10_W0p5_WNone_LN_08b35698
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_taper_electrical_.yml
+++ b/test-data-regression/test_netlists_taper_electrical_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: taper_L10_W0p5_WNone_PN_78a0ca3a
+name: taper_L10_W0p5_WNone_LN_f522d331
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_wire_corner_.yml
+++ b/test-data-regression/test_netlists_wire_corner_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: wire_corner_CSmetal_routing
+name: wire_corner_CSmetal_rou_ac763080
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_wire_corner_.yml
+++ b/test-data-regression/test_netlists_wire_corner_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: wire_corner_CSmetal_rou_ac763080
+name: wire_corner_CSmetal_rou_e242889c
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_wire_straight_.yml
+++ b/test-data-regression/test_netlists_wire_straight_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: straight_L10_N2_CSmetal_routing
+name: straight_L10_N2_CSmetal_15618557
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_bend_euler_s_.yml
+++ b/test-data-regression/test_settings_bend_euler_s_.yml
@@ -1,6 +1,10 @@
 info:
   length: 33.274
-name: bend_euler_s_Po1_Po2
+name: bend_euler_s_RNone_P0p5_a75130fe
 settings:
+  allow_min_radius_violation: false
+  cross_section: strip
+  p: 0.5
   port1: o1
   port2: o2
+  with_arc_floorplan: true

--- a/test-data-regression/test_settings_edge_coupler_silicon_.yml
+++ b/test-data-regression/test_settings_edge_coupler_silicon_.yml
@@ -2,7 +2,7 @@ info:
   length: 100
   width1: 0.5
   width2: 0.2
-name: taper_L100_W0p5_W0p2_PN_82884949
+name: taper_L100_W0p5_W0p2_LN_b7de9566
 settings:
   cross_section: strip
   length: 100

--- a/test-data-regression/test_settings_grating_coupler_elliptical_lumerical_.yml
+++ b/test-data-regression/test_settings_grating_coupler_elliptical_lumerical_.yml
@@ -2,11 +2,11 @@ info:
   polarization: te
   wavelength: 1.554
   xinput: -2.43
-name: grating_coupler_ellipti_b2b21f8a
+name: grating_coupler_ellipti_4c46b398
 settings:
   bias_gap: 0
+  cross_section: strip
   fiber_angle: 5
-  layer: WG
   layer_slab: SLAB150
   parameters:
   - -2.43

--- a/test-data-regression/test_settings_straight_.yml
+++ b/test-data-regression/test_settings_straight_.yml
@@ -5,7 +5,7 @@ info:
   route_info_type: strip
   route_info_weight: 10
   width: 0.5
-name: straight_L10_N2_CSstrip
+name: straight_L10_N2_CSstrip_WNone
 settings:
   cross_section: strip
   length: 10

--- a/test-data-regression/test_settings_taper2_.yml
+++ b/test-data-regression/test_settings_taper2_.yml
@@ -2,7 +2,7 @@ info:
   length: 10
   width1: 0.5
   width2: 3
-name: taper_L10_W0p5_W3_PNone_8fb8efc8
+name: taper_L10_W0p5_W3_LNone_5e3a56c5
 settings:
   cross_section: strip
   length: 10

--- a/test-data-regression/test_settings_taper_.yml
+++ b/test-data-regression/test_settings_taper_.yml
@@ -2,7 +2,7 @@ info:
   length: 10
   width1: 0.5
   width2: 0.5
-name: taper_L10_W0p5_WNone_PN_19aa93b7
+name: taper_L10_W0p5_WNone_LN_08b35698
 settings:
   cross_section: strip
   length: 10

--- a/test-data-regression/test_settings_taper_electrical_.yml
+++ b/test-data-regression/test_settings_taper_electrical_.yml
@@ -2,7 +2,7 @@ info:
   length: 10
   width1: 0.5
   width2: 0.5
-name: taper_L10_W0p5_WNone_PN_78a0ca3a
+name: taper_L10_W0p5_WNone_LN_f522d331
 settings:
   cross_section: metal_routing
   length: 10

--- a/test-data-regression/test_settings_wire_corner_.yml
+++ b/test-data-regression/test_settings_wire_corner_.yml
@@ -1,6 +1,12 @@
 info:
   dy: 10
   length: 10
-name: wire_corner_CSmetal_routing
+name: wire_corner_CSmetal_rou_ac763080
 settings:
   cross_section: metal_routing
+  port_names:
+  - e1
+  - e2
+  port_types:
+  - electrical
+  - electrical

--- a/test-data-regression/test_settings_wire_corner_.yml
+++ b/test-data-regression/test_settings_wire_corner_.yml
@@ -1,7 +1,7 @@
 info:
   dy: 10
   length: 10
-name: wire_corner_CSmetal_rou_ac763080
+name: wire_corner_CSmetal_rou_e242889c
 settings:
   cross_section: metal_routing
   port_names:

--- a/test-data-regression/test_settings_wire_straight_.yml
+++ b/test-data-regression/test_settings_wire_straight_.yml
@@ -5,7 +5,7 @@ info:
   route_info_type: metal_routing
   route_info_weight: 10
   width: 10
-name: straight_L10_N2_CSmetal_routing
+name: straight_L10_N2_CSmetal_15618557
 settings:
   cross_section: metal_routing
   length: 10

--- a/tests/routing/test_route_dubin.py
+++ b/tests/routing/test_route_dubin.py
@@ -10,8 +10,8 @@ def sample_route_dubin_basic() -> gf.Component:
     c = gf.Component()
 
     # Create two straight waveguides with different orientations
-    wg1 = c << gf.components.straight(length=100, width=3.2, layer=(30, 0))
-    wg2 = c << gf.components.straight(length=100, width=3.2, layer=(30, 0))
+    wg1 = c << gf.components.straight(length=100, width=3.2)
+    wg2 = c << gf.components.straight(length=100, width=3.2)
 
     # Move and rotate the second waveguide
     wg2.move((300, 50))
@@ -22,7 +22,7 @@ def sample_route_dubin_basic() -> gf.Component:
         c,
         port1=wg1.ports["o2"],
         port2=wg2.ports["o1"],
-        cross_section=gf.cross_section.strip(width=3.2, layer=(30, 0), radius=100),
+        cross_section=gf.cross_section.strip(width=3.2, radius=100),
     )
     return c
 

--- a/tests/routing/test_routing_route_bundle_udirect.py
+++ b/tests/routing/test_routing_route_bundle_udirect.py
@@ -31,7 +31,7 @@ def test_route_bundle_udirect_pads(
     pbports.reverse()
 
     routes = gf.routing.route_bundle_electrical(
-        c, pbports, ptports, radius=5, cross_section="metal_routing"
+        c, pbports, ptports, cross_section="metal_routing"
     )
 
     lengths = {}


### PR DESCRIPTION
Passing kwargs to component PCells often leads to incorrect argument errors, which can be challenging to debug.

This PR addresses the issue by reducing the reliance on kwargs.

## Summary 

Enhancements:
- Reduce reliance on kwargs in component PCells to prevent incorrect argument errors.
- pdk.get_cross_section pops any `None` values