### PR TITLE
Fix wrong Component.copy

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -300,6 +300,12 @@ class ComponentReference(kf.Instance):
 
 
 class ComponentReferences(kf.kcell.Instances):
+    def __init__(self, insts: list[kf.Instance] | None = None) -> None:
+        """Initialize the ComponentReferences."""
+        super().__init__()
+        if insts:
+            self._insts = insts
+
     def __getitem__(self, key: str | int) -> ComponentReference:
         """Retrieve instance by index or by name."""
         if isinstance(key, int):
@@ -930,7 +936,7 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
     ) -> None:
         """Initializes a Component."""
         kf.KCell.__init__(self, name=name, kcl=kcl, kdb_cell=kdb_cell, ports=ports)
-        self.insts = ComponentReferences()
+        self.insts = ComponentReferences(list(self.insts))
 
     def __lshift__(self, component: kf.KCell) -> ComponentReference:
         """Creates a ComponentReference to a Component."""

--- a/test-data-regression/test_netlists_text_rectangular_multi_layer_.yml
+++ b/test-data-regression/test_netlists_text_rectangular_multi_layer_.yml
@@ -1,5 +1,77 @@
-instances: {}
+instances:
+  text_rectangular_Tabcd__1d0edb8e_0_0:
+    component: text_rectangular
+    info: {}
+    settings:
+      font: rectangular_font
+      justify: left
+      layer: M2
+      layers: null
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+  text_rectangular_Tabcd__37f0fce6_0_0:
+    component: text_rectangular
+    info: {}
+    settings:
+      font: rectangular_font
+      justify: left
+      layer: MTOP
+      layers: null
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+  text_rectangular_Tabcd__63bc9b1f_0_0:
+    component: text_rectangular
+    info: {}
+    settings:
+      font: rectangular_font
+      justify: left
+      layer: M1
+      layers: null
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
+  text_rectangular_Tabcd__bf562ff8_0_0:
+    component: text_rectangular
+    info: {}
+    settings:
+      font: rectangular_font
+      justify: left
+      layer: WG
+      layers: null
+      position:
+      - 0
+      - 0
+      size: 10
+      text: abcd
 name: text_rectangular_multi__068a5741
 nets: []
-placements: {}
+placements:
+  text_rectangular_Tabcd__1d0edb8e_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+  text_rectangular_Tabcd__37f0fce6_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+  text_rectangular_Tabcd__63bc9b1f_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
+  text_rectangular_Tabcd__bf562ff8_0_0:
+    mirror: false
+    rotation: 0
+    x: 0
+    y: 0
 ports: {}

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -7,10 +7,15 @@ from gdsfactory.generic_tech import LAYER
 
 
 def test_component_copy() -> None:
-    c1 = gf.components.straight(length=10)
-    c2 = c1.dup()
-    assert c1.settings.length == 10
+    c1 = gf.components.mzi(delta_length=10)
+    c2 = c1.copy()
+    assert c1.settings.delta_length == 10
     assert c1.info == c2.info
+
+    assert len(c1.ports) == len(c2.ports)
+    assert len(list(c1.insts)) == len(list(c2.insts)), (
+        f"{len(list(c1.insts))} != {len(list(c2.insts))}"
+    )
 
 
 def test_extract() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Fix Component.copy to copy instances and ports.

Bug Fixes:
- Fixed a bug where `Component.copy` did not copy instances and ports.

Tests:
- Added tests to verify that `Component.copy` copies instances and ports.