### PR TITLE
Update bundle syntax within from_yaml parser

### DIFF
--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -951,7 +951,7 @@ def _add_routes(
     """Add routes to component."""
     from gdsfactory.pdk import get_routing_strategies
 
-    routes_dict: dict[str, dict[str, Route]] = {}
+    routes_dict: dict[str, Route] = {}
     routing_strategies = routing_strategies or get_routing_strategies()
     for bundle_name, bundle in routes.items():
         try:
@@ -976,7 +976,7 @@ def _add_routes(
             ports1 += _get_ports_from_portnames(refs, first1, middles1, last1)
             ports2 += _get_ports_from_portnames(refs, first2, middles2, last2)
             route_names += [
-                f"{first1}{m1}{last1}:{first2}{m2}{last2}"
+                f"{bundle_name}-{first1}{m1}{last1}-{first2}{m2}{last2}"
                 for m1, m2 in zip(middles1, middles2)
             ]
 
@@ -986,7 +986,7 @@ def _add_routes(
             ports2=ports2,
             **bundle.settings,
         )
-        routes_dict[bundle_name] = dict(zip(route_names, routes_list))
+        routes_dict.update(dict(zip(route_names, routes_list)))
         c.routes = routes_dict  # type: ignore
     return c
 
@@ -1228,9 +1228,7 @@ def _split_route_link(s: str) -> tuple[str, list[str], str]:
     if s.count("-") > 1:
         raise error
     elif "-" not in s:
-        first, last = s.split(",")
-        middles = [""]
-        return first, middles, last
+        return s, [""], ""
     else:
         first, last = s.split("-")
         first, j = _first_index(first)

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import itertools
 import pathlib
 import re
+import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from functools import partial
@@ -950,7 +951,7 @@ def _add_routes(
     """Add routes to component."""
     from gdsfactory.pdk import get_routing_strategies
 
-    routes_dict: dict[str, Route] = {}
+    routes_dict: dict[str, dict[str, Route]] = {}
     routing_strategies = routing_strategies or get_routing_strategies()
     for bundle_name, bundle in routes.items():
         try:
@@ -966,16 +967,17 @@ def _add_routes(
         route_names: list[str] = []
 
         for ip1, ip2 in bundle.links.items():
-            i1, p1s = _split_route_link(ip1)
-            i2, p2s = _split_route_link(ip2)
-            if len(p1s) != len(p2s):
+            first1, middles1, last1 = _split_route_link(ip1)
+            first2, middles2, last2 = _split_route_link(ip2)
+            if len(middles1) != len(middles2):
                 raise ValueError(
                     f"length of array bundles don't match. Got {ip1} <-> {ip2}"
                 )
-            ports1 += _get_ports_from_portnames(refs, i1, p1s)
-            ports2 += _get_ports_from_portnames(refs, i2, p2s)
+            ports1 += _get_ports_from_portnames(refs, first1, middles1, last1)
+            ports2 += _get_ports_from_portnames(refs, first2, middles2, last2)
             route_names += [
-                f"{bundle_name}-{i1},{p1}-{i2},{p2}" for p1, p2 in zip(p1s, p2s)
+                f"{first1}{m1}{last1}:{first2}{m2}{last2}"
+                for m1, m2 in zip(middles1, middles2)
             ]
 
         routes_list = routing_strategy(  # type: ignore
@@ -984,7 +986,7 @@ def _add_routes(
             ports2=ports2,
             **bundle.settings,
         )
-        routes_dict.update(dict(zip(route_names, routes_list)))
+        routes_dict[bundle_name] = dict(zip(route_names, routes_list))
         c.routes = routes_dict  # type: ignore
     return c
 
@@ -1182,10 +1184,18 @@ def _get_directed_connections(
     return ret
 
 
-def _split_route_link(s: str) -> tuple[str, list[str]]:
+def _split_route_link(s: str) -> tuple[str, list[str], str]:
     error = ValueError(
-        "The format for bundle routing is 'inst,port{i}-{j}' "
-        f"or 'inst,port'. Got: {s!r}"
+        f"Invalid instance port format: {s!r}."
+        "The format for a link instance port is 'inst,port',\n"
+        "Whereas the format for bundle routing instance ports are one of the following:\n"
+        "1. 'inst,port{i}-{j}' (enumerate port index)\n"
+        "2. 'inst{i}-{j},port' (enumerate instance index)\n"
+        "3. 'inst<{i}-{j}.{k}>,port (enumerate array instance index)"
+    )
+    warning = (
+        "Bundle format 'inst,port:{i}:{j}' (with two columns) has been "
+        "deprecated. Please use 'inst,port{i}-{j}' (with a single dash)"
     )
 
     def _try_int(i: str) -> int:
@@ -1194,47 +1204,58 @@ def _split_route_link(s: str) -> tuple[str, list[str]]:
         except ValueError as e:
             raise error from e
 
+    def _first_index(ip: str) -> tuple[str, int]:
+        p = re.sub("[0-9][0-9]*$", "", ip)
+        idx = re.sub(f"^{p}", "", ip)
+        return p, _try_int(idx)
+
+    def _second_index(ip: str) -> tuple[str, int]:
+        p = re.sub("^[0-9][0-9]*", "", ip)
+        idx = re.sub(f"{p}$", "", ip)
+        return p, _try_int(idx)
+
     if ":" in s:
-        raise error
+        if s.count(":") == 2:
+            s = s.replace(":", "", 1)
+            s = s.replace(":", "-", 1)
+            warnings.warn(warning, category=DeprecationWarning)
+        else:
+            raise error
+
+    if s.count(",") != 1:
+        raise ValueError(f"Exactly one ',' expected in a route bundle link. Got: {s!r}")
 
     if s.count("-") > 1:
         raise error
-    elif "-" in s:
-        ip, k = s.split("-")
-        ip, j = _split_index(ip)
-        jk = [j, k]
+    elif "-" not in s:
+        first, last = s.split(",")
+        middles = [""]
+        return first, middles, last
     else:
-        ip, jk = s, []
-    if ip.count(",") != 1:
-        raise ValueError(f"Exactly one ',' expected in a route bundle link. Got: {s!r}")
-    i, p = ip.split(",")
-    if not jk:
-        return i, [f"{p}"]
-    j, k = jk
-    j_int = _try_int(j)
-    k_int = _try_int(k)
-    j_int, k_int = min(j_int, k_int), max(j_int, k_int)
-    return (i, [f"{p}{i}" for i in range(j_int, k_int + 1)])
+        first, last = s.split("-")
+        first, j = _first_index(first)
+        last, k = _second_index(last)
 
-
-def _split_index(p: str) -> tuple[str, str]:
-    port_name = re.sub("[0-9][0-9]*$", "", p)
-    idx = re.sub(f"^{port_name}", "", p)
-    return port_name, idx
+        if k >= j:
+            middles = [f"{i}" for i in range(j, k + 1, 1)]
+        else:
+            middles = [f"{i}" for i in range(j, k - 1, -1)]
+        return first, middles, last
 
 
 def _get_ports_from_portnames(
-    refs: dict[str, ComponentReference], i: str, ps: list[str]
+    refs: dict[str, ComponentReference], first: str, middles: list[str], last: str
 ) -> list[typings.Port]:
-    i, ia, ib = _parse_maybe_arrayed_instance(i)
-    ref = refs[i]
-    ports: list[typings.Port] = []
-    for p in ps:
+    ports = []
+    for middle in middles:
+        ip = first + middle + last
+        i, p = ip.split(",")
+        i, ia, ib = _parse_maybe_arrayed_instance(i)
+        ref = refs[i]
         if p not in ref.ports:
             raise ValueError(
                 f"{p!r} not in {i!r} available ports: {[p.name for p in ref.ports]}"
             )
-
         port = ref.ports[p] if (ia is None or ib is None) else ref.ports[p, ia, ib]
         ports.append(port)
     return ports
@@ -1904,8 +1925,9 @@ instances:
         - 270
       port_orientation: null
       port_type: electrical
-    columns: 3
-    column_pitch: 150
+    array:
+      columns: 3
+      column_pitch: 150
   b:
     component: pad
     settings:
@@ -1913,8 +1935,9 @@ instances:
         - 90
       port_orientation: null
       port_type: electrical
-    columns: 3
-    column_pitch: 150
+    array:
+      columns: 3
+      column_pitch: 150
 
 placements:
   t:
@@ -1930,8 +1953,7 @@ routes:
       allow_width_mismatch: True
       sort_ports: True
     links:
-      t<0.0>,e1: b<0.0>,e1
-      # t,e:3:1: b,e:1:3
+      t<0-2.0>,e1: b<2-0.0>,e1
 """
 
 port_array_optical = """
@@ -1954,7 +1976,7 @@ routes:
     settings:
         cross_section: strip
     links:
-      a,o:3:4: b,o:4:3
+      a,o3-4: b,o4-3
 """
 
 mirror = """

--- a/gdsfactory/samples/netlists/mzi.yml
+++ b/gdsfactory/samples/netlists/mzi.yml
@@ -1,38 +1,38 @@
 nets:
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_-5500,o1
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_m5500,o1
     p2: cp1,o3
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_-5500,o2
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_m5500,o2
     p2: syl,o1
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_5500,o1
     p2: cp1,o2
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_20625_5500,o2
     p2: sytl,o1
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_-17812,o1
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_m17812,o1
     p2: syl,o2
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_-17812,o2
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_m17812,o2
     p2: sxb,o1
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_17750,o1
     p2: sxt,o1
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_30375_17750,o2
     p2: sytl,o2
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_-17812,o1
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_m17812,o1
     p2: sxb,o2
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_-17812,o2
-    p2: straight_L2p0615_N2_CSstrip_45600_-11656,o1
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_m17812,o2
+    p2: straight_L2p0615_N2_CSstrip_45600_m11656,o1
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_17750,o1
     p2: straight_L2_N2_CSstrip_45600_11625,o2
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_40725_17750,o2
     p2: sxt,o2
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_-5500,o1
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_m5500,o1
     p2: cp2,o3
-  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_-5500,o2
-    p2: straight_L2p0615_N2_CSstrip_45600_-11656,o2
+  - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_m5500,o2
+    p2: straight_L2p0615_N2_CSstrip_45600_m11656,o2
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_5500,o1
     p2: straight_L2_N2_CSstrip_45600_11625,o1
   - p1: bend_euler_RNone_A90_P0_d7c3a5a9_50475_5500,o2
     p2: cp2,o2
 instances:
-  bend_euler_RNone_A90_P0_d7c3a5a9_20625_-5500:
+  bend_euler_RNone_A90_P0_d7c3a5a9_20625_m5500:
     component: bend_euler
     info:
       length: 16.637
@@ -70,7 +70,7 @@ instances:
       with_arc_floorplan: true
       cross_section: strip
       allow_min_radius_violation: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_30375_-17812:
+  bend_euler_RNone_A90_P0_d7c3a5a9_30375_m17812:
     component: bend_euler
     info:
       length: 16.637
@@ -108,7 +108,7 @@ instances:
       with_arc_floorplan: true
       cross_section: strip
       allow_min_radius_violation: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_40725_-17812:
+  bend_euler_RNone_A90_P0_d7c3a5a9_40725_m17812:
     component: bend_euler
     info:
       length: 16.637
@@ -146,7 +146,7 @@ instances:
       with_arc_floorplan: true
       cross_section: strip
       allow_min_radius_violation: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_50475_-5500:
+  bend_euler_RNone_A90_P0_d7c3a5a9_50475_m5500:
     component: bend_euler
     info:
       length: 16.637
@@ -221,7 +221,7 @@ instances:
       length: 2
       npoints: 2
       cross_section: strip
-  straight_L2p0615_N2_CSstrip_45600_-11656:
+  straight_L2p0615_N2_CSstrip_45600_m11656:
     component: straight
     info:
       length: 2.062
@@ -287,7 +287,7 @@ instances:
       npoints: 2
       cross_section: strip
 placements:
-  bend_euler_RNone_A90_P0_d7c3a5a9_20625_-5500:
+  bend_euler_RNone_A90_P0_d7c3a5a9_20625_m5500:
     x: 15.5
     'y': -0.625
     rotation: 0
@@ -297,7 +297,7 @@ placements:
     'y': 0.625
     rotation: 0
     mirror: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_30375_-17812:
+  bend_euler_RNone_A90_P0_d7c3a5a9_30375_m17812:
     x: 25.5
     'y': -12.687
     rotation: 270
@@ -307,7 +307,7 @@ placements:
     'y': 22.625
     rotation: 180
     mirror: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_40725_-17812:
+  bend_euler_RNone_A90_P0_d7c3a5a9_40725_m17812:
     x: 35.6
     'y': -22.687
     rotation: 0
@@ -317,7 +317,7 @@ placements:
     'y': 12.625
     rotation: 90
     mirror: false
-  bend_euler_RNone_A90_P0_d7c3a5a9_50475_-5500:
+  bend_euler_RNone_A90_P0_d7c3a5a9_50475_m5500:
     x: 55.6
     'y': -0.625
     rotation: 180
@@ -342,7 +342,7 @@ placements:
     'y': 10.625
     rotation: 90
     mirror: false
-  straight_L2p0615_N2_CSstrip_45600_-11656:
+  straight_L2p0615_N2_CSstrip_45600_m11656:
     x: 45.6
     'y': -12.687
     rotation: 90

--- a/gdsfactory/samples/netlists/straight_with_bend.yml
+++ b/gdsfactory/samples/netlists/straight_with_bend.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_15125_-4875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_15125_m4875:
     component: bend_euler
     info:
       dy: 10
@@ -34,10 +34,10 @@ instances:
       npoints: 2
 name: straight_with_bend_R10
 nets:
-  - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_15125_-4875,o1
+  - p1: bend_euler_R10_A90_P0p5_2f1f5c6d_15125_m4875,o1
     p2: straight_L10_N2_CSstrip_5000_0,o2
 placements:
-  bend_euler_R10_A90_P0p5_2f1f5c6d_15125_-4875:
+  bend_euler_R10_A90_P0p5_2f1f5c6d_15125_m4875:
     mirror: true
     rotation: 0
     x: 10
@@ -49,4 +49,4 @@ placements:
     y: 0
 ports:
   o1: straight_L10_N2_CSstrip_5000_0,o1
-  o2: bend_euler_R10_A90_P0p5_2f1f5c6d_15125_-4875,o2
+  o2: bend_euler_R10_A90_P0p5_2f1f5c6d_15125_m4875,o2

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -183,12 +183,12 @@ class Netlist(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    # @model_validator(mode="after")
-    # def validate_instance_names(self) -> Self:
-    #    self.instances = {
-    #        _validate_instance_name(k): v for k, v in self.instances.items()
-    #    }
-    #    return self
+    @model_validator(mode="after")
+    def validate_instance_names(self) -> Self:
+        self.instances = {
+            _validate_instance_name(k): v for k, v in self.instances.items()
+        }
+        return self
 
 
 _route_counter = 0

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -183,6 +183,13 @@ class Netlist(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    @model_validator(mode="after")
+    def validate_instance_names(self) -> Self:
+        self.instances = {
+            _validate_instance_name(k): v for k, v in self.instances.items()
+        }
+        return self
+
 
 _route_counter = 0
 
@@ -433,6 +440,22 @@ def write_schema(
         json.dump(s, f, indent=2)
     with open(schema_path_yaml, "w") as f:
         yaml.dump(s, f)
+
+
+def _validate_instance_name(name: str) -> str:
+    if "," in name:
+        raise ValueError(
+            f"Having a ',' in an instance name is not supported. The ',' is used for port-delineation. Got: {name!r}."
+        )
+    if "-" in name:
+        raise ValueError(
+            f"Having a '-' in an instance name is not supported. The '-' is used for bundle routing. Got: {name!r}."
+        )
+    if ":" in name:
+        raise ValueError(
+            f"Having a ':' in an instance name is not supported. The ':' is used for bundle routing. Got: {name!r}."
+        )
+    return name
 
 
 if __name__ == "__main__":

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -183,12 +183,12 @@ class Netlist(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    @model_validator(mode="after")
-    def validate_instance_names(self) -> Self:
-        self.instances = {
-            _validate_instance_name(k): v for k, v in self.instances.items()
-        }
-        return self
+    # @model_validator(mode="after")
+    # def validate_instance_names(self) -> Self:
+    #    self.instances = {
+    #        _validate_instance_name(k): v for k, v in self.instances.items()
+    #    }
+    #    return self
 
 
 _route_counter = 0


### PR DESCRIPTION
The current bundle syntax in the yaml flow has a few (minor) issues:

**example:**
```yaml
routes:
  optical:
    settings:
        cross_section: strip
    links:
      a,o:3:4: b,o:4:3
```

**issues:**
1. Having two colons in there seems a bit *unnatural*. It might be easier to parse but not easier to write for a human
2. Having colons in there to begin with seems not smart in yaml, where colon is a delimiter between keys and values
3. Currently, there is no way to itemize over the instance names

**proposal:**
```
links:
    a,o3-4: b,o4-3
    c<3-4.0>,o1: d,o4-3
    e3-4,o1: f,o4-3
```
* use a (single) dash instead of two colons
* support itemization in array instances too: `c<3-4.0>,o1: d,o4-3`
* support itemization in normal instances too: `e3-4,o1: f,o4-3`
* keep previous behavior working (for now) but issue a deprecation warning

Any thoughts?
@joamatab , @tvt173 