### PR TITLE
fix python3.10

### DIFF
--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -10,7 +10,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from typing import Any
+
+    from typing_extensions import Self
+
 
 import numpy as np
 import numpy.typing as npt

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -12,11 +12,12 @@ import hashlib
 import math
 import warnings
 from collections.abc import Callable, Iterator
-from typing import Any, Literal, Self, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 import numpy as np
 import numpy.typing as npt
 from numpy import mod, pi
+from typing_extensions import Self
 
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.component_layout import (

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -1,11 +1,12 @@
 import json
 from pathlib import Path
-from typing import Any, Self
+from typing import Any
 
 import networkx as nx
 import yaml
 from graphviz import Digraph
 from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
 
 import gdsfactory
 from gdsfactory._deprecation import deprecate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
   "attrs",
   "graphviz",
   "pyglet<2",
-  "pytest-only>=2.1.2"
+  "pytest-only>=2.1.2",
+  "typing-extensions"
 ]
 description = "python library to generate GDS layouts"
 keywords = ["eda", "photonics", "python"]

--- a/uv.lock
+++ b/uv.lock
@@ -1037,6 +1037,7 @@ dependencies = [
     { name = "trimesh" },
     { name = "typer" },
     { name = "types-pyyaml" },
+    { name = "typing-extensions" },
     { name = "watchdog" },
 ]
 
@@ -1145,6 +1146,7 @@ requires-dist = [
     { name = "types-cachetools", marker = "extra == 'dev'" },
     { name = "types-pyyaml" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
+    { name = "typing-extensions" },
     { name = "watchdog", specifier = "<7" },
     { name = "xdoctest", marker = "extra == 'maintainer'" },
 ]


### PR DESCRIPTION
Fix gdsfactory typing imports to keep compatibility with python3.10


Thanks for reporting this Maximo
@mbalestrini
@MatthewMckee4

## Summary by Sourcery

Bug Fixes:
- Add 'typing-extensions' to dependencies to ensure compatibility with Python 3.10.