### PR TITLE
Update dev command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ install310:
 	uv sync --extra docs --extra dev
 
 dev:
-	pip install -e .[dev,docs] pre-commit
+	uv venv --python 3.12
+	uv sync --all-extras
+	uv pip install -e .
+	uv run pre-commit install
 	gf install-klayout-genericpdk
 	gf install-git-diff
 


### PR DESCRIPTION
Just a small change to make getting set up for developing easier

## Summary by Sourcery

Build:
- Update the 'dev' command in the Makefile to use 'uv' for virtual environment management and package installation.