### PR TITLE
fix duplicate ports

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -124,7 +124,7 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
 
   import gdsfactory as gf
 
-  c = gf.components.{name}({kwargs})
+  c = gf.components.{name}({kwargs}).copy()
   c.draw_ports()
   c.plot()
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -396,7 +396,6 @@ class ComponentBase:
 
     def copy(self) -> Component:
         """Copy the full cell."""
-        deprecate("copy", "dup")
         return self.dup()
 
     def dup(self) -> Component:


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3531

@sebastian-goeldi

## Summary by Sourcery

Fix duplicate port bug.

Bug Fixes:
- Fixed a bug that caused duplicate ports when copying a component.

Enhancements:
- Deprecated `Component.copy()` in favor of `Component.dup()` and updated usage in `write_cells.py` and `component.py`.