### PR TITLE
Fix grating coupler array ports

### DIFF
--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -44,7 +44,7 @@ def grating_coupler_array(
         gc.dx = (i - (n - 1) / 2) * pitch if centered else i * pitch
         port_name_new = f"o{i}"
         ports[port_name_new] = gc.ports[port_name]
-        if with_loopback and i not in [0, n - 1]:
+        if not with_loopback or i not in [0, n - 1]:
             c.add_port(port=gc.ports[port_name], name=port_name_new)
 
     if with_loopback:
@@ -86,7 +86,7 @@ def grating_coupler_array(
 
 if __name__ == "__main__":
     c = grating_coupler_array(
-        with_loopback=True, centered=True, cross_section="rib_bbox"
+        with_loopback=False, centered=True, cross_section="rib_bbox", n=2
     )
     c.pprint_ports()
     c.show()

--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -28,7 +28,7 @@ def add_pads_bot(
     pad: ComponentSpec = "pad_rectangular",
     bend: ComponentSpec = "wire_corner",
     straight_separation: float = 15.0,
-    pad_pitch: float | str = "pad_pitch",
+    pad_pitch: float = 100.0,
     port_type: str = "electrical",
     allow_width_mismatch: bool = True,
     fanout_length: float | None = 0,
@@ -104,7 +104,6 @@ def add_pads_bot(
     component_new = Component()
     component = gf.get_component(component)
 
-    pad_pitch = gf.get_constant(pad_pitch)
     cref = component_new << component
     ports = [cref[port_name] for port_name in port_names] if port_names else None
     ports_list: Sequence[kf.Port] = ports or select_ports(cref.ports)
@@ -126,8 +125,6 @@ def add_pads_bot(
         raise ValueError(
             f"select_ports or port_names did not match any ports in {list(component.ports)}"
         )
-
-    assert isinstance(pad_pitch, float)
 
     route_fiber_array(
         component_new,
@@ -164,7 +161,7 @@ def add_pads_top(
     pad: ComponentSpec = "pad_rectangular",
     bend: ComponentSpec = "wire_corner",
     straight_separation: float = 15.0,
-    pad_pitch: float | str = "pad_pitch",
+    pad_pitch: float = 100.0,
     port_type: str = "electrical",
     allow_width_mismatch: bool = True,
     fanout_length: float | None = 0,


### PR DESCRIPTION
## Summary by Sourcery

Fix grating coupler array port creation and update default `pad_pitch` value in `add_pads` functions.

Bug Fixes:
- Fixed an issue where grating coupler array ports were not being created correctly when `with_loopback` was enabled.
- Set default `pad_pitch` to 100.0 in `add_pads_top` and `add_pads_bot` functions to avoid relying on constants.