### PR TITLE
flatten_nitride_transition

### DIFF
--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -303,6 +303,7 @@ def taper_nc_sc(
     ref.mirror_x()
     c.add_ports(ref.ports)
     c.auto_rename_ports()
+    c.flatten()
     return c
 
 

--- a/test-data-regression/test_netlists_taper_nc_sc_.yml
+++ b/test-data-regression/test_netlists_taper_nc_sc_.yml
@@ -1,25 +1,5 @@
-instances:
-  taper_sc_nc_W0p5_W1_L20_c1d76730_0_0:
-    component: taper_sc_nc
-    info:
-      length: 20
-    settings:
-      cross_section: strip
-      layer_nitride: WGN
-      layer_wg: WG
-      length: 20
-      width1: 0.5
-      width2: 1
-      width_tip_nitride: 0.15
-      width_tip_silicon: 0.15
+instances: {}
 name: taper_nc_sc_W1_W0p5_L20_9adc884b
 nets: []
-placements:
-  taper_sc_nc_W0p5_W1_L20_c1d76730_0_0:
-    mirror: true
-    rotation: 180
-    x: 0
-    y: 0
-ports:
-  o1: taper_sc_nc_W0p5_W1_L20_c1d76730_0_0,o2
-  o2: taper_sc_nc_W0p5_W1_L20_c1d76730_0_0,o1
+placements: {}
+ports: {}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Flatten the nitride-cladded silicon taper to simplify its representation in GDSII.