### PR TITLE
Add kwargs to route_ports_to_side

### DIFF
--- a/gdsfactory/routing/route_ports_to_side.py
+++ b/gdsfactory/routing/route_ports_to_side.py
@@ -37,6 +37,7 @@ def route_ports_to_side(
     side: Literal["north", "east", "south", "west"] = "north",
     x: float | None = None,
     y: float | None = None,
+    **kwargs: Any,
 ) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     """Routes ports to a given side.
 
@@ -94,6 +95,7 @@ def route_ports_to_side(
             y=xy_ns,
             side=side,
             cross_section=cross_section,
+            **kwargs,
         )
     xy_ew = x if x is not None else side
     return route_ports_to_x(
@@ -102,6 +104,7 @@ def route_ports_to_side(
         x=xy_ew,
         side=side,
         cross_section=cross_section,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
Fixes #3545

## Summary by Sourcery

Add support for passing keyword arguments to the `route_ports_to_side` function. This allows users to pass additional parameters to the underlying routing functions.

Bug Fixes:
- Fixes an issue where additional parameters could not be passed to the underlying routing functions.

Enhancements:
- Improve the flexibility of the `route_ports_to_side` function.