### PR TITLE
fix grating_coupler_tree

### DIFF
--- a/gdsfactory/components/grating_couplers/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_tree.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import ComponentSpec
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
 @gf.cell
@@ -13,6 +15,8 @@ def grating_coupler_tree(
     with_loopback: bool = False,
     bend: ComponentSpec = "bend_euler",
     fanout_length: float = 0.0,
+    cross_section: CrossSectionSpec = "strip",
+    **kwargs: Any,
 ) -> Component:
     """Array of straights connected with grating couplers.
 
@@ -25,6 +29,8 @@ def grating_coupler_tree(
         with_loopback: adds loopback.
         bend: bend spec.
         fanout_length: in um.
+        cross_section: cross_section function.
+        kwargs: additional arguments.
     """
     c = gf.c.straight_array(
         n=n,
@@ -37,6 +43,8 @@ def grating_coupler_tree(
         grating_coupler=grating_coupler,
         fanout_length=fanout_length,
         bend=bend,
+        cross_section=cross_section,
+        **kwargs,
     )
 
 

--- a/test-data-regression/test_netlists_grating_coupler_tree_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_tree_.yml
@@ -591,7 +591,7 @@ instances:
       length: 10
       n: 4
       spacing: 4
-name: grating_coupler_tree_N4_86453336
+name: grating_coupler_tree_N4_ba9ff4d7
 nets:
 - p1: bend_euler_RNone_A90_P0_d7c3a5a9_195500_m5500,o1
   p2: straight_L64_N2_CSstrip_WNone_195500_m5500,o1

--- a/test-data-regression/test_settings_grating_coupler_tree_.yml
+++ b/test-data-regression/test_settings_grating_coupler_tree_.yml
@@ -1,7 +1,8 @@
 info: {}
-name: grating_coupler_tree_N4_86453336
+name: grating_coupler_tree_N4_ba9ff4d7
 settings:
   bend: bend_euler
+  cross_section: strip
   fanout_length: 0
   grating_coupler: grating_coupler_elliptical_te
   n: 4


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow customization of the waveguide cross-section in `grating_coupler_tree`.