### PR TITLE
Small improvements

### DIFF
--- a/gdsfactory/routing/route_single_sbend.py
+++ b/gdsfactory/routing/route_single_sbend.py
@@ -60,6 +60,7 @@ def route_single_sbend(
             f"Ports need to have orthogonal orientation {orthogonality_error}\n"
             f"port1 = {port1.orientation} deg and port2 = {port2.orientation}"
         )
+    return bend_ref
 
 
 if __name__ == "__main__":

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -316,6 +316,7 @@ class LayerLevel(BaseModel):
         derived_layer: if the layer is derived, LogicalLayer to assign to the derived layer.
         thickness: layer thickness in um.
         thickness_tolerance: layer thickness tolerance in um.
+        width_tolerance: layer width tolerance in um.
         zmin: height position where material starts in um.
         zmin_tolerance: layer height tolerance in um.
         sidewall_angle: in degrees with respect to normal.
@@ -340,6 +341,7 @@ class LayerLevel(BaseModel):
     # Extrusion rules
     thickness: float
     thickness_tolerance: float | None = None
+    width_tolerance: float | None = None
     zmin: float
     zmin_tolerance: float | None = None
     sidewall_angle: float = 0.0


### PR DESCRIPTION
- Adds `width tolerance` to layer properties
- Returns the sbend reference when using `route_single_sbend` as indicated in the docstring.

## Summary by Sourcery

Introduce width tolerance to layer properties and enhance the route_single_sbend function to return the sbend reference.

New Features:
- Add width tolerance to layer properties in the LayerLevel class.

Enhancements:
- Return the sbend reference in the route_single_sbend function.