### PR TITLE
Refactor all warnings deprecation warnings to use deprecate function

### DIFF
--- a/gdsfactory/_deprecation.py
+++ b/gdsfactory/_deprecation.py
@@ -3,11 +3,11 @@ import warnings
 from gdsfactory.config import __next_major_version__
 
 
-def deprecate(old_name: str, new_name: str | None = None) -> None:
+def deprecate(old_name: str, new_name: str | None = None, stacklevel: int = 3) -> None:
     warnings.warn(
         f"{old_name} is deprecated."
         + (f" Use {new_name} instead." if new_name else "")
         + f" It will be removed in {__next_major_version__}.",
         DeprecationWarning,
-        stacklevel=3,
+        stacklevel=stacklevel,
     )

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1035,7 +1035,7 @@ class ComponentBase:
         import matplotlib.pyplot as plt
         import networkx as nx
 
-        from gdsfactory.get_netlist import _nets_to_connections
+        from gdsfactory.get_netlist import nets_to_connections
 
         plt.figure()
         netlist = self.get_netlist(recursive=recursive, **kwargs)
@@ -1047,7 +1047,7 @@ class ComponentBase:
             for net in netlist.values():
                 nets = net.get("nets", [])
                 connections = net.get("connections", {})
-                connections = _nets_to_connections(nets, connections)
+                connections = nets_to_connections(nets, connections)
                 placements = net["placements"]
                 G.add_edges_from(
                     [
@@ -1061,7 +1061,7 @@ class ComponentBase:
         else:
             nets = netlist.get("nets", [])
             connections = netlist.get("connections", {})
-            connections = _nets_to_connections(nets, connections)
+            connections = nets_to_connections(nets, connections)
             placements = netlist["placements"]
             G.add_edges_from(
                 [

--- a/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
@@ -38,7 +38,7 @@ def add_fiber_array_optical_south_electrical_north(
         electrical_port_orientation: orientation of electrical ports. Defaults to 90.
         npads: number of pads. Defaults to one per electrical_port_names.
         port_types_grating_couplers: port types for grating couplers. Defaults to vertical TE, TM, and dual.
-        pad_spacing: Deprecated. Use pad_pitch instead.
+        pad_spacing: (deprecated).
         kwargs: additional arguments.
 
     Keyword Args:

--- a/gdsfactory/components/containers/array_component.py
+++ b/gdsfactory/components/containers/array_component.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.typings import AnyComponentPostProcess, ComponentSpec, Float2, Spacing
 
@@ -26,7 +26,7 @@ def array(
 
     Args:
         component: to replicate.
-        spacing: x, y spacing. Deprecated, use column_pitch and row_pitch.
+        spacing: x, y spacing (deprecated).
         columns: in x.
         rows: in y.
         column_pitch: pitch between columns.
@@ -56,7 +56,7 @@ def array(
         |___|      |___|     |___|      |___|
     """
     if spacing:
-        warnings.warn("spacing is deprecated, use column_pitch and row_pitch")
+        deprecate("spacing", "column_pitch and row_pitch")
         column_pitch, row_pitch = spacing
 
     if size:

--- a/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
@@ -95,7 +95,11 @@ def grating_coupler_dual_pol(
 
     unit_cell_grating = gf.get_component(unit_cell)
     g = c.add_ref(
-        unit_cell_grating, columns=num_x, rows=num_y, spacing=(period_x, period_y)
+        unit_cell_grating,
+        columns=num_x,
+        rows=num_y,
+        column_pitch=period_x,
+        row_pitch=period_y,
     )
     g.dxmin = x_start
     g.dymin = y_start

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -118,7 +118,7 @@ def pad_array(
         column_pitch: x pitch.
         row_pitch: y pitch.
         port_orientation: port orientation in deg. None for low speed DC ports.
-        orientation: Deprecated, use port_orientation.
+        orientation: (deprecated).
         size: pad size.
         layer: pad layer.
         centered_ports: True add ports to center. False add ports to the edge.

--- a/gdsfactory/components/pads/rectangle_with_slits.py
+++ b/gdsfactory/components/pads/rectangle_with_slits.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.typings import Float2, LayerSpec, Size
 
@@ -64,9 +63,7 @@ def rectangle_with_slits(
     layer = gf.get_layer(layer)
 
     if slit_spacing:
-        warnings.warn(
-            "slit_spacing is deprecated. Use slit_column_pitch and slit_row_pitch instead"
-        )
+        deprecate("slit_spacing", "slit_column_pitch and slit_row_pitch")
         slit_column_pitch = slit_spacing[0]
         slit_row_pitch = slit_spacing[1]
 

--- a/gdsfactory/components/pcms/cutback_bend.py
+++ b/gdsfactory/components/pcms/cutback_bend.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
@@ -45,6 +46,7 @@ def cutback_bend(
 
         _ this is a row
     """
+    deprecate("cutback_bend", "cutback_bend90")
     from gdsfactory.pdk import get_component
 
     bend90 = get_component(component, **kwargs)

--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from functools import partial
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size, Spacing
 
@@ -27,8 +28,8 @@ def via(
 
     Args:
         size: in x and y direction.
-        spacing: pitch_x, pitch_y. Deprecated, use pitch instead.
-        gap: edge to edge via gap in x, y. Deprecated, use pitch instead.
+        spacing: pitch_x, pitch_y. (deprecated).
+        gap: edge to edge via gap in x, y. (deprecated).
         enclosure: inclusion of via.
         layer: via layer.
         bbox_layers: layers for the bounding box.
@@ -54,11 +55,11 @@ def via(
         |_______________________________________|
     """
     if spacing is not None:
-        warnings.warn("spacing is deprecated, use pitch, row_pitch or column_pitch")
+        deprecate("spacing", "pitch, row_pitch or column_pitch")
         pitch = spacing[0]
 
     if gap is not None:
-        warnings.warn("gap is deprecated, use pitch, row_pitch or column_pitch")
+        deprecate("gap", "pitch, row_pitch or column_pitch")
 
     row_pitch = row_pitch or pitch
     column_pitch = column_pitch or pitch

--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from functools import partial
 

--- a/gdsfactory/components/vias/via_corner.py
+++ b/gdsfactory/components/vias/via_corner.py
@@ -97,7 +97,11 @@ def via_corner(
         nb_vias_x = int(floor(nb_vias_x)) or 1
         nb_vias_y = int(floor(nb_vias_y)) or 1
         ref = c.add_ref(
-            via, columns=nb_vias_x, rows=nb_vias_y, spacing=(pitch_x, pitch_y)
+            via,
+            columns=nb_vias_x,
+            rows=nb_vias_y,
+            column_pitch=pitch_x,
+            row_pitch=pitch_y,
         )
 
         cw = (min_width - (nb_vias_x - 1) * pitch_x - w) / 2

--- a/gdsfactory/components/vias/via_stack.py
+++ b/gdsfactory/components/vias/via_stack.py
@@ -7,6 +7,7 @@ from functools import partial
 import numpy as np
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, Floats, Ints, LayerSpec, LayerSpecs, Size
 
@@ -39,7 +40,7 @@ def via_stack(
         layer_offsets: Optional offsets for each layer with respect to size.
             positive grows, negative shrinks the size.
         vias: vias to use to fill the rectangles.
-        layer_port: if None assumes port is on the last layer. Deprecated.
+        layer_port: if None assumes port is on the last layer. (deprecated).
         layer_to_port_orientations: dictionary of layer to port_orientations.
         correct_size: if True, if the specified dimensions are too small it increases
             them to the minimum possible to fit a via.
@@ -71,9 +72,7 @@ def via_stack(
         )
 
     if layer_port:
-        warnings.warn(
-            "layer_port is deprecated. Use layer_to_ports instead", stacklevel=2
-        )
+        deprecate("layer_port", "layer_to_ports")
 
     c = Component()
     c.info["xsize"], c.info["ysize"] = size

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -10,6 +10,7 @@ import numpy.typing as npt
 from numpy import cos, float64, sin
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 
 if TYPE_CHECKING:
     from gdsfactory.component import Component, Instance
@@ -354,9 +355,7 @@ def extrude_path(
     end_angle: int | None = None,
     grid: float | None = None,
 ) -> npt.NDArray[np.float64]:
-    """Deprecated. Use gdsfactory.path.Path.extrude() instead.
-
-    Extrude a path of `width` along a curve defined by `points`.
+    """Extrude a path of `width` along a curve defined by `points`.
 
     Args:
         points: numpy 2D array of shape (N, 2).
@@ -370,6 +369,7 @@ def extrude_path(
     Returns:
         numpy 2D array of shape (2*N, 2).
     """
+    deprecate("extrude_path", "gdsfactory.path.Path.extrude()")
     grid = grid or gf.kcl.dbu
 
     if isinstance(points, list):

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -18,6 +18,7 @@ import numpy as np
 import numpy.typing as npt
 from numpy import mod, pi
 
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.component_layout import (
     GeometryHelper,
@@ -109,10 +110,7 @@ class Path(GeometryHelper):
             "dymax",
             "dysize",
         }:
-            warnings.warn(
-                f"Deprecation warning. Use {__k[1:]!r} instead of {__k!r} for Path objects.",
-                stacklevel=2,
-            )
+            deprecate(__k, f"{__k[1:]}")
             return getattr(self, f"{__k[1:]}")
         return super().__getattribute__(__k)
 
@@ -904,10 +902,7 @@ def extrude(
     c = ComponentAllAngle() if all_angle else Component()
 
     if isinstance(cross_section, Transition):
-        warnings.warn(
-            "Use extrude_transition() instead of extrude() for Transition cross-sections",
-            stacklevel=2,
-        )
+        deprecate("extrude", "extrude_transition")
         return extrude_transition(p, transition=cross_section)
 
     x = get_cross_section(cross_section)

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -8,6 +8,7 @@ from typing import Any
 import kfactory as kf
 from kfactory import KCLayout
 
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.typings import PostProcesses
 
@@ -27,11 +28,11 @@ def import_gds(
         cellname: name of the cell to return. Defaults to top cell.
         post_process: function to run after reading the GDS file.
         rename_duplicated_cells: if True, rename duplicated cells.
-        kwargs: deprecated and ignored.
+        kwargs: (deprecated and ignored).
     """
     if kwargs:
         for k in kwargs:
-            warnings.warn(f"kwargs {k!r} is deprecated and ignored")
+            deprecate(f"kwargs {k!r}")
 
     temp_kcl = KCLayout(name=str(gdspath))
     options = kf.kcell.load_layout_options()
@@ -81,7 +82,7 @@ def import_gds_with_conflicts(
         gdspath: path to GDS file.
         cellname: name of the cell to return. Defaults to top cell.
         name: optional name.
-        kwargs: deprecated and ignored.
+        kwargs: (deprecated and ignored).
 
     Modes:
         AddToCell: Add content to existing cell. Content of new cells is simply added to existing cells with the same name.
@@ -89,9 +90,9 @@ def import_gds_with_conflicts(
         RenameCell: The new cell will be renamed to become unique
         SkipNewCell: The new cell is skipped entirely (including child cells which are not used otherwise)
     """
-    warnings.warn(
-        "import_gds_with_conflicts is deprecated, use import_gds with rename_duplicated_cells=True"
-    )
+    if kwargs:
+        for k in kwargs:
+            deprecate(f"kwargs {k!r}")
 
     return import_gds(
         gdspath, cellname=cellname, rename_duplicated_cells=True, **kwargs

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from functools import cache
 from pathlib import Path
 from typing import Any

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -59,7 +59,7 @@ def add_pads_bot(
         route_width: width of the route. If None, defaults to cross_section.width.
         bboxes: list bounding boxes to avoid for routing.
         avoid_component_bbox: avoid component bbox for routing.
-        pad_spacing: deprecated. Use pad_pitch instead.
+        pad_spacing: (deprecated).
         kwargs: additional arguments.
 
     Keyword Args:

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -113,7 +113,7 @@ def route_fiber_array(
         steps: steps for the route.
         bboxes: list bounding boxes to avoid for routing.
         avoid_component_bbox: avoid component bbox for routing.
-        fiber_spacing: Deprecated. Use pitch instead.
+        fiber_spacing: (deprecated).
         kwargs: route_bundle settings.
     """
     # c = component

--- a/gdsfactory/routing/route_single_from_steps.py
+++ b/gdsfactory/routing/route_single_from_steps.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping, Sequence
 from functools import partial
 from typing import Any, Literal
@@ -8,6 +7,7 @@ from typing import Any, Literal
 from kfactory.routing.generic import ManhattanRoute
 
 import gdsfactory as gf
+from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.routing.route_single import route_single
 from gdsfactory.typings import (
@@ -85,9 +85,7 @@ def route_single_from_steps(
         c.plot()
 
     """
-    warnings.warn(
-        "route_single_from_steps is deprecated, use route_single instead", stacklevel=2
-    )
+    deprecate("route_single_from_steps", "route_single")
     x, y = port1.dcenter
     waypoints: list[Coordinate] = []
     steps = list(steps or [])
@@ -170,4 +168,5 @@ if __name__ == "__main__":
     #     # cross_section='metal_routing',
     #     # bend=gf.components.wire_corner,
     # )
+    # c.add(route.references)
     # c.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ full = [
   "autograd"
 ]
 maintainer = [
-  "ruff",
+  "ruff>=0.8.3",
   "doc8",
   "xdoctest",
   "mypy",

--- a/tests/routing/test_routing_route_bundle_udirect.py
+++ b/tests/routing/test_routing_route_bundle_udirect.py
@@ -17,7 +17,7 @@ def test_route_bundle_udirect_pads(
 
     pad = partial(gf.components.pad, size=(10, 10))
     pad_south = gf.components.pad_array(
-        port_orientation=270, spacing=(15.0, 0), pad=pad
+        port_orientation=270, column_pitch=15.0, row_pitch=0, pad=pad
     )
     pt = c << pad_south
     pb = c << pad_south

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -204,21 +204,21 @@ def test_length() -> None:
 
 def test_dmove() -> None:
     path = Path([[0, 0], [1, 1], [2, 0]])
-    path.dmove((0, 0), (1, 1))
+    path.move((0, 0), (1, 1))
     expected_points = np.array([[1, 1], [2, 2], [3, 1]])
     assert np.array_equal(path.points, expected_points)
 
 
 def test_drotate() -> None:
     path = Path([[0, 0], [1, 1], [2, 0]])
-    path.drotate(90)
+    path.rotate(90)
     expected_points = np.array([[0, 0], [-1, 1], [0, 2]])
     np.testing.assert_allclose(path.points, expected_points, atol=1e-4)
 
 
 def test_dmirror() -> None:
     path = Path([[0, 0], [1, 1], [2, 0]])
-    path.dmirror((0, 0), (0, 1))
+    path.mirror((0, 0), (0, 1))
     expected_points = np.array([[0, 0], [-1, 1], [-2, 0]])
     np.testing.assert_allclose(path.points, expected_points, atol=1e-4)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1131,7 +1131,7 @@ requires-dist = [
     { name = "qrcode" },
     { name = "rectpack", specifier = "<1" },
     { name = "rich", specifier = "<14" },
-    { name = "ruff", marker = "extra == 'maintainer'" },
+    { name = "ruff", marker = "extra == 'maintainer'", specifier = ">=0.8.3" },
     { name = "scikit-image" },
     { name = "scikit-rf", marker = "extra == 'full'" },
     { name = "scipy", specifier = "<2" },
@@ -4127,27 +4127,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.6.9"
+version = "0.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/0d/6148a48dab5662ca1d5a93b7c0d13c03abd3cc7e2f35db08410e47cef15d/ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2", size = 3095355 }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/5e/683c7ef7a696923223e7d95ca06755d6e2acbc5fd8382b2912a28008137c/ruff-0.8.3.tar.gz", hash = "sha256:5e7558304353b84279042fc584a4f4cb8a07ae79b2bf3da1a7551d960b5626d3", size = 3378522 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/8f/f7a0a0ef1818662efb32ed6df16078c95da7a0a3248d64c2410c1e27799f/ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd", size = 10440526 },
-    { url = "https://files.pythonhosted.org/packages/8b/69/b179a5faf936a9e2ab45bb412a668e4661eded964ccfa19d533f29463ef6/ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec", size = 10034612 },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/fd1b4be979c579d191eeac37b5cfc0ec906de72c8bcd8595e2c81bb700c1/ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c", size = 9706197 },
-    { url = "https://files.pythonhosted.org/packages/29/61/b376d775deb5851cb48d893c568b511a6d3625ef2c129ad5698b64fb523c/ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e", size = 10751855 },
-    { url = "https://files.pythonhosted.org/packages/13/d7/def9e5f446d75b9a9c19b24231a3a658c075d79163b08582e56fa5dcfa38/ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577", size = 10200889 },
-    { url = "https://files.pythonhosted.org/packages/6c/d6/7f34160818bcb6e84ce293a5966cba368d9112ff0289b273fbb689046047/ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829", size = 11038678 },
-    { url = "https://files.pythonhosted.org/packages/13/34/a40ff8ae62fb1b26fb8e6fa7e64bc0e0a834b47317880de22edd6bfb54fb/ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5", size = 11808682 },
-    { url = "https://files.pythonhosted.org/packages/2e/6d/25a4386ae4009fc798bd10ba48c942d1b0b3e459b5403028f1214b6dd161/ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7", size = 11330446 },
-    { url = "https://files.pythonhosted.org/packages/f7/f6/bdf891a9200d692c94ebcd06ae5a2fa5894e522f2c66c2a12dd5d8cb2654/ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f", size = 12483048 },
-    { url = "https://files.pythonhosted.org/packages/a7/86/96f4252f41840e325b3fa6c48297e661abb9f564bd7dcc0572398c8daa42/ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa", size = 10936855 },
-    { url = "https://files.pythonhosted.org/packages/45/87/801a52d26c8dbf73424238e9908b9ceac430d903c8ef35eab1b44fcfa2bd/ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb", size = 10713007 },
-    { url = "https://files.pythonhosted.org/packages/be/27/6f7161d90320a389695e32b6ebdbfbedde28ccbf52451e4b723d7ce744ad/ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0", size = 10274594 },
-    { url = "https://files.pythonhosted.org/packages/00/52/dc311775e7b5f5b19831563cb1572ecce63e62681bccc609867711fae317/ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625", size = 10608024 },
-    { url = "https://files.pythonhosted.org/packages/98/b6/be0a1ddcbac65a30c985cf7224c4fce786ba2c51e7efeb5178fe410ed3cf/ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039", size = 10982085 },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/c84bc13d0b573cf7bb7d17b16d6d29f84267c92d79b2f478d4ce322e8e72/ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d", size = 8522088 },
-    { url = "https://files.pythonhosted.org/packages/74/be/fc352bd8ca40daae8740b54c1c3e905a7efe470d420a268cd62150248c91/ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117", size = 9359275 },
-    { url = "https://files.pythonhosted.org/packages/3e/14/fd026bc74ded05e2351681545a5f626e78ef831f8edce064d61acd2e6ec7/ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93", size = 8679879 },
+    { url = "https://files.pythonhosted.org/packages/f8/c4/bfdbb8b9c419ff3b52479af8581026eeaac3764946fdb463dec043441b7d/ruff-0.8.3-py3-none-linux_armv6l.whl", hash = "sha256:8d5d273ffffff0acd3db5bf626d4b131aa5a5ada1276126231c4174543ce20d6", size = 10535860 },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/0aabdc9314b4b6f051168ac45227e2aa8e1c6d82718a547455e40c9c9faa/ruff-0.8.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4d66a21de39f15c9757d00c50c8cdd20ac84f55684ca56def7891a025d7e939", size = 10346327 },
+    { url = "https://files.pythonhosted.org/packages/1a/78/4843a59e7e7b398d6019cf91ab06502fd95397b99b2b858798fbab9151f5/ruff-0.8.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c356e770811858bd20832af696ff6c7e884701115094f427b64b25093d6d932d", size = 9942585 },
+    { url = "https://files.pythonhosted.org/packages/91/5a/642ed8f1ba23ffc2dd347697e01eef3c42fad6ac76603be4a8c3a9d6311e/ruff-0.8.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c0a60a825e3e177116c84009d5ebaa90cf40dfab56e1358d1df4e29a9a14b13", size = 10797597 },
+    { url = "https://files.pythonhosted.org/packages/30/25/2e654bc7226da09a49730a1a2ea6e89f843b362db80b4b2a7a4f948ac986/ruff-0.8.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fb782f4db39501210ac093c79c3de581d306624575eddd7e4e13747e61ba18", size = 10307244 },
+    { url = "https://files.pythonhosted.org/packages/c0/2d/a224d56bcd4383583db53c2b8f410ebf1200866984aa6eb9b5a70f04e71f/ruff-0.8.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f26bc76a133ecb09a38b7868737eded6941b70a6d34ef53a4027e83913b6502", size = 11362439 },
+    { url = "https://files.pythonhosted.org/packages/82/01/03e2857f9c371b8767d3e909f06a33bbdac880df17f17f93d6f6951c3381/ruff-0.8.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:01b14b2f72a37390c1b13477c1c02d53184f728be2f3ffc3ace5b44e9e87b90d", size = 12078538 },
+    { url = "https://files.pythonhosted.org/packages/af/ae/ff7f97b355da16d748ceec50e1604a8215d3659b36b38025a922e0612e9b/ruff-0.8.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53babd6e63e31f4e96ec95ea0d962298f9f0d9cc5990a1bbb023a6baf2503a82", size = 11616172 },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/6156d4d1e53ebd17747049afe801c5d7e3014d9b2f398b9236fe36ba4320/ruff-0.8.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ae441ce4cf925b7f363d33cd6570c51435972d697e3e58928973994e56e1452", size = 12919886 },
+    { url = "https://files.pythonhosted.org/packages/4e/84/affcb30bacb94f6036a128ad5de0e29f543d3f67ee42b490b17d68e44b8a/ruff-0.8.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7c65bc0cadce32255e93c57d57ecc2cca23149edd52714c0c5d6fa11ec328cd", size = 11212599 },
+    { url = "https://files.pythonhosted.org/packages/60/b9/5694716bdefd8f73df7c0104334156c38fb0f77673d2966a5a1345bab94d/ruff-0.8.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5be450bb18f23f0edc5a4e5585c17a56ba88920d598f04a06bd9fd76d324cb20", size = 10784637 },
+    { url = "https://files.pythonhosted.org/packages/24/7e/0e8f835103ac7da81c3663eedf79dec8359e9ae9a3b0d704bae50be59176/ruff-0.8.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8faeae3827eaa77f5721f09b9472a18c749139c891dbc17f45e72d8f2ca1f8fc", size = 10390591 },
+    { url = "https://files.pythonhosted.org/packages/27/da/180ec771fc01c004045962ce017ca419a0281f4bfaf867ed0020f555b56e/ruff-0.8.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:db503486e1cf074b9808403991663e4277f5c664d3fe237ee0d994d1305bb060", size = 10894298 },
+    { url = "https://files.pythonhosted.org/packages/6d/f8/29f241742ed3954eb2222314b02db29f531a15cab3238d1295e8657c5f18/ruff-0.8.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6567be9fb62fbd7a099209257fef4ad2c3153b60579818b31a23c886ed4147ea", size = 11275965 },
+    { url = "https://files.pythonhosted.org/packages/79/e9/5b81dc9afc8a80884405b230b9429efeef76d04caead904bd213f453b973/ruff-0.8.3-py3-none-win32.whl", hash = "sha256:19048f2f878f3ee4583fc6cb23fb636e48c2635e30fb2022b3a1cd293402f964", size = 8807651 },
+    { url = "https://files.pythonhosted.org/packages/ea/67/7291461066007617b59a707887b90e319b6a043c79b4d19979f86b7a20e7/ruff-0.8.3-py3-none-win_amd64.whl", hash = "sha256:f7df94f57d7418fa7c3ffb650757e0c2b96cf2501a0b192c18e4fb5571dfada9", size = 9625289 },
+    { url = "https://files.pythonhosted.org/packages/03/8f/e4fa95288b81233356d9a9dcaed057e5b0adc6399aa8fd0f6d784041c9c3/ruff-0.8.3-py3-none-win_arm64.whl", hash = "sha256:fe2756edf68ea79707c8d68b78ca9a58ed9af22e430430491ee03e718b5e4936", size = 9078754 },
 ]
 
 [[package]]


### PR DESCRIPTION
Also update ruff in pyproject to latest version to fix ANN101 and ANN102 errors

## Summary by Sourcery

Refactor deprecation warnings to use a centralized 'deprecate' function and update 'ruff' to version 0.8.3 in the build configuration.

Enhancements:
- Refactor all deprecation warnings to use a centralized 'deprecate' function for consistency and maintainability.

Build:
- Update 'ruff' in the pyproject.toml to version 0.8.3 to address ANN101 and ANN102 errors.