### PR TITLE
disable_netlist_list_conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test: test-data-gds
 	pytest -s
 
 test-force:
-	run pytest --force-regen -s
+	pytest -n auto --randomly-seed=41 --force-regen
 
 uv-test: test-data-gds
 	uv run pytest -s

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -19,7 +19,7 @@ from trimesh.scene.scene import Scene
 from gdsfactory.config import CONF, GDSDIR_TEMP
 from gdsfactory.functions import get_polygons, get_polygons_points
 from gdsfactory.port import pprint_ports, select_ports, to_dict
-from gdsfactory.serialization import clean_value_json, convert_tuples_to_lists
+from gdsfactory.serialization import clean_value_json
 
 if TYPE_CHECKING:
     import networkx as nx  # type: ignore[import-untyped]
@@ -1019,7 +1019,6 @@ class ComponentBase:
             netlist: netlist to write.
             filepath: Optional file path to write to.
         """
-        netlist = convert_tuples_to_lists(netlist)
         yaml_string = yaml.dump(netlist)
         if filepath:
             filepath = pathlib.Path(filepath)


### PR DESCRIPTION
## Summary by Sourcery

Enhance the netlist writing process by removing the conversion of tuples to lists and update the test command to run tests in parallel with a specific random seed.

Enhancements:
- Remove the conversion of tuples to lists in the netlist writing process.

Tests:
- Update the test command in the Makefile to run tests in parallel with a random seed.