### PR TITLE
Underscore intermediate functions

### DIFF
--- a/gdsfactory/components/pcms/cutback_2x2.py
+++ b/gdsfactory/components/pcms/cutback_2x2.py
@@ -6,7 +6,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
 @gf.cell
-def bendu_double(
+def _bendu_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
     bend180: ComponentSpec = "bend_circular180",
@@ -46,7 +46,7 @@ def bendu_double(
 
 
 @gf.cell
-def straight_double(
+def _straight_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
     port1: str = "o1",
@@ -122,7 +122,7 @@ def cutback_2x2(
     """
     component = gf.get_component(component)
 
-    bendu = bendu_double(
+    bendu = _bendu_double(
         component=component,
         cross_section=cross_section,
         bend180=bend180,
@@ -130,7 +130,7 @@ def cutback_2x2(
         port2=port2,
     )
 
-    straight_component = straight_double(
+    straight_component = _straight_double(
         component=component,
         cross_section=cross_section,
         straight_length=straight_length,

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -24,7 +24,7 @@ cross_section_pn = partial(
     layer_metal="M1",
     width_metal=0.5,
 )
-heater_vias = partial(
+_heater_vias = partial(
     via_stack,
     size=(0.5, 0.5),
     layers=("M1", "M2", "M3"),
@@ -55,7 +55,7 @@ def ring_double_pn(
     doped_heater_layer: LayerSpec = "NPP",
     doped_heater_width: float = 0.5,
     doped_heater_waveguide_offset: float = 2.175,
-    heater_vias: ComponentSpec = heater_vias,
+    heater_vias: ComponentSpec = _heater_vias,
     with_drop: bool = True,
     **kwargs: Any,
 ) -> gf.Component:
@@ -213,7 +213,7 @@ def ring_single_pn(
     doped_heater_layer: LayerSpec = "NPP",
     doped_heater_width: float = 0.5,
     doped_heater_waveguide_offset: float = 1.175,
-    heater_vias: ComponentSpec = heater_vias,
+    heater_vias: ComponentSpec = _heater_vias,
     pn_vias: ComponentSpec = "via_stack_slab_m3",
     pn_vias_width: float = 3,
 ) -> gf.Component:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Make `bendu_double`, `straight_double`, and `heater_vias` private functions by prefixing them with an underscore.