### PR TITLE
making auto tapering reflexive

### DIFF
--- a/tests/routing/test_auto_taper.py
+++ b/tests/routing/test_auto_taper.py
@@ -1,0 +1,28 @@
+from gdsfactory.component import Component
+from gdsfactory.components import straight, taper_sc_nc
+from gdsfactory.generic_tech.layer_map import LAYER
+from gdsfactory.routing.auto_taper import auto_taper_to_cross_section
+
+LAYER_TRANSITIONS = {(LAYER.WG, LAYER.WGN): taper_sc_nc}
+
+
+def test_auto_taper() -> None:
+    c = Component()
+    ref = c << straight(cross_section="strip")
+    auto_taper_to_cross_section(
+        c,
+        port=ref.ports["o2"],
+        cross_section="nitride",
+        layer_transitions=LAYER_TRANSITIONS,
+    )
+
+
+def test_auto_taper_reversed() -> None:
+    c = Component()
+    ref = c << straight(cross_section="nitride")
+    auto_taper_to_cross_section(
+        c,
+        port=ref.ports["o2"],
+        cross_section="strip",
+        layer_transitions=LAYER_TRANSITIONS,
+    )


### PR DESCRIPTION
until now, in the pdk's `layer_transitions` dictionary, we had to register a taper component in each direction between two layers. now, we can register just one, and the opposite direction will be handled correctly, automatically. this reduces redundant code in our PDKs

## Summary by Sourcery

Add reflexive auto-tapers.

New Features:
- Auto-tapers are now reflexive, meaning only one direction needs to be specified between two layers.

Tests:
- Added tests for reflexive auto-tapers.