### PR TITLE
Add more tests and change inheritance of Path

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -29,27 +29,19 @@ jobs:
       max-parallel: 12
       matrix:
         python-version: ["3.11", "3.13"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/pip
-          key: ${{ hashFiles('pyproject.toml') }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          make install
-          make test-data
+          make install test-data
       - name: Test with pytest
         run: |
           make uv-test
+
   test_code_coverage:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-force:
 	uv run pytest -n logical --force-regen -s
 
 uv-test: test-data-gds
-	uv run pytest -s -v -n logical
+	uv run pytest -s -n logical
 
 cov:
 	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered

--- a/Makefile
+++ b/Makefile
@@ -89,4 +89,20 @@ git-rm-merged:
 notebooks:
 	jupytext docs/notebooks/*.py --to ipynb
 
+clean:
+	rm -rf .venv
+	find src -name "*.c" | xargs rm -rf
+	find src -name "*.pyc" | xargs rm -rf
+	find src -name "*.so" | xargs rm -rf
+	find src -name "*.pyd" | xargs rm -rf
+	find . -name "*.egg_info" | xargs rm -rf
+	find . -name ".ipynb_checkpoints" | xargs rm -rf
+	find . -name ".mypy_cache" | xargs rm -rf
+	find . -name ".pytest_cache" | xargs rm -rf
+	find . -name ".ruff_cache" | xargs rm -rf
+	find . -name "__pycache__" | xargs rm -rf
+	find . -name "build" | xargs rm -rf
+	find . -name "builds" | xargs rm -rf
+	find . -name "dist" -not -path "*node_modules*" | xargs rm -rf
+
 .PHONY: gdsdiff build conda gdslib docs doc install

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-force:
 	uv run pytest -n logical --force-regen -s
 
 uv-test: test-data-gds
-	uv run pytest -s -n logical
+	uv run pytest -s -v -n logical
 
 cov:
 	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered

--- a/gdsfactory/component_layout.py
+++ b/gdsfactory/component_layout.py
@@ -5,14 +5,13 @@ Adapted from PHIDL https://github.com/amccaugh/phidl/ by Adam McCaughan
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from gdsfactory.port import to_dict
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from typing import Any
 
 
 import numpy as np
@@ -48,165 +47,6 @@ def pprint_ports(ports: Sequence[gf.Port]) -> None:
         table.add_row(*row)
 
     console.print(table)
-
-
-class GeometryHelper(ABC):
-    """Helper class for a class with functions move() and the property bbox.
-
-    It uses that function+property to enable you to do things like check what the
-    center of the bounding box is (self.center), and also to do things like move
-    the bounding box such that its maximum x value is 5.2 (self.xmax = 5.2).
-    """
-
-    @property
-    @abstractmethod
-    def bbox(self) -> npt.NDArray[np.floating[Any]]: ...
-
-    @abstractmethod
-    def move(
-        self,
-        origin: Coordinate,
-        destination: Coordinate | None = None,
-        axis: Axis | None = None,
-    ) -> Self: ...
-
-    @property
-    def center(self) -> Coordinate:
-        """Returns the center of the bounding box."""
-        return tuple(np.sum(self.bbox, 0) / 2)
-
-    @center.setter
-    def center(self, destination: Coordinate) -> None:
-        """Sets the center of the bounding box.
-
-        Args:
-            destination : array-like[2] Coordinates of the new bounding box center.
-        """
-        self.move(destination=destination, origin=self.center)
-
-    @property
-    def x(self) -> float:
-        """Returns the x-coordinate of the center of the bounding box."""
-        return float(np.sum(self.bbox, 0)[0] / 2)
-
-    @x.setter
-    def x(self, destination: float) -> None:
-        """Sets the x-coordinate of the center of the bounding box.
-
-        Args:
-            destination : int or float x-coordinate of the bbox center.
-        """
-        destination_t = (destination, self.center[1])
-        self.move(destination=destination_t, origin=self.center, axis="x")
-
-    @property
-    def y(self) -> float:
-        """Returns the y-coordinate of the center of the bounding box."""
-        return float(np.sum(self.bbox, 0)[1] / 2)
-
-    @y.setter
-    def y(self, destination: float) -> None:
-        """Sets the y-coordinate of the center of the bounding box.
-
-        Args:
-        destination : int or float
-            y-coordinate of the bbox center.
-        """
-        destination_t = (self.center[0], destination)
-        self.move(destination=destination_t, origin=self.center, axis="y")
-
-    @property
-    def xmax(self) -> float:
-        """Returns the maximum x-value of the bounding box."""
-        return float(self.bbox[1][0])
-
-    @xmax.setter
-    def xmax(self, destination: float) -> None:
-        """Sets the x-coordinate of the maximum edge of the bounding box.
-
-        Args:
-        destination : int or float
-            x-coordinate of the maximum edge of the bbox.
-        """
-        self.move(destination=(destination, 0), origin=self.bbox[1], axis="x")
-
-    @property
-    def ymax(self) -> float:
-        """Returns the maximum y-value of the bounding box."""
-        return float(self.bbox[1][1])
-
-    @ymax.setter
-    def ymax(self, destination: float) -> None:
-        """Sets the y-coordinate of the maximum edge of the bounding box.
-
-        Args:
-            destination : int or float y-coordinate of the maximum edge of the bbox.
-        """
-        self.move(destination=(0, destination), origin=self.bbox[1], axis="y")
-
-    @property
-    def xmin(self) -> float:
-        """Returns the minimum x-value of the bounding box."""
-        return float(self.bbox[0][0])
-
-    @xmin.setter
-    def xmin(self, destination: float) -> None:
-        """Sets the x-coordinate of the minimum edge of the bounding box.
-
-        Args:
-            destination : int or float x-coordinate of the minimum edge of the bbox.
-        """
-        self.move(destination=(destination, 0), origin=self.bbox[0], axis="x")
-
-    @property
-    def ymin(self) -> float:
-        """Returns the minimum y-value of the bounding box."""
-        return float(self.bbox[0][1])
-
-    @ymin.setter
-    def ymin(self, destination: float) -> None:
-        """Sets the y-coordinate of the minimum edge of the bounding box.
-
-        Args:
-            destination : int or float y-coordinate of the minimum edge of the bbox.
-        """
-        self.move(destination=(0, destination), origin=self.bbox[0], axis="y")
-
-    @property
-    def size(self) -> tuple[float, float]:
-        """Returns the (x, y) size of the bounding box."""
-        bbox = self.bbox
-        return tuple(bbox[1] - bbox[0])
-
-    @property
-    def xsize(self) -> float:
-        """Returns the horizontal size of the bounding box."""
-        bbox = self.bbox
-        return float(bbox[1][0] - bbox[0][0])
-
-    @property
-    def ysize(self) -> float:
-        """Returns the vertical size of the bounding box."""
-        bbox = self.bbox
-        return float(bbox[1][1] - bbox[0][1])
-
-    def movex(self, value: float) -> Self:
-        """Moves an object by a specified x-distance.
-
-        Args:
-            value: distance to move the object in the x-direction in um.
-        """
-        self.x += value
-        return self
-
-    def movey(self, value: float) -> Self:
-        """Moves an object by a specified y-distance.
-
-        Args:
-            value: distance to move the object in the y-direction in um.
-        """
-        self.y += value
-        return self
 
 
 def rotate_points(

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -128,18 +128,25 @@ class Path(UMGeometricObject):
             trans_ = kdb.DCplxTrans(trans.to_dtype(gf.kcl.dbu))
         else:
             trans_ = trans.to_itrans(gf.kcl.dbu)
-        angle_rad = np.radians(trans_.angle)
-        cos_angle = np.cos(angle_rad)
-        sin_angle = np.sin(angle_rad)
 
-        rotation_matrix = np.array([[cos_angle, sin_angle], [-sin_angle, cos_angle]])
+        new_points = self.points
 
-        self.points = np.dot(self.points, rotation_matrix) + np.array(
-            [trans_.disp.x, trans_.disp.y]
-        )
+        if trans_.angle != 0:
+            angle_rad = np.radians(trans_.angle)
+            cos_angle = np.cos(angle_rad)
+            sin_angle = np.sin(angle_rad)
+
+            rotation_matrix = np.array(
+                [[cos_angle, sin_angle], [-sin_angle, cos_angle]]
+            )
+            new_points = np.dot(self.points, rotation_matrix)
+
+        new_points = new_points + np.array([trans_.disp.x, trans_.disp.y])
 
         if trans_.mirror:
-            self.points[:, 1] = -self.points[:, 1]
+            new_points[:, 1] = -new_points[:, 1]
+
+        self.points = new_points
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
         return kdb.DBox(*self.bbox_np().flatten())

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -128,8 +128,8 @@ class Path(UMGeometricObject):
         else:
             trans_ = trans.to_itrans(gf.kcl.dbu)
 
-        for i, (x, y) in enumerate(self.points):
-            new_point = trans_ * kdb.DPoint(x, y)
+        for i, point in enumerate(self.points):
+            new_point = trans_ * kdb.DPoint(point[0], point[1])
             self.points[i] = (new_point.x, new_point.y)
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
@@ -1671,6 +1671,7 @@ def smooth(
     # Move arcs into position
     new_points: list[npt.NDArray[np.floating[Any]]] = []
     new_points.append(np.array([points[0, :]]))
+    print(len(dtheta))
     for n in range(len(dtheta)):
         p = paths[n]
         p.rotate(theta[n] - 0)

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -511,10 +511,6 @@ class Pdk(BaseModel):
         from gdsfactory.components import bbox_to_points
 
         exclude = exclude or []
-        for cell_name, cell in self.cells.items():
-            if cell_name not in exclude:
-                print(cell_name)
-                print(cell())
         _blocks = {
             cell_name: cell()
             for cell_name, cell in self.cells.items()

--- a/notebooks/03_Path_CrossSection.ipynb
+++ b/notebooks/03_Path_CrossSection.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p2 = P.copy().rotate()\n",
+    "p2 = P.copy().rotate(45)\n",
     "f = p2.plot()"
    ]
   },

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -373,11 +373,6 @@ def test_path_hash_geometry() -> None:
     )
 
 
-def test_path_plot() -> None:
-    path = Path([(0, 0), (1, 1), (2, 0)])
-    path.plot()
-
-
 def test_path_extrude_transition() -> None:
     path = Path([(0, 0), (1, 0), (1, 1)])
     transition = gf.path.transition(

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import klayout.db as kdb
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -11,7 +12,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.difftest import difftest
 from gdsfactory.generic_tech import LAYER
-from gdsfactory.path import Path
+from gdsfactory.path import Path, _parabolic_transition
 
 
 def test_path_zero_length() -> None:
@@ -155,13 +156,13 @@ def test_path_add() -> None:
 
 def test_init_with_no_path() -> None:
     path = Path()
-    assert np.array_equal(path.points, np.array([[0, 0]], dtype=np.float64))
+    assert np.array_equal(path.points, np.array([(0, 0)], dtype=np.float64))
     assert path.start_angle == 0
     assert path.end_angle == 0
 
 
 def test_init_with_array() -> None:
-    points = [[0, 0], [1, 1], [2, 0]]
+    points = [(0, 0), (1, 1), [2, 0]]
     path = Path(points)
     assert np.array_equal(path.points, np.array(points))
     assert path.start_angle == pytest.approx(45.0)
@@ -169,7 +170,7 @@ def test_init_with_array() -> None:
 
 
 def test_init_with_path() -> None:
-    original_path = Path([[0, 0], [1, 1], [2, 0]])
+    original_path = Path([(0, 0), (1, 1), [2, 0]])
     path = Path(original_path)
     assert np.array_equal(path.points, original_path.points)
     assert path.start_angle == original_path.start_angle
@@ -182,44 +183,44 @@ def test_invalid_path() -> None:
 
 
 def test_append_path() -> None:
-    path1 = Path([[0, 0], [1, 1]])
-    path2 = Path([[0, 0], [1, 1]])
+    path1 = Path([(0, 0), (1, 1)])
+    path2 = Path([(0, 0), (1, 1)])
     path1.append(path2)
-    expected_points = np.array([[0, 0], [1, 1], [2, 2]])
+    expected_points = np.array([(0, 0), (1, 1), (2, 2)])
     assert np.array_equal(path1.points, expected_points)
 
 
 def test_append_points() -> None:
-    path = Path([[0, 0], [1, 1]])
-    points = [[1, 1], [2, 2]]
+    path = Path([(0, 0), (1, 1)])
+    points = [(1, 1), (2, 2)]
     path.append(points)
-    expected_points = np.array([[0, 0], [1, 1], [2, 2]])
+    expected_points = np.array([(0, 0), (1, 1), (2, 2)])
     assert np.array_equal(path.points, expected_points)
 
 
 def test_length() -> None:
-    path = Path([[0, 0], [1, 1], [2, 0]])
+    path = Path([(0, 0), (1, 1), [2, 0]])
     assert path.length() == pytest.approx(2.8284, rel=1e-3)
 
 
 def test_dmove() -> None:
-    path = Path([[0, 0], [1, 1], [2, 0]])
+    path = Path([(0, 0), (1, 1), [2, 0]])
     path.move((0, 0), (1, 1))
-    expected_points = np.array([[1, 1], [2, 2], [3, 1]])
+    expected_points = np.array([(1, 1), (2, 2), [3, 1]])
     assert np.array_equal(path.points, expected_points)
 
 
 def test_drotate() -> None:
-    path = Path([[0, 0], [1, 1], [2, 0]])
+    path = Path([(0, 0), (1, 1), [2, 0]])
     path.rotate(90)
-    expected_points = np.array([[0, 0], [-1, 1], [0, 2]])
+    expected_points = np.array([(0, 0), [-1, 1], [0, 2]])
     np.testing.assert_allclose(path.points, expected_points, atol=1e-4)
 
 
 def test_dmirror() -> None:
-    path = Path([[0, 0], [1, 1], [2, 0]])
+    path = Path([(0, 0), (1, 1), [2, 0]])
     path.mirror((0, 0), (0, 1))
-    expected_points = np.array([[0, 0], [-1, 1], [-2, 0]])
+    expected_points = np.array([(0, 0), [-1, 1], [-2, 0]])
     np.testing.assert_allclose(path.points, expected_points, atol=1e-4)
 
 
@@ -240,5 +241,209 @@ def test_path_append_list() -> None:
     assert p.length() == 56.545, p.length()
 
 
+def test_path_init() -> None:
+    path_empty = Path()
+    assert np.array_equal(path_empty.points, np.array([(0, 0)]))
+
+    path_multiple = Path([(0, 0), (1, 1), (2, 2)])
+    expected_points = np.array([(0, 0), (1, 1), (2, 2)])
+    assert np.array_equal(path_multiple.points, expected_points)
+
+    with pytest.raises(ValueError):
+        Path([(0, 0), (1,)])
+
+    with pytest.raises(ValueError):
+        Path([(1,)])
+
+    path_from_path = Path(path_multiple)
+    assert np.array_equal(path_from_path.points, expected_points)
+
+
+def test_path_len() -> None:
+    path = Path([(0, 0), (1, 1), (2, 0)])
+    assert len(path) == 3
+
+    path = Path()
+    assert len(path) == 1
+
+
+def test_path_bbox_np() -> None:
+    path = Path([(0, 0), (1, 1), (2, 0)])
+    assert np.array_equal(path.bbox_np(), np.array([(0, 0), (2, 1)]))
+
+
+def test_path_offset() -> None:
+    path = Path([(i, 0) for i in range(10)])
+    path.offset(2)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(i, -2) for i in range(10)], dtype=np.float64)
+    )
+
+    path = Path([(i, 0) for i in range(10)])
+    path.offset(lambda t: t * 9)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(i, -i) for i in range(10)], dtype=np.float64)
+    )
+
+    path = Path([(i, 0) for i in range(10)])
+    path.offset(0)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(i, 0) for i in range(10)], dtype=np.float64)
+    )
+
+
+def test_rotate() -> None:
+    path = Path([(i, 0) for i in range(10)])
+    path.rotate(90)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(0, i) for i in range(10)], dtype=np.float64)
+    )
+
+    path = Path([(i, 0) for i in range(10)])
+    path.rotate(0)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(i, 0) for i in range(10)], dtype=np.float64)
+    )
+
+    path = Path([(i, 0) for i in range(10)])
+    path.rotate(45)
+    expected_points = np.array(
+        [
+            (
+                i * np.cos(np.radians(45)) - 0 * np.sin(np.radians(45)),
+                i * np.sin(np.radians(45)) + 0 * np.cos(np.radians(45)),
+            )
+            for i in range(10)
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_array_almost_equal(path.points, expected_points)
+
+
+def test_mirror() -> None:
+    path = Path([(i, 0) for i in range(10)])
+    path.mirror((0, 0), (0, 1))
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(-i, 0) for i in range(10)], dtype=np.float64)
+    )
+
+    path = Path([(i, 0) for i in range(10)])
+    path.mirror((0, 0), (1, 0))
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(i, 0) for i in range(10)], dtype=np.float64)
+    )
+
+
+def test_centerpoint_offset_curve() -> None:
+    path = Path([(0, 0), (1, 0), (2, 0)])
+    offset_distance = [0.5]
+    new_points = path.centerpoint_offset_curve(path.points, offset_distance)
+    expected_points = np.array(
+        [
+            (0, -0.5),
+            (1, -0.5),
+            (2, -0.5),
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_array_almost_equal(new_points, expected_points)
+
+    path = Path([(0, 0), (1, 0), (2, 0)])
+    offset_distance = np.array([0.5, 1, 0.5], dtype=np.float64)
+    new_points = path.centerpoint_offset_curve(path.points, offset_distance)
+    expected_points = np.array(
+        [
+            (0, -0.5),
+            (1, -1),
+            (2, -0.5),
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_array_almost_equal(new_points, expected_points)
+
+
+def test_path_hash() -> None:
+    assert hash(Path([(0, 0), (1, 1), (2, 0)])) == hash(Path([(0, 0), (1, 1), (2, 0)]))
+
+
+def test_path_hash_geometry() -> None:
+    assert (
+        Path([(0, 0), (1, 1), (2, 0)]).hash_geometry()
+        == Path([(0, 0), (1, 1), (2, 0)]).hash_geometry()
+    )
+
+
+def test_path_plot() -> None:
+    path = Path([(0, 0), (1, 1), (2, 0)])
+    path.plot()
+
+
+def test_path_extrude_transition() -> None:
+    path = Path([(0, 0), (1, 0), (1, 1)])
+    transition = gf.path.transition(
+        cross_section1=gf.cross_section.cross_section,
+        cross_section2=gf.cross_section.cross_section,
+    )
+    c = path.extrude_transition(transition)
+    assert c.bbox() == kdb.DBox(0, -0.25, 1.25, 1)
+
+
+def test_path_copy() -> None:
+    path = gf.path.euler()
+    path_copy = path.copy()
+    assert np.array_equal(path_copy.points, path.points)
+    assert path_copy.start_angle == path.start_angle
+    assert path_copy.end_angle == path.end_angle
+
+
+def test_parabolic_transition() -> None:
+    y1 = 1.0
+    y2 = 3.0
+    transition_func = _parabolic_transition(y1, y2)
+
+    t_scalar = 0.5
+    assert transition_func(t_scalar) == y1 + np.sqrt(t_scalar) * (y2 - y1)
+
+    t_array = np.array([0.0, 0.5, 1.0])
+    expected_array = y1 + np.sqrt(t_array) * (y2 - y1)
+    np.testing.assert_array_equal(transition_func(t_array), expected_array)
+
+
+def test_path_bbox() -> None:
+    path = Path([(0, 0), (1, 0), (1, 1)])
+    assert path.bbox() == kdb.DBox(0, 0, 1, 1)
+
+
+def test_path_transform_drans() -> None:
+    x = 1.111111111
+    path = Path([(0, 0), (x, 0), (x, x)])
+    trans = kdb.DTrans(x=1, y=1)
+    path.transform(trans)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(1, 1), (x + 1, 1), (x + 1, x + 1)])
+    )
+
+
+def test_path_transform_trans() -> None:
+    x = 1.111111111
+    path = Path([(0, 0), (x, 0), (x, x)])
+    trans = kdb.Trans(x=1000, y=1000)
+    path.transform(trans)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(1, 1), (x + 1, 1), (x + 1, x + 1)])
+    )
+
+
+def test_path_transform_icplx() -> None:
+    x = 1.111111111
+    path = Path([(0, 0), (x, 0), (x, x)])
+    trans = kdb.ICplxTrans(x=1000, y=1000)
+    path.transform(trans)
+    np.testing.assert_array_almost_equal(
+        path.points, np.array([(1, 1), (x + 1, 1), (x + 1, x + 1)])
+    )
+    assert gf.path.Path().kcl is gf.kcl
+
+
 if __name__ == "__main__":
-    test_path_append_list()
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
## Summary by Sourcery

Refactor `Path` object, add more tests, and add makefile `clean` target.

Build:
- Add `clean` target to Makefile to remove build artifacts and virtual environments

Tests:
- Add tests for `Path` initialization, length, bounding box, offsetting, rotation, mirroring, centerpoint offset curve, hashing, plotting, extrusion, copying, parabolic transitions, and transformations.

Chores:
- Change `Path` inheritance from `GeometryHelper` to `UMGeometricObject`