### PR TITLE
Correct doc example in 11_best_practices.ipynb

### DIFF
--- a/notebooks/11_best_practices.ipynb
+++ b/notebooks/11_best_practices.ipynb
@@ -84,7 +84,7 @@
     "@gf.cell\n",
     "def my_pcell(length=10):\n",
     "    c = gf.Component()\n",
-    "    ref = c1.add_ref(gf.components.straight(length=length))\n",
+    "    ref = c.add_ref(gf.components.straight(length=length))\n",
     "    c.add_ports(ref.ports)\n",
     "    return c\n",
     "\n",


### PR DESCRIPTION
A typo was present in 11_best_practices.ipynb.

Change c1 to c in the function my_pcell

## Summary by Sourcery

Documentation:
- Correct the `my_pcell` function example in `11_best_practices.ipynb` to use the correct variable name.