### PR TITLE
remove dup

### DIFF
--- a/gdsfactory/components/extension.py
+++ b/gdsfactory/components/extension.py
@@ -104,10 +104,9 @@ def extend_ports(
         clockwise: if True, sort ports clockwise, False: counter-clockwise.
     """
     c = gf.Component()
-    component = gf.get_component(component).dup()
+    component = gf.get_component(component)
 
     cref = c << component
-
     if centered:
         cref.dx = 0
         cref.dy = 0
@@ -121,7 +120,7 @@ def extend_ports(
 
     if auto_taper and cross_section:
         ports_to_extend = add_auto_tapers(
-            component=component, ports=ports_to_extend, cross_section=cross_section
+            component=c, ports=ports_to_extend, cross_section=cross_section
         )
 
     for port_name in ports_to_extend_names:
@@ -180,4 +179,5 @@ if __name__ == "__main__":
     # p0 = c0["o1"]
     # c = extend_ports(c0, extension=t)
     c = extend_ports()
+    c.pprint_ports()
     c.show()

--- a/gdsfactory/components/mzi_arm.py
+++ b/gdsfactory/components/mzi_arm.py
@@ -59,7 +59,6 @@ def mzi_arm(
     # Each character in the sequence represents a component
     sequence = "bLB-BRb"
     c = component_sequence(sequence=sequence, symbol_to_component=symbol_to_component)
-    c = c.dup()
     c.auto_rename_ports()
     c.info["length_x"] = length_x
     c.info["length_xsize"] = straight_x.dxsize
@@ -67,6 +66,7 @@ def mzi_arm(
 
 
 if __name__ == "__main__":
-    c = mzi_arm(straight_x=gf.components.straight_heater_metal)
+    # c = mzi_arm(straight_x=gf.components.straight_heater_metal)
+    c = mzi_arm()
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/mzi_arms.py
+++ b/gdsfactory/components/mzi_arms.py
@@ -71,8 +71,6 @@ def mzi_arms(
             |          |          |
             |__________|          |__________
     """
-    from gdsfactory.pdk import get_component
-
     combiner = combiner or splitter
 
     straight_x_top = straight_x_top or straight
@@ -80,8 +78,8 @@ def mzi_arms(
     straight_y = straight_y or straight
 
     c = Component()
-    cp1 = get_component(splitter)
-    cp2 = get_component(combiner)
+    cp1 = gf.get_component(splitter)
+    cp2 = gf.get_component(combiner)
 
     cin: ComponentReference | None = None
     if with_splitter:

--- a/test-data-regression/test_netlists_extend_ports_.yml
+++ b/test-data-regression/test_netlists_extend_ports_.yml
@@ -1,4 +1,17 @@
 instances:
+  mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0:
+    component: mmi1x2
+    info: {}
+    settings:
+      cross_section: strip
+      gap_mmi: 0.25
+      length_mmi: 5.5
+      length_taper: 10
+      straight: straight
+      taper: taper
+      width: null
+      width_mmi: 2.5
+      width_taper: 1
   straight_L5_N2_CSxs_940_9241d340_15500_625:
     component: straight
     info:
@@ -42,8 +55,19 @@ instances:
       npoints: 2
       width: null
 name: extend_ports_Cmmi1x2_PN_b9f68e2a
-nets: []
+nets:
+- p1: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o1
+  p2: straight_L5_N2_CSxs_940_9241d340_m10000_0,o1
+- p1: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o2
+  p2: straight_L5_N2_CSxs_940_9241d340_15500_625,o1
+- p1: mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0,o3
+  p2: straight_L5_N2_CSxs_940_9241d340_15500_m625,o1
 placements:
+  mmi1x2_WNone_WT1_LT10_L_4e0f7121_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
   straight_L5_N2_CSxs_940_9241d340_15500_625:
     mirror: false
     rotation: 0
@@ -63,18 +87,3 @@ ports:
   o1: straight_L5_N2_CSxs_940_9241d340_m10000_0,o2
   o2: straight_L5_N2_CSxs_940_9241d340_15500_625,o2
   o3: straight_L5_N2_CSxs_940_9241d340_15500_m625,o2
-warnings:
-  optical:
-    unconnected_ports:
-    - message: 3 unconnected optical ports!
-      ports:
-      - straight_L5_N2_CSxs_940_9241d340_m10000_0,o1
-      - straight_L5_N2_CSxs_940_9241d340_15500_625,o1
-      - straight_L5_N2_CSxs_940_9241d340_15500_m625,o1
-      values:
-      - - -10000
-        - 0
-      - - 15500
-        - 625
-      - - 15500
-        - -625


### PR DESCRIPTION
## Summary by Sourcery

Clean up code by removing unused imports and duplicate component assignments, and update component retrieval to use gf.get_component for consistency.

Enhancements:
- Replace direct import of get_component with gf.get_component for consistency.

Chores:
- Remove unused import statement from mzi_arms.py.
- Remove duplicate component assignment in mzi_arm.py.