### PR TITLE
Fix sections type

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -162,7 +162,7 @@ class ComponentAlongPath(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
 
-Sections = Sequence[Section]
+Sections = tuple[Section, ...]
 
 
 class CrossSection(BaseModel):

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -155,10 +155,17 @@ def test_extrude_component_along_path() -> None:
         component=gf.c.rectangle(size=(1, 1), centered=True), spacing=5, padding=2
     )
     s = gf.Section(width=0.5, offset=0, layer=(1, 0), port_names=("in", "out"))
-    x = gf.CrossSection(sections=[s], components_along_path=[via])
+    x = gf.CrossSection(sections=(s,), components_along_path=(via,))
 
     # Combine the path with the cross-section
     c = gf.path.extrude(p, cross_section=x)
+    assert c
+
+
+def test_extrude_cross_section_list_of_sections() -> None:
+    s = gf.Section(width=0.5, offset=0.5, layer="WG")
+    xs = gf.CrossSection(sections=[s])  # type: ignore
+    c = gf.c.straight(cross_section=xs)
     assert c
 
 


### PR DESCRIPTION
- Ensure we can extrude a CrossSection where sections are defined as a list of sections instead of a tuple. Pydantic will do the conversion
- Add a test for that common case

## Summary by Sourcery

Fix the CrossSection class to accept sections as a tuple instead of a list and add a test to ensure extrusion works with sections defined as a list.

Bug Fixes:
- Fix the handling of sections in CrossSection to accept a tuple instead of a list, ensuring compatibility with Pydantic's type conversion.

Tests:
- Add a test to verify that CrossSection can be extruded when sections are defined as a list.