### PR TITLE
Fix mypy errors in generic_tech and technology folders

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -448,7 +448,7 @@ class Transition(BaseModel):
         )
 
 
-cross_sections = {}
+cross_sections: dict[str, CrossSectionFactory] = {}
 _cross_section_default_names = {}
 
 

--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -70,8 +70,8 @@ def get_generic_pdk() -> Pdk:
         layers=LAYER,
         layer_stack=LAYER_STACK,
         layer_views=LAYER_VIEWS,
-        layer_transitions=layer_transitions,
-        materials_index=materials_index,
+        layer_transitions=layer_transitions,  # type: ignore
+        materials_index=materials_index,  # type: ignore
         constants=constants,
         connectivity=LAYER_CONNECTIVITY,
     )
@@ -89,12 +89,12 @@ if __name__ == "__main__":
 
     t = KLayoutTechnology(
         name="generic_tech",
-        layer_map=LAYER,
+        layer_map=LAYER,  # type: ignore
         layer_views=LAYER_VIEWS,
         layer_stack=LAYER_STACK,
         connectivity=connectivity,
     )
-    t.write_tech(tech_dir=PATH.klayout)
+    t.write_tech(tech_dir=PATH.klayout)  # type: ignore
 
     layer_views = LayerViews(filepath=PATH.klayout_yaml)
     layer_views.to_lyp(PATH.klayout_lyp)

--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -11,6 +11,8 @@ from gdsfactory.technology import LayerViews
 if typing.TYPE_CHECKING:
     from gdsfactory.pdk import Pdk
 
