### PR TITLE
deprecate d-attributes for path

### DIFF
--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -51,16 +51,16 @@ class GeometryHelper(ABC):
     """Helper class for a class with functions move() and the property bbox.
 
     It uses that function+property to enable you to do things like check what the
-    center of the bounding box is (self.dcenter), and also to do things like move
-    the bounding box such that its maximum x value is 5.2 (self.dxmax = 5.2).
+    center of the bounding box is (self.center), and also to do things like move
+    the bounding box such that its maximum x value is 5.2 (self.xmax = 5.2).
     """
 
     @property
     @abstractmethod
-    def dbbox(self) -> npt.NDArray[np.float64]: ...
+    def bbox(self) -> npt.NDArray[np.float64]: ...
 
     @abstractmethod
-    def dmove(
+    def move(
         self,
         origin: Coordinate,
         destination: Coordinate | None = None,
@@ -68,140 +68,140 @@ class GeometryHelper(ABC):
     ) -> Self: ...
 
     @property
-    def dcenter(self) -> Coordinate:
+    def center(self) -> Coordinate:
         """Returns the center of the bounding box."""
-        return tuple(np.sum(self.dbbox, 0) / 2)
+        return tuple(np.sum(self.bbox, 0) / 2)
 
-    @dcenter.setter
-    def dcenter(self, destination: Coordinate) -> None:
+    @center.setter
+    def center(self, destination: Coordinate) -> None:
         """Sets the center of the bounding box.
 
         Args:
             destination : array-like[2] Coordinates of the new bounding box center.
         """
-        self.dmove(destination=destination, origin=self.dcenter)
+        self.move(destination=destination, origin=self.center)
 
     @property
-    def dx(self) -> float:
+    def x(self) -> float:
         """Returns the x-coordinate of the center of the bounding box."""
-        return float(np.sum(self.dbbox, 0)[0] / 2)
+        return float(np.sum(self.bbox, 0)[0] / 2)
 
-    @dx.setter
-    def dx(self, destination: float) -> None:
+    @x.setter
+    def x(self, destination: float) -> None:
         """Sets the x-coordinate of the center of the bounding box.
 
         Args:
             destination : int or float x-coordinate of the bbox center.
         """
-        destination_t = (destination, self.dcenter[1])
-        self.dmove(destination=destination_t, origin=self.dcenter, axis="x")
+        destination_t = (destination, self.center[1])
+        self.move(destination=destination_t, origin=self.center, axis="x")
 
     @property
-    def dy(self) -> float:
+    def y(self) -> float:
         """Returns the y-coordinate of the center of the bounding box."""
-        return float(np.sum(self.dbbox, 0)[1] / 2)
+        return float(np.sum(self.bbox, 0)[1] / 2)
 
-    @dy.setter
-    def dy(self, destination: float) -> None:
+    @y.setter
+    def y(self, destination: float) -> None:
         """Sets the y-coordinate of the center of the bounding box.
 
         Args:
         destination : int or float
             y-coordinate of the bbox center.
         """
-        destination_t = (self.dcenter[0], destination)
-        self.dmove(destination=destination_t, origin=self.dcenter, axis="y")
+        destination_t = (self.center[0], destination)
+        self.move(destination=destination_t, origin=self.center, axis="y")
 
     @property
-    def dxmax(self) -> float:
+    def xmax(self) -> float:
         """Returns the maximum x-value of the bounding box."""
-        return float(self.dbbox[1][0])
+        return float(self.bbox[1][0])
 
-    @dxmax.setter
-    def dxmax(self, destination: float) -> None:
+    @xmax.setter
+    def xmax(self, destination: float) -> None:
         """Sets the x-coordinate of the maximum edge of the bounding box.
 
         Args:
         destination : int or float
             x-coordinate of the maximum edge of the bbox.
         """
-        self.dmove(destination=(destination, 0), origin=self.dbbox[1], axis="x")
+        self.move(destination=(destination, 0), origin=self.bbox[1], axis="x")
 
     @property
-    def dymax(self) -> float:
+    def ymax(self) -> float:
         """Returns the maximum y-value of the bounding box."""
-        return float(self.dbbox[1][1])
+        return float(self.bbox[1][1])
 
-    @dymax.setter
-    def dymax(self, destination: float) -> None:
+    @ymax.setter
+    def ymax(self, destination: float) -> None:
         """Sets the y-coordinate of the maximum edge of the bounding box.
 
         Args:
             destination : int or float y-coordinate of the maximum edge of the bbox.
         """
-        self.dmove(destination=(0, destination), origin=self.dbbox[1], axis="y")
+        self.move(destination=(0, destination), origin=self.bbox[1], axis="y")
 
     @property
-    def dxmin(self) -> float:
+    def xmin(self) -> float:
         """Returns the minimum x-value of the bounding box."""
-        return float(self.dbbox[0][0])
+        return float(self.bbox[0][0])
 
-    @dxmin.setter
-    def dxmin(self, destination: float) -> None:
+    @xmin.setter
+    def xmin(self, destination: float) -> None:
         """Sets the x-coordinate of the minimum edge of the bounding box.
 
         Args:
             destination : int or float x-coordinate of the minimum edge of the bbox.
         """
-        self.dmove(destination=(destination, 0), origin=self.dbbox[0], axis="x")
+        self.move(destination=(destination, 0), origin=self.bbox[0], axis="x")
 
     @property
-    def dymin(self) -> float:
+    def ymin(self) -> float:
         """Returns the minimum y-value of the bounding box."""
-        return float(self.dbbox[0][1])
+        return float(self.bbox[0][1])
 
-    @dymin.setter
-    def dymin(self, destination: float) -> None:
+    @ymin.setter
+    def ymin(self, destination: float) -> None:
         """Sets the y-coordinate of the minimum edge of the bounding box.
 
         Args:
             destination : int or float y-coordinate of the minimum edge of the bbox.
         """
-        self.dmove(destination=(0, destination), origin=self.dbbox[0], axis="y")
+        self.move(destination=(0, destination), origin=self.bbox[0], axis="y")
 
     @property
-    def dsize(self) -> tuple[float, float]:
+    def size(self) -> tuple[float, float]:
         """Returns the (x, y) size of the bounding box."""
-        dbbox = self.dbbox
-        return tuple(dbbox[1] - dbbox[0])
+        bbox = self.bbox
+        return tuple(bbox[1] - bbox[0])
 
     @property
     def xsize(self) -> float:
         """Returns the horizontal size of the bounding box."""
-        bbox = self.dbbox
+        bbox = self.bbox
         return float(bbox[1][0] - bbox[0][0])
 
     @property
     def ysize(self) -> float:
         """Returns the vertical size of the bounding box."""
-        bbox = self.dbbox
+        bbox = self.bbox
         return float(bbox[1][1] - bbox[0][1])
 
-    def dmovex(self, value: float) -> None:
+    def movex(self, value: float) -> None:
         """Moves an object by a specified x-distance.
 
         Args:
             value: distance to move the object in the x-direction in um.
         """
-        self.dx += value
+        self.x += value
 
-    def dmovey(self, value: float) -> Self:
+    def movey(self, value: float) -> Self:
         """Moves an object by a specified y-distance.
 
         Args:
             value: distance to move the object in the y-direction in um.
         """
-        self.dy += value
+        self.y += value
 
 
 def rotate_points(

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -95,24 +95,28 @@ class Path(GeometryHelper):
                 )
 
     def __getattribute__(self, __k: str) -> Any:
-        """Shadow dbu based attributes with um based ones."""
+        """Deprecate dbu prefixed attributes."""
         if __k in {
-            "center",
-            "mirror",
-            "move",
-            "movex",
-            "movey",
-            "rotate",
-            "x",
-            "xmin",
-            "xmax",
-            "xsize",
-            "y",
-            "ymin",
-            "ymax",
-            "ysize",
+            "dcenter",
+            "dmirror",
+            "dmove",
+            "dmovex",
+            "dmovey",
+            "drotate",
+            "dx",
+            "dxmin",
+            "dxmax",
+            "dxsize",
+            "dy",
+            "dymin",
+            "dymax",
+            "dysize",
         }:
-            return getattr(self, f"d{__k}")
+            warnings.warn(
+                f"Deprecation warning. Use {__k[1:]!r} instead of {__k!r} for Path objects.",
+                stacklevel=2,
+            )
+            return getattr(self, f"{__k[1:]}")
         return super().__getattribute__(__k)
 
     def __repr__(self) -> str:
@@ -137,7 +141,7 @@ class Path(GeometryHelper):
         return new.append(path)
 
     @property
-    def dbbox(self) -> npt.NDArray[np.float64]:
+    def bbox(self) -> npt.NDArray[np.float64]:
         """Returns the bounding box of the Path."""
         bbox = [
             (np.min(self.points[:, 0]), np.min(self.points[:, 1])),
@@ -243,7 +247,7 @@ class Path(GeometryHelper):
         self.end_angle = end_angle
         return self
 
-    def dmove(
+    def move(
         self,
         origin: Coordinate,
         destination: Coordinate | None = None,
@@ -263,7 +267,7 @@ class Path(GeometryHelper):
         self.points += np.array([dx, dy])
         return self
 
-    def drotate(self, angle: float = 45, center: Coordinate = (0, 0)) -> Self:
+    def rotate(self, angle: float = 45, center: Coordinate = (0, 0)) -> Self:
         """Rotates all Polygons in the Component around the specified center point.
 
         If no center point specified will rotate around (0,0).
@@ -281,7 +285,7 @@ class Path(GeometryHelper):
             self.end_angle = mod(self.end_angle + angle, 360)
         return self
 
-    def dmirror(self, p1: Coordinate = (0, 1), p2: Coordinate = (0, 0)) -> Path:
+    def mirror(self, p1: Coordinate = (0, 1), p2: Coordinate = (0, 0)) -> Path:
         """Mirrors the Path across the line formed between the two specified points.
 
         ``points`` may be input as either single points [1,2]
@@ -1591,7 +1595,7 @@ def euler(
     path.info["Reff"] = Reff * scale
     path.info["Rmin"] = Rmin * scale
     if mirror:
-        path.dmirror((1, 0))
+        path.mirror((1, 0))
     return path
 
 
@@ -1732,16 +1736,16 @@ def smooth(
     new_points.append([points[0, :]])
     for n in range(len(dtheta)):
         P = paths[n]
-        P.drotate(theta[n] - 0)
-        P.dmove(p1[n])
+        P.rotate(theta[n] - 0)
+        P.move(p1[n])
         new_points.append(P.points)
     new_points.append([points[-1, :]])
     new_points = np.concatenate(new_points)
 
     P = Path()
-    P.drotate(theta[0])
+    P.rotate(theta[0])
     P.append(new_points)
-    P.dmove(points[0, :])
+    P.move(points[0, :])
     return P
 
 

--- a/notebooks/03_Path_CrossSection.ipynb
+++ b/notebooks/03_Path_CrossSection.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p2 = P.copy().drotate()\n",
+    "p2 = P.copy().rotate()\n",
     "f = p2.plot()"
    ]
   },
@@ -213,7 +213,7 @@
     "s0 = gf.Section(width=1, offset=0, layer=(1, 0), port_names=(\"in\", \"out\"))\n",
     "s1 = gf.Section(width=2, offset=2, layer=(2, 0))\n",
     "s2 = gf.Section(width=2, offset=-2, layer=(2, 0))\n",
-    "x = gf.CrossSection(sections=[s0, s1, s2])\n",
+    "x = gf.CrossSection(sections=(s0, s1, s2))\n",
     "\n",
     "c = gf.path.extrude(p, cross_section=x)\n",
     "c.plot()"
@@ -263,7 +263,7 @@
     "    component=gf.c.rectangle(size=(1, 1), centered=True), spacing=5, padding=2\n",
     ")\n",
     "s = gf.Section(width=0.5, offset=0, layer=(1, 0), port_names=(\"in\", \"out\"))\n",
-    "x = gf.CrossSection(sections=[s], components_along_path=[via])\n",
+    "x = gf.CrossSection(sections=(s,), components_along_path=(via,))\n",
     "\n",
     "# Combine the path with the cross-section\n",
     "c = gf.path.extrude(p, cross_section=x)\n",
@@ -289,7 +289,7 @@
     "via0 = ComponentAlongPath(component=gf.c.via1(), spacing=5, padding=2, offset=0)\n",
     "viap = ComponentAlongPath(component=gf.c.via1(), spacing=5, padding=2, offset=+2)\n",
     "vian = ComponentAlongPath(component=gf.c.via1(), spacing=5, padding=2, offset=-2)\n",
-    "x = gf.CrossSection(sections=[s], components_along_path=[via0, viap, vian])\n",
+    "x = gf.CrossSection(sections=[s], components_along_path=(via0, viap, vian))\n",
     "\n",
     "# Combine the path with the cross-section\n",
     "c = gf.path.extrude(p, cross_section=x)\n",
@@ -539,7 +539,6 @@
     "s2 = gf.Section(width=1.5, offset=-2.5, layer=(3, 0))\n",
     "X = gf.CrossSection(sections=[s0, s1, s2])\n",
     "c = gf.path.extrude(P, X)\n",
-    "c.show()\n",
     "c.plot()"
    ]
   },
@@ -585,14 +584,14 @@
     "P.append(gf.path.straight())\n",
     "P.append(gf.path.arc(radius=5, angle=-90))\n",
     "P.append(looploop(num_pts=1000))\n",
-    "P.drotate(-45)\n",
+    "P.rotate(-45)\n",
     "\n",
     "# Create the crosssection\n",
     "s0 = gf.Section(width=1, offset=0, layer=(1, 0), port_names=(\"in\", \"out\"))\n",
     "s1 = gf.Section(width=0.5, offset=2, layer=(2, 0))\n",
     "s2 = gf.Section(width=0.5, offset=4, layer=(3, 0))\n",
     "s3 = gf.Section(width=1, offset=0, layer=(4, 0))\n",
-    "X = gf.CrossSection(sections=[s0, s1, s2, s3])\n",
+    "X = gf.CrossSection(sections=(s0, s1, s2, s3))\n",
     "\n",
     "c = gf.path.extrude(P, X)\n",
     "c.plot()"
@@ -1054,7 +1053,7 @@
     "# Create two cross-sections: one fixed width, one modulated by my_custom_offset_fun\n",
     "s0 = gf.Section(width=3, offset=-6, layer=(2, 0))\n",
     "s1 = gf.Section(width=0, width_function=my_custom_width_fun, offset=0, layer=(1, 0))\n",
-    "X = gf.CrossSection(sections=[s0, s1])\n",
+    "X = gf.CrossSection(sections=(s0, s1))\n",
     "\n",
     "# Extrude the Path to create the Component\n",
     "c = gf.path.extrude(P, cross_section=X)\n",
@@ -1096,9 +1095,9 @@
     "    width=1,\n",
     "    offset_function=my_custom_offset_fun,\n",
     "    layer=(2, 0),\n",
-    "    port_names=[\"clad1\", \"clad2\"],\n",
+    "    port_names=(\"clad1\", \"clad2\"),\n",
     ")\n",
-    "X = gf.CrossSection(sections=[s0, s1])\n",
+    "X = gf.CrossSection(sections=(s0, s1))\n",
     "\n",
     "# Extrude the Path to create the Component\n",
     "c = gf.path.extrude(P, cross_section=X)\n",
@@ -1147,7 +1146,7 @@
    "outputs": [],
    "source": [
     "P2 = P1.copy()  # Make a copy of the Path\n",
-    "P2.dmirror((1, 0))  # reflect across X-axis\n",
+    "P2.mirror((1, 0))  # reflect across X-axis\n",
     "f2 = P2.plot()"
    ]
   },
@@ -1307,8 +1306,8 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "from gdsfactory.cross_section import CrossSection, LayerSpec, cross_section, xsection\n",
-    "\n",
+    "from gdsfactory.cross_section import CrossSection, cross_section, xsection\n",
+    "from gdsfactory.typings import LayerSpec\n",
     "\n",
     "@xsection\n",
     "def pin(\n",
@@ -1495,7 +1494,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xs_bbox = gf.cross_section.cross_section(bbox_layers=[(3, 0)], bbox_offsets=[3])\n",
+    "xs_bbox = gf.cross_section.cross_section(bbox_layers=((3, 0),), bbox_offsets=(3,))\n",
     "w1 = gf.components.bend_euler(cross_section=xs_bbox)\n",
     "w1.plot()"
    ]
