### PR TITLE
Fix metal routing docstrings

### DIFF
--- a/gdsfactory/boolean.py
+++ b/gdsfactory/boolean.py
@@ -18,11 +18,14 @@ def boolean(
     layer2: LayerSpec | None = None,
     layer: LayerSpec = (1, 0),
 ) -> Component:
-    """Performs boolean operations between 2 Component/Reference/list objects.
+    """Performs boolean operations between 2 Component or Instance objects.
 
-    ``operation`` should be one of {'not', 'and', 'or', 'xor', '-', '&', '|', '^'}.
-    Note that '|' is equivalent to 'or', '-' is equivalent to 'not',
-    '&' is equivalent to 'and', and '^' is equivalent to 'xor'.
+    The `operation` parameter specifies the type of boolean operation to perform.
+    Supported operations include {'not', 'and', 'or', 'xor', '-', '&', '|', '^'}:
+      - `'|'` is equivalent to `'or'`
+      - `'-'` is equivalent to `'not'`
+      - `'&'` is equivalent to `'and'`
+      - `'^'` is equivalent to `'xor'`
 
     Args:
         A: Component(/Reference) or list of Component(/References).
@@ -35,13 +38,6 @@ def boolean(
     Returns: Component with polygon(s) of the boolean operations between
       the 2 input Components performed.
 
-    Notes:
-    -----
-    - '|' is equivalent to 'or'.
-    - '-' is equivalent to 'not'.
-    - '&' is equivalent to 'and'.
-    - '^' is equivalent to 'not'.
-
     .. plot::
       :include-source:
 
@@ -50,7 +46,7 @@ def boolean(
       c = gf.Component()
       c1 = c << gf.components.circle(radius=10)
       c2 = c << gf.components.circle(radius=9)
-      c2.dmovex(5)
+      c2.movex(5)
 
       c = gf.boolean(c1, c2, operation="xor")
       c.plot()

--- a/gdsfactory/components/shapes/triangles.py
+++ b/gdsfactory/components/shapes/triangles.py
@@ -60,6 +60,7 @@ def triangle2(spacing: float = 3, **kwargs: Any) -> Component:
         layer: layer.
 
     .. code::
+
           _
          | \
          |  \

--- a/gdsfactory/components/superconductors/optimal_step.py
+++ b/gdsfactory/components/superconductors/optimal_step.py
@@ -31,9 +31,6 @@ def optimal_step(
         layer: layer spec to put polygon geometry on.
 
     based on phidl.geometry
-
-    Notes:
-    -----
     Optimal structure from https://doi.org/10.1103/PhysRevB.84.174510
     Clem, J., & Berggren, K. (2011). Geometry-dependent critical currents in
     superconducting nanocircuits. Physical Review B, 84(17), 1-27.

--- a/gdsfactory/components/vias/via_stack_with_offset.py
+++ b/gdsfactory/components/vias/via_stack_with_offset.py
@@ -207,9 +207,9 @@ if __name__ == "__main__":
     c = via_stack_with_offset(
         layers=("M1", "M2", "MTOP"),
         size=None,
-        sizes=((10, 10), (20, 20), (50, 30)),
+        sizes=((10, 10), (5, 5), (5, 5)),
         vias=(None, "via1", "via2"),
-        layer_to_port_orientations={"MTOP": [90], "M1": [270]},
+        # layer_to_port_orientations={"MTOP": [90], "M1": [270]},
     )
     # c = via_stack_with_offset_m1_m3(layer_offsets=[0, 5, 10])
     # c = via_stack_with_offset(vias=(None, None))

--- a/gdsfactory/components/waveguides/straight_heater_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_doped.py
@@ -48,11 +48,12 @@ def straight_heater_doped_rib(
 
     .. code::
 
+
                               length
         |<--------------------------------------------->|
         |              length_section                   |
         |    <--------------------------->              |
-        |  length_via_stack                               |
+        |  length_via_stack                             |
         |    <------->                             taper|
         |    __________                   _________     |
         |   |          |                  |        |    |

--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -169,7 +169,7 @@ def grid_with_text(
 
             if text:
                 for text_offset, text_anchor in zip_longest(text_offsets, text_anchors):
-                    t = c << text(text_string)
+                    t = c << gf.get_component(text, text=text_string)
                     size_info = instance.dsize_info
                     text_offset = text_offset or (0, 0)
                     text_anchor = text_anchor or "center"

--- a/gdsfactory/routing/add_electrical_pads_shortest.py
+++ b/gdsfactory/routing/add_electrical_pads_shortest.py
@@ -41,9 +41,8 @@ def add_electrical_pads_shortest(
         :include-source:
 
         import gdsfactory as gf
-        c = gf.components.straight_heater_metal(length=100)
-        wire_long = gf.components.wire_straight(length=200.)
-        c = gf.routing.add_electrical_pads_shortest(wire_long)
+        c = gf.components.cross(length=100, layer=(49, 0), port_type="electrical")
+        c = gf.routing.add_electrical_pads_shortest(c, pad_port_spacing=200)
         c.plot()
 
     """

--- a/gdsfactory/routing/add_electrical_pads_top.py
+++ b/gdsfactory/routing/add_electrical_pads_top.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, Float2, LayerSpec, SelectPorts, St
 
 
 def add_electrical_pads_top(
-    component: ComponentSpec = "wire",
+    component: ComponentSpec,
     direction: Literal["top", "right"] = "top",
     spacing: Float2 = (0.0, 100.0),
     pad_array: ComponentSpec = "pad_array",

--- a/gdsfactory/routing/add_electrical_pads_top_dc.py
+++ b/gdsfactory/routing/add_electrical_pads_top_dc.py
@@ -3,28 +3,26 @@ from __future__ import annotations
 from typing import Any
 
 import gdsfactory as gf
-from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
 from gdsfactory.port import select_ports_electrical
 from gdsfactory.routing.route_bundle import route_bundle_electrical
 from gdsfactory.routing.sort_ports import sort_ports_x
 from gdsfactory.typings import (
-    ComponentFactory,
     ComponentSpec,
+    CrossSectionSpec,
     Float2,
     SelectPorts,
     Strs,
 )
 
 
-@gf.cell
 def add_electrical_pads_top_dc(
-    component: ComponentSpec = "wire",
+    component: ComponentSpec,
     spacing: Float2 = (0.0, 100.0),
-    pad_array: ComponentFactory = "pad_array270",
-    pad_array_factory: ComponentFactory = "pad_array270",
+    pad_array: ComponentSpec = "pad_array270",
     select_ports: SelectPorts = select_ports_electrical,
     port_names: Strs | None = None,
+    cross_section: CrossSectionSpec = "metal_routing",
     **kwargs: Any,
 ) -> Component:
     """Returns new component with electrical ports connected to top pad array.
@@ -33,10 +31,10 @@ def add_electrical_pads_top_dc(
         component: component spec to connect to.
         spacing: component to pad spacing.
         pad_array: component factor for pad_array. (deprecated)
-        pad_array_factory: component factory for pad_array.
         select_ports: function to select_ports.
         route_bundle_function: function to route bundle of ports.
         port_names: optional port names. Overrides select_ports.
+        cross_section: cross_section for the route.
         kwargs: route settings.
 
     .. plot::
@@ -48,10 +46,6 @@ def add_electrical_pads_top_dc(
         c.plot()
 
     """
-    if pad_array is not None:
-        deprecate("pad_array", "pad_array_factory")
-        pad_array_factory = pad_array
-
     c = Component()
     component = gf.get_component(component)
 
@@ -73,7 +67,7 @@ def add_electrical_pads_top_dc(
     for port in ports_component:
         port.dangle = 90
 
-    pad_array_component = pad_array_factory(columns=len(ports))
+    pad_array_component = gf.get_component(pad_array, columns=len(ports))
     pads = c << pad_array_component
     pads.dx = cref.dx + spacing[0]
     pads.dymin = cref.dymax + spacing[1]
@@ -82,7 +76,9 @@ def add_electrical_pads_top_dc(
     ports_component = sort_ports_x(ports_component)
     ports_pads = sort_ports_x(ports_pads)
 
-    route_bundle_electrical(c, ports_component, ports_pads, **kwargs)
+    route_bundle_electrical(
+        c, ports_component, ports_pads, cross_section=cross_section, **kwargs
+    )
 
     for port in cref.ports:
         if port not in ports_component:
@@ -95,5 +91,6 @@ def add_electrical_pads_top_dc(
 
 
 if __name__ == "__main__":
-    cc = add_electrical_pads_top_dc()
+    c = gf.c.wire_straight(length=200.0)
+    cc = add_electrical_pads_top_dc(c)
     cc.show()

--- a/gdsfactory/routing/fanout2x2.py
+++ b/gdsfactory/routing/fanout2x2.py
@@ -80,9 +80,10 @@ def fanout2x2(
     c.info["min_bend_radius"] = bend.info["min_bend_radius"]
 
     optical_ports = select_ports(ref.ports)
+    optical_port_names = [port.name for port in optical_ports]
     for port in ref.ports:
         port_name = port.name
-        if port_name not in optical_ports:
+        if port_name not in optical_port_names:
             c.add_port(port_name, port=ref.ports[port_name])
     c.copy_child_info(component)
     return c

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -170,7 +170,7 @@ def route_bundle(
         ports2 = [gf.Port(f"bot_{i}", center=(xs2[i], dy), width=0.5, orientation=a2, layer=(1,0)) for i in range(N)]
 
         c = gf.Component()
-        gf.routing.route_bundle(c, ports1, ports2)
+        gf.routing.route_bundle(component=c, ports1=ports1, ports2=ports2, cross_section='strip', separation=5)
         c.plot()
 
     """

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -49,13 +49,13 @@ def route_quad(
         pad2 = c << gf.components.pad(size=(10, 10))
         pad2.dmovex(100)
         pad2.dmovey(50)
-        route_gnd = c << gf.routing.route_quad(
+        gf.routing.route_quad(
+            c,
             pad1.ports["e2"],
             pad2.ports["e4"],
             width1=None,
             width2=None,
         )
-        c.show()
         c.plot()
 
     """
@@ -96,8 +96,8 @@ if __name__ == "__main__":
     c = gf.Component()
     pad1 = c << pad(size=(50, 50))
     pad2 = c << pad(size=(10, 10))
-    pad2.dmovex(100)
-    pad2.dmovey(50)
+    pad2.movex(100)
+    pad2.movey(50)
     route_quad(
         c,
         pad1.ports["e2"],

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -324,14 +324,14 @@ def route_sharp(
 
         import gdsfactory as gf
 
-        c = gf.Component("pads")
+        c = gf.Component()
         c1 = c << gf.components.pad(port_orientation=None)
         c2 = c << gf.components.pad(port_orientation=None)
 
         c2.dmovex(400)
         c2.dmovey(-200)
 
-        route = c << gf.routing.route_sharp(c1.ports["e4"], c2.ports["e1"], path_type="L")
+        gf.routing.route_sharp(c, c1.ports["e4"], c2.ports["e1"], path_type="L")
         c.plot()
 
     """

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -94,11 +94,11 @@ def route_single(
 
         import gdsfactory as gf
 
-        c = gf.Component('sample_connect')
+        c = gf.Component()
         mmi1 = c << gf.components.mmi1x2()
         mmi2 = c << gf.components.mmi1x2()
         mmi2.dmove((40, 20))
-        gf.routing.route_single(c, mmi1.ports["o2"], mmi2.ports["o1"], radius=5)
+        gf.routing.route_single(c, mmi1.ports["o2"], mmi2.ports["o1"], radius=5, cross_section="strip")
         c.plot()
     """
     p1 = port1


### PR DESCRIPTION
## Summary by Sourcery

Fix and refactor the 'add_electrical_pads_top_dc' function to remove deprecated parameters and improve component retrieval. Enhance routing functions for better parameter handling and update port handling logic in 'fanout2x2'. Clean up documentation in 'optimal_step'.

Bug Fixes:
- Fix incorrect usage of deprecated 'pad_array' parameter in 'add_electrical_pads_top_dc' function.

Enhancements:
- Refactor 'add_electrical_pads_top_dc' to use 'gf.get_component' for pad array component retrieval.
- Update 'route_quad' and 'route_bundle' functions to improve routing logic and parameter handling.
- Improve port handling in 'fanout2x2' by using a list of optical port names.

Documentation:
- Remove unnecessary notes section from the 'optimal_step' function documentation.