### PR TITLE
Fix mypy errors in labels and read folders

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -9,7 +9,7 @@ from toolz import compose  # type: ignore
 from aenum import constant  # type: ignore[import-untyped]
 
 import kfactory as kf
-from kfactory.kcell import LayerEnum, kcl, show
+from kfactory.kcell import LayerEnum, kcl, show, Instance
 from kfactory import logger
 import klayout.db as kdb
 
@@ -20,7 +20,6 @@ from gdsfactory.component import (
     ComponentBase,
     ComponentAllAngle,
     ComponentReference,
-    Instance,
     container,
     component_with_function,
 )

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -20,7 +20,7 @@ import kfactory as kf
 import numpy as np
 import numpy.typing as npt
 import yaml
-from kfactory import Instance, LayerEnum
+from kfactory import Instance
 
 import gdsfactory as gf
 from gdsfactory.component import container

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -14,12 +14,13 @@ import json
 import warnings
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import kfactory as kf
 import numpy as np
 import numpy.typing as npt
 import yaml
+from kfactory import Instance, LayerEnum
 
 import gdsfactory as gf
 from gdsfactory.component import container
@@ -28,13 +29,13 @@ from gdsfactory.port import select_ports
 from gdsfactory.serialization import convert_tuples_to_lists
 
 if TYPE_CHECKING:
-    from gdsfactory.component import Component, Instance
+    from gdsfactory.component import Component
     from gdsfactory.port import Port
 
-Layer = tuple[int, int]
-Layers = tuple[Layer, ...]
-LayerSpec = Layer | str | int
-LayerSpecs = tuple[LayerSpec, ...]
+Layer: TypeAlias = tuple[int, int]
+Layers: TypeAlias = tuple[Layer, ...]
+LayerSpec: TypeAlias = Layer | str | int
+LayerSpecs: TypeAlias = tuple[LayerSpec, ...]
 nm = 1e-3
 
 

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     pass
 
 __version__ = "8.23.0"
+__next_major_version__ = "9.0.0"
+
 PathType = str | pathlib.Path
 
 home = pathlib.Path.home()

--- a/gdsfactory/labels/add_labels.py
+++ b/gdsfactory/labels/add_labels.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import gdsfactory as gf
 from gdsfactory.typings import LayerSpec, Ports
 
@@ -6,7 +8,7 @@ def add_port_labels(
     component: gf.Component,
     ports: Ports,
     layer: LayerSpec,
-    texts: list[str] | None = None,
+    texts: Sequence[str] | None = None,
 ) -> gf.Component:
     """Add port labels to a component.
 
@@ -16,7 +18,7 @@ def add_port_labels(
         layer: layer to add the labels.
         texts: text to add to the labels. Defaults to port names.
     """
