### PR TITLE
make netlist array instances nicer

### DIFF
--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -122,6 +122,10 @@ def _is_array_reference(ref: ComponentReference) -> bool:
     return ref.na > 1 or ref.nb > 1
 
 
+def _is_orthogonal_array_reference(ref: ComponentReference) -> bool:
+    return abs(ref.a.y) == 0 and abs(ref.b.x) == 0
+
+
 def get_netlist(
     component: Component,
     exclude_port_types: list[str] | tuple[str] | None = (
@@ -185,9 +189,6 @@ def get_netlist(
         x = origin.x
         y = origin.y
         reference_name = get_instance_name(reference)
-        is_array_ref = False
-        if _is_array_reference(reference):
-            is_array_ref = True
         instance = {}
 
         if c.info:
@@ -214,13 +215,21 @@ def get_netlist(
             "mirror": reference.dtrans.mirror,
         }
 
-        if is_array_ref:
-            instances[reference_name].update(
-                columns=reference.na,
-                rows=reference.nb,
-                column_pitch=reference.da.x,
-                row_pitch=reference.db.y,
-            )
+        if _is_array_reference(reference):
+            if _is_orthogonal_array_reference(reference):
+                instances[reference_name]["array"] = {
+                    "columns": reference.na,
+                    "rows": reference.nb,
+                    "column_pitch": reference.da.x,
+                    "row_pitch": reference.db.y,
+                }
+            else:
+                instances[reference_name]["array"] = {
+                    "num_a": reference.na,
+                    "num_b": reference.nb,
+                    "pitch_a": (reference.da.x, reference.da.y),
+                    "pitch_b": (reference.db.x, reference.db.y),
+                }
             reference_name = get_instance_name(reference)
             for ia in range(reference.na):
                 for ib in range(reference.nb):

--- a/notebooks/10_yaml_component.ipynb
+++ b/notebooks/10_yaml_component.ipynb
@@ -541,10 +541,11 @@
     "instances:\n",
     "  sa:\n",
     "    component: straight\n",
-    "    columns: 2\n",
-    "    column_pitch: 20\n",
-    "    rows: 3\n",
-    "    row_pitch: 20\n",
+    "    array:\n",
+    "        columns: 2\n",
+    "        column_pitch: 20\n",
+    "        rows: 3\n",
+    "        row_pitch: 20\n",
     "\n",
     "  b:\n",
     "    component: bend_euler\n",
@@ -779,7 +780,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -793,7 +794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/11_best_practices.ipynb
+++ b/notebooks/11_best_practices.ipynb
@@ -13,7 +13,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Use @cell decorator\n",
+    "## Use cell decorator\n",
     "\n",
     "- Do not name leave cells Unnamed.\n",
     "\n",
@@ -266,7 +266,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -280,7 +280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/test-data-regression/test_netlists_array_.yml
+++ b/test-data-regression/test_netlists_array_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 6
+    array:
+      column_pitch: 150
+      columns: 6
+      row_pitch: 150
+      rows: 1
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 1
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_dbr_.yml
+++ b/test-data-regression/test_netlists_dbr_.yml
@@ -1,11 +1,12 @@
 instances:
   dbr_cell_W0p45_W0p55_L0_81fd17cb_0_0:
-    column_pitch: 0.318
-    columns: 10
+    array:
+      column_pitch: 0.318
+      columns: 10
+      row_pitch: 0
+      rows: 1
     component: dbr_cell
     info: {}
-    row_pitch: 0
-    rows: 1
     settings:
       cross_section: strip
       l1: 0.159

--- a/test-data-regression/test_netlists_grating_coupler_dual_pol_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_dual_pol_.yml
@@ -1,11 +1,12 @@
 instances:
   rectangle_S0p3_0p3_LSLA_62b062b0_m5070_m5070:
-    column_pitch: 0.58
-    columns: 18
+    array:
+      column_pitch: 0.58
+      columns: 18
+      row_pitch: 0.58
+      rows: 18
     component: rectangle
     info: {}
-    row_pitch: 0.58
-    rows: 18
     settings:
       centered: true
       layer: SLAB150

--- a/test-data-regression/test_netlists_pad_array0_.yml
+++ b/test-data-regression/test_netlists_pad_array0_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 1
+    array:
+      column_pitch: 150
+      columns: 1
+      row_pitch: 150
+      rows: 3
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 3
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_pad_array180_.yml
+++ b/test-data-regression/test_netlists_pad_array180_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 1
+    array:
+      column_pitch: 150
+      columns: 1
+      row_pitch: 150
+      rows: 3
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 3
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_pad_array270_.yml
+++ b/test-data-regression/test_netlists_pad_array270_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 6
+    array:
+      column_pitch: 150
+      columns: 6
+      row_pitch: 150
+      rows: 1
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 1
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_pad_array90_.yml
+++ b/test-data-regression/test_netlists_pad_array90_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 6
+    array:
+      column_pitch: 150
+      columns: 6
+      row_pitch: 150
+      rows: 1
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 1
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_pad_array_.yml
+++ b/test-data-regression/test_netlists_pad_array_.yml
@@ -1,7 +1,10 @@
 instances:
   pad_S100_100_LMTOP_BLNo_163fd346_0_0:
-    column_pitch: 150
-    columns: 6
+    array:
+      column_pitch: 150
+      columns: 6
+      row_pitch: 150
+      rows: 1
     component: pad
     info:
       size:
@@ -9,8 +12,6 @@ instances:
       - 100
       xsize: 100
       ysize: 100
-    row_pitch: 150
-    rows: 1
     settings:
       bbox_layers: null
       bbox_offsets: null

--- a/test-data-regression/test_netlists_via_chain_.yml
+++ b/test-data-regression/test_netlists_via_chain_.yml
@@ -1,11 +1,12 @@
 instances:
   rectangle_S2p7_6p4_LM2__c8f1a350_36000_m1000:
-    column_pitch: 7.4
-    columns: 1
+    array:
+      column_pitch: 7.4
+      columns: 1
+      row_pitch: 7.4
+      rows: 5
     component: rectangle
     info: {}
-    row_pitch: 7.4
-    rows: 5
     settings:
       centered: false
       layer: M2
@@ -19,12 +20,13 @@ instances:
       - 2.7
       - 6.4
   rectangle_S2p7_6p4_LM2__c8f1a350_m1000_2700:
-    column_pitch: 7.4
-    columns: 1
+    array:
+      column_pitch: 7.4
+      columns: 1
+      row_pitch: 7.4
+      rows: 4
     component: rectangle
     info: {}
-    row_pitch: 7.4
-    rows: 4
     settings:
       centered: false
       layer: M2
@@ -38,12 +40,13 @@ instances:
       - 2.7
       - 6.4
   rectangles_S6p4_2p7_O0_LM1_CTrue_5900_350:
-    column_pitch: 7.4
-    columns: 5
+    array:
+      column_pitch: 7.4
+      columns: 5
+      row_pitch: 3.7
+      rows: 10
     component: rectangles
     info: {}
-    row_pitch: 3.7
-    rows: 10
     settings:
       centered: true
       layers:
@@ -54,12 +57,13 @@ instances:
       - 6.4
       - 2.7
   rectangles_S6p4_2p7_O0_LM2_CTrue_2200_350:
-    column_pitch: 7.4
-    columns: 5
+    array:
+      column_pitch: 7.4
+      columns: 5
+      row_pitch: 3.7
+      rows: 10
     component: rectangles
     info: {}
-    row_pitch: 3.7
-    rows: 10
     settings:
       centered: true
       layers:
@@ -70,16 +74,17 @@ instances:
       - 6.4
       - 2.7
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_4050_350:
-    column_pitch: 3.7
-    columns: 10
+    array:
+      column_pitch: 3.7
+      columns: 10
+      row_pitch: 3.7
+      rows: 10
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 3.7
-    rows: 10
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_.yml
+++ b/test-data-regression/test_netlists_via_stack_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_heater_m2_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_m2_.yml
@@ -32,16 +32,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_heater_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_m3_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_heater_mtop_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_m1_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_m1_m3_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
+++ b/test-data-regression/test_netlists_via_stack_m1_mtop_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_m2_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_m2_m3_.yml
@@ -32,16 +32,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_npp_m1_.yml
+++ b/test-data-regression/test_netlists_via_stack_npp_m1_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m1_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m1_.yml
@@ -32,16 +32,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -55,16 +56,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m1_horizontal_.yml
@@ -32,16 +32,17 @@ instances:
       - 11
       - 11
   via_S7_0p70000000000000_6ce51dbf_0_m3000:
-    column_pitch: 2
-    columns: 1
+    array:
+      column_pitch: 2
+      columns: 1
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -55,16 +56,17 @@ instances:
       - 0.7
       spacing: null
   via_S9_0p70000000000000_a6f786c9_0_m4000:
-    column_pitch: 2
-    columns: 1
+    array:
+      column_pitch: 2
+      columns: 1
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 9
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m2_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m2_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -71,16 +72,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_slab_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_m3_.yml
@@ -64,16 +64,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -87,16 +88,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m3000_m3000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -110,16 +112,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_slab_npp_m3_.yml
@@ -48,16 +48,17 @@ instances:
       - 11
       - 11
   via_S0p7_0p7_SNone_GNon_372ed4f2_m4000_m4000:
-    column_pitch: 2
-    columns: 5
+    array:
+      column_pitch: 2
+      columns: 5
+      row_pitch: 2
+      rows: 5
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 5
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_with_offset_.yml
+++ b/test-data-regression/test_netlists_via_stack_with_offset_.yml
@@ -60,16 +60,17 @@ instances:
       - 10
       - 10
   via_S0p7_0p7_SNone_GNon_372ed4f2_m3000_2000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_with_offset_m1_m3_.yml
+++ b/test-data-regression/test_netlists_via_stack_with_offset_m1_m3_.yml
@@ -88,16 +88,17 @@ instances:
       - 10
       - 10
   via_S0p7_0p7_SNone_GNon_c3f5c6aa_m2000_3000:
-    column_pitch: 2
-    columns: 3
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 3
     component: via
     info:
       enclosure: 2
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 3
     settings:
       bbox_layers: null
       bbox_offset: 0
@@ -111,16 +112,17 @@ instances:
       - 0.7
       spacing: null
   via_S0p7_0p7_SNone_GNon_e14245b6_m3000_12000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/test-data-regression/test_netlists_via_stack_with_offset_ppp_m1_.yml
+++ b/test-data-regression/test_netlists_via_stack_with_offset_ppp_m1_.yml
@@ -60,16 +60,17 @@ instances:
       - 10
       - 10
   via_S0p7_0p7_SNone_GNon_372ed4f2_m3000_2000:
-    column_pitch: 2
-    columns: 4
+    array:
+      column_pitch: 2
+      columns: 4
+      row_pitch: 2
+      rows: 4
     component: via
     info:
       enclosure: 1
       pitch: 2
       xsize: 0.7
       ysize: 0.7
-    row_pitch: 2
-    rows: 4
     settings:
       bbox_layers: null
       bbox_offset: 0

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -508,8 +508,6 @@ instances:
       - 50
       bend_s: bend_s
       cross_section: strip
-    columns: 1
-    rows: 1
   dbr:
     component: array
     settings:
@@ -521,8 +519,6 @@ instances:
       rows: 8
       add_ports: true
       centered: true
-    columns: 1
-    rows: 1
 placements:
   s:
     x: 0.0
@@ -563,10 +559,11 @@ name: sample_array
 instances:
   sa1:
     component: straight
-    columns: 5
-    column_pitch: 50
-    rows: 4
-    row_pitch: 10
+    array:
+      columns: 5
+      column_pitch: 50
+      rows: 4
+      row_pitch: 10
   s2:
     component: straight
 
@@ -592,10 +589,11 @@ name: sample_array_connect
 instances:
   sa:
     component: straight
-    columns: 1
-    column_pitch: 20
-    rows: 3
-    row_pitch: 20
+    array:
+      columns: 1
+      column_pitch: 20
+      rows: 3
+      row_pitch: 20
 
   b1:
     component: bend_euler

--- a/tests/test_get_netlist.py
+++ b/tests/test_get_netlist.py
@@ -63,8 +63,8 @@ def test_get_netlist_cell_array() -> None:
             assert n["ports"][expected_port_name] == expected_lower_port_name
 
     inst = list(n["instances"].values())[0]
-    n_rows = inst["rows"]
-    n_columns = inst["columns"]
+    n_rows = inst["array"]["rows"]
+    n_columns = inst["array"]["columns"]
     assert (
         n_rows == rows and n_columns == 1
     ), f"Expected {n_rows=}={rows} and {n_columns=}=1"
@@ -90,7 +90,7 @@ def test_get_netlist_cell_array_no_ports() -> None:
         len(n["instances"]) == 1
     ), f"Expected only one instance for array. Got {len(n['instances'])}"
     inst = list(n["instances"].values())[0]
-    assert inst["columns"] == 1 and inst["rows"] == rows
+    assert inst["array"]["columns"] == 1 and inst["array"]["rows"] == rows
 
 
 def test_get_netlist_cell_array_connecting() -> None:


### PR DESCRIPTION
This places the array configuration of an instance in the netlist in its own subsection.

For example:

**old:**
```yaml
instances:
  straight_array:
    columns: 5
    column_pitch: 50
    component: straight
    rows: 4
    row_pitch: 10
```

**new:**
```yaml
instances:
  straight_array:
    component: straight
    array:
      columns: 5
      column_pitch: 50
      rows: 4
      row_pitch: 10
```

Advantages:
- array settings are always grouped together
- it's very clear when an instance is an array instance by adding an 'array' section to the instance
- You can support multiple array configurations (I added a 'generic' array config for example supporting non-orthogonal array references). But you could for example add a HorizontalArrayConfig or a VerticalArrayConfig as well if you'd like.


Let me know what you think.

## Summary by Sourcery

Enhancements:
- Refactor netlist YAML structure to group array configurations under a dedicated 'array' subsection, improving clarity and flexibility.