+__all__ = ["LAYER", "LAYER_STACK", "get_generic_pdk"]
+
 
 PORT_MARKER_LAYER_TO_TYPE = {
     LAYER.PORT: "optical",

--- a/gdsfactory/generic_tech/klayout/lvs/run_lvs.py
+++ b/gdsfactory/generic_tech/klayout/lvs/run_lvs.py
@@ -21,6 +21,7 @@ Options:
 
 import logging
 import os
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from subprocess import check_call
 
@@ -154,7 +155,7 @@ def build_switches_string(sws: dict[str, str]) -> str:
     return " ".join(f"-rd {k}={v}" for k, v in sws.items())
 
 
-def check_lvs_results(results_db_files: list[str]) -> None:
+def check_lvs_results(results_db_files: Sequence[str]) -> None:
     """check_lvs_results Checks the results db generated from run and report at the end if the LVS run failed or passed.
 
     Parameters

--- a/gdsfactory/generic_tech/klayout/python/kgdsfactory/__init__.py
+++ b/gdsfactory/generic_tech/klayout/python/kgdsfactory/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from kgdsfactory.shortcuts import set_shortcuts
+from kgdsfactory.shortcuts import set_shortcuts  # type: ignore
 
 __all__ = ("set_shortcuts",)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import pathlib
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import cached_property, partial, wraps
 from typing import Any
 
@@ -150,7 +150,7 @@ class Pdk(BaseModel):
         default_factory=dict, exclude=True
     )
     cells: dict[str, ComponentFactory] = Field(default_factory=dict, exclude=True)
-    models: dict[str, Callable] = Field(default_factory=dict, exclude=True)
+    models: dict[str, Callable[..., Any]] = Field(default_factory=dict, exclude=True)
     symbols: dict[str, ComponentFactory] = Field(default_factory=dict)
     default_symbol_factory: Callable[..., ComponentFactory] = Field(
         default=floorplan_with_block_letters, exclude=True
@@ -169,7 +169,7 @@ class Pdk(BaseModel):
     materials_index: dict[str, MaterialSpec] = Field(default_factory=dict)
     routing_strategies: RoutingStrategies | None = None
     bend_points_distance: float = 20 * nm
-    connectivity: list[ConnectivitySpec] | None = None
+    connectivity: Sequence[ConnectivitySpec] | None = None
     max_cellname_length: int = CONF.max_cellname_length
 
     model_config = ConfigDict(

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -80,7 +80,7 @@ class KLayoutTechnology(BaseModel):
         lyp_filename: str = "layers.lyp",
         lyt_filename: str = "tech.lyt",
         d25_filename: str | None = None,
-        mebes_config: dict | None = None,
+        mebes_config: dict[str, Any] | None = None,
     ) -> None:
         """Write technology files into 'tech_dir'.
 
@@ -135,8 +135,9 @@ class KLayoutTechnology(BaseModel):
             ET.SubElement(mebes, k).text = v
 
         reader_opts = root.find("reader-options")
-        lefdef_idx = list(reader_opts).index(reader_opts.find("lefdef"))
-        reader_opts.insert(lefdef_idx + 1, mebes)
+        if reader_opts is not None:
+            lefdef_idx = list(reader_opts).index(reader_opts.find("lefdef"))  # type: ignore
+            reader_opts.insert(lefdef_idx + 1, mebes)
 
         # FIXME
         if self.layer_stack:
@@ -161,10 +162,10 @@ class KLayoutTechnology(BaseModel):
     def _define_connections(self, root: ET.Element) -> None:
         if not self.connectivity:
             return
-        src_element = [e for e in list(root) if e.tag == "connectivity"]
-        if len(src_element) != 1:
+        src_elements = [e for e in list(root) if e.tag == "connectivity"]
+        if len(src_elements) != 1:
             raise KeyError("Could not get a single index for the src element.")
-        src_element = src_element[0]
+        src_element = src_elements[0]
         layers: set[str] = set()
         for first_layer_name, *layer_names in self.connectivity:
             connection = ",".join(
@@ -213,7 +214,7 @@ if __name__ == "__main__":
         name="generic_tech",
         layer_views=lyp,
         connectivity=connectivity,
-        layer_map=LAYER,
+        layer_map=LAYER,  # type: ignore
         layer_stack=LAYER_STACK,
     )
     tech_dir = PATH.klayout_tech

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -5,6 +5,7 @@ This module enables conversion between gdsfactory settings and KLayout technolog
 
 import pathlib
 import xml.etree.ElementTree as ET
+from collections.abc import Sequence
 from typing import Any
 
 import aenum
@@ -59,7 +60,7 @@ class KLayoutTechnology(BaseModel):
     layer_map: dict[str, tuple[int, int]]
     layer_views: LayerViews | None = None
     layer_stack: LayerStack | None = None
-    connectivity: list[ConnectivitySpec] | None = None
+    connectivity: Sequence[ConnectivitySpec] | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 import gdsfactory as gf
-from gdsfactory.component import Component
+from gdsfactory.component import Component, boolean_operations
 
 if TYPE_CHECKING:
     from gdsfactory.technology import LayerViews
@@ -285,7 +285,7 @@ class DerivedLayer(AbstractLayer):
         """
         r1 = self.layer1.get_shapes(component)
         r2 = self.layer2.get_shapes(component)
-        region = gf.component.boolean_operations[self.operation](r1, r2)
+        region = boolean_operations[self.operation](r1, r2)
         if not (
             all(v == 0 for v in self.sizings_xoffsets)
             and all(v == 0 for v in self.sizings_yoffsets)
@@ -593,12 +593,12 @@ class LayerStack(BaseModel):
                         if layer1 in layer_views:  # type: ignore
                             props = layer_views.get_from_tuple(layer1)  # type: ignore
                             if hasattr(props, "color"):
-                                if props.color.fill == props.color.frame:
-                                    txt += f"color: {props.color.fill}"
+                                if props.color.fill == props.color.frame:  # type: ignore
+                                    txt += f"color: {props.color.fill}"  # type: ignore
                                 else:
                                     txt += (
-                                        f"fill: {props.color.fill}, "
-                                        f"frame: {props.color.frame}"
+                                        f"fill: {props.color.fill}, "  # type: ignore
+                                        f"frame: {props.color.frame}"  # type: ignore
                                     )
                     txt += ")"
                     out += f"{txt}\n"
@@ -620,12 +620,12 @@ class LayerStack(BaseModel):
                     txt += ", "
                     props = layer_views.get_from_tuple(layer_tuple)
                     if hasattr(props, "color"):
-                        if props.color.fill == props.color.frame:
-                            txt += f"color: {props.color.fill}"
+                        if props.color.fill == props.color.frame:  # type: ignore
+                            txt += f"color: {props.color.fill}"  # type: ignore
                         else:
                             txt += (
-                                f"fill: {props.color.fill}, "
-                                f"frame: {props.color.frame}"
+                                f"fill: {props.color.fill}, "  # type: ignore
+                                f"frame: {props.color.frame}"  # type: ignore
                             )
 
                 txt += ")"

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -618,7 +618,7 @@ class LayerStack(BaseModel):
                 )
                 if layer_views:
                     txt += ", "
-                    props = layer_views.get_from_tuple(layer_tuple)
+                    props = layer_views.get_from_tuple(tuple(layer_tuple))
                     if hasattr(props, "color"):
                         if props.color.fill == props.color.frame:  # type: ignore
                             txt += f"color: {props.color.fill}"  # type: ignore

--- a/gdsfactory/technology/processes.py
+++ b/gdsfactory/technology/processes.py
@@ -108,13 +108,13 @@ class Lithography(ProcessStep):
     """
 
     layer: Layer | None = None
-    layers_or: list | None = None
-    layers_diff: list | None = None
-    layers_and: list | None = None
-    layers_xor: list | None = None
+    layers_or: list[Layer] | None = None
+    layers_diff: list[Layer] | None = None
+    layers_and: list[Layer] | None = None
+    layers_xor: list[Layer] | None = None
     resist_thickness: float | None = 0
     positive_tone: bool = True
-    planarization_height: float = None
+    planarization_height: float | None = None
 
 
 @dataclass(kw_only=True)
@@ -190,9 +190,9 @@ class ImplantPhysical(Lithography):
     ion: str
     energy: float
     dose: float
-    tilt: float = None
-    twist: float = None
-    rotation: float = None
+    tilt: float | None = None
+    twist: float | None = None
+    rotation: float | None = None
 
 
 @dataclass(kw_only=True)

--- a/gdsfactory/technology/yaml_utils.py
+++ b/gdsfactory/technology/yaml_utils.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+from typing import Any
+
 import yaml
 from pydantic_extra_types.color import Color
 
@@ -7,10 +10,12 @@ from gdsfactory.technology.color_utils import ensure_six_digit_hex_color
 def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
     """Add a custom YAML presenter for Color objects."""
 
-    def _color_presenter(dumper: yaml.Dumper, data: Color) -> yaml.ScalarNode:
-        data = data.as_named(fallback=True) if prefer_named_color else data.as_hex()
+    def _color_presenter(
+        dumper: yaml.representer.SafeRepresenter, data: Color
+    ) -> yaml.Node:
+        data_str = data.as_named(fallback=True) if prefer_named_color else data.as_hex()
         return dumper.represent_scalar(
-            "tag:yaml.org,2002:str", ensure_six_digit_hex_color(data), style='"'
+            "tag:yaml.org,2002:str", ensure_six_digit_hex_color(data_str), style='"'
         )
 
     yaml.add_representer(Color, _color_presenter)
@@ -20,7 +25,9 @@ def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
 def add_tuple_yaml_presenter() -> None:
     """Add a custom YAML presenter for tuple objects."""
 
-    def _tuple_presenter(dumper: yaml.Dumper, data: tuple) -> yaml.SequenceNode:
+    def _tuple_presenter(
+        dumper: yaml.representer.SafeRepresenter, data: Iterable[Any]
+    ) -> yaml.Node:
         return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=True)
 
     yaml.add_representer(tuple, _tuple_presenter)