-    texts = texts or [port.name for port in ports]
+    texts = texts or [port.name for port in ports if port.name is not None]
 
     for text, port in zip(texts, ports):
         component.add_label(
@@ -29,10 +31,12 @@ def add_port_labels(
 
 if __name__ == "__main__":
     c = gf.Component()
+    from gdsfactory.components.wire import wire_straight
+
     # ref = c << gf.components.straight()
     # ref = c << gf.routing.add_fiber_array(gf.components.straight())
     # ref = c << gf.routing.add_fiber_array(gf.components.nxn())
-    ref = c << gf.routing.add_pads_top(gf.components.wire_straight())
+    ref = c << gf.routing.add_pads_top(wire_straight())
     # c = add_port_labels(c, [ref.ports["o1"]], layer=(2, 0))
     # c = add_port_labels(c, ref.ports, layer=(2, 0))
     # c = label_farthest_right_port(c, ref.ports, layer=(2, 0), text="output")

--- a/gdsfactory/labels/ehva.py
+++ b/gdsfactory/labels/ehva.py
@@ -100,12 +100,12 @@ if __name__ == "__main__":
         die="demo_die",
         metadata_include_parent=["grating_coupler:settings:polarization"],
     )
+    from gdsfactory.components.mmi2x2 import mmi2x2
 
     c = gf.c.straight(length=11)
-    c = gf.c.mmi2x2(length_mmi=2.2)
+    c = mmi2x2(length_mmi=2.2)
     c = gf.routing.add_fiber_array(
         c,
-        grating_coupler=gf.c.grating_coupler_te,
     )
     c = add_label_ehva(c)
 

--- a/gdsfactory/labels/write_test_manifest.py
+++ b/gdsfactory/labels/write_test_manifest.py
@@ -3,7 +3,7 @@
 import csv
 import json
 import pathlib
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import gdsfactory as gf
 
@@ -12,7 +12,7 @@ def write_test_manifest(
     component: gf.Component,
     csvpath: str | pathlib.Path,
     search_strings: Iterable[str] | None = None,
-    parameters: tuple[str, ...] = (
+    parameters: Sequence[str] = (
         "doe",
         "analysis",
         "analysis_parameters",
@@ -55,7 +55,7 @@ def write_test_manifest(
 
         ci = c._kdb_cell.begin_instances_rec()
         if search_strings:
-            ci.targets = "{" + ",".join(search_strings) + "}"
+            ci.targets = "{" + ",".join(search_strings) + "}"  # type: ignore[assignment]
         else:
             ci.targets = c.called_cells()
 
@@ -80,7 +80,7 @@ def write_test_manifest(
                         cell.name,
                         disp.x * c.kcl.dbu,
                         disp.y * c.kcl.dbu,
-                        json.dumps(cell.info.model_dump(exclude=parameters)),
+                        json.dumps(cell.info.model_dump(exclude=set(parameters))),
                         json.dumps(ports),
                         cell.settings.model_dump_json(),
                     ]
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 
     gdspath = c.write_gds()
     csvpath = gdspath.with_suffix(".csv")
-    write_test_manifest(c, csvpath)
+    write_test_manifest(c, csvpath, search_strings=["ring_10"])
     df = pd.read_csv(csvpath)
     print(df.columns)
     c.show()

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -41,6 +41,7 @@ import numpy as np
 from rich.console import Console
 from rich.table import Table
 
+from gdsfactory import typings
 from gdsfactory.cross_section import CrossSectionSpec
 
 if TYPE_CHECKING:
@@ -168,7 +169,7 @@ class Port(kf.Port):
         return to_dict(self)
 
 
-def to_dict(port: Port) -> dict[str, Any]:
+def to_dict(port: typings.Port) -> dict[str, Any]:
     """Returns dict."""
     return {
         "name": port.name,

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -41,10 +41,10 @@ import numpy as np
 from rich.console import Console
 from rich.table import Table
 
-from gdsfactory import typings
 from gdsfactory.cross_section import CrossSectionSpec
 
 if TYPE_CHECKING:
+    from gdsfactory import typings
     from gdsfactory.component import Component
     from gdsfactory.typings import (
         AngleInDegrees,
@@ -169,7 +169,7 @@ class Port(kf.Port):
         return to_dict(self)
 
 
-def to_dict(port: typings.Port) -> dict[str, Any]:
+def to_dict(port: "typings.Port") -> dict[str, Any]:
     """Returns dict."""
     return {
         "name": port.name,

--- a/gdsfactory/read/from_gdspaths.py
+++ b/gdsfactory/read/from_gdspaths.py
@@ -44,5 +44,5 @@ if __name__ == "__main__":
 
     # c = gdspaths([gf.components.straight(), gf.components.bend_circular()])
     # leave these two lines to end up tests showing the diff
-    c = from_gdspaths(diff_path.glob("*.gds"))
+    c = from_gdspaths(list(diff_path.glob("*.gds")))
     c.show()

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -23,7 +23,7 @@ def compute_area_signed(pr: npt.NDArray[np.floating[Any]]) -> float:
     xs, ys = map(list, zip(*pr))
     xs.append(xs[1])
     ys.append(ys[1])
-    return sum(xs[i] * (ys[i + 1] - ys[i - 1]) for i in range(1, len(pr))) / 2.0
+    return sum(xs[i] * (ys[i + 1] - ys[i - 1]) for i in range(1, len(pr))) / 2.0  # type: ignore[no-any-return]
 
 
 def from_np(
@@ -49,7 +49,7 @@ def from_np(
     c = Component()
     d = Component()
     ndarray = np.pad(ndarray, 2)
-    contours = measure.find_contours(ndarray, threshold)
+    contours = measure.find_contours(ndarray, threshold)  # type: ignore[no-untyped-call]
     assert len(contours) > 0, (
         f"no contours found for threshold = {threshold}, maybe you can reduce the"
         " threshold"

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -271,7 +271,7 @@ if __name__ == "__main__":
     c.show()
 """
     if filepath_out:
-        dirpath = filepath_out.parent
+        dirpath = pathlib.Path(filepath_out).parent
         dirpath.mkdir(parents=True, exist_ok=True)
         filepath_out = pathlib.Path(filepath_out)
         filepath_out.write_text(script)

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import itertools
 import pathlib
+import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from functools import partial
@@ -59,13 +60,15 @@ from typing import IO, TYPE_CHECKING, Any, Literal, Protocol
 import kfactory as kf
 import networkx as nx
 import yaml
+from kfactory.kcell import Instance
 
+from gdsfactory import typings
 from gdsfactory.add_pins import add_instance_label
-from gdsfactory.component import Component, ComponentReference, Instance
-from gdsfactory.port import Port
+from gdsfactory.component import Component, ComponentReference
+from gdsfactory.config import __next_major_version__
 from gdsfactory.schematic import Bundle, Netlist, Placement
 from gdsfactory.schematic import Instance as NetlistInstance
-from gdsfactory.typings import Route, RoutingStrategies, RoutingStrategy
+from gdsfactory.typings import LayerSpec, Route, RoutingStrategies
 
 if TYPE_CHECKING:
     from gdsfactory.pdk import Pdk
@@ -73,7 +76,11 @@ if TYPE_CHECKING:
 
 class LabelInstanceFunction(Protocol):
     def __call__(
-        self, component: Component, instance_name: str, reference: ComponentReference
+        self,
+        component: Component,
+        reference: Instance,
+        layer: LayerSpec | None = None,
+        instance_name: str | None = None,
     ) -> None: ...
 
 
@@ -148,11 +155,10 @@ def _get_anchor_point_from_name(
     ref: Instance, anchor_name: str
 ) -> tuple[float, float] | None:
     if anchor_name in valid_anchor_point_keywords:
-        return getattr(ref.dsize_info, anchor_name)
+        return getattr(ref.dsize_info, anchor_name)  # type: ignore[no-any-return]
     elif anchor_name in ref.ports:
         return ref.ports[anchor_name].dcenter
-    else:
-        return None
+    return None
 
 
 def _get_anchor_value_from_name(
@@ -160,7 +166,7 @@ def _get_anchor_value_from_name(
 ) -> float | None:
     """Return the x or y value of an anchor point or port on a reference."""
     if anchor_name in valid_anchor_value_keywords:
-        return getattr(ref.dsize_info, anchor_name)
+        return getattr(ref.dsize_info, anchor_name)  # type: ignore[no-any-return]
     anchor_point = _get_anchor_point_from_name(ref, anchor_name)
     if anchor_point is None:
         return None
@@ -238,19 +244,18 @@ def _parse_maybe_arrayed_instance(inst_spec: str) -> tuple[str, int | None, int 
             )
         ia, ib = array_spec.split(".")
         try:
-            ia = int(ia)
+            ia_int = int(ia)
         except ValueError as e:
             raise ValueError(
                 f"When parsing array reference specifier '{inst_spec}', got a non-integer index '{ia}'"
             ) from e
         try:
-            ib = int(ib)
+            ib_int = int(ib)
         except ValueError as exc:
             raise ValueError(
                 f"When parsing array reference specifier '{inst_spec}', got a non-integer index '{ib}'"
             ) from exc
-        return inst_name, ia, ib
-    # in the non-arrayed case, return none for the indices
+        return inst_name, ia_int, ib_int
     return inst_spec, None, None
 
 
@@ -361,7 +366,7 @@ def place(
             ref.dy -= a[1]
 
         if x is not None:
-            ref.dx += _move_ref(
+            _dx = _move_ref(
                 x,
                 x_or_y="x",
                 placements_conf=placements_conf,
@@ -370,9 +375,11 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert _dx is not None
+            ref.dx += _dx
 
         if y is not None:
-            ref.dy += _move_ref(
+            _dy = _move_ref(
                 y,
                 x_or_y="y",
                 placements_conf=placements_conf,
@@ -381,11 +388,13 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert _dy is not None
+            ref.dy += _dy
 
         if ymin is not None and ymax is not None:
             raise ValueError("You cannot set ymin and ymax")
         elif ymax is not None:
-            ref.dymax = _move_ref(
+            dymax = _move_ref(
                 ymax,
                 x_or_y="y",
                 placements_conf=placements_conf,
@@ -394,8 +403,10 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert dymax is not None
+            ref.dymax = dymax
         elif ymin is not None:
-            ref.dymin = _move_ref(
+            dymin = _move_ref(
                 ymin,
                 x_or_y="y",
                 placements_conf=placements_conf,
@@ -404,11 +415,13 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert dymin is not None
+            ref.dymin = dymin
 
         if xmin is not None and xmax is not None:
             raise ValueError("You cannot set xmin and xmax")
         elif xmin is not None:
-            ref.dxmin = _move_ref(
+            dxmin = _move_ref(
                 xmin,
                 x_or_y="x",
                 placements_conf=placements_conf,
@@ -417,8 +430,10 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert dxmin is not None
+            ref.dxmin = dxmin
         elif xmax is not None:
-            ref.dxmax = _move_ref(
+            dxmax = _move_ref(
                 xmax,
                 x_or_y="x",
                 placements_conf=placements_conf,
@@ -427,11 +442,13 @@ def place(
                 encountered_insts=encountered_insts,
                 all_remaining_insts=all_remaining_insts,
             )
+            assert dxmax is not None
+            ref.dxmax = dxmax
         if dx:
-            ref.dx += dx
+            ref.dx += float(dx)
 
         if dy:
-            ref.dy += dy
+            ref.dy += float(dy)
 
     if instance_name in connections_by_transformed_inst:
         conn_info = connections_by_transformed_inst[instance_name]
@@ -446,15 +463,16 @@ def place(
                 all_remaining_insts,
             )
 
-        make_connection(instances=instances, **conn_info)
-        # placements_conf.pop(instance_name)
+        make_connection(instances=instances, **conn_info)  # type: ignore[arg-type]
 
 
-def transform_connections_dict(connections_conf: dict[str, str]) -> dict[str, dict]:
+def transform_connections_dict(
+    connections_conf: dict[str, str],
+) -> dict[str, dict[str, str | int | None]]:
     """Returns Dict with source_instance_name key and connection properties."""
     if not connections_conf:
         return {}
-    attrs_by_src_inst = {}
+    attrs_by_src_inst: dict[str, dict[str, str | int | None]] = {}
     for port_src_string, port_dst_string in connections_conf.items():
         instance_src_name, port_src_name = port_src_string.split(",")
         instance_dst_name, port_dst_name = port_dst_string.split(",")
@@ -530,15 +548,15 @@ def make_connection(
             f" {instance_dst_name!r}"
         )
 
-    if src_ia is None:
+    if src_ia is None or src_ib is None:
         src_port = instance_src.ports[port_src_name]
     else:
-        src_port = instance_src.ports[(port_src_name, src_ia, src_ib)]
+        src_port = instance_src.ports[port_src_name, src_ia, src_ib]
 
-    if dst_ia is None:
+    if dst_ia is None or dst_ib is None:
         dst_port = instance_dst.ports[port_dst_name]
     else:
-        dst_port = instance_dst.ports[(port_dst_name, dst_ia, dst_ib)]
+        dst_port = instance_dst.ports[port_dst_name, dst_ia, dst_ib]
 
     instance_src.connect(port=src_port, other=dst_port, use_mirror=True, mirror=False)
 
@@ -585,19 +603,20 @@ ports:
 
 def cell_from_yaml(
     yaml_str: str | pathlib.Path | IO[Any] | dict[str, Any],
-    routing_strategy: RoutingStrategy | None = None,
-    label_instance_function: Callable = add_instance_label,
+    routing_strategy: RoutingStrategies | None = None,
+    routing_strategies: RoutingStrategies | None = None,
+    label_instance_function: LabelInstanceFunction = add_instance_label,
     name: str | None = None,
     prefix: str | None = None,
-    **kwargs: Any,
-) -> Callable:
+) -> Callable[[], Component]:
     """Returns Component factory from YAML string or file.
 
     YAML includes instances, placements, routes, ports and connections.
 
     Args:
         yaml_str: YAML string or file.
-        routing_strategy: for each route.
+        routing_strategy: for each route. (deprecated)
+        routing_strategies: for each route.
         label_instance_function: to label each instance.
         name: Optional name.
         prefix: name prefix.
@@ -670,21 +689,35 @@ def cell_from_yaml(
                     mmi_top,o3: mmi_bot,o1
 
     """
+    if prefix is not None:
+        warnings.warn(
+            f"The 'prefix' parameter is deprecated and will be removed in gdsfactory {__next_major_version__}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    if routing_strategy is not None:
+        warnings.warn(
+            f"The 'routing_strategy' parameter is deprecated and will be removed in gdsfactory {__next_major_version__}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    routing_strategies = (routing_strategies or {}) | (routing_strategy or {})
+
     return partial(
         from_yaml,
         yaml_str=yaml_str,
-        routing_strategy=routing_strategy,
+        routing_strategy=routing_strategies,
         label_instance_function=label_instance_function,
         name=name,
-        prefix=prefix,
-        **kwargs,
     )
 
 
 def from_yaml(
     yaml_str: str | pathlib.Path | IO[Any] | dict[str, Any],
     routing_strategy: RoutingStrategies | None = None,
-    label_instance_function: Callable = add_instance_label,
+    routing_strategies: RoutingStrategies | None = None,
+    label_instance_function: LabelInstanceFunction = add_instance_label,
     name: str | None = None,
 ) -> Component:
     """Returns Component from YAML string or file.
@@ -693,7 +726,8 @@ def from_yaml(
 
     Args:
         yaml_str: YAML string or file.
-        routing_strategy: for each route.
+        routing_strategy: for each route. (deprecated)
+        routing_strategies: for each route.
         label_instance_function: to label each instance.
         name: Optional name.
 
@@ -765,6 +799,15 @@ def from_yaml(
 
     """
     from gdsfactory.pdk import get_active_pdk
+
+    if routing_strategy is not None:
+        warnings.warn(
+            f"The 'routing_strategy' parameter is deprecated and will be removed in gdsfactory {__next_major_version__}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    routing_strategies = (routing_strategies or {}) | (routing_strategy or {})
 
     c = Component()
     dct = _load_yaml_str(yaml_str)
@@ -877,8 +920,8 @@ def _place_and_connect(
             if ports is not None:  # no elif!
                 p1, p2 = ports
                 i2name, i2a, i2b = _parse_maybe_arrayed_instance(i2)
-                if (i2a is not None) or (i2b is not None):
-                    refs[i1].connect(p1, refs[i2name].ports[(p2, i2a, i2b)])
+                if i2a is not None and i2b is not None:
+                    refs[i1].connect(p1, refs[i2name].ports[p2, i2a, i2b])
                 else:
                     refs[i1].connect(p1, refs[i2].ports[p2])
 
@@ -903,8 +946,8 @@ def _add_routes(
                 f"Got:{bundle.routing_strategy}"
             ) from e
 
-        ports1: list[Port] = []
-        ports2: list[Port] = []
+        ports1: list[typings.Port] = []
+        ports2: list[typings.Port] = []
         route_names: list[str] = []
 
         for ip1, ip2 in bundle.links.items():
@@ -1041,7 +1084,9 @@ def _update_reference_by_placement(
     elif isinstance(x, str):
         i, q = x.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dx += _get_anchor_value_from_name(refs[i], q, "x")
+            _dx = _get_anchor_value_from_name(refs[i], q, "x")
+            assert _dx is not None, f"dx is None for {i!r}, {q!r}"
+            ref.dx += _dx
         else:
             ref.dx += float(refs[i].ports[q].dx)
     elif x is not None:
@@ -1049,7 +1094,9 @@ def _update_reference_by_placement(
     elif isinstance(xmin, str):
         i, q = xmin.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dxmin = _get_anchor_value_from_name(refs[i], q, "x")
+            dxmin = _get_anchor_value_from_name(refs[i], q, "x")
+            assert dxmin is not None, f"dxmin is None for {i!r}, {q!r}"
+            ref.dxmin = dxmin
         else:
             ref.dxmin = float(refs[i].ports[q].dx)
     elif xmin is not None:
@@ -1057,7 +1104,9 @@ def _update_reference_by_placement(
     elif isinstance(xmax, str):
         i, q = xmax.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dxmax = _get_anchor_value_from_name(refs[i], q, "x")
+            dxmax = _get_anchor_value_from_name(refs[i], q, "x")
+            assert dxmax is not None, f"dxmax is None for {i!r}, {q!r}"
+            ref.dxmax = dxmax
         else:
             ref.dxmax = float(refs[i].ports[q].dx)
     elif xmax is not None:
@@ -1070,7 +1119,9 @@ def _update_reference_by_placement(
     elif isinstance(y, str):
         i, q = y.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dy += _get_anchor_value_from_name(refs[i], q, "y")
+            _dy = _get_anchor_value_from_name(refs[i], q, "y")
+            assert _dy is not None, f"dy is None for {i!r}, {q!r}"
+            ref.dy += _dy
         else:
             ref.dy += float(refs[i].ports[q].dy)
     elif y is not None:
@@ -1078,7 +1129,9 @@ def _update_reference_by_placement(
     elif isinstance(ymin, str):
         i, q = ymin.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dymin = _get_anchor_value_from_name(refs[i], q, "y")
+            dymin = _get_anchor_value_from_name(refs[i], q, "y")
+            assert dymin is not None, f"dymin is None for {i!r}, {q!r}"
+            ref.dymin = dymin
         else:
             ref.dymin = float(refs[i].ports[q].dy)
     elif ymin is not None:
@@ -1086,7 +1139,9 @@ def _update_reference_by_placement(
     elif isinstance(ymax, str):
         i, q = ymax.split(",")
         if q in valid_anchor_value_keywords:
-            ref.dymax = _get_anchor_value_from_name(refs[i], q, "y")
+            dymax = _get_anchor_value_from_name(refs[i], q, "y")
+            assert dymax is not None, f"dymax is None for {i!r}, {q!r}"
+            ref.dymax = dymax
         else:
             ref.dymax = float(refs[i].ports[q].dy)
     elif ymax is not None:
@@ -1136,27 +1191,28 @@ def _split_route_link(s: str) -> tuple[str, list[str]]:
                 f"The format for bundle routing is 'inst,port_base:i0:i1' with i0 and i1 integers. Got: {s!r}"
             )
 
-    j = _try_int(j)
-    k = _try_int(k)
+    j_int = _try_int(j)
+    k_int = _try_int(k)
     return (
-        (i, [f"{p}{idx}" for idx in range(j, k + 1)])
-        if k > j
-        else (i, [f"{p}{idx}" for idx in range(j, k - 1, -1)])
+        (i, [f"{p}{idx}" for idx in range(j_int, k_int + 1)])
+        if k_int > j_int
+        else (i, [f"{p}{idx}" for idx in range(j_int, k_int - 1, -1)])
     )
 
 
 def _get_ports_from_portnames(
     refs: dict[str, ComponentReference], i: str, ps: list[str]
-) -> list[Port]:
+) -> list[typings.Port]:
     i, ia, ib = _parse_maybe_arrayed_instance(i)
     ref = refs[i]
-    ports: list[Port] = []
+    ports: list[typings.Port] = []
     for p in ps:
         if p not in ref.ports:
             raise ValueError(
                 f"{p!r} not in {i!r} available ports: {[p.name for p in ref.ports]}"
             )
-        port = ref.ports[p] if ia is None else ref.ports[p, ia, ib]
+
+        port = ref.ports[p] if (ia is None or ib is None) else ref.ports[p, ia, ib]
         ports.append(port)
     return ports
 

--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -1,5 +1,4 @@
 import pathlib
-from collections.abc import Iterable
 from inspect import Parameter, Signature, signature
 from io import IOBase
 from typing import IO, Any
@@ -17,7 +16,7 @@ __all__ = ["cell_from_yaml_template"]
 _YamlDefinition = str | IO[Any] | pathlib.Path
 
 
-def split_default_settings_from_yaml(yaml_lines: Iterable[str]) -> tuple[str, str]:
+def split_default_settings_from_yaml(yaml_lines: list[str]) -> tuple[str, str]:
     """Separates out the 'default_settings' block from the rest of the file body.
 
     Note: 'default settings' MUST be at the TOP of the file.
@@ -57,7 +56,7 @@ def _split_yaml_definition(subpic_yaml: _YamlDefinition) -> tuple[str, dict[str,
         f = subpic_yaml
         subpic_text = f.readlines()
     else:
-        with open(subpic_yaml) as f:
+        with pathlib.Path(subpic_yaml).open() as f:  # type: ignore[arg-type]
             subpic_text = f.readlines()
     main_file, default_settings_string = split_default_settings_from_yaml(subpic_text)
     if default_settings_string:
@@ -155,7 +154,7 @@ def yaml_cell(
 
     _yaml_func.__name__ = name
     _yaml_func.__module__ = "yaml_jinja"
-    _yaml_func.__signature__ = new_sig
+    _yaml_func.__signature__ = new_sig  # type: ignore[attr-defined]
     _yaml_func.__doc__ = docstring
     return cell(_yaml_func)
 

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -99,9 +99,9 @@ def import_gds_with_conflicts(
 
 
 if __name__ == "__main__":
-    import gdsfactory as gf
+    from gdsfactory.components.mzi import mzi
 
-    c = gf.components.mzi()
+    c = mzi()
     c.pprint_ports()
     gdspath = c.write_gds()
 

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -122,7 +122,7 @@ AngleInDegrees: TypeAlias = float
 
 Layer: TypeAlias = tuple[int, int]
 Layers: TypeAlias = Sequence[Layer]
-LayerSpec: TypeAlias = LayerEnum | str | tuple[int, int] | int
+LayerSpec: TypeAlias = Layer | str | int | LayerEnum
 LayerSpecs: TypeAlias = Sequence[LayerSpec]
 
 AnyComponent: TypeAlias = Component | ComponentAllAngle


### PR DESCRIPTION
Some changes include __next_major_version__ to config.py which is used in deprecation warnings

## Summary by Sourcery

Fix mypy errors in the labels and read folders by adding type annotations and ignoring specific type checks. Refactor code to improve type safety and clarity with more specific type annotations and assertions.

Bug Fixes:
- Fix mypy errors by adding type annotations and ignoring specific type checks where necessary.

Enhancements:
- Refactor code to improve type safety and clarity by using more specific type annotations and assertions.