### PR TITLE
Unclamp trimesh dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "mapbox_earcut",
   "networkx",
   "scikit-image",
-  "trimesh>=4.4.1,<4.6",
+  "trimesh>=4.4.1",
   "ipykernel",
   "attrs",
   "graphviz",

--- a/uv.lock
+++ b/uv.lock
@@ -1196,7 +1196,7 @@ requires-dist = [
     { name = "tbump", marker = "extra == 'maintainer'" },
     { name = "toolz", specifier = "<2" },
     { name = "towncrier", marker = "extra == 'maintainer'" },
-    { name = "trimesh", specifier = ">=4.4.1,<4.6" },
+    { name = "trimesh", specifier = ">=4.4.1" },
     { name = "typer", specifier = "<1" },
     { name = "types-cachetools", marker = "extra == 'dev'" },
     { name = "types-pyyaml" },
@@ -1643,7 +1643,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.31.1"
+version = "8.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1658,9 +1658,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/35/6f90fdddff7a08b7b715fccbd2427b5212c9525cd043d26fdc45bee0708d/ipython-8.31.1.tar.gz", hash = "sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b", size = 5501011 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/35/6f90fdddff7a08b7b715fccbd2427b5212c9525cd043d26fdc45bee0708d/ipython-8.31.0.tar.gz", hash = "sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b", size = 5501011 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/60/d0feb6b6d9fe4ab89fe8fe5b47cbf6cd936bfd9f1e7ffa9d0015425aeed6/ipython-8.31.1-py3-none-any.whl", hash = "sha256:46ec58f8d3d076a61d128fe517a51eb730e3aaf0c184ea8c17d16e366660c6a6", size = 821583 },
+    { url = "https://files.pythonhosted.org/packages/04/60/d0feb6b6d9fe4ab89fe8fe5b47cbf6cd936bfd9f1e7ffa9d0015425aeed6/ipython-8.31.0-py3-none-any.whl", hash = "sha256:46ec58f8d3d076a61d128fe517a51eb730e3aaf0c184ea8c17d16e366660c6a6", size = 821583 },
 ]
 
 [[package]]


### PR DESCRIPTION
Tests seem to work fine with the latest version.

## Summary by Sourcery

Enhancements:
- Allow newer versions of trimesh to be installed.