### PR TITLE
Add via circular pitch

### DIFF
--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -96,6 +96,8 @@ def via_circular(
     enclosure: float = 1.0,
     layer: LayerSpec = "VIAC",
     pitch: float | None = 2,
+    column_pitch: float | None = None,
+    row_pitch: float | None = None,
 ) -> Component:
     """Circular via.
 
@@ -104,10 +106,16 @@ def via_circular(
         enclosure: inclusion of via in um for the layer above.
         layer: via layer.
         pitch: pitch between vias.
+        column_pitch: Optional pitch between columns of vias. Default is pitch.
+        row_pitch: Optional pitch between rows of vias. Default is pitch.
     """
     c = Component()
     _ = c << gf.c.circle(radius=radius, layer=layer)
-    c.info["pitch"] = pitch
+    row_pitch = row_pitch or pitch
+    column_pitch = column_pitch or pitch
+
+    c.info["row_pitch"] = row_pitch
+    c.info["column_pitch"] = column_pitch
     c.info["enclosure"] = enclosure
     c.info["radius"] = radius
     c.info["xsize"] = 2 * radius

--- a/test-data-regression/test_netlists_via_circular_.yml
+++ b/test-data-regression/test_netlists_via_circular_.yml
@@ -6,7 +6,7 @@ instances:
       angle_resolution: 2.5
       layer: VIAC
       radius: 0.35
-name: via_circular_R0p35_E1_LVIAC_P2
+name: via_circular_R0p35_E1_L_23e09619
 nets: []
 placements:
   circle_R0p35_AR2p5_LVIAC_0_0:

--- a/test-data-regression/test_settings_via_circular_.yml
+++ b/test-data-regression/test_settings_via_circular_.yml
@@ -1,10 +1,11 @@
 info:
+  column_pitch: 2
   enclosure: 1
-  pitch: 2
   radius: 0.35
+  row_pitch: 2
   xsize: 0.7
   ysize: 0.7
-name: via_circular_R0p35_E1_LVIAC_P2
+name: via_circular_R0p35_E1_L_23e09619
 settings:
   enclosure: 1
   layer: VIAC


### PR DESCRIPTION
add colum_pitch and row_pitch to via info

## Summary by Sourcery

Add column_pitch and row_pitch parameters to the via_circular function to provide flexibility in specifying pitches for columns and rows of vias, and update tests accordingly.

New Features:
- Introduce column_pitch and row_pitch parameters to the via_circular function to allow specifying different pitches for columns and rows of vias.

Tests:
- Update test settings and netlists to include new column_pitch and row_pitch parameters.