@@ -1580,14 +1579,6 @@
     "c = gf.components.straight(cross_section=xs_waveguide_heater_with_ports)\n",
     "c.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "100",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1611,7 +1602,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/08_pdk.ipynb
+++ b/notebooks/08_pdk.ipynb
@@ -160,7 +160,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gdsfactory.cross_section import CrossSection, LayerSpec, cross_section, xsection\n",
+    "from gdsfactory.cross_section import CrossSection, cross_section, xsection\n",
+    "from gdsfactory.typings import LayerSpec\n",
     "\n",
     "\n",
     "@xsection\n",
@@ -390,7 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pdk1.get_layer([1, 0])"
+    "pdk1.get_layer((1, 0))"
    ]
   },
   {
@@ -570,6 +571,22 @@
     "gds2 = mmi2.write_gds()\n",
     "gf.diff(gds1, gds2)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -592,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/09_pdk_import.ipynb
+++ b/notebooks/09_pdk_import.ipynb
@@ -443,7 +443,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/10_schematic.ipynb
+++ b/notebooks/10_schematic.ipynb
@@ -32,7 +32,8 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "import gdsfactory.schematic as gt"
+    "import gdsfactory.schematic as gt\n",
+    "import yaml"
    ]
   },
   {
@@ -191,7 +192,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import yaml"
+    "yaml_component = yaml.dump(s.netlist.model_dump(exclude_none=True))\n",
+    "print(yaml_component)"
    ]
   },
   {
@@ -201,23 +203,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "yaml_component = yaml.dump(s.netlist.model_dump(exclude_none=True))\n",
-    "print(yaml_component)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "yaml.dump(s.netlist.model_dump(exclude_none=True), open(\"schematic.yaml\", \"w\"))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Python routing"
@@ -226,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,12 +280,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import yaml\n",
-    "\n",
     "from gdsfactory.serialization import convert_tuples_to_lists\n",
     "\n",
     "conf = s.netlist.model_dump(exclude_none=True)\n",
@@ -306,21 +295,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
     "c = gf.read.from_yaml(yaml_component)\n",
     "c"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/11_best_practices.ipynb
+++ b/notebooks/11_best_practices.ipynb
@@ -258,22 +258,6 @@
     "c = pad_array_fast()\n",
     "c.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -128,7 +128,7 @@
    },
    "outputs": [],
    "source": [
-    "def bend(radius: float = 5) -> gf.typings.Component:\n",
+    "def bend(radius: float = 5) -> gf.Component:\n",
     "    return gf.components.bend_euler(radius=radius)\n",
     "\n",
     "\n",


### PR DESCRIPTION
- As we don't plan to expose Path attributes in DBU, this PR deprecates them

## Summary by Sourcery

Deprecate 'd-' prefixed attributes in the GeometryHelper and Path classes, replacing them with non-prefixed versions, and update related documentation and examples.

Enhancements:
- Deprecate the use of 'd-' prefixed attributes in the GeometryHelper and Path classes, replacing them with non-prefixed versions.

Documentation:
- Update Jupyter notebook examples to reflect the deprecation of 'd-' prefixed attributes and the use of tuples instead of lists for certain parameters.