### PR TITLE
fix FileWatcher

### DIFF
--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -92,11 +92,12 @@ def watch(
     """
     path_path = pathlib.Path(path)
     path_path = path_path if path_path.is_dir() else path_path.parent
+    path = str(path_path.absolute())
     if overwrite:
         from gdsfactory import CONF
 
         CONF.cell_overwrite_existing = True
-    _watch(str(path), pdk=pdk, run_main=run_main, run_cells=run_cells, pre_run=pre_run)
+    _watch(path, pdk=pdk, run_main=run_main, run_cells=run_cells, pre_run=pre_run)
 
 
 @app.command()


### PR DESCRIPTION
fixes filewatcher

## Summary by Sourcery

Fix the FileWatcher to correctly handle file modification events and refactor the component retrieval logic for YAML files.

Bug Fixes:
- Fix the handling of file modification events in the FileWatcher to correctly identify and process modified files.

Enhancements:
- Refactor the get_component method to delegate YAML file processing to a new get_component_yaml method for better code organization.