### PR TITLE
Enforce layer in section

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -113,7 +113,7 @@ class Section(BaseModel):
     width: float
     offset: float = 0
     insets: tuple[float, float] | None = None
-    layer: typings.LayerSpec | None = None
+    layer: typings.LayerSpec
     port_names: tuple[str | None, str | None] = (None, None)
     port_types: tuple[str, str] = ("optical", "optical")
     name: str | None = None
@@ -246,7 +246,7 @@ class CrossSection(BaseModel):
         return self.sections[0].width
 
     @property
-    def layer(self) -> typings.LayerSpec | None:
+    def layer(self) -> typings.LayerSpec:
         return self.sections[0].layer
 
     def append_sections(self, sections: Sections) -> CrossSection:
@@ -474,7 +474,7 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 def cross_section(
     width: float = 0.5,
     offset: float = 0,
-    layer: typings.LayerSpec | None = "WG",
+    layer: typings.LayerSpec = "WG",
     sections: Sections | None = None,
     port_names: typings.IOPorts = ("o1", "o2"),
     port_types: typings.IOPorts = ("optical", "optical"),
@@ -819,7 +819,7 @@ def slot(
 
     return strip(
         width=width,
-        layer=None,
+        layer="WG_ABSTRACT",
         sections=sections,
     )
 
@@ -833,7 +833,7 @@ def rib_with_trenches(
     simplify_slab: float | None = None,
     layer: typings.LayerSpec | None = "WG",
     layer_trench: typings.LayerSpec = "DEEP_ETCH",
-    wg_marking_layer: typings.LayerSpec | None = None,
+    wg_marking_layer: typings.LayerSpec = "WG_ABSTRACT",
     sections: Sections | None = None,
     **kwargs: Any,
 ) -> CrossSection:
@@ -929,7 +929,7 @@ def l_with_trenches(
     width: float = 0.5,
     width_trench: float = 2.0,
     width_slab: float = 7.0,
-    layer: typings.LayerSpec | None = "WG",
+    layer: typings.LayerSpec = "WG",
     layer_slab: typings.LayerSpec | None = "WG",
     layer_trench: typings.LayerSpec = "DEEP_ETCH",
     mirror: bool = False,
@@ -1416,7 +1416,7 @@ def pn(
 @xsection
 def pn_with_trenches(
     width: float = 0.5,
-    layer: typings.LayerSpec | None = None,
+    layer: typings.LayerSpec = "WG",
     layer_trench: typings.LayerSpec = "DEEP_ETCH",
     gap_low_doping: float = 0.0,
     gap_medium_doping: float | None = 0.5,
@@ -1635,7 +1635,7 @@ def pn_with_trenches(
 @xsection
 def pn_with_trenches_asymmetric(
     width: float = 0.5,
-    layer: typings.LayerSpec | None = None,
+    layer: typings.LayerSpec = "WG",
     layer_trench: typings.LayerSpec = "DEEP_ETCH",
     gap_low_doping: float | tuple[float, float] = (0.0, 0.0),
     gap_medium_doping: float | tuple[float, float] | None = (0.5, 0.2),
@@ -1866,7 +1866,7 @@ def pn_with_trenches_asymmetric(
 @xsection
 def l_wg_doped_with_trenches(
     width: float = 0.5,
-    layer: typings.LayerSpec | None = None,
+    layer: typings.LayerSpec = "WG",
     layer_trench: typings.LayerSpec = "DEEP_ETCH",
     gap_low_doping: float = 0.0,
     gap_medium_doping: float | None = 0.5,

--- a/gdsfactory/generic_tech/layer_map.py
+++ b/gdsfactory/generic_tech/layer_map.py
@@ -26,6 +26,7 @@ class LAYER(gf.LayerEnum):
     UNDERCUT: Layer = (6, 0)
     WGN: Layer = (34, 0)
     WGN_CLAD: Layer = (36, 0)
+    WG_ABSTRACT: Layer = (1, 5)
 
     N: Layer = (20, 0)
     NP: Layer = (22, 0)

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_nc_.yml
@@ -7,9 +7,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_0cd5d5fa
+  route_info_type: xs_332a0fe1
   route_info_weight: 16.637
-  route_info_xs_0cd5d5fa_length: 16.637
+  route_info_xs_332a0fe1_length: 16.637
   width: 1
 name: bend_euler_nc_CSstrip_nc
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_no_.yml
@@ -7,9 +7,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_211e810a
+  route_info_type: xs_0d742c37
   route_info_weight: 16.637
-  route_info_xs_211e810a_length: 16.637
+  route_info_xs_0d742c37_length: 16.637
   width: 0.9
 name: bend_euler_no_CSstrip_no
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_sc_.yml
@@ -7,9 +7,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_94a72d8e
+  route_info_type: xs_6c16190b
   route_info_weight: 16.637
-  route_info_xs_94a72d8e_length: 16.637
+  route_info_xs_6c16190b_length: 16.637
   width: 0.5
 name: bend_euler_sc_CSstrip_sc
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_so_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_bend_euler_so_.yml
@@ -7,9 +7,9 @@ info:
   route_info_length: 16.637
   route_info_min_bend_radius: 7.061
   route_info_n_bend_90: 1
-  route_info_type: xs_d70275a4
+  route_info_type: xs_29b56862
   route_info_weight: 16.637
-  route_info_xs_d70275a4_length: 16.637
+  route_info_xs_29b56862_length: 16.637
   width: 0.4
 name: bend_euler_so_CSstrip_so
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_nc_.yml
@@ -2,9 +2,9 @@ info:
   length: 10
   pdk: fab_c
   route_info_length: 10
-  route_info_type: xs_0cd5d5fa
+  route_info_type: xs_332a0fe1
   route_info_weight: 10
-  route_info_xs_0cd5d5fa_length: 10
+  route_info_xs_332a0fe1_length: 10
   width: 1
 name: straight_nc_CSstrip_nc
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_no_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_no_.yml
@@ -2,9 +2,9 @@ info:
   length: 10
   pdk: fab_c
   route_info_length: 10
-  route_info_type: xs_211e810a
+  route_info_type: xs_0d742c37
   route_info_weight: 10
-  route_info_xs_211e810a_length: 10
+  route_info_xs_0d742c37_length: 10
   width: 0.9
 name: straight_no_CSstrip_no
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_sc_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_sc_.yml
@@ -2,9 +2,9 @@ info:
   length: 10
   pdk: fab_c
   route_info_length: 10
-  route_info_type: xs_0cd5d5fa
+  route_info_type: xs_332a0fe1
   route_info_weight: 10
-  route_info_xs_0cd5d5fa_length: 10
+  route_info_xs_332a0fe1_length: 10
   width: 1
 name: straight_sc_CSstrip_nc
 settings:

--- a/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_so_.yml
+++ b/gdsfactory/samples/pdk/test_fab_c/test_settings_straight_so_.yml
@@ -2,9 +2,9 @@ info:
   length: 10
   pdk: fab_c
   route_info_length: 10
-  route_info_type: xs_d70275a4
+  route_info_type: xs_29b56862
   route_info_weight: 10
-  route_info_xs_d70275a4_length: 10
+  route_info_xs_29b56862_length: 10
   width: 0.4
 name: straight_so_CSstrip_so
 settings:


### PR DESCRIPTION
will help with typing

@MatthewMckee4

## Summary by Sourcery

Enforce the 'layer' attribute in the Section class to be mandatory, enhancing type safety and consistency across the codebase. Update related YAML configuration files to align with the new layer specifications.

Enhancements:
- Make the 'layer' attribute in the Section class mandatory instead of optional, improving type safety.

Chores:
- Update YAML configuration files to reflect changes in route information types.