### PR TITLE
Eliminate side effects to global yaml behavior

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -25,11 +25,7 @@ from pydantic_extra_types.color import Color
 from gdsfactory.name import clean_name
 from gdsfactory.technology.color_utils import ensure_six_digit_hex_color
 from gdsfactory.technology.xml_utils import make_pretty_xml
-from gdsfactory.technology.yaml_utils import (
-    add_color_yaml_presenter,
-    add_multiline_str_yaml_presenter,
-    add_tuple_yaml_presenter,
-)
+from gdsfactory.technology.yaml_utils import TechnologyDumper
 
 if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, DictStrAny, MappingIntStrAny
@@ -1137,22 +1133,15 @@ class LayerViews(BaseModel):
             custom_line_styles=line_styles,
         )
 
-    def to_yaml(
-        self, layer_file: str | pathlib.Path, prefer_named_color: bool = True
-    ) -> None:
+    def to_yaml(self, layer_file: str | pathlib.Path) -> None:
         """Export layer properties to a YAML file.
 
         Args:
             layer_file: Name of the file to write LayerViews to.
-            prefer_named_color: Write the name of a color instead of its hex representation when possible.
         """
         lf_path = pathlib.Path(layer_file)
         dirpath = lf_path.parent
         dirpath.mkdir(exist_ok=True, parents=True)
-
-        add_tuple_yaml_presenter()
-        add_multiline_str_yaml_presenter()
-        add_color_yaml_presenter(prefer_named_color=prefer_named_color)
 
         lvs = {
             name: lv.dict(exclude_none=True, exclude_defaults=True, exclude_unset=True)
@@ -1181,6 +1170,7 @@ class LayerViews(BaseModel):
                 sort_keys=False,
                 default_flow_style=False,
                 encoding="utf-8",
+                Dumper=TechnologyDumper,
             )
         )
 

--- a/gdsfactory/technology/yaml_utils.py
+++ b/gdsfactory/technology/yaml_utils.py
@@ -11,7 +11,7 @@ class TechnologyDumper(yaml.SafeDumper):
     pass
 
 
-def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
+def add_color_yaml_representer(prefer_named_color: bool = True) -> None:
     """Add a custom YAML presenter for Color objects."""
 
     def _color_presenter(
@@ -25,7 +25,7 @@ def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
     TechnologyDumper.add_representer(Color, _color_presenter)
 
 
-def add_tuple_yaml_presenter() -> None:
+def add_tuple_yaml_representer() -> None:
     """Add a custom YAML presenter for tuple objects."""
 
     def _tuple_presenter(
@@ -36,7 +36,7 @@ def add_tuple_yaml_presenter() -> None:
     TechnologyDumper.add_representer(tuple, _tuple_presenter)
 
 
-def add_multiline_str_yaml_presenter() -> None:
+def add_multiline_str_yaml_representer() -> None:
     """Add a custom YAML presenter for multiline strings."""
 
     def _str_presenter(
@@ -49,6 +49,6 @@ def add_multiline_str_yaml_presenter() -> None:
     TechnologyDumper.add_representer(str, _str_presenter)
 
 
-add_color_yaml_presenter()
-add_tuple_yaml_presenter()
-add_multiline_str_yaml_presenter()
+add_color_yaml_representer()
+add_tuple_yaml_representer()
+add_multiline_str_yaml_representer()

--- a/gdsfactory/technology/yaml_utils.py
+++ b/gdsfactory/technology/yaml_utils.py
@@ -7,6 +7,10 @@ from pydantic_extra_types.color import Color
 from gdsfactory.technology.color_utils import ensure_six_digit_hex_color
 
 
+class TechnologyDumper(yaml.SafeDumper):
+    pass
+
+
 def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
     """Add a custom YAML presenter for Color objects."""
 
@@ -18,8 +22,7 @@ def add_color_yaml_presenter(prefer_named_color: bool = True) -> None:
             "tag:yaml.org,2002:str", ensure_six_digit_hex_color(data_str), style='"'
         )
 
-    yaml.add_representer(Color, _color_presenter)
-    yaml.representer.SafeRepresenter.add_representer(Color, _color_presenter)
+    TechnologyDumper.add_representer(Color, _color_presenter)
 
 
 def add_tuple_yaml_presenter() -> None:
@@ -30,8 +33,7 @@ def add_tuple_yaml_presenter() -> None:
     ) -> yaml.Node:
         return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=True)
 
-    yaml.add_representer(tuple, _tuple_presenter)
-    yaml.representer.SafeRepresenter.add_representer(tuple, _tuple_presenter)
+    TechnologyDumper.add_representer(tuple, _tuple_presenter)
 
 
 def add_multiline_str_yaml_presenter() -> None:
@@ -44,5 +46,9 @@ def add_multiline_str_yaml_presenter() -> None:
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
-    yaml.add_representer(str, _str_presenter)
-    yaml.representer.SafeRepresenter.add_representer(str, _str_presenter)
+    TechnologyDumper.add_representer(str, _str_presenter)
+
+
+add_color_yaml_presenter()
+add_tuple_yaml_presenter()
+add_multiline_str_yaml_presenter()


### PR DESCRIPTION
There were some yaml representers being registered globally within a function to write out the tech yaml files. This globally changes the behavior of writing to yaml, which can cause strange side effects. I created a specific dumper for that case, and only add the representers there.

After this PR, the tests can be run in random order and multiple cores, reliably.

## Summary by Sourcery

Enhancements:
- Introduce a specific YAML dumper class, TechnologyDumper, to encapsulate custom representers for Color, tuple, and multiline string objects, preventing global side effects.