### PR TITLE
allow zero length coupling rings

### DIFF
--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -51,11 +51,11 @@ def ring_single(
                          │gap
                  o1──────▼─────────o2
     """
-    if length_y <= 0:
-        raise ValueError(f"length_y={length_y} must be > 0")
+    if length_y < 0:
+        raise ValueError(f"length_y={length_y} must be >= 0")
 
-    if length_x <= 0:
-        raise ValueError(f"length_x={length_x} must be > 0")
+    if length_x < 0:
+        raise ValueError(f"length_x={length_x} must be >= 0")
 
     c = gf.Component()
     cb = c << gf.get_component(
@@ -92,7 +92,7 @@ def ring_single(
 if __name__ == "__main__":
     # c = ring_single(layer=(2, 0), cross_section_factory=gf.cross_section.pin, width=1)
     # c = ring_single(width=2, gap=1, layer=(2, 0), radius=7, length_y=1)
-    c = ring_single(radius=5, gap=0.111, bend="bend_circular")
+    c = ring_single(radius=5, gap=0.111, bend="bend_circular", length_x=0, length_y=0)
     # print(c.ports)
 
     # c = gf.routing.add_fiber_array(ring_single)


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Allow `length_x` and `length_y` to be zero for `ring_single` component, enabling the creation of zero-length coupling rings