### PR TITLE
expose sbend

### DIFF
--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -118,6 +118,7 @@ def coupler(
     dx: Delta = 10.0,
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
+    bend: ComponentSpec = "bend_s",
 ) -> Component:
     r"""Symmetric coupler.
 
@@ -128,6 +129,7 @@ def coupler(
         dx: length of bend in x direction in um.
         cross_section: spec (CrossSection, string or dict).
         allow_min_radius_violation: if True does not check for min bend radius.
+        bend: input and output sbend components.
 
     .. code::
 
@@ -144,7 +146,9 @@ def coupler(
                         coupler_straight  coupler_symmetric
     """
     c = Component()
-    sbend = coupler_symmetric(gap=gap, dy=dy, dx=dx, cross_section=cross_section)
+    sbend = coupler_symmetric(
+        gap=gap, dy=dy, dx=dx, cross_section=cross_section, bend=bend
+    )
 
     sr = c << sbend
     sl = c << sbend

--- a/test-data-regression/test_netlists_cavity_.yml
+++ b/test-data-regression/test_netlists_cavity_.yml
@@ -1,11 +1,12 @@
 instances:
-  coupler_G0p2_L0p1_D4_D1_250a8812_0_0:
+  coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0:
     component: coupler
     info:
       length: 10.19
       min_bend_radius: 11.744
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
@@ -35,12 +36,12 @@ instances:
       w2: 0.55
 name: cavity_Cdbr_Ccoupler_L0p1_G0p2
 nets:
-- p1: coupler_G0p2_L0p1_D4_D1_250a8812_0_0,o2
+- p1: coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0,o2
   p2: dbr_W0p45_W0p55_L0p159__efcfb70c_m10010_2350,o1
-- p1: coupler_G0p2_L0p1_D4_D1_250a8812_0_0,o3
+- p1: coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0,o3
   p2: dbr_W0p45_W0p55_L0p159__efcfb70c_10110_2350,o1
 placements:
-  coupler_G0p2_L0p1_D4_D1_250a8812_0_0:
+  coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -56,5 +57,5 @@ placements:
     x: -10.01
     y: 2.35
 ports:
-  o1: coupler_G0p2_L0p1_D4_D1_250a8812_0_0,o1
-  o2: coupler_G0p2_L0p1_D4_D1_250a8812_0_0,o4
+  o1: coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0,o1
+  o2: coupler_G0p2_L0p1_D4_D1_7603bdbf_0_0,o4

--- a/test-data-regression/test_netlists_coupler_.yml
+++ b/test-data-regression/test_netlists_coupler_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: coupler_G0p236_L20_D4_D_83b94450
+name: coupler_G0p236_L20_D4_D_b138340a
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_mzi_coupler_.yml
+++ b/test-data-regression/test_netlists_mzi_coupler_.yml
@@ -198,6 +198,7 @@ instances:
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
@@ -210,6 +211,7 @@ instances:
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4

--- a/test-data-regression/test_netlists_mzi_lattice_.yml
+++ b/test-data-regression/test_netlists_mzi_lattice_.yml
@@ -1,12 +1,12 @@
 instances:
-  mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0:
+  mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0:
     component: mzi
     info: {}
     settings:
       add_optical_ports_arms: false
       auto_rename_ports: true
       bend: bend_euler
-      combiner: coupler_G0p3_L20_D4_D10_c2ceaa55
+      combiner: coupler_G0p3_L20_D4_D10_55e1ee37
       cross_section: strip
       cross_section_x_bot: null
       cross_section_x_top: null
@@ -22,7 +22,7 @@ instances:
       port_e0_splitter: o4
       port_e1_combiner: o3
       port_e1_splitter: o3
-      splitter: coupler_G0p2_L10_D4_D10_369dc87b
+      splitter: coupler_G0p2_L10_D4_D10_5ac6992b
       straight: straight
       straight_x_bot: null
       straight_x_top: null
@@ -31,13 +31,13 @@ instances:
 name: mzi_lattice_CL10_20_CG0_bf9216d8
 nets: []
 placements:
-  mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0:
+  mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0,o1
-  o2: mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0,o2
-  o3: mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0,o3
-  o4: mzi_DL10_LY2_LXNone_Bbe_0085e214_0_0,o4
+  o1: mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0,o1
+  o2: mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0,o2
+  o3: mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0,o3
+  o4: mzi_DL10_LY2_LXNone_Bbe_5ea98e8e_0_0,o4

