### PR TITLE
Remove terminated ports from gc array

### DIFF
--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -36,13 +36,16 @@ def grating_coupler_array(
     """
     c = Component()
     grating_coupler = gf.get_component(grating_coupler)
+    ports = {}
 
     for i in range(n):
         gc = c << grating_coupler
         gc.drotate(rotation)
         gc.dx = (i - (n - 1) / 2) * pitch if centered else i * pitch
         port_name_new = f"o{i}"
-        c.add_port(port=gc.ports[port_name], name=port_name_new)
+        ports[port_name_new] = gc.ports[port_name]
+        if with_loopback and i not in [0, n - 1]:
+            c.add_port(port=gc.ports[port_name], name=port_name_new)
 
     if with_loopback:
         if rotation != -90:
@@ -52,8 +55,8 @@ def grating_coupler_array(
         routing_xs = gf.get_cross_section(cross_section)
         radius = radius or routing_xs.radius
 
-        port0 = c.ports["o0"]
-        port1 = c.ports[f"o{n - 1}"]
+        port0 = ports["o0"]
+        port1 = ports[f"o{n - 1}"]
         radius = radius
         radius_dbu = round(radius / c.kcl.dbu)
         d_loop_um = straight_to_grating_spacing + max(
@@ -85,4 +88,5 @@ if __name__ == "__main__":
     c = grating_coupler_array(
         with_loopback=True, centered=True, cross_section="rib_bbox"
     )
+    c.pprint_ports()
     c.show()

--- a/test-data-regression/test_netlists_die_with_pads_.yml
+++ b/test-data-regression/test_netlists_die_with_pads_.yml
@@ -1859,34 +1859,30 @@ ports:
   e7: pad_S100_100_LMTOP_BLNo_163fd346_m2650000_m2250000,e2
   e8: pad_S100_100_LMTOP_BLNo_163fd346_m2350000_m2250000,e2
   e9: pad_S100_100_LMTOP_BLNo_163fd346_m2050000_m2250000,e2
-  o1: grating_coupler_array_G_2a505a43_5524199_0,o0
-  o10: grating_coupler_array_G_2a505a43_5524199_0,o9
-  o11: grating_coupler_array_G_2a505a43_5524199_0,o10
-  o12: grating_coupler_array_G_2a505a43_5524199_0,o11
-  o13: grating_coupler_array_G_2a505a43_5524199_0,o12
-  o14: grating_coupler_array_G_2a505a43_5524199_0,o13
-  o15: grating_coupler_array_G_2a505a43_m5524199_0,o0
-  o16: grating_coupler_array_G_2a505a43_m5524199_0,o1
-  o17: grating_coupler_array_G_2a505a43_m5524199_0,o2
-  o18: grating_coupler_array_G_2a505a43_m5524199_0,o3
-  o19: grating_coupler_array_G_2a505a43_m5524199_0,o4
-  o2: grating_coupler_array_G_2a505a43_5524199_0,o1
-  o20: grating_coupler_array_G_2a505a43_m5524199_0,o5
-  o21: grating_coupler_array_G_2a505a43_m5524199_0,o6
-  o22: grating_coupler_array_G_2a505a43_m5524199_0,o7
-  o23: grating_coupler_array_G_2a505a43_m5524199_0,o8
-  o24: grating_coupler_array_G_2a505a43_m5524199_0,o9
-  o25: grating_coupler_array_G_2a505a43_m5524199_0,o10
-  o26: grating_coupler_array_G_2a505a43_m5524199_0,o11
-  o27: grating_coupler_array_G_2a505a43_m5524199_0,o12
-  o28: grating_coupler_array_G_2a505a43_m5524199_0,o13
-  o3: grating_coupler_array_G_2a505a43_5524199_0,o2
-  o4: grating_coupler_array_G_2a505a43_5524199_0,o3
-  o5: grating_coupler_array_G_2a505a43_5524199_0,o4
-  o6: grating_coupler_array_G_2a505a43_5524199_0,o5
-  o7: grating_coupler_array_G_2a505a43_5524199_0,o6
-  o8: grating_coupler_array_G_2a505a43_5524199_0,o7
-  o9: grating_coupler_array_G_2a505a43_5524199_0,o8
+  o1: grating_coupler_array_G_2a505a43_5524199_0,o1
+  o10: grating_coupler_array_G_2a505a43_5524199_0,o10
+  o11: grating_coupler_array_G_2a505a43_5524199_0,o11
+  o12: grating_coupler_array_G_2a505a43_5524199_0,o12
+  o13: grating_coupler_array_G_2a505a43_m5524199_0,o1
+  o14: grating_coupler_array_G_2a505a43_m5524199_0,o2
+  o15: grating_coupler_array_G_2a505a43_m5524199_0,o3
+  o16: grating_coupler_array_G_2a505a43_m5524199_0,o4
+  o17: grating_coupler_array_G_2a505a43_m5524199_0,o5
+  o18: grating_coupler_array_G_2a505a43_m5524199_0,o6
+  o19: grating_coupler_array_G_2a505a43_m5524199_0,o7
+  o2: grating_coupler_array_G_2a505a43_5524199_0,o2
+  o20: grating_coupler_array_G_2a505a43_m5524199_0,o8
+  o21: grating_coupler_array_G_2a505a43_m5524199_0,o9
+  o22: grating_coupler_array_G_2a505a43_m5524199_0,o10
+  o23: grating_coupler_array_G_2a505a43_m5524199_0,o11
+  o24: grating_coupler_array_G_2a505a43_m5524199_0,o12
+  o3: grating_coupler_array_G_2a505a43_5524199_0,o3
+  o4: grating_coupler_array_G_2a505a43_5524199_0,o4
+  o5: grating_coupler_array_G_2a505a43_5524199_0,o5
+  o6: grating_coupler_array_G_2a505a43_5524199_0,o6
+  o7: grating_coupler_array_G_2a505a43_5524199_0,o7
+  o8: grating_coupler_array_G_2a505a43_5524199_0,o8
+  o9: grating_coupler_array_G_2a505a43_5524199_0,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/test-data-regression/test_netlists_grating_coupler_array_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_array_.yml
@@ -158,10 +158,28 @@ placements:
     rotation: 270
     x: -63.5
     y: 0
-ports:
-  o0: grating_coupler_ellipti_07e69d9a_m317500_0,o1
-  o1: grating_coupler_ellipti_07e69d9a_m190500_0,o1
-  o2: grating_coupler_ellipti_07e69d9a_m63500_0,o1
-  o3: grating_coupler_ellipti_07e69d9a_63500_0,o1
-  o4: grating_coupler_ellipti_07e69d9a_190500_0,o1
-  o5: grating_coupler_ellipti_07e69d9a_317500_0,o1
+ports: {}
+warnings:
+  optical:
+    unconnected_ports:
+    - message: 6 unconnected optical ports!
+      ports:
+      - grating_coupler_ellipti_07e69d9a_m317500_0,o1
+      - grating_coupler_ellipti_07e69d9a_m190500_0,o1
+      - grating_coupler_ellipti_07e69d9a_m63500_0,o1
+      - grating_coupler_ellipti_07e69d9a_63500_0,o1
+      - grating_coupler_ellipti_07e69d9a_190500_0,o1
+      - grating_coupler_ellipti_07e69d9a_317500_0,o1
+      values:
+      - - -317500
+        - 0
+      - - -190500
+        - 0
+      - - -63500
+        - 0
+      - - 63500
+        - 0
+      - - 190500
+        - 0
+      - - 317500
+        - 0


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b7e3567e-415c-4773-8e8f-365d550e3ac6)


## Summary

Remove terminated ports from the grating coupler array and refactor the function to use a local ports dictionary for better management of port names.

Bug Fixes:
- Fix the issue of terminated ports being incorrectly added to the grating coupler array by removing them from the ports dictionary.

Enhancements:
- Refactor the grating coupler array function to use a local ports dictionary for managing port names, improving code clarity and maintainability.