### PR TITLE
Simpler straight heater meander default args

### DIFF
--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -76,7 +76,7 @@ def straight_heater_meander(
     ##############
     # Straights
     ##############
-    total_length = 0
+    total_length = 0.0
 
     for row, straight_width in enumerate(straight_widths):
         cross_section1 = gf.get_cross_section(cross_section, width=straight_width)
@@ -228,7 +228,7 @@ def straight_heater_meander(
 
 if __name__ == "__main__":
     c = straight_heater_meander(
-        radius=5
+        radius=5.0
         # heater_taper_length=0,
         # straight_widths=(0.5,) * 7,
         # taper_length=10,

--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -20,9 +20,9 @@ def straight_heater_meander(
     port_orientation1: float | None = None,
     port_orientation2: float | None = None,
     heater_taper_length: float = 10.0,
-    straight_widths: Floats = (0.8, 0.9, 0.8),
+    straight_widths: Floats | None = None,
     taper_length: float = 10,
-    n: int | None = None,
+    n: int | None = 3,
 ) -> Component:
     """Returns a meander based heater.
 
@@ -49,6 +49,9 @@ def straight_heater_meander(
     """
     if n and straight_widths:
         raise ValueError("n and straight_widths are mutually exclusive")
+
+    if n is None and straight_widths is None:
+        raise ValueError("Either n or straight_widths should be provided")
 
     rows = n or len(straight_widths)
     c = gf.Component()

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -155,6 +155,7 @@ def straight_heater_metal_undercut(
     c.info["resistance"] = (
         ohms_per_square * heater_width * length if ohms_per_square else 0
     )
+    c.info["length"] = length
     c.flatten()
     return c
 
@@ -245,6 +246,7 @@ def straight_heater_metal_simple(
     c.info["resistance"] = (
         ohms_per_square * heater_width * length if ohms_per_square else None
     )
+    c.info["length"] = length
     return c
 
 
@@ -280,6 +282,6 @@ if __name__ == "__main__":
     # n = c.get_netlist()
     # c = straight_heater_metal(length=20)
     # c = straight_heater_metal_90_90(length=50)
-    c.show()
+    # c.show()
     # scene = c.to_3d()
     # scene.show()

--- a/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi2x2_2x2_phase_shifter_.yml
@@ -234,6 +234,7 @@ instances:
   sxt:
     component: straight_heater_metal_undercut
     info:
+      length: 200
       resistance: 0
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_phase_shifter_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_.yml
@@ -234,6 +234,7 @@ instances:
   sxt:
     component: straight_heater_metal_undercut
     info:
+      length: 200
       resistance: 0
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
+++ b/test-data-regression/test_netlists_mzi_phase_shifter_top_heater_metal_.yml
@@ -234,6 +234,7 @@ instances:
   sxt:
     component: straight_heater_metal_undercut
     info:
+      length: 200
       resistance: 0
     settings:
       cross_section: strip

--- a/test-data-regression/test_netlists_straight_heater_meander_.yml
+++ b/test-data-regression/test_netlists_straight_heater_meander_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: straight_heater_meander_2df29628
+name: straight_heater_meander_4b36cd9b
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_add_pads0_.yml
+++ b/test-data-regression/test_settings_add_pads0_.yml
@@ -1,4 +1,5 @@
 info:
+  length: 101
   resistance: 0
 name: add_pads0
 settings: {}

--- a/test-data-regression/test_settings_straight_heater_meander_.yml
+++ b/test-data-regression/test_settings_straight_heater_meander_.yml
@@ -1,4 +1,5 @@
-info: {}
+info:
+  length: 529.664
 name: straight_heater_meander_4b36cd9b
 settings:
   cross_section: strip

--- a/test-data-regression/test_settings_straight_heater_meander_.yml
+++ b/test-data-regression/test_settings_straight_heater_meander_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: straight_heater_meander_2df29628
+name: straight_heater_meander_4b36cd9b
 settings:
   cross_section: strip
   extension_length: 15
@@ -7,10 +7,7 @@ settings:
   heater_width: 2.5
   layer_heater: HEATER
   length: 300
+  n: 3
   spacing: 2
-  straight_widths:
-  - 0.8
-  - 0.9
-  - 0.8
   taper_length: 10
   via_stack: via_stack_heater_mtop

--- a/test-data-regression/test_settings_straight_heater_metal_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_.yml
@@ -1,4 +1,5 @@
 info:
+  length: 320
   resistance: 0
 name: straight_heater_metal_u_ba1ec95a
 settings:

--- a/test-data-regression/test_settings_straight_heater_metal_90_90_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_90_90_.yml
@@ -1,4 +1,5 @@
 info:
+  length: 320
   resistance: 0
 name: straight_heater_metal_u_31c36232
 settings:

--- a/test-data-regression/test_settings_straight_heater_metal_simple_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_simple_.yml
@@ -1,4 +1,5 @@
-info: {}
+info:
+  length: 320
 name: straight_heater_metal_s_61c5bdef
 settings:
   cross_section_heater: heater_metal

--- a/test-data-regression/test_settings_straight_heater_metal_undercut_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_undercut_.yml
@@ -1,4 +1,5 @@
 info:
+  length: 320
   resistance: 0
 name: straight_heater_metal_u_22706e47
 settings:

--- a/test-data-regression/test_settings_straight_heater_metal_undercut_90_90_.yml
+++ b/test-data-regression/test_settings_straight_heater_metal_undercut_90_90_.yml
@@ -1,4 +1,5 @@
 info:
+  length: 320
   resistance: 0
 name: straight_heater_metal_u_a5599ea2
 settings:


### PR DESCRIPTION
## Summary by Sourcery

Simplify the `straight_heater_meander` component by making the number of meanders (`n`) a required argument with a default value of 3. This removes the `straight_widths` argument when `n` is provided.

Enhancements:
- Make the number of meanders a required argument with a default value of 3 in the `straight_heater_meander` component.

Tests:
- Update test settings to reflect the change in default arguments.