### PR TITLE
remove default 1,0 boolean layer

### DIFF
--- a/gdsfactory/boolean.py
+++ b/gdsfactory/boolean.py
@@ -14,9 +14,9 @@ def boolean(
     A: ComponentOrReference,
     B: ComponentOrReference,
     operation: str,
+    layer: LayerSpec,
     layer1: LayerSpec | None = None,
     layer2: LayerSpec | None = None,
-    layer: LayerSpec = (1, 0),
 ) -> Component:
     """Performs boolean operations between 2 Component or Instance objects.
 
@@ -31,9 +31,9 @@ def boolean(
         A: Component(/Reference) or list of Component(/References).
         B: Component(/Reference) or list of Component(/References).
         operation: {'not', 'and', 'or', 'xor', '-', '&', '|', '^'}.
+        layer: Specific layer to put polygon geometry on.
         layer1: Specific layer to get polygons.
         layer2: Specific layer to get polygons.
-        layer: Specific layer to put polygon geometry on.
 
     Returns: Component with polygon(s) of the boolean operations between
       the 2 input Components performed.

--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -160,10 +160,10 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
         c2.add_polygon(np.array(p), layer=(1, 0))
     if orientation == 0:
         # TrueType specification, fill the clockwise contour
-        component = boolean(c1, c2, operation="not")
+        component = boolean(c1, c2, operation="not", layer=(1, 0))
     else:
         # PostScript specification, fill the counterclockwise contour
-        component = boolean(c2, c1, operation="not")
+        component = boolean(c2, c1, operation="not", layer=(1, 0))
 
     component.name = block_name
 

--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -65,8 +65,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import gdsfactory as gf\n",
-    "\n",
     "operation = \"not\"\n",
     "operation = \"and\"\n",
     "operation = \"or\"\n",
@@ -90,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c4 = gf.boolean(c1, c2, operation=operation)\n",
+    "c4 = gf.boolean(c1, c2, operation=operation, layer=(1, 0))\n",
     "c4.plot()"
    ]
   },

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -56,6 +56,6 @@ def test_boolean_array(c1: gf.Component, c2: gf.Component) -> None:
     ref_a = c << a
     ref_b = c.add_ref(b, columns=3, rows=3, spacing=(200, 200))
 
-    d = gf.boolean(ref_a, ref_b, "not", layer1=(1, 0), layer2=(2, 0))
+    d = gf.boolean(ref_a, ref_b, "not", layer1=(1, 0), layer2=(2, 0), layer=(1, 0))
 
     assert d.area((1, 0)) == 500 * 500 - 90_000


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- The `layer` parameter in the `boolean` function is now required.