### PR TITLE
Fix route ports to side kwargs

### DIFF
--- a/docs/api_routing.rst
+++ b/docs/api_routing.rst
@@ -52,6 +52,8 @@ use `route_ports_to_side` before calling `route_bundle`
    :toctree: _autosummary/
 
    route_ports_to_side
+   route_ports_to_x
+   route_ports_to_y
    route_south
 
 

--- a/gdsfactory/routing/__init__.py
+++ b/gdsfactory/routing/__init__.py
@@ -15,7 +15,11 @@ from gdsfactory.routing.route_bundle import route_bundle, route_bundle_electrica
 from gdsfactory.routing.route_bundle_all_angle import route_bundle_all_angle
 from gdsfactory.routing.route_bundle_sbend import route_bundle_sbend
 from gdsfactory.routing.route_dubin import route_dubin as route_dubin
-from gdsfactory.routing.route_ports_to_side import route_ports_to_side
+from gdsfactory.routing.route_ports_to_side import (
+    route_ports_to_side,
+    route_ports_to_x,
+    route_ports_to_y,
+)
 from gdsfactory.routing.route_quad import route_quad
 from gdsfactory.routing.route_sharp import route_sharp
 from gdsfactory.routing.route_single import route_single, route_single_electrical
@@ -42,6 +46,8 @@ __all__ = [
     "route_bundle_sbend",
     "route_dubin",
     "route_ports_to_side",
+    "route_ports_to_x",
+    "route_ports_to_y",
     "route_quad",
     "route_sharp",
     "route_single",

--- a/gdsfactory/routing/route_ports_to_side.py
+++ b/gdsfactory/routing/route_ports_to_side.py
@@ -88,23 +88,27 @@ def route_ports_to_side(
         return [], []
 
     if side in {"north", "south"}:
-        xy_ns = y if y is not None else side
+        y_value = y if y is not None else side
+        if isinstance(y_value, str):
+            y_value = cast(Literal["north", "south"], y_value)
         side = cast(Literal["north", "south"], side)
         return route_ports_to_y(
             component=component,
             ports=ports,
-            y=xy_ns,
+            y=y_value,
             side=side,
             cross_section=cross_section,
             **kwargs,
         )
     elif side in {"east", "west"}:
-        xy_ew = x if x is not None else side
+        x_value = x if x is not None else side
+        if isinstance(x_value, str):
+            x_value = cast(Literal["east", "west"], x_value)
         side = cast(Literal["west", "east"], side)
         return route_ports_to_x(
             component=component,
             ports=ports,
-            x=xy_ew,
+            x=x_value,
             side=side,
             cross_section=cross_section,
             **kwargs,

--- a/gdsfactory/routing/route_ports_to_side.py
+++ b/gdsfactory/routing/route_ports_to_side.py
@@ -37,6 +37,7 @@ def route_ports_to_side(
     side: Literal["north", "east", "south", "west"] = "north",
     x: float | None = None,
     y: float | None = None,
+    **kwargs: Any,
 ) -> tuple[list[ManhattanRoute], list[kf.Port]]:
     """Routes ports to a given side.
 
@@ -86,7 +87,7 @@ def route_ports_to_side(
     if not ports:
         return [], []
 
-    if side == "north" or side == "south":
+    if side in ["north", "south"]:
         xy_ns = y if y is not None else side
         return route_ports_to_y(
             component=component,
@@ -94,6 +95,7 @@ def route_ports_to_side(
             y=xy_ns,
             side=side,
             cross_section=cross_section,
+            **kwargs,
         )
     xy_ew = x if x is not None else side
     return route_ports_to_x(
@@ -102,6 +104,7 @@ def route_ports_to_side(
         x=xy_ew,
         side=side,
         cross_section=cross_section,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
fixes #3546 

thanks to @kuangfio

## Summary by Sourcery

Fix routing of ports to a specified side by passing additional keyword arguments to the underlying routing functions.

New Features:
- Add support for additional keyword arguments when routing ports to a side, allowing for more flexibility in the routing process.

Bug Fixes:
- Fix issue #3546: Incorrect routing of ports when using side keyword arguments.

Enhancements:
- Expose `route_ports_to_x` and `route_ports_to_y` in `__init__.py`.