### PR TITLE
add remove_old_layer_flag to over_under

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1356,7 +1356,9 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
             exclude_layers=exclude_layers,
         )
 
-    def over_under(self, layer: "LayerSpec", distance: float = 0.001) -> None:
+    def over_under(
+        self, layer: "LayerSpec", distance: float = 0.001, remove_old_layer: bool = True
+    ) -> None:
         """Returns a Component over-under on a layer in the Component.
 
         For big components use tiled version.
@@ -1364,6 +1366,7 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
         Args:
             layer: layer to perform over-under on.
             distance: distance to perform over-under in um.
+            remove_old_layer: if True, removes the old layer.
         """
         from gdsfactory import get_layer
 
@@ -1375,7 +1378,8 @@ class Component(ComponentBase, kf.KCell):  # type: ignore
         layer_index = get_layer(layer)
         region = kdb.Region(self._kdb_cell.begin_shapes_rec(layer_index))
         region.size(+distance_dbu).size(-distance_dbu)
-        self.remove_layers([layer])
+        if remove_old_layer:
+            self.remove_layers([layer])
         self._kdb_cell.shapes(layer_index).insert(region)
 
         self.kcl.layout.end_changes()

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -54,7 +54,7 @@ def test_boolean_array(c1: gf.Component, c2: gf.Component) -> None:
 
     c = gf.Component()
     ref_a = c << a
-    ref_b = c.add_ref(b, columns=3, rows=3, spacing=(200, 200))
+    ref_b = c.add_ref(b, columns=3, rows=3, column_pitch=200, row_pitch=200)
 
     d = gf.boolean(ref_a, ref_b, "not", layer1=(1, 0), layer2=(2, 0), layer=(1, 0))
 


### PR DESCRIPTION
Marc found some strange case where the remove_layer part was making the layout layer disappear when running the cell multiple times

this PR adds a flag to make the remove_old_layer optional