### PR TITLE
Layer stack accepts layers

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -159,7 +159,7 @@ class AbstractLayer(BaseModel):
 class LogicalLayer(AbstractLayer):
     """GDS design layer."""
 
-    layer: tuple[int, int] | LayerEnum
+    layer: tuple[int, int] | LayerEnum | str | int
 
     def __eq__(self, other: object) -> bool:
         """Check if two LogicalLayer instances are equal.
@@ -354,7 +354,9 @@ class LayerLevel(BaseModel):
 
     @field_validator("layer")
     @classmethod
-    def check_layer(cls, layer: AbstractLayerSubClass) -> LogicalLayer | DerivedLayer:
+    def check_layer(
+        cls, layer: AbstractLayerSubClass | int | str | tuple[int, int] | LayerEnum
+    ) -> LogicalLayer | DerivedLayer:
         if isinstance(layer, int | str | tuple | LayerEnum):
             layer = gf.get_layer(layer)
             return LogicalLayer(layer=layer)

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -331,7 +331,7 @@ class LayerLevel(BaseModel):
 
     # ID
     name: str | None = None
-    layer: AbstractLayerSubClass
+    layer: AbstractLayerSubClass | int | str | tuple[int, int] | LayerEnum
     derived_layer: LogicalLayer | None = None
 
     # Extrusion rules

--- a/tests/technology/test_layerstack.py
+++ b/tests/technology/test_layerstack.py
@@ -1,8 +1,13 @@
 import pytest
 
-from gdsfactory.generic_tech import LAYER_STACK
+import gdsfactory as gf
+from gdsfactory.generic_tech import LAYER, LAYER_STACK
+from gdsfactory.technology import LayerLevel
+
+nm = 1e-3
 
 
+# TODO: fix this test
 @pytest.mark.skip(
     reason="Skipping as it is not implemented yet for the new LayerStack."
 )
@@ -22,9 +27,18 @@ def test_layerstack_copy() -> None:
     assert len(ls2.layers) == len(ls1.layers) + 1
 
 
-def test_component_with_derived_layers() -> None:
-    assert True
+def test_layer_level() -> None:
+    layers = ["WG", (1, 0), LAYER.WG]
 
-
-if __name__ == "__main__":
-    test_component_with_derived_layers()
+    for layer in layers:
+        level = LayerLevel(
+            layer=layer,
+            thickness=220 * nm,
+            thickness_tolerance=5 * nm,
+            material="Si",
+            mesh_order=2,
+            zmin=0,
+            sidewall_angle=10,
+            sidewall_angle_tolerance=2,
+        )
+        assert int(gf.get_layer(level.layer.layer)) == 1, int(level.layer)


### PR DESCRIPTION
## Summary by Sourcery

Enhance LayerLevel to accept various layer formats and add a corresponding test to verify this functionality.

Enhancements:
- Allow LayerLevel to accept layers as int, str, tuple, or LayerEnum.

Tests:
- Add test for LayerLevel to verify it accepts different layer formats.