### PR TITLE
add file path to yaml cell

### DIFF
--- a/gdsfactory/read/from_yaml_template.py
+++ b/gdsfactory/read/from_yaml_template.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from inspect import Parameter, Signature, signature
 from io import IOBase
@@ -85,9 +86,12 @@ def cell_from_yaml_template(
 
     if routing_strategy is None:
         routing_strategy = get_routing_strategies()
-    return yaml_cell(
+    cell = yaml_cell(
         yaml_definition=filename, name=name, routing_strategy=routing_strategy
     )
+    if os.path.exists(str(filename)):
+        cell.__file__ = os.path.abspath(str(filename))  # type: ignore
+    return cell
 
 
 def get_default_settings_dict(


### PR DESCRIPTION
Sometimes its useful to know the source of a yaml-defined cell.

## Summary by Sourcery

New Features:
- Store the absolute path of the YAML source file as a `__file__` attribute on the generated cell.