### PR TITLE
Add more tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit =
     fixme/*
     docs/*
     extra/*
+    gdsfactory/samples/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ uv-test: test-data-gds
 	uv run pytest -s -n logical
 
 cov:
-	uv run pytest --cov=gdsfactory
+	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered
+
+dev-cov:
+	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered
 
 test-samples:
 	uv run pytest tests/test_samples.py

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -452,7 +452,11 @@ def add_settings_label(
     layer_label = get_layer(layer_label)
 
     reference_or_component = reference or component
-    info = reference_or_component.cell.info
+    info = (
+        reference_or_component.cell.info
+        if hasattr(reference_or_component, "cell")
+        else reference_or_component.info
+    )
     settings_dict = dict(info)
     settings_string = (
         yaml.dump(convert_tuples_to_lists(settings_dict))

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -121,7 +121,7 @@ class Port(kf.Port):
     def __init__(
         self,
         name: str | None,
-        orientation: AngleInDegrees | None,
+        orientation: AngleInDegrees,
         center: tuple[float, ...] | kf.kdb.Point | kf.kdb.DPoint,
         width: float | None = None,
         layer: LayerSpec | None = None,

--- a/gdsfactory/routing/sort_ports.py
+++ b/gdsfactory/routing/sort_ports.py
@@ -41,6 +41,7 @@ def sort_ports(
             If False, the two lists will be sorted independently.
 
     """
+    original_ports1 = list(ports1)
     ports1_list = list(ports1)
     ports2_list = list(ports2)
 
@@ -50,8 +51,6 @@ def sort_ports(
         )
     if not ports1_list:
         raise ValueError("ports1 is an empty list")
-    if not ports2_list:
-        raise ValueError("ports2 is an empty list")
 
     if ports1_list[0].orientation in [0, 180] and ports2_list[0].orientation in [
         0,
@@ -65,13 +64,13 @@ def sort_ports(
         _sort(get_port_x, ports1_list, enforce_port_ordering, ports2_list)
     else:
         axis = "X" if ports1_list[0].orientation in [0, 180] else "Y"
-        f_key1 = get_port_y if axis in {"X", "x"} else get_port_x
+        f_key1 = get_port_y if axis == "X" else get_port_x
         ports1_list.sort(key=f_key1)
         if not enforce_port_ordering:
             ports2_list.sort(key=f_key1)
 
     if enforce_port_ordering:
-        ports2_list = [ports2_list[ports1_list.index(p1)] for p1 in ports1_list]
+        ports2_list = [ports2_list[original_ports1.index(p1)] for p1 in ports1_list]
 
     return ports1_list, ports2_list
 

--- a/gdsfactory/routing/validation.py
+++ b/gdsfactory/routing/validation.py
@@ -59,7 +59,7 @@ def is_invalid_bundle_topology(ports1: list[Port], ports2: list[Port]) -> bool:
     if len(ports1) < 2:
         # if there's only one route, the bundle topology is always valid
         return False
-    if any(p.orientation is None for p in ports1 + ports2):
+    if any(not p.orientation for p in ports1 + ports2):
         # don't check if the ports do not have orientation
         return False
 

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -3,12 +3,12 @@
 This module enables conversion between gdsfactory settings and KLayout technology.
 """
 
-import enum
 import pathlib
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from typing import Any
 
+import aenum
 import klayout.db as db
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -65,7 +65,7 @@ class KLayoutTechnology(BaseModel):
     @field_validator("layer_map", mode="before")
     @classmethod
     def check_layer_map(cls, layer_map: Any) -> Any:
-        if isinstance(layer_map, enum.EnumType):
+        if isinstance(layer_map, aenum.EnumType):
             _layer_map: dict[str, tuple[int, int]] = {
                 name: (layer_enum.layer, layer_enum.datatype)
                 for name, layer_enum in layer_map.__members__.items()

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -66,10 +66,11 @@ class KLayoutTechnology(BaseModel):
     @classmethod
     def check_layer_map(cls, layer_map: Any) -> Any:
         if isinstance(layer_map, enum.EnumType):
-            layer_map: dict[str, tuple[int, int]] = {
+            _layer_map: dict[str, tuple[int, int]] = {
                 name: (layer_enum.layer, layer_enum.datatype)
                 for name, layer_enum in layer_map.__members__.items()
             }
+            return _layer_map
         return layer_map
 
     def write_tech(

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -3,14 +3,14 @@
 This module enables conversion between gdsfactory settings and KLayout technology.
 """
 
+import enum
 import pathlib
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from typing import Any
 
-import aenum
 import klayout.db as db
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from gdsfactory.config import PATH
 from gdsfactory.technology import LayerStack, LayerViews
@@ -62,17 +62,15 @@ class KLayoutTechnology(BaseModel):
     layer_stack: LayerStack | None = None
     connectivity: Sequence[ConnectivitySpec] | None = None
 
-    @model_validator(mode="before")
+    @field_validator("layer_map", mode="before")
     @classmethod
-    def check_layer_map(cls, data: Any) -> Any:
-        layer_map = data.get("layer_map")
-        if isinstance(layer_map, aenum.EnumType):
-            layer_map = {
+    def check_layer_map(cls, layer_map: Any) -> Any:
+        if isinstance(layer_map, enum.EnumType):
+            return {
                 name: (layer_enum.layer, layer_enum.datatype)
                 for name, layer_enum in layer_map.__members__.items()
             }
-            data["layer_map"] = layer_map
-        return data
+        return layer_map
 
     def write_tech(
         self,

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -66,7 +66,7 @@ class KLayoutTechnology(BaseModel):
     @classmethod
     def check_layer_map(cls, data: Any) -> Any:
         layer_map = data.get("layer_map")
-        if isinstance(layer_map, aenum._enum.EnumType):
+        if isinstance(layer_map, aenum.EnumType):
             layer_map = {
                 name: (layer_enum.layer, layer_enum.datatype)
                 for name, layer_enum in layer_map.__members__.items()

--- a/gdsfactory/technology/klayout_tech.py
+++ b/gdsfactory/technology/klayout_tech.py
@@ -66,7 +66,7 @@ class KLayoutTechnology(BaseModel):
     @classmethod
     def check_layer_map(cls, layer_map: Any) -> Any:
         if isinstance(layer_map, enum.EnumType):
-            return {
+            layer_map: dict[str, tuple[int, int]] = {
                 name: (layer_enum.layer, layer_enum.datatype)
                 for name, layer_enum in layer_map.__members__.items()
             }

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -7,7 +7,6 @@ You can maintain LayerViews in YAML (.yaml) or Klayout XML file (.lyp)
 from __future__ import annotations
 
 import builtins
-import os
 import pathlib
 import re
 import warnings
@@ -1068,8 +1067,10 @@ class LayerViews(BaseModel):
 
         filepath = pathlib.Path(filepath)
 
-        if not os.path.exists(filepath):
-            raise OSError(f"File {str(filepath)!r} does not exist, cannot read.")
+        if not filepath.exists():
+            raise FileNotFoundError(
+                f"File {str(filepath)!r} does not exist, cannot read."
+            )
 
         tree = ET.parse(filepath)
         root = tree.getroot()

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import TypeAlias
 
 import kfactory as kf
-from IPython.terminal.embed import embed  # type: ignore[unused-ignore]
+from IPython.terminal.embed import embed  # type: ignore
 from watchdog.events import (
     DirCreatedEvent,
     DirDeletedEvent,
@@ -29,7 +29,7 @@ from watchdog.observers import Observer
 
 from gdsfactory.component import Component
 from gdsfactory.config import cwd
-from gdsfactory.pdk import get_active_pdk
+from gdsfactory.pdk import Pdk, get_active_pdk
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
 from gdsfactory.typings import ComponentFactory, ComponentSpec, PathType
 
@@ -226,10 +226,12 @@ class FileWatcher(FileSystemEventHandler):
 
 def watch(
     path: PathType | None = cwd,
-    pdk: str | None = None,
+    pdk: Pdk | str | None = None,
     run_main: bool = True,
     run_cells: bool = True,
     pre_run: bool = False,
+    logger: logging.Logger | None = None,
+    run_embed: bool = True,
 ) -> None:
     """Starts the file watcher.
 
@@ -238,20 +240,28 @@ def watch(
         pdk: the name of the PDK to use.
         run_main: if True, will execute the main function of the file.
         run_cells: if True, will execute the cells of the file.
-        run_cells: if True, will execute the cells of the file.
         pre_run: build all cells on startup
+        logger: the logger to use.
+        run_embed: if True, will run the embed function.
     """
     path = str(path)
+    logger = logger or logging.root
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     if pdk:
-        get_active_pdk(name=pdk)
+        if isinstance(pdk, str):
+            get_active_pdk(name=pdk)
+        else:
+            pdk.activate()
+    pdk_name = get_active_pdk().name if pdk else None
 
-    print(f"Watching {path=}, {pdk=} {run_main=}, {run_cells=}, {pre_run=}")
-    watcher = FileWatcher(path=path, run_main=run_main, run_cells=run_cells)
+    print(f"Watching {path=}, {pdk_name=} {run_main=}, {run_cells=}, {pre_run=}")
+    watcher = FileWatcher(
+        path=path, run_main=run_main, run_cells=run_cells, logger=logger
+    )
     watcher.start()
     if pre_run:
         for root, _, fns in os.walk(path):
@@ -261,10 +271,11 @@ def watch(
                     event = SimpleNamespace(is_directory=False, src_path=path)
                     watcher.on_created(event)  # type: ignore
 
-    logging.info(
+    logger.info(
         f"File watcher looking for changes in *.py and *.pic.yml files in {path!r}. Stop with Ctrl+C"
     )
-    embed()  # type: ignore
+    if run_embed:
+        embed()  # type: ignore
     watcher.stop()
 
 

--- a/tests/export/test_to_svg.py
+++ b/tests/export/test_to_svg.py
@@ -16,6 +16,7 @@ def test_to_svg() -> None:
     component = gf.c.grating_coupler_elliptical_trenches()
 
     # Step 2: Define the SVG filename within the temporary directory
+    GDSDIR_TEMP.mkdir(exist_ok=True, parents=True)
     svg_filename: Path = GDSDIR_TEMP / "test_component.svg"
 
     # Step 3: Call the to_svg function

--- a/tests/routing/test_route_single_from_steps.py
+++ b/tests/routing/test_route_single_from_steps.py
@@ -100,5 +100,6 @@ def test_route_waypoints_numpy() -> None:
 
 
 if __name__ == "__main__":
-    # test_route_from_steps()
+    test_route_from_steps()
     test_route_waypoints()
+    test_route_waypoints_numpy()

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+import gdsfactory as gf
+
+
+def test_route_single_sbend() -> None:
+    c = gf.Component("test_route_single_sbend")
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.movex(50)
+    mmi2.movey(5)
+
+    gf.routing.route_single_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])
+    assert len(c.references) == 3
+
+
+def test_route_single_sbend_non_orthogonal() -> None:
+    c = gf.Component("test_route_single_sbend_non_orthogonal")
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.rotate(45)  # type: ignore
+
+    with pytest.raises(ValueError, match="Ports need to have orthogonal orientation"):
+        gf.routing.route_single_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])
+
+
+if __name__ == "__main__":
+    test_route_single_sbend()
+    test_route_single_sbend_non_orthogonal()  # This will raise an error

--- a/tests/routing/test_route_south.py
+++ b/tests/routing/test_route_south.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
@@ -19,5 +20,78 @@ def test_route_south(
         data_regression.check(lengths)  # type: ignore
 
 
+def test_route_south_nxn() -> None:
+    c = gf.Component()
+    cr = c << gf.components.nxn(north=4, south=2, west=2, east=2)
+    routes = gf.routing.route_south(c, cr)
+    assert len(routes) == 6  # 4 north + 2 east ports
+
+
+def test_route_south_mzi_with_bend() -> None:
+    c = gf.Component()
+
+    @gf.cell
+    def mzi_with_bend() -> gf.Component:
+        c = gf.Component()
+        bend = c.add_ref(gf.components.bend_euler(radius=10))
+        mzi = c.add_ref(gf.components.mzi())
+        bend.connect("o1", mzi.ports["o2"])
+        c.add_port(name="o1", port=mzi.ports["o1"])
+        c.add_port(name="o2", port=bend.ports["o2"])
+        return c
+
+    cr = c << mzi_with_bend()
+    routes = gf.routing.route_south(c, cr)
+    assert len(routes) == 1
+
+
+def test_route_south_with_auto_taper() -> None:
+    c = gf.Component()
+    cr = c << gf.components.straight(length=10, width=2)
+    routes = gf.routing.route_south(c, cr, auto_taper=True)
+    assert len(routes) == 1
+
+
+def test_route_south_invalid_type() -> None:
+    c = gf.Component()
+    cr = c << gf.components.mmi2x2()
+    with pytest.raises(ValueError, match="not in supported"):
+        gf.routing.route_south(c, cr, optical_routing_type=3)
+
+
+def test_route_south_empty_ports() -> None:
+    c = gf.Component()
+    cr = c << gf.components.mmi2x2()
+    routes = gf.routing.route_south(c, cr, excluded_ports=("o1", "o2", "o3", "o4"))
+    assert len(routes) == 0
+
+
+def test_route_south_with_port_names() -> None:
+    c = gf.Component()
+    cr = c << gf.components.nxn(north=4, south=2, west=2, east=2)
+    routes = gf.routing.route_south(c, cr, port_names=["o7", "o8"])
+    assert len(routes) == 2
+
+
+def test_route_south_with_io_gratings() -> None:
+    c = gf.Component()
+    cr = c << gf.components.nxn(north=4, south=2, west=2, east=2)
+
+    gc_line = [c << gf.components.grating_coupler_elliptical() for _ in range(6)]
+    for i, gc in enumerate(gc_line[1:], 1):
+        gc.movex(gc_line[0].x + i * 127)
+
+    routes = gf.routing.route_south(
+        component=c, component_to_route=cr, io_gratings_lines=[gc_line]
+    )
+    assert len(routes) == 6  # 4 north + 2 east ports
+
+
 if __name__ == "__main__":
     test_route_south(None, check=False)  # type: ignore
+    test_route_south_nxn()
+    test_route_south_mzi_with_bend()
+    test_route_south_with_auto_taper()
+    test_route_south_empty_ports()
+    test_route_south_with_port_names()
+    test_route_south_with_io_gratings()

--- a/tests/routing/test_sort_ports.py
+++ b/tests/routing/test_sort_ports.py
@@ -1,0 +1,337 @@
+import pytest
+from kfactory.kcell import Port
+
+from gdsfactory.routing.sort_ports import sort_ports, sort_ports_x, sort_ports_y
+
+
+def test_sort_ports_x() -> None:
+    ports = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(3, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(1, 0),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(2, 0),
+        ),
+    ]
+    sorted_ports = sort_ports_x(ports)
+    assert [p.name for p in sorted_ports] == ["p2", "p3", "p1"]
+
+
+def test_sort_ports_y() -> None:
+    ports = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 3),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 2),
+        ),
+    ]
+    sorted_ports = sort_ports_y(ports)
+    assert [p.name for p in sorted_ports] == ["p2", "p3", "p1"]
+
+
+def test_sort_ports_horizontal() -> None:
+    ports1 = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 3),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 2),
+        ),
+    ]
+    ports2 = [
+        Port(
+            name="p4",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 2),
+        ),
+        Port(
+            name="p5",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 1),
+        ),
+        Port(
+            name="p6",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 3),
+        ),
+    ]
+
+    sorted1, sorted2 = sort_ports(ports1, ports2, enforce_port_ordering=False)
+    assert [p.name for p in sorted1] == ["p2", "p3", "p1"]
+    assert [p.name for p in sorted2] == ["p5", "p4", "p6"]
+
+
+def test_sort_ports_vertical() -> None:
+    ports1 = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(3, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(1, 0),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(2, 0),
+        ),
+    ]
+    ports2 = [
+        Port(
+            name="p4",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=270,
+            dcenter=(2, 10),
+        ),
+        Port(
+            name="p5",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=270,
+            dcenter=(1, 10),
+        ),
+        Port(
+            name="p6",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=270,
+            dcenter=(3, 10),
+        ),
+    ]
+
+    sorted1, sorted2 = sort_ports(ports1, ports2, enforce_port_ordering=False)
+    assert [p.name for p in sorted1] == ["p2", "p3", "p1"]
+    assert [p.name for p in sorted2] == ["p5", "p4", "p6"]
+
+
+def test_sort_ports_enforce_ordering() -> None:
+    ports1 = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 3),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 2),
+        ),
+    ]
+    ports2 = [
+        Port(
+            name="p4",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 2),
+        ),
+        Port(
+            name="p5",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 1),
+        ),
+        Port(
+            name="p6",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 3),
+        ),
+    ]
+
+    sorted1, sorted2 = sort_ports(ports1, ports2, enforce_port_ordering=True)
+    assert [p.name for p in sorted1] == ["p2", "p3", "p1"]
+    assert [p.name for p in sorted2] == ["p5", "p6", "p4"]
+
+
+def test_sort_ports_mixed_orientation() -> None:
+    ports1 = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 3),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+    ]
+    ports2 = [
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(10, 2),
+        ),
+        Port(
+            name="p4",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(10, 1),
+        ),
+    ]
+
+    sorted1, sorted2 = sort_ports(ports1, ports2, enforce_port_ordering=False)
+    assert [p.name for p in sorted1] == ["p2", "p1"]
+    assert [p.name for p in sorted2] == ["p4", "p3"]
+
+    sorted1, sorted2 = sort_ports(ports1, ports2, enforce_port_ordering=True)
+    assert [p.name for p in sorted1] == ["p2", "p1"]
+    assert [p.name for p in sorted2] == ["p4", "p3"]
+
+
+def test_sort_ports_validation() -> None:
+    ports1 = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 0),
+        )
+    ]
+    ports2 = [
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 0),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(10, 1),
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="ports1=1 and ports2=2 must be equal"):
+        sort_ports(ports1, ports2, enforce_port_ordering=False)
+
+    with pytest.raises(ValueError, match="ports1 is an empty list"):
+        sort_ports([], [], enforce_port_ordering=False)
+
+
+if __name__ == "__main__":
+    test_sort_ports_validation()
+    test_sort_ports_horizontal()
+    test_sort_ports_vertical()
+    test_sort_ports_mixed_orientation()
+    test_sort_ports_enforce_ordering()
+    test_sort_ports_x()
+    test_sort_ports_y()

--- a/tests/routing/test_utils.py
+++ b/tests/routing/test_utils.py
@@ -1,0 +1,227 @@
+import pytest
+
+from gdsfactory.routing.utils import (
+    check_ports_have_equal_spacing,
+    direction_ports_from_list_ports,
+    get_list_ports_angle,
+)
+from gdsfactory.typings import Port
+
+
+def test_direction_ports_from_list_ports() -> None:
+    ports = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=180,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p4",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=270,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p5",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p6",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(1, 0),
+        ),
+    ]
+
+    result = direction_ports_from_list_ports(ports)
+
+    assert len(result["E"]) == 2
+    assert len(result["N"]) == 2
+    assert len(result["W"]) == 1
+    assert len(result["S"]) == 1
+
+    assert result["E"][0].dy < result["E"][1].dy
+    assert result["N"][0].dx < result["N"][1].dx
+
+
+def test_check_ports_have_equal_spacing() -> None:
+    ports_h = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 2),
+        ),
+    ]
+    assert check_ports_have_equal_spacing(ports_h) == 1.0
+
+    ports_v = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(1, 0),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(2, 0),
+        ),
+    ]
+    assert check_ports_have_equal_spacing(ports_v) == 1.0
+
+    ports_unequal = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 1),
+        ),
+        Port(
+            name="p3",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(0, 2.5),
+        ),
+    ]
+    with pytest.raises(ValueError, match="Ports should have the same separation"):
+        check_ports_have_equal_spacing(ports_unequal)
+
+    with pytest.raises(ValueError, match="list_ports should be a list of ports"):
+        check_ports_have_equal_spacing(tuple())  # type: ignore
+
+    with pytest.raises(ValueError, match="list_ports should not be empty"):
+        check_ports_have_equal_spacing([])
+
+
+def test_get_list_ports_angle() -> None:
+    ports_single = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(0, 0),
+        )
+    ]
+    assert get_list_ports_angle(ports_single) == 90
+
+    ports_same = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(1, 0),
+        ),
+    ]
+    assert get_list_ports_angle(ports_same) == 90
+
+    assert get_list_ports_angle([]) is None
+
+    ports_different = [
+        Port(
+            name="p1",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=90,
+            dcenter=(0, 0),
+        ),
+        Port(
+            name="p2",
+            dwidth=0.5,
+            layer=1,
+            port_type="optical",
+            dangle=0,
+            dcenter=(1, 0),
+        ),
+    ]
+    with pytest.raises(ValueError, match="All port angles should be the same"):
+        get_list_ports_angle(ports_different)
+
+
+if __name__ == "__main__":
+    test_direction_ports_from_list_ports()
+    test_check_ports_have_equal_spacing()
+    test_get_list_ports_angle()

--- a/tests/routing/test_validation.py
+++ b/tests/routing/test_validation.py
@@ -1,0 +1,100 @@
+import pytest
+
+import gdsfactory as gf
+from gdsfactory.port import Port
+from gdsfactory.routing.utils import RouteWarning
+from gdsfactory.routing.validation import is_invalid_bundle_topology, make_error_traces
+
+
+def test_make_error_traces() -> None:
+    c = gf.Component()
+    ports1 = [
+        Port(name="p1", orientation=0, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=0, center=(0, 10), width=0.5, layer=1),
+    ]
+    ports2 = [
+        Port(name="p3", orientation=180, center=(10, 0), width=0.5, layer=1),
+        Port(name="p4", orientation=180, center=(10, 10), width=0.5, layer=1),
+    ]
+
+    with pytest.warns(RouteWarning, match="test message"):
+        make_error_traces(c, ports1, ports2, "test message")
+
+    assert len(c.references) == 2  # Two error traces created
+
+
+def test_is_invalid_bundle_topology() -> None:
+    p1 = [Port(name="p1", orientation=90, center=(0, 0), width=0.5, layer=1)]
+    p2 = [Port(name="p2", orientation=180, center=(10, 0), width=0.5, layer=1)]
+    assert not is_invalid_bundle_topology(p1, p2)
+
+    p1_no_angle = Port(name="p1", orientation=0, center=(0, 0), width=0.5, layer=1)
+    p2_no_angle = Port(name="p2", orientation=0, center=(10, 0), width=0.5, layer=1)
+    assert not is_invalid_bundle_topology([p1_no_angle], [p2_no_angle])
+
+    p1 = [
+        Port(name="p1", orientation=90, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=90, center=(0, 10), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p3", orientation=180, center=(10, 0), width=0.5, layer=1),
+        Port(name="p4", orientation=180, center=(10, 10), width=0.5, layer=1),
+    ]
+    assert not is_invalid_bundle_topology(p1, p2)
+
+    p1 = [
+        Port(name="p1", orientation=45, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=-45, center=(0, 10), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p3", orientation=-135, center=(10, 10), width=0.5, layer=1),
+        Port(name="p4", orientation=135, center=(10, 0), width=0.5, layer=1),
+    ]
+    assert is_invalid_bundle_topology(p1, p2)
+
+    p1 = [
+        Port(name="p1", orientation=-135, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=135, center=(0, 10), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p3", orientation=45, center=(10, 10), width=0.5, layer=1),
+        Port(name="p4", orientation=-45, center=(10, 0), width=0.5, layer=1),
+    ]
+    assert is_invalid_bundle_topology(p1, p2)
+
+    p1 = [
+        Port(name="p1", orientation=90, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=90, center=(0, 10), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p3", orientation=90, center=(10, 5), width=0.5, layer=1),
+        Port(name="p4", orientation=90, center=(10, 15), width=0.5, layer=1),
+    ]
+    assert is_invalid_bundle_topology(p1, p2)
+
+    p1 = [
+        Port(name="p1", orientation=90, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=90, center=(0, 10), width=0.5, layer=1),
+        Port(name="p3", orientation=180, center=(0, 20), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p4", orientation=180, center=(10, 0), width=0.5, layer=1),
+        Port(name="p5", orientation=180, center=(10, 10), width=0.5, layer=1),
+        Port(name="p6", orientation=270, center=(10, 20), width=0.5, layer=1),
+    ]
+    assert not is_invalid_bundle_topology(p1, p2)
+
+    p1 = [
+        Port(name="p1", orientation=1e-11, center=(0, 0), width=0.5, layer=1),
+        Port(name="p2", orientation=90, center=(0, 10), width=0.5, layer=1),
+    ]
+    p2 = [
+        Port(name="p3", orientation=180, center=(10, 0), width=0.5, layer=1),
+        Port(name="p4", orientation=180 + 1e-11, center=(10, 10), width=0.5, layer=1),
+    ]
+    assert not is_invalid_bundle_topology(p1, p2)
+
+
+if __name__ == "__main__":
+    test_make_error_traces()
+    test_is_invalid_bundle_topology()

--- a/tests/routing/test_validation.py
+++ b/tests/routing/test_validation.py
@@ -20,7 +20,7 @@ def test_make_error_traces() -> None:
     with pytest.warns(RouteWarning, match="test message"):
         make_error_traces(c, ports1, ports2, "test message")
 
-    assert len(c.references) == 2  # Two error traces created
+    assert len(c.insts) == 2
 
 
 def test_is_invalid_bundle_topology() -> None:

--- a/tests/technology/test_color_utils.py
+++ b/tests/technology/test_color_utils.py
@@ -1,0 +1,19 @@
+from gdsfactory.technology.color_utils import ensure_six_digit_hex_color
+
+
+def test_ensure_six_digit_hex_color() -> None:
+    assert ensure_six_digit_hex_color(0xFF00FF) == "#ff00ff"
+    assert ensure_six_digit_hex_color(0x000000) == "#000000"
+
+    assert ensure_six_digit_hex_color("0xFF00FF") == "#FF00FF"
+    assert ensure_six_digit_hex_color("0x000000") == "#000000"
+
+    assert ensure_six_digit_hex_color("#FF00FF") == "#FF00FF"
+    assert ensure_six_digit_hex_color("#000000") == "#000000"
+
+    assert ensure_six_digit_hex_color("#0fc") == "#00ffcc"
+    assert ensure_six_digit_hex_color("#f0f") == "#ff00ff"
+
+
+if __name__ == "__main__":
+    test_ensure_six_digit_hex_color()

--- a/tests/technology/test_klayout_tech.py
+++ b/tests/technology/test_klayout_tech.py
@@ -1,0 +1,108 @@
+import enum
+import pathlib
+import tempfile
+import xml.etree.ElementTree as ET
+
+from gdsfactory.technology import LayerViews
+from gdsfactory.technology.klayout_tech import KLayoutTechnology
+from gdsfactory.technology.layer_views import LayerView
+
+
+def test_klayout_tech_basic() -> None:
+    """Test basic KLayoutTechnology functionality."""
+    tech = KLayoutTechnology(
+        name="test_tech", layer_map={"M1": (1, 0), "M2": (2, 0), "VIA1": (3, 0)}
+    )
+    assert tech.name == "test_tech"
+    assert tech.layer_map["M1"] == (1, 0)
+
+
+def test_klayout_tech_write(tmp_path: pathlib.Path) -> None:
+    """Test writing technology files."""
+    tech = KLayoutTechnology(
+        name="test_tech",
+        layer_map={"M1": (1, 0), "M2": (2, 0), "VIA1": (3, 0)},
+        connectivity=[("M1", "VIA1", "M2")],
+    )
+
+    tech.write_tech(tech_dir=tmp_path)
+
+    # Verify files were created
+    assert (tmp_path / "tech.lyt").exists()
+    assert (tmp_path / "d25").exists()
+
+    # Test loading written tech file
+    tech_xml = (tmp_path / "tech.lyt").read_bytes()
+    root = ET.XML(tech_xml)
+
+    # Verify connectivity was written correctly
+    connections = root.findall(".//connection")
+    assert len(connections) == 1
+    assert connections[0].text == "M1,VIA1,M2"
+
+    symbols = root.findall(".//symbols")
+    assert len(symbols) == 2  # VIA1 and M2
+    assert any(s.text is not None and "M2='2/0'" in s.text for s in symbols)
+    assert any(s.text is not None and "VIA1='3/0'" in s.text for s in symbols)
+
+
+def test_klayout_tech_mebes_config(tmp_path: pathlib.Path) -> None:
+    """Test mebes configuration."""
+    custom_mebes = {"invert": True, "data-layer": 5, "boundary-name": "TEST"}
+
+    tech = KLayoutTechnology(name="test_tech", layer_map={"M1": (1, 0)})
+
+    tech.write_tech(tech_dir=tmp_path, mebes_config=custom_mebes)
+
+    tech_xml = (tmp_path / "tech.lyt").read_bytes()
+    root = ET.XML(tech_xml)
+
+    mebes = root.find(".//mebes")
+    assert mebes is not None
+    assert mebes.find("invert").text == "true"
+    assert mebes.find("data-layer").text == "5"
+    assert mebes.find("boundary-name").text == "TEST"
+
+
+def test_klayout_tech_layer_views(tmp_path: pathlib.Path) -> None:
+    """Test layer views integration."""
+    layer_views = LayerViews(
+        filepath=None, layer_views={"M1": LayerView(name="M1", fill_color="#FF0000")}
+    )
+
+    tech = KLayoutTechnology(
+        name="test_tech",
+        layer_map={"M1": (1, 0), "M2": (2, 0)},
+        layer_views=layer_views,
+    )
+
+    tech.write_tech(tech_dir=tmp_path)
+    assert (tmp_path / "layers.lyp").exists()
+
+
+def test_klayout_tech_enum_layer_map() -> None:
+    """Test using enum for layer map."""
+
+    class TestLayers(enum.Enum):
+        M1 = (1, 0)
+        M2 = (2, 0)
+
+        def __new__(cls, layer: int, datatype: int) -> "TestLayers":
+            obj = object.__new__(cls)
+            obj._value_ = (layer, datatype)
+            obj.layer = layer
+            obj.datatype = datatype
+            return obj
+
+    tech = KLayoutTechnology(name="test_tech", layer_map=TestLayers)
+
+    assert tech.layer_map["M1"] == (1, 0)
+    assert tech.layer_map["M2"] == (2, 0)
+
+
+if __name__ == "__main__":
+    test_klayout_tech_enum_layer_map()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        test_klayout_tech_write(pathlib.Path(tmp_dir))
+        test_klayout_tech_mebes_config(pathlib.Path(tmp_dir))
+        test_klayout_tech_layer_views(pathlib.Path(tmp_dir))

--- a/tests/technology/test_klayout_tech.py
+++ b/tests/technology/test_klayout_tech.py
@@ -1,7 +1,8 @@
-import enum
 import pathlib
 import tempfile
 import xml.etree.ElementTree as ET
+
+import aenum
 
 from gdsfactory.technology import LayerViews
 from gdsfactory.technology.klayout_tech import KLayoutTechnology
@@ -83,7 +84,7 @@ def test_klayout_tech_layer_views(tmp_path: pathlib.Path) -> None:
 def test_klayout_tech_enum_layer_map() -> None:
     """Test using enum for layer map."""
 
-    class TestLayers(enum.Enum):
+    class TestLayers(aenum.Enum):
         M1 = (1, 0)
         M2 = (2, 0)
 

--- a/tests/technology/test_layer_map.py
+++ b/tests/technology/test_layer_map.py
@@ -1,0 +1,50 @@
+import pathlib
+import tempfile
+
+import pytest
+
+from gdsfactory.technology.layer_map import lyp_to_dataclass
+
+
+def test_lyp_to_dataclass(tmp_path: pathlib.Path) -> None:
+    """Test converting KLayout lyp file to LayerMap dataclass."""
+    lyp_content = """<?xml version="1.0" encoding="utf-8"?>
+<layer-properties>
+ <properties>
+  <frame-color>#ff0000</frame-color>
+  <fill-color>#ff0000</fill-color>
+  <frame-brightness>0</frame-brightness>
+  <fill-brightness>0</fill-brightness>
+  <dither-pattern>1</dither-pattern>
+  <line-style/>
+  <valid>true</valid>
+  <visible>true</visible>
+  <transparent>false</transparent>
+  <width>1</width>
+  <marked>false</marked>
+  <xfill>false</xfill>
+  <animation>0</animation>
+  <name>M1</name>
+  <source>1/0@1</source>
+ </properties>
+</layer-properties>"""
+
+    lyp_file = tmp_path / "test.lyp"
+    lyp_file.write_text(lyp_content)
+
+    script = lyp_to_dataclass(lyp_file)
+    assert "M1: Layer = (1, 0)" in script
+    assert "class LayerMapFab(LayerMap):" in script
+
+    py_file = lyp_file.with_suffix(".py")
+    py_file.write_text("existing content")
+    with pytest.raises(FileExistsError):
+        lyp_to_dataclass(lyp_file, overwrite=False)
+
+    with pytest.raises(FileNotFoundError):
+        lyp_to_dataclass("nonexistent.lyp")
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_lyp_to_dataclass(pathlib.Path(tmpdir))

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -133,13 +133,25 @@ def test_layer_view_init() -> None:
 
 def test_layer_view_dict() -> None:
     lv = LayerView(color="#FF0000")
-    assert lv.dict()
+
+    d = lv.dict(simplify=False)
+    assert "fill_color" in d
+    assert "frame_color" in d
+    assert "color" not in d
+    assert d["fill_color"] == d["frame_color"] == Color("#FF0000")
+
+    d = lv.dict(simplify=True)
+    assert "fill_color" not in d
+    assert "frame_color" not in d
+    assert "color" in d
+    assert d["color"] == Color("#FF0000")
+
+
+def test_layer_view_str() -> None:
+    lv = LayerView(color="#00FF00")
+    assert str(lv)
 
 
 if __name__ == "__main__":
-    test_hatch_pattern_to_klayout_xml()
-    test_hatch_pattern_custom_pattern()
-    test_line_style_custom_style()
-    test_line_style_to_klayout_xml()
-    test_layer_view_init()
-    test_layer_view_dict()
+    lv = LayerView(color="#00FF00")
+    print(repr(lv))

--- a/tests/technology/test_xml_utils.py
+++ b/tests/technology/test_xml_utils.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from xml.dom.minidom import parseString
+from xml.dom.minidom import Node, parseString
 
 from gdsfactory.technology.xml_utils import make_pretty_xml, strip_xml
 
@@ -28,6 +28,15 @@ def test_make_pretty_xml() -> None:
 def test_strip_xml() -> None:
     xml_str = "<root>  <child>  text  </child>  </root>"
     doc = parseString(xml_str)
+
+    text_node = doc.createTextNode("  text with spaces  ")
+    assert text_node.nodeType == Node.TEXT_NODE
+    strip_xml(text_node)
+    assert "text with spaces" in text_node.nodeValue
+
+    element = doc.createElement("test")
+    assert element.nodeType == Node.ELEMENT_NODE
+    strip_xml(element)
 
     strip_xml(doc)
 

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -41,5 +41,51 @@ def test_add_bbox() -> None:
     assert bbox[1, 1] == 0.5
 
 
+def test_add_pins_siepic() -> None:
+    c = gf.components.straight(length=10).copy()
+    c = gf.add_pins.add_pins_siepic(c)
+    assert len(c.get_polygons()[LAYER.PORT]) == 2
+
+
+def test_add_pins_siepic_electrical() -> None:
+    c = gf.components.straight_heater_metal().copy()
+    c = gf.add_pins.add_pins_siepic_electrical(c)
+    assert len(c.get_polygons()[LAYER.PORTE]) == 8
+
+
+def test_add_outline() -> None:
+    c = gf.components.straight().copy()
+    gf.add_pins.add_outline(c, layer=LAYER.DEVREC)
+    assert len(c.get_polygons()[LAYER.DEVREC]) == 1
+
+
+def test_add_settings_label() -> None:
+    c = gf.components.straight().copy()
+    gf.add_pins.add_settings_label(c)
+    assert len(c.get_labels(LAYER.LABEL_SETTINGS)) == 1
+
+
+def test_add_instance_label() -> None:
+    c = gf.Component()
+    ref = c << gf.components.straight()
+    gf.add_pins.add_instance_label(c, ref)
+    assert len(c.get_labels(LAYER.LABEL_INSTANCE)) == 1
+
+
+def test_add_pins_and_outline() -> None:
+    c = gf.components.straight().copy()
+    gf.add_pins.add_pins_and_outline(c)
+    assert len(c.get_polygons()[LAYER.PORT]) == 2
+    assert len(c.get_polygons()[LAYER.DEVREC]) == 1
+
+
 if __name__ == "__main__":
     test_add_bbox()
+    test_add_pins()
+    test_add_pins_triangle()
+    test_add_pins_siepic()
+    test_add_pins_siepic_electrical()
+    test_add_outline()
+    test_add_settings_label()
+    test_add_instance_label()
+    test_add_pins_and_outline()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -6,10 +6,29 @@ import tempfile
 import time
 from unittest.mock import MagicMock
 
-import gdsfactory as gf
-from gdsfactory.watch import FileWatcher
+from watchdog.events import (
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
 
-wait_time = 1.1
+import gdsfactory as gf
+from gdsfactory.pdk import get_active_pdk
+from gdsfactory.watch import FileWatcher, watch
+
+
+def _wait_for_log_message(
+    mock_logger: MagicMock, message: str, timeout: float = 5
+) -> bool:
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        for call in mock_logger.info.call_args_list:
+            print(f"call: {call}")
+            if message.lower() in str(call).lower():
+                return True
+        time.sleep(0.1)
+    return False
 
 
 def test_file_watcher() -> None:
@@ -20,7 +39,7 @@ def test_file_watcher() -> None:
             path=tmp_dir, run_main=False, run_cells=True, logger=mock_logger
         )
         watcher.start()
-        time.sleep(wait_time)
+        time.sleep(0.5)
 
         py_path = pathlib.Path(tmp_dir) / "test.py"
         py_content = """
@@ -30,8 +49,7 @@ def straight():
     return gf.components.straight(length=10, width=0.5)
 """
         py_path.write_text(py_content)
-        time.sleep(wait_time)
-        mock_logger.info.assert_called()
+        assert _wait_for_log_message(mock_logger, "Created")
 
         yaml_path = pathlib.Path(tmp_dir) / "test.pic.yml"
         yaml_content = """
@@ -44,21 +62,18 @@ instances:
             length_mmi: 10
 """
         yaml_path.write_text(yaml_content)
-        time.sleep(wait_time)
-        mock_logger.info.assert_called()
+        assert _wait_for_log_message(mock_logger, "Created")
 
         py_path.write_text(py_content + "\n# Modified")
-        time.sleep(wait_time)
-        mock_logger.info.assert_called()
+        assert _wait_for_log_message(mock_logger, "Modified")
 
         new_yaml_path = pathlib.Path(tmp_dir) / "new_test.pic.yml"
         yaml_path.rename(new_yaml_path)
-        time.sleep(wait_time)
-        mock_logger.info.assert_called()
-
+        res = _wait_for_log_message(mock_logger, "Moved")
+        print(f"res: {res}")
+        assert res
         new_yaml_path.unlink()
-        time.sleep(wait_time)
-        mock_logger.info.assert_called()
+        assert _wait_for_log_message(mock_logger, "Deleted")
 
         watcher.stop()
 
@@ -71,10 +86,10 @@ def test_file_watcher_ignored_files() -> None:
             path=tmp_dir, run_main=False, run_cells=True, logger=mock_logger
         )
         watcher.start()
+        time.sleep(1)
 
         txt_path = pathlib.Path(tmp_dir) / "test.txt"
         txt_path.write_text("Some text")
-        time.sleep(wait_time)
 
         mock_logger.info.assert_not_called()
 
@@ -100,7 +115,230 @@ invalid:
         assert set(cells_before) == set(cells_after)
 
 
+def test_file_watcher_run_loop() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+
+        mock_observer = MagicMock()
+        mock_observer.is_alive.side_effect = [False, True, True]
+        watcher.observer = mock_observer
+
+        watcher.start()
+        time.sleep(0.1)
+
+        assert mock_observer.start.call_count == 1
+
+        time.sleep(1.1)
+        assert mock_observer.start.call_count == 1
+
+        watcher.stop()
+
+        mock_observer.stop.assert_called_once()
+        mock_observer.join.assert_called_once()
+
+
+def test_on_moved() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+        watcher.start()
+        time.sleep(0.1)
+
+        yaml_path = pathlib.Path(tmp_dir) / "file.pic.yml"
+        yaml_path.write_text("name: test\ninstances: {}")
+
+        create_event = FileCreatedEvent(src_path=str(yaml_path).encode())
+        watcher.on_created(create_event)
+
+        new_path = pathlib.Path(tmp_dir) / "moved_file.pic.yml"
+        yaml_path.rename(new_path)
+        event = FileMovedEvent(
+            src_path=str(yaml_path).encode(), dest_path=str(new_path).encode()
+        )
+        watcher.on_moved(event)
+
+        mock_logger.info.assert_called_with("Moved %s: %s", "file", str(new_path))
+
+        watcher.stop()
+
+
+def test_on_created() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+        watcher.start()
+        time.sleep(0.1)
+
+        yaml_path = b"/path/to/file.pic.yml"
+        event = FileCreatedEvent(src_path=yaml_path)
+        watcher.on_created(event)
+        mock_logger.info.assert_called_with(
+            "Created %s: %s", "file", "/path/to/file.pic.yml"
+        )
+
+        py_path = b"/path/to/file.py"
+        event = FileCreatedEvent(src_path=py_path)
+        watcher.on_created(event)
+        mock_logger.info.assert_called_with(
+            "Created %s: %s", "file", "/path/to/file.py"
+        )
+
+        other_path = b"/path/to/file.txt"
+        event = FileCreatedEvent(src_path=other_path)
+        watcher.on_created(event)
+        assert mock_logger.info.call_count == 2
+
+        watcher.stop()
+
+
+def test_on_deleted() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+        watcher.start()
+        time.sleep(0.1)
+
+        pdk = get_active_pdk().model_copy(deep=True)
+        pdk.activate()
+
+        yaml_path = pathlib.Path(tmp_dir) / "yaml_component.pic.yml"
+        yaml_content = """
+name: yaml_component
+"""
+        yaml_path.write_text(yaml_content)
+
+        create_event_yaml = FileCreatedEvent(src_path=str(yaml_path).encode())
+        watcher.on_created(create_event_yaml)
+        time.sleep(0.5)
+
+        print(list(pdk.cells.keys()))
+
+        event = FileDeletedEvent(src_path=str(yaml_path).encode())
+        watcher.on_deleted(event)
+        assert _wait_for_log_message(mock_logger, "Deleted")
+        assert _wait_for_log_message(mock_logger, "yaml_component")
+
+        watcher.stop()
+
+
+def test_on_modified() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+        watcher.start()
+        time.sleep(0.1)
+
+        yaml_path = b"/path/to/file.pic.yml"
+        event = FileModifiedEvent(src_path=yaml_path)
+        watcher.on_modified(event)
+        mock_logger.info.assert_called_with(
+            "Modified %s: %s", "file", "/path/to/file.pic.yml"
+        )
+
+        py_path = b"/path/to/file.py"
+        event = FileModifiedEvent(src_path=py_path)
+        watcher.on_modified(event)
+        mock_logger.info.assert_called_with(
+            "Modified %s: %s", "file", "/path/to/file.py"
+        )
+
+        other_path = b"/path/to/file.txt"
+        event = FileModifiedEvent(src_path=other_path)
+        watcher.on_modified(event)
+        assert mock_logger.info.call_count == 2
+
+        str_path = "/path/to/file.py"
+        event = FileModifiedEvent(src_path=str_path)
+        watcher.on_modified(event)
+        mock_logger.info.assert_called_with("Modified %s: %s", "file", str_path)
+
+        watcher.stop()
+
+
+def test_get_component() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+        watcher = FileWatcher(path=tmp_dir, logger=mock_logger)
+        watcher.start()
+        time.sleep(0.1)
+
+        yaml_path = pathlib.Path(tmp_dir) / "test.pic.yml"
+        yaml_content = """
+name: test_component
+instances:
+    mmi:
+        component: mmi1x2
+        settings:
+            width_mmi: 4.5
+            length_mmi: 10
+"""
+        yaml_path.write_text(yaml_content)
+        component = watcher.get_component(yaml_path)
+        assert component is not None
+
+        py_path = pathlib.Path(tmp_dir) / "test.py"
+        py_content = """
+import gdsfactory as gf
+
+def straight():
+    return gf.components.straight(length=10, width=0.5)
+"""
+        py_path.write_text(py_content)
+        component = watcher.get_component(py_path)
+        assert component is None
+
+        watcher.run_main = True
+        component = watcher.get_component(py_path)
+        assert component is None
+
+        watcher.run_cells = False
+        component = watcher.get_component(py_path)
+        assert component is None
+
+        nonexistent = pathlib.Path(tmp_dir) / "nonexistent.pic.yml"
+        component = watcher.get_component(nonexistent)
+        assert component is None
+
+        other_path = pathlib.Path(tmp_dir) / "test.txt"
+        other_path.write_text("some content")
+        component = watcher.get_component(other_path)
+        assert component is None
+
+        watcher.stop()
+
+
+def test_watch() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_logger = MagicMock(spec=logging.Logger)
+
+        watch(
+            path=tmp_dir,
+            pdk=None,
+            run_main=True,
+            run_cells=True,
+            pre_run=False,
+            logger=mock_logger,
+            run_embed=False,
+        )
+
+        mock_logger.info.assert_called()
+
+        pdk = get_active_pdk().model_copy(deep=True)
+
+        watch(
+            path=tmp_dir,
+            pdk=pdk,
+            pre_run=True,
+            logger=mock_logger,
+            run_embed=False,
+        )
+
+        py_path = pathlib.Path(tmp_dir) / "test.py"
+        py_path.write_text("import gdsfactory as gf")
+
+        watch(path=tmp_dir, pre_run=True, logger=mock_logger, run_embed=False)
+
+
 if __name__ == "__main__":
-    test_update_cell_invalid_yaml()
-    test_file_watcher()
-    test_file_watcher_ignored_files()
+    test_on_moved()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -158,7 +158,7 @@ def test_on_moved() -> None:
         )
         watcher.on_moved(event)
 
-        mock_logger.info.assert_called_with("Moved")
+        assert _wait_for_log_message(mock_logger, "Moved")
 
         watcher.stop()
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -158,7 +158,7 @@ def test_on_moved() -> None:
         )
         watcher.on_moved(event)
 
-        mock_logger.info.assert_called_with("Moved %s: %s", "file", str(new_path))
+        mock_logger.info.assert_called_with("Moved")
 
         watcher.stop()
 


### PR DESCRIPTION
## Summary by Sourcery

Improve test coverage for `FileWatcher` and add support for routing NxN components south.

Enhancements:
- Simplify `LayerView` dictionary representation.
- Improve type hints for `Port` orientation and `route_south` excluded ports.
- Update `KLayoutTechnology` to handle enum layer maps and improve MEBES configuration.
- Enhance `strip_xml` to handle text nodes and elements.
- Refine `sort_ports` logic for consistent port ordering.

Tests:
- Add tests for `FileWatcher` run loop, file move, create, delete, and modify events.
- Add tests for routing NxN components south.
- Add tests for routing with bend and auto taper.
- Add tests for routing with invalid type and empty ports.
- Add tests for routing with port names and IO gratings.
- Add tests for `LayerView` string representation.
- Add tests for `strip_xml` function.
- Add tests for `sort_ports` function.
- Add tests for routing waypoints with NumPy arrays.
- Add tests for `check_ports_have_equal_spacing`, `direction_ports_from_list_ports`, and `get_list_ports_angle`.
- Add tests for `lyp_to_dataclass` function.
- Add tests for `route_single_sbend` with non-orthogonal ports.
- Add tests for `ensure_six_digit_hex_color` function.