### PR TITLE
add angle resolution to via_circular

### DIFF
--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import partial
 
+import numpy as np
+
 import gdsfactory as gf
 from gdsfactory._deprecation import deprecate
 from gdsfactory.component import Component
@@ -98,6 +100,7 @@ def via_circular(
     pitch: float | None = 2,
     column_pitch: float | None = None,
     row_pitch: float | None = None,
+    angle_resolution: float = 2.5,
 ) -> Component:
     """Circular via.
 
@@ -108,9 +111,15 @@ def via_circular(
         pitch: pitch between vias.
         column_pitch: Optional pitch between columns of vias. Default is pitch.
         row_pitch: Optional pitch between rows of vias. Default is pitch.
+        angle_resolution: number of degrees per point.
     """
+    if radius <= 0:
+        raise ValueError(f"radius={radius} must be > 0")
     c = Component()
-    _ = c << gf.c.circle(radius=radius, layer=layer)
+    t = np.linspace(0, 360, int(360 / angle_resolution) + 1) * np.pi / 180
+    xpts = (radius * np.cos(t)).tolist()
+    ypts = (radius * np.sin(t)).tolist()
+    c.add_polygon(points=list(zip(xpts, ypts)), layer=layer)
     row_pitch = row_pitch or pitch
     column_pitch = column_pitch or pitch
 

--- a/test-data-regression/test_netlists_via_circular_.yml
+++ b/test-data-regression/test_netlists_via_circular_.yml
@@ -1,17 +1,5 @@
-instances:
-  circle_R0p35_AR2p5_LVIAC_0_0:
-    component: circle
-    info: {}
-    settings:
-      angle_resolution: 2.5
-      layer: VIAC
-      radius: 0.35
-name: via_circular_R0p35_E1_L_23e09619
+instances: {}
+name: via_circular_R0p35_E1_L_74f6c43d
 nets: []
-placements:
-  circle_R0p35_AR2p5_LVIAC_0_0:
-    mirror: false
-    rotation: 0
-    x: 0
-    y: 0
+placements: {}
 ports: {}

--- a/test-data-regression/test_settings_via_circular_.yml
+++ b/test-data-regression/test_settings_via_circular_.yml
@@ -5,8 +5,9 @@ info:
   row_pitch: 2
   xsize: 0.7
   ysize: 0.7
-name: via_circular_R0p35_E1_L_23e09619
+name: via_circular_R0p35_E1_L_74f6c43d
 settings:
+  angle_resolution: 2.5
   enclosure: 1
   layer: VIAC
   pitch: 2


### PR DESCRIPTION
## Summary by Sourcery

Add angle resolution parameter to via_circular function to allow customization of the circular via's point density and improve input validation by checking for non-positive radius values.

New Features:
- Introduce angle resolution parameter to the via_circular function, allowing control over the number of degrees per point in the circular via.

Enhancements:
- Enhance via_circular function to raise a ValueError if the radius is less than or equal to zero, ensuring valid input.