### PR TITLE
Fix label side effect

### DIFF
--- a/test-data-regression/test_import_json_label.yml
+++ b/test-data-regression/test_import_json_label.yml
@@ -7,7 +7,7 @@ analysis_settings:
 doe: null
 measurement: null
 measurement_settings: {}
-name: straight_L10_N2_CSstrip_WNone
+name: straight__test_import_json_label
 xelec: []
 xopt:
 - 0

--- a/tests/read/test_import_gds.py
+++ b/tests/read/test_import_gds.py
@@ -34,7 +34,8 @@ def test_import_gds_hierarchy() -> None:
 
 def test_import_json_label(data_regression: DataRegressionFixture) -> None:
     """Import ports from GDS."""
-    c = gf.components.straight()
+    c = gf.components.straight().dup()
+    c.name = "straight__test_import_json_label"
     c1 = gf.labels.add_label_json(c)
     gdspath = c1.write_gds()
     csvpath = gf.labels.write_labels(gdspath, prefixes=["{"])


### PR DESCRIPTION
alternative to #3482

## Summary by Sourcery

Fix label side effect by duplicating the component and renaming it in the test to prevent unintended modifications and ensure consistent test results.

Bug Fixes:
- Fix label side effect by duplicating the component and renaming it to avoid unintended modifications.

Tests:
- Update test 'test_import_json_label' to use a duplicated component with a specific name to ensure consistent test results.