### PR TITLE
raise error for locked components

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -53,7 +53,9 @@ class LockedError(AttributeError):
     Modifications to such cells are disabled to ensure consistency.
     """
 
-    def __init__(self, component: kf.KCell | kf.VKCell | Component) -> None:
+    def __init__(
+        self, component: kf.KCell | kf.VKCell | Component | ComponentBase
+    ) -> None:
         """Initialize the LockedError.
 
         Args:
@@ -1364,7 +1366,9 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):  # type: ignore
 
 
 def container(
-    component: "ComponentSpec", function: Callable[..., None], **kwargs: Any
+    component: "ComponentSpec",
+    function: Callable[..., None] | None = None,
+    **kwargs: Any,
 ) -> Component:
     """Returns new component with a component reference.
 
@@ -1379,7 +1383,8 @@ def container(
     c = Component()
     cref = c << component
     c.add_ports(cref.ports)
-    function(component=c, **kwargs)
+    if function:
+        function(component=c, **kwargs)
     c.copy_child_info(component)
     return c
 

--- a/gdsfactory/samples/sample_reticle_electrical_with_labels.py
+++ b/gdsfactory/samples/sample_reticle_electrical_with_labels.py
@@ -29,14 +29,19 @@ def label_farthest_right_port(
     return component
 
 
-def resistance_sheet(width: float = 5, **kwargs: Any) -> gf.Component:
+@gf.cell
+def resistance(width: float = 5, **kwargs: Any) -> gf.Component:
     """Returns a resistance sheet.
 
     Args:
         width: width of the resistance sheet.
         kwargs: additional settings.
     """
-    c = gf.components.resistance_sheet(width=width, **kwargs)
+    r = gf.components.resistance_sheet(width=width, **kwargs)
+    c = gf.container(r)
+
+    c.copy_child_info(r)
+
     c.info["doe"] = "resistance_sheet"
     c.info["measurement"] = "iv"
     c.info["measurement_parameters"] = (
@@ -90,7 +95,7 @@ def via_chain(
 
 def sample_reticle_with_labels(grid: bool = False) -> gf.Component:
     """Returns electrical test structures."""
-    res = [resistance_sheet(width=width) for width in [5, 10, 15]]
+    res = [resistance(width=width) for width in [5, 10, 15]]
     via_chains_ = [via_chain(num_vias=num_vias) for num_vias in [100, 200, 500]]
 
     copies = 3  # number of copies of each component

--- a/notebooks/03_layer_stack.ipynb
+++ b/notebooks/03_layer_stack.ipynb
@@ -220,6 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "c = c.copy()\n",
     "remap = c.remap_layers({(2, 0): (34, 0)})\n",
     "remap.plot()"
    ]
@@ -898,7 +899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -462,6 +462,7 @@
    "outputs": [],
    "source": [
     "c = gf.c.straight()\n",
+    "c = c.copy()\n",
     "c.copy_layers(layer_map=dict(WG=(2, 0)), recursive=False) # type: ignore\n",
     "c"
    ]
@@ -585,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,6 +1,8 @@
 import kfactory as kf
+import pytest
 
 import gdsfactory as gf
+from gdsfactory.component import LockedError
 from gdsfactory.generic_tech import LAYER
 
 
@@ -84,3 +86,28 @@ def test_remove_layers_flat() -> None:
     empty.remove_layers(layers=[(2, 0)])
     assert c.area((2, 0)) == 100, f"{c.area((2, 0))}"
     assert empty.area((2, 0)) == 0, f"{empty.area((2, 0))}"
+
+
+def test_locked_cell() -> None:
+    c = gf.components.straight()
+
+    with pytest.raises(LockedError):
+        c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(2, 0))
+
+    with pytest.raises(LockedError):
+        c.remove_layers(layers=["WG"])
+
+    with pytest.raises(LockedError):
+        c.remap_layers({"WG": "SLAB90"})
+
+    with pytest.raises(LockedError):
+        c.copy_layers({"WG": "SLAB90"})
+
+    with pytest.raises(LockedError):
+        c.over_under("WG")
+
+    with pytest.raises(LockedError):
+        c.offset("WG", distance=0.1)
+
+    with pytest.raises(LockedError):
+        c.add_port(name="o1", center=(0, 0), width=0.5, orientation=0, layer="WG")


### PR DESCRIPTION
fixes  https://github.com/gdsfactory/gdsfactory/issues/3553

Raises error if cell is locked

## Summary by Sourcery

Prevent modification of cached components by raising a LockedError.

Bug Fixes:
- Fix issue where cached components could be modified, leading to inconsistencies.

Tests:
- Add tests to verify that a LockedError is raised when attempting to modify a cached component.