@@ -30,7 +37,9 @@ def add_tuple_yaml_presenter() -> None:
 def add_multiline_str_yaml_presenter() -> None:
     """Add a custom YAML presenter for multiline strings."""
 
-    def _str_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    def _str_presenter(
+        dumper: yaml.representer.SafeRepresenter, data: str
+    ) -> yaml.Node:
         if "\n" in data:  # check for multiline string
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -143,7 +143,9 @@ PathTypes: TypeAlias = Sequence[PathType]
 Metadata: TypeAlias = dict[str, int | float | str]
 PostProcess: TypeAlias = Callable[[Component], None]
 PostProcesses: TypeAlias = Sequence[PostProcess]
-MaterialSpec: TypeAlias = str | float | tuple[float, float] | Callable[..., Any]
+MaterialSpec: TypeAlias = (
+    str | float | tuple[float, float] | Callable[..., Any] | npt.NDArray[np.float64]
+)
 
 Instance: TypeAlias = ComponentReference
 ComponentOrPath: TypeAlias = PathType | Component
@@ -192,7 +194,7 @@ MultiCrossSectionAngleSpec: TypeAlias = Sequence[
 
 
 ConductorConductorName: TypeAlias = tuple[str, str]
-ConductorViaConductorName: TypeAlias = tuple[str, str, str] | tuple[str, str]
+ConductorViaConductorName: TypeAlias = tuple[str, str, str] | ConductorConductorName
 ConnectivitySpec: TypeAlias = ConductorConductorName | ConductorViaConductorName
 
 Route: TypeAlias = (

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -42,7 +42,14 @@ from gdsfactory.cross_section import (  # type: ignore[attr-defined]
     CrossSection,
     Transition,
 )
-from gdsfactory.technology import LayerLevel, LayerMap, LayerStack, LayerViews
+from gdsfactory.technology import (
+    DerivedLayer,
+    LayerLevel,
+    LayerMap,
+    LayerStack,
+    LayerViews,
+    LogicalLayer,
+)
 
 STEP_DIRECTIVES = {
     "x",
@@ -117,9 +124,8 @@ AngleInDegrees: TypeAlias = float
 
 Layer: TypeAlias = tuple[int, int]
 Layers: TypeAlias = Sequence[Layer]
-LayerSpec: TypeAlias = LayerEnum | str | tuple[int, int]
+LayerSpec: TypeAlias = LayerEnum | str | tuple[int, int] | int
 LayerSpecs: TypeAlias = Sequence[LayerSpec]
-
 
 AnyComponent: TypeAlias = Component | ComponentAllAngle
 AnyComponentT = TypeVar("AnyComponentT", bound=AnyComponent)

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -43,12 +43,10 @@ from gdsfactory.cross_section import (  # type: ignore[attr-defined]
     Transition,
 )
 from gdsfactory.technology import (
-    DerivedLayer,
     LayerLevel,
     LayerMap,
     LayerStack,
     LayerViews,
-    LogicalLayer,
 )
 
 STEP_DIRECTIVES = {


### PR DESCRIPTION
Some more significant changes:
- layer types in LogicLayer and DerivedLayer have had int removed, there are places all across the layer_stack.py file that index layer, layer1 or layer2 with [0] or [1]. Nowhere in the repository are these objects made with int layers. Im happy to hear that this isnt the right change, but it seems more appropriate.

## Summary by Sourcery

Fix mypy errors in the generic_tech and technology folders by updating type annotations and refactoring layer handling to use more appropriate types.

Bug Fixes:
- Fix mypy errors in the generic_tech and technology folders by updating type annotations and ensuring compatibility with type checking.

Enhancements:
- Refactor layer handling in layer_stack.py to use more appropriate types, removing int from layer types in LogicLayer and DerivedLayer.