### PR TITLE
swap_inheritance_order

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -492,7 +492,7 @@ def add_instance_label(
         layer = (1, 0)
     instance_name = (
         instance_name
-        or f"{reference.parent.name},{int(reference.dx)},{int(reference.dy)}"
+        or f"{reference.cell.name},{int(reference.dx)},{int(reference.dy)}"
     )
 
     layer = layer or CONF.layer_label

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -14,7 +14,14 @@ import numpy as np
 import numpy.typing as npt
 import yaml
 from kfactory import Instance, kdb
-from kfactory.kcell import PROPID, BaseKCell, cell, save_layout_options
+from kfactory.kcell import (
+    PROPID,
+    BaseKCell,
+    KCLayout,
+    VInstance,
+    cell,
+    save_layout_options,
+)
 from pydantic import Field
 from trimesh.scene.scene import Scene
 from typing_extensions import Self
@@ -1327,7 +1334,7 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
     def __init__(
         self,
         name: str | None = None,
-        kcl: kf.KCLayout | None = None,
+        kcl: KCLayout | None = None,
         kdb_cell: kdb.Cell | None = None,
         ports: kf.Ports | None = None,
     ) -> None:
@@ -1408,13 +1415,13 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):  # type: ignore
         if self.name is not None:
             c.name = self.name
 
-        kf.VInstance(self).insert_into_flat(c, levels=0)
+        VInstance(self).insert_into_flat(c, levels=0)
         c.plot(**kwargs)
 
     def __init__(
         self,
         name: str | None = None,
-        kcl: kf.KCLayout | None = None,
+        kcl: KCLayout | None = None,
         info: dict[str, int | float | str] | None = None,
     ) -> None:
         """Initializes a ComponentAllAngle."""

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1401,7 +1401,7 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
         return self
 
 
-class ComponentAllAngle(kf.VKCell, ComponentBase):  # type: ignore
+class ComponentAllAngle(ComponentBase, kf.VKCell):  # type: ignore
     def plot(self, **kwargs: Any) -> None:  # type: ignore
         """Plots the Component using klayout."""
         c = Component()

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1418,7 +1418,7 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):  # type: ignore
         info: dict[str, int | float | str] | None = None,
     ) -> None:
         """Initializes a ComponentAllAngle."""
-        super().__init__(name=name, kcl=kcl, info=info)
+        kf.VKCell.__init__(self, name=name, kcl=kcl, info=info)
 
     def dup(self) -> ComponentAllAngle:
         """Copy the full cell."""

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -13,7 +13,7 @@ def test_route_single_sbend() -> None:
     mmi2.movey(5)
 
     gf.routing.route_single_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])
-    assert len(c.references) == 3
+    assert len(c.insts) == 3
 
 
 def test_route_single_sbend_non_orthogonal() -> None:


### PR DESCRIPTION
make sure ComponentBase overloads take precedence

## Summary by Sourcery

Enhancements:
- Prioritize ComponentBase inheritance over kf.VKCell for ComponentAllAngle.