### PR TITLE
improve migration guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 [![codecov](https://img.shields.io/codecov/c/github/gdsfactory/gdsfactory)](https://codecov.io/gh/gdsfactory/gdsfactory/tree/main/gdsfactory)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/binder-sandbox/HEAD)
 
-> 🚀 **Notice: Major Release**
->
-> We are excited to announce that GDSFactory has upgraded its backend from gdstk to KLayout. This change brings enhanced routing functions and additional features from KLayout, including DRC, dummy fill, and connectivity checks.
->
-> Notice that the routing and some advanced functions have changed. For a complete list of changes, please refer to our [migration guide](https://gdsfactory.github.io/gdsfactory/notebooks/21_migration_guide_7_8.html) or review the updated layout tutorial.
-
-GDSFactory is a powerful Python library for designing a wide range of complex systems, including photonic circuits, analog devices, quantum components, MEMs, 3D printed objects, and PCBs. With GDSFactory, you can create and refine your designs using Python or YAML, perform rigorous verification through Design Rule Checking (DRC), Layout Versus Schematic (LVS) checks, and simulations. Additionally, it facilitates automated lab testing to ensure that your fabricated devices meet precise specifications, streamlining the entire design-to-fabrication workflow.
-
 
 As input you write python code, as an output GDSFactory creates CAD files (GDS, OASIS, STL, GERBER).
 

--- a/notebooks/21_migration_guide_7_8.ipynb
+++ b/notebooks/21_migration_guide_7_8.ipynb
@@ -5,7 +5,8 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "## Gdsfactory v8 Upgrade\n",
+    "## 7 to 8\n",
+    "\n",
     "\n",
     "Gdsfactory v8, based on KFactory, offers enhanced routing functions and additional features from KLayout, including DRC, dummy fill, and connectivity checks.\n",
     "\n",

--- a/notebooks/22_migration_8.ipynb
+++ b/notebooks/22_migration_8.ipynb
@@ -4,14 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Gdsfactory v8 small migration guide"
+    "## 8 to 9"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Migration to v8.33\n",
     "\n",
     "Due to the recent release of KFactory v1.0.0, we have had to make some small changes to the API of the following classes:\n",
     "- Component\n",
@@ -19,7 +18,7 @@
     "- ComponentReference\n",
     "- ComponentReferences\n",
     "\n",
-    "v8.33 is not a major migration, but it is a good idea to make sure your code is compatible with the new API."
+    "GDSFactory v9 is not a big change but it makes ports and instance units consistent with each other."
    ]
   },
   {
@@ -72,11 +71,95 @@
     "- `NameToFunctionDict`\n",
     "- `ComponentBaseFactory`"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "c = gf.components.straight(length=10)\n",
+    "c.pprint_ports()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('port orientation in degrees', c.ports['o2'].orientation)\n",
+    "print('port x in um', c.ports['o2'].x)\n",
+    "print('port dx in um (decimal)', c.ports['o2'].dx)\n",
+    "print('port ix in integer (database units)', c.ports['o2'].ix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "ref = c << gf.c.straight()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref.xmin = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('reference x in um', ref.x)\n",
+    "print('reference dx in um (decimal)', ref.dx)\n",
+    "print('reference ix in integer (database units)', ref.ix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Updated migration guides for versions 7 to 8 and 8 to 9, including details about API changes and examples of how to use the new API. Also removed outdated migration information from the README