### PR TITLE
Update taper_cross_section.py

### DIFF
--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -46,6 +46,7 @@ def taper_cross_section(
         cross_section1=x1,
         cross_section2=x2,
         width_type="linear" if linear else width_type,  # type: ignore
+        offset_type="linear" if linear else width_type,  # type: ignore
     )
     taper_path = gf.path.straight(length=length, npoints=npoints)
 


### PR DESCRIPTION
Ensured the 'linear' (or more generally 'width_type') arg is applied to all sections from the cross_sections and not only to the main one.

Motivated by the fact that the following code: 

![ah](https://github.com/user-attachments/assets/9c82bd36-5903-4a93-91e6-b27c63d1f61e)

(where the two cross_sections have several sections) would produce: 

![bh](https://github.com/user-attachments/assets/bb740e59-393e-4053-8815-4120d067cca2)

instead of the expected: 

![dh](https://github.com/user-attachments/assets/ad296a21-6e0f-4242-9845-76023e00b8c7)

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where the `width_type` argument was only being applied to the main section of the cross-sections, and not to all of them.