--- a/test-data-regression/test_netlists_mzit_.yml
+++ b/test-data-regression/test_netlists_mzit_.yml
@@ -95,25 +95,27 @@ instances:
       radius: null
       width: 0.55
       with_arc_floorplan: true
-  coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050:
+  coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050:
     component: coupler
     info:
       length: 10.03
       min_bend_radius: 28.187
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 2
       gap: 0.2
       length: 5
-  coupler_G0p3_L10_D2_D10_d71490ab_0_0:
+  coupler_G0p3_L10_D2_D10_cae1714f_0_0:
     component: coupler
     info:
       length: 10.026
       min_bend_radius: 30.486
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 2
@@ -331,13 +333,13 @@ nets:
   p2: straight_L4_N2_CSstrip_W0p55_38000_9400,o2
 - p1: bend_euler_RNone_A90_P0_903f8d22_38000_13400,o2
   p2: straight_L3_N2_CSstrip_W0p55_28000_23400,o1
-- p1: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o3
+- p1: coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050,o3
   p2: taper_L5_W0p45_W0p5_LNo_018a50c4_19000_23400,o2
-- p1: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o4
+- p1: coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050,o4
   p2: taper_L5_W0p55_W0p5_LNo_61376476_19000_21400,o2
-- p1: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o3
+- p1: coupler_G0p3_L10_D2_D10_cae1714f_0_0,o3
   p2: taper_L5_W0p5_W0p45_LNo_e894c800_20000_1400,o1
-- p1: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o4
+- p1: coupler_G0p3_L10_D2_D10_cae1714f_0_0,o4
   p2: taper_L5_W0p5_W0p55_LNo_4599d000_20000_m600,o1
 - p1: straight_L1_N2_CSstrip_W0p45_20000_23400,o1
   p2: taper_L5_W0p55_W0p45_LN_836f292d_25000_23400,o2
@@ -372,12 +374,12 @@ placements:
     rotation: 90
     x: 38
     y: 13.4
-  coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050:
+  coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050:
     mirror: false
     rotation: 0
     x: -1
     y: 22.05
-  coupler_G0p3_L10_D2_D10_d71490ab_0_0:
+  coupler_G0p3_L10_D2_D10_cae1714f_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -438,7 +440,7 @@ placements:
     x: 20
     y: -0.6
 ports:
-  o1: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o1
-  o2: coupler_G0p3_L10_D2_D10_d71490ab_0_0,o2
-  o3: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o1
-  o4: coupler_G0p2_L5_D2_D10__7f1a17d4_m1000_22050,o2
+  o1: coupler_G0p3_L10_D2_D10_cae1714f_0_0,o1
+  o2: coupler_G0p3_L10_D2_D10_cae1714f_0_0,o2
+  o3: coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050,o1
+  o4: coupler_G0p2_L5_D2_D10__8ec5ca3b_m1000_22050,o2

--- a/test-data-regression/test_netlists_ring_crow_couplers_.yml
+++ b/test-data-regression/test_netlists_ring_crow_couplers_.yml
@@ -125,49 +125,53 @@ instances:
       npoints: null
       radius: 10
       width: null
-  coupler_G0p236_L20_D4_D_83b94450_0_0:
+  coupler_G0p236_L20_D4_D_b138340a_0_0:
     component: coupler
     info:
       length: 10.186
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
       gap: 0.236
       length: 20
-  coupler_G0p236_L20_D4_D_83b94450_0_24000:
+  coupler_G0p236_L20_D4_D_b138340a_0_24000:
     component: coupler
     info:
       length: 10.186
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
       gap: 0.236
       length: 20
-  coupler_G0p236_L20_D4_D_83b94450_0_48000:
+  coupler_G0p236_L20_D4_D_b138340a_0_48000:
     component: coupler
     info:
       length: 10.186
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
       gap: 0.236
       length: 20
-  coupler_G0p236_L20_D4_D_83b94450_0_72000:
+  coupler_G0p236_L20_D4_D_b138340a_0_72000:
     component: coupler
     info:
       length: 10.186
       min_bend_radius: 11.857
     settings:
       allow_min_radius_violation: false
+      bend: bend_s
       cross_section: strip
       dx: 10
       dy: 4
@@ -304,38 +308,38 @@ nets:
 - p1: bot_left_bend_ring_0,o1
   p2: top_left_bend_ring_0,o2
 - p1: bot_left_bend_ring_0,o2
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_0,o2
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_0,o2
 - p1: bot_left_bend_ring_1,o1
   p2: top_left_bend_ring_1,o2
 - p1: bot_left_bend_ring_1,o2
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_24000,o2
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_24000,o2
 - p1: bot_left_bend_ring_2,o1
   p2: top_left_bend_ring_2,o2
 - p1: bot_left_bend_ring_2,o2
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_48000,o2
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_48000,o2
 - p1: bot_right_bend_ring_0,o1
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_0,o3
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_0,o3
 - p1: bot_right_bend_ring_0,o2
   p2: top_right_bend_ring_0,o1
 - p1: bot_right_bend_ring_1,o1
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_24000,o3
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_24000,o3
 - p1: bot_right_bend_ring_1,o2
   p2: top_right_bend_ring_1,o1
 - p1: bot_right_bend_ring_2,o1
-  p2: coupler_G0p236_L20_D4_D_83b94450_0_48000,o3
+  p2: coupler_G0p236_L20_D4_D_b138340a_0_48000,o3
 - p1: bot_right_bend_ring_2,o2
   p2: top_right_bend_ring_2,o1
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_24000,o1
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_24000,o1
   p2: top_left_bend_ring_0,o1
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_24000,o4
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_24000,o4
   p2: top_right_bend_ring_0,o2
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_48000,o1
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_48000,o1
   p2: top_left_bend_ring_1,o1
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_48000,o4
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_48000,o4
   p2: top_right_bend_ring_1,o2
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_72000,o1
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_72000,o1
   p2: top_left_bend_ring_2,o1
-- p1: coupler_G0p236_L20_D4_D_83b94450_0_72000,o4
+- p1: coupler_G0p236_L20_D4_D_b138340a_0_72000,o4
   p2: top_right_bend_ring_2,o2
 placements:
   bot_left_bend_ring_0:
@@ -368,22 +372,22 @@ placements:
     rotation: 0
     x: 30
     y: 50.368
-  coupler_G0p236_L20_D4_D_83b94450_0_0:
+  coupler_G0p236_L20_D4_D_b138340a_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  coupler_G0p236_L20_D4_D_83b94450_0_24000:
+  coupler_G0p236_L20_D4_D_b138340a_0_24000:
     mirror: false
     rotation: 0
     x: 0
     y: 24
-  coupler_G0p236_L20_D4_D_83b94450_0_48000:
+  coupler_G0p236_L20_D4_D_b138340a_0_48000:
     mirror: false
     rotation: 0
     x: 0
     y: 48
-  coupler_G0p236_L20_D4_D_83b94450_0_72000:
+  coupler_G0p236_L20_D4_D_b138340a_0_72000:
     mirror: false
     rotation: 0
     x: 0
@@ -419,7 +423,7 @@ placements:
     x: 40
     y: 60.368
 ports:
-  o1: coupler_G0p236_L20_D4_D_83b94450_0_0,o1
-  o2: coupler_G0p236_L20_D4_D_83b94450_0_0,o4
-  o3: coupler_G0p236_L20_D4_D_83b94450_0_72000,o2
-  o4: coupler_G0p236_L20_D4_D_83b94450_0_72000,o3
+  o1: coupler_G0p236_L20_D4_D_b138340a_0_0,o1
+  o2: coupler_G0p236_L20_D4_D_b138340a_0_0,o4
+  o3: coupler_G0p236_L20_D4_D_b138340a_0_72000,o2
+  o4: coupler_G0p236_L20_D4_D_b138340a_0_72000,o3

--- a/test-data-regression/test_settings_coupler_.yml
+++ b/test-data-regression/test_settings_coupler_.yml
@@ -1,9 +1,10 @@
 info:
   length: 10.186
   min_bend_radius: 11.857
-name: coupler_G0p236_L20_D4_D_83b94450
+name: coupler_G0p236_L20_D4_D_b138340a
 settings:
   allow_min_radius_violation: false
+  bend: bend_s
   cross_section: strip
   dx: 10
   dy: 4


### PR DESCRIPTION
## Summary by Sourcery

Expose the "bend" setting in the coupler to allow using Sbend couplers.

New Features:
- Allow using Sbend couplers by exposing the "bend" setting in the coupler.

Tests:
- Update test netlists to use the new "bend" setting.