### PR TITLE
Update taper_adiabatic.py

### DIFF
--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -81,7 +81,12 @@ def taper_adiabatic(
 
     # Obtain optimal curve
     x_opt, w_opt = transition_adiabatic(
-        width1, width2, neff_w=neff_w, wavelength=wavelength, alpha=alpha, max_length=max_length
+        width1,
+        width2,
+        neff_w=neff_w,
+        wavelength=wavelength,
+        alpha=alpha,
+        max_length=max_length,
     )
 
     # Resample the points

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -52,6 +52,7 @@ def taper_adiabatic(
     wavelength: float = 1.55,
     npoints: int = 200,
     cross_section: CrossSectionSpec = "strip",
+    max_length: float = 200,
 ) -> gf.Component:
     """Returns a straight adiabatic_taper from an effective index callable.
 
@@ -80,7 +81,7 @@ def taper_adiabatic(
 
     # Obtain optimal curve
     x_opt, w_opt = transition_adiabatic(
-        width1, width2, neff_w=neff_w, wavelength=wavelength, alpha=alpha
+        width1, width2, neff_w=neff_w, wavelength=wavelength, alpha=alpha, max_length=max_length
     )
 
     # Resample the points

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -69,6 +69,7 @@ def taper_adiabatic(
         wavelength: wavelength in um.
         npoints: number of points for sampling.
         cross_section: cross_section specification.
+        max_length: maximum length for the taper.
 
     References:
         [1] Burns, W. K., et al. "Optical waveguide parabolic coupling horns." Appl. Phys. Lett., vol. 30, no. 1, 1 Jan. 1977, pp. 28-30, doi:10.1063/1.89199.

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -666,7 +666,7 @@ def transition_adiabatic(
                 By default, use a compact model of neff(y) for fundamental 1550 nm TE \
                 mode of 220nm-thick core with 3.45 index, fully clad with 1.44 index.\
                 Many coefficients are needed to capture the behaviour.
-        wavelength: wavelength, in same units as widths
+        wavelength: wavelength, in same units as widths.
         alpha: parameter that scales the rate of width change
             - closer to 0 means longer and more adiabatic;
             - 1 is the intuitive limit beyond which higher order modes are excited;

--- a/test-data-regression/test_netlists_taper_adiabatic_.yml
+++ b/test-data-regression/test_netlists_taper_adiabatic_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: taper_adiabatic_W0p5_W5_c4618eba
+name: taper_adiabatic_W0p5_W5_ef25f05a
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_taper_adiabatic_.yml
+++ b/test-data-regression/test_settings_taper_adiabatic_.yml
@@ -1,9 +1,10 @@
 info: {}
-name: taper_adiabatic_W0p5_W5_c4618eba
+name: taper_adiabatic_W0p5_W5_ef25f05a
 settings:
   alpha: 1
   cross_section: strip
   length: 0
+  max_length: 200
   neff_w: neff_TE1550SOI_220nm
   npoints: 200
   wavelength: 1.55


### PR DESCRIPTION
Added max_length to allow adiabatic tapers longer than 200 um. Had to extend for a large, low index structure.

## Summary by Sourcery

New Features:
- Allow creating adiabatic tapers longer than 200 µm via a new `max_length` parameter in the `taper_adiabatic` function.