### PR TITLE
Add more tests

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -119,7 +119,6 @@ __all__ = (
     "c",
     "cell",
     "clear_cache",
-    "component_with_function",
     "components",
     "compose",
     "constant",

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -19,7 +19,7 @@ def add_ports_from_markers_square(
     component: Component,
     pin_layer: LayerSpec = "DEVREC",
     port_layer: LayerSpec | None = None,
-    orientation: AngleInDegrees | None = 90,
+    orientation: AngleInDegrees = 90,
     min_pin_area_um2: float = 0,
     max_pin_area_um2: float | None = 150 * 150,
     pin_extra_width: float = 0.0,
@@ -519,7 +519,7 @@ def add_ports_from_labels(
     get_name_from_label: bool = False,
     layer_label: LayerSpec | None = None,
     fail_on_duplicates: bool = False,
-    port_orientation: AngleInDegrees | None = None,
+    port_orientation: AngleInDegrees = 0,
     guess_port_orientation: bool = True,
     port_filter_prefix: str | None = None,
 ) -> Component:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -163,7 +163,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         port: ProtoPort[Any] | None = None,
         center: Position | kdb.DPoint | None = None,
         width: float | None = None,
-        orientation: AngleInDegrees | None = None,
+        orientation: AngleInDegrees = 0,
         layer: LayerSpec | None = None,
         port_type: str = "optical",
         keep_mirror: bool = False,
@@ -213,11 +213,9 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             xs = get_cross_section(cross_section)
             width = xs.width
 
-        if orientation is None:
-            orientation = 0
-
         if center is None:
             raise ValueError("Must specify center")
+
         elif isinstance(center, kdb.DPoint):
             layer = get_layer(layer)
             trans = kdb.DCplxTrans(1, orientation, False, center.to_v())

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -10,16 +10,16 @@ from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, overload
 
 import kfactory as kf
 import klayout.lay as lay
-import networkx as nx  # type: ignore[import-untyped]
+import networkx as nx
 import numpy as np
 import numpy.typing as npt
 import yaml
+from graphviz import Digraph
 from kfactory import (
     DInstance,
     DInstances,
     DPort,
     DPorts,
-    Instance,
     VInstance,
     cell,
     kdb,
@@ -214,7 +214,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             width = xs.width
 
         if orientation is None:
-            raise ValueError("Must specify orientation")
+            orientation = 0
 
         if center is None:
             raise ValueError("Must specify center")
@@ -337,6 +337,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         """
         if self.locked:
             raise LockedError(self)
+
         info = dict(component.info)
 
         for k, v in info.items():
@@ -404,22 +405,6 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         pprint_ports(ports)
 
-    def get_netlist(self, recursive: bool = False, **kwargs: Any) -> dict[str, Any]:
-        """Returns a place-aware netlist for circuit simulation.
-
-        It includes not only the connectivity information (nodes and connections) but also the specific placement coordinates for each component or cell in the layout.
-
-        Args:
-            recursive: if True, returns a recursive netlist.
-            kwargs: keyword arguments to get_netlist.
-        """
-        from gdsfactory.get_netlist import get_netlist, get_netlist_recursive
-
-        if recursive:
-            return get_netlist_recursive(self, **kwargs)  # type: ignore[arg-type]
-
-        return get_netlist(self, **kwargs)  # type: ignore[arg-type]
-
     def write_netlist(
         self, netlist: dict[str, Any], filepath: str | pathlib.Path | None = None
     ) -> str:
@@ -435,112 +420,6 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             filepath = pathlib.Path(filepath)
             filepath.write_text(yaml_string)
         return yaml_string
-
-    def plot_netlist(
-        self,
-        recursive: bool = False,
-        with_labels: bool = True,
-        font_weight: str = "normal",
-        **kwargs: Any,
-    ) -> nx.Graph:
-        """Plots a netlist graph with networkx.
-
-        Args:
-            recursive: if True, returns a recursive netlist.
-            with_labels: add label to each node.
-            font_weight: normal, bold.
-            kwargs: keyword arguments to get_netlist.
-
-        Keyword Args:
-            tolerance: tolerance in grid_factor to consider two ports connected.
-            exclude_port_types: optional list of port types to exclude from netlisting.
-            get_instance_name: function to get instance name.
-            allow_multiple: False to raise an error if more than two ports share the same connection. \
-                    if True, will return key: [value] pairs with [value] a list of all connected instances.
-        """
-        import matplotlib.pyplot as plt
-        import networkx as nx
-
-        from gdsfactory.get_netlist import nets_to_connections
-
-        plt.figure()
-        netlist = self.get_netlist(recursive=recursive, **kwargs)
-        G = nx.Graph()
-
-        if recursive:
-            pos: dict[str, tuple[float, float]] = {}
-            labels: dict[str, str] = {}
-            for net in netlist.values():
-                nets = net.get("nets", [])
-                connections = net.get("connections", {})
-                connections = nets_to_connections(nets, connections)
-                placements = net["placements"]
-                G.add_edges_from(
-                    [
-                        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                        for k, v in connections.items()
-                    ]
-                )
-                pos |= {k: (v["x"], v["y"]) for k, v in placements.items()}
-                labels |= {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
-
-        else:
-            nets = netlist.get("nets", [])
-            connections = netlist.get("connections", {})
-            connections = nets_to_connections(nets, connections)
-            placements = netlist["placements"]
-            G.add_edges_from(
-                [
-                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
-                    for k, v in connections.items()
-                ]
-            )
-            pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
-            labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
-
-        nx.draw(
-            G,
-            with_labels=with_labels,
-            font_weight=font_weight,
-            labels=labels,
-            pos=pos,
-        )
-        return G
-
-    def plot_netlist_graphviz(
-        self, recursive: bool = False, interactive: bool = False, splines: str = "ortho"
-    ) -> None:
-        """Plots a netlist graph with graphviz.
-
-        Args:
-            recursive: if True, returns a recursive netlist.
-            interactive: if True, opens the graph in a browser.
-            splines: ortho, spline, polyline, line, curved.
-        """
-        from gdsfactory.schematic import plot_graphviz
-
-        n = self.to_graphviz(
-            recursive=recursive,
-        )
-        plot_graphviz(n, splines=splines, interactive=interactive)
-
-    def to_graphviz(
-        self,
-        recursive: bool = False,
-    ) -> nx.DiGraph:
-        """Returns a netlist graph with graphviz.
-
-        Args:
-            recursive: if True, returns a recursive netlist.
-        """
-        from gdsfactory.schematic import to_graphviz
-
-        netlist = self.get_netlist(recursive=recursive)
-        return to_graphviz(
-            netlist["instances"],
-            placements=netlist["placements"],
-            nets=netlist["nets"],
-        )
 
     def to_dict(self, with_ports: bool = False) -> dict[str, Any]:
         """Returns a dictionary representation of the Component."""
@@ -590,7 +469,7 @@ class Component(ComponentBase, kf.DKCell):
             if not self.bbox(self.kcl.layout.layer(info)).empty()
         ]
 
-    def add(self, instances: list[Instance] | Instance) -> None:
+    def add(self, instances: Iterable[ComponentReference] | ComponentReference) -> None:
         if self.locked:
             raise LockedError(self)
 
@@ -1108,6 +987,125 @@ class Component(ComponentBase, kf.DKCell):
         )  # Remove any padding
         plt.tight_layout(pad=0)  # Ensure no space is wasted
         return fig if return_fig else None
+
+    def get_netlist(self, recursive: bool = False, **kwargs: Any) -> dict[str, Any]:
+        """Returns a place-aware netlist for circuit simulation.
+
+        It includes not only the connectivity information (nodes and connections) but also the specific placement coordinates for each component or cell in the layout.
+
+        Args:
+            recursive: if True, returns a recursive netlist.
+            kwargs: keyword arguments to get_netlist.
+        """
+        from gdsfactory.get_netlist import get_netlist, get_netlist_recursive
+
+        if recursive:
+            return get_netlist_recursive(self, **kwargs)
+
+        return get_netlist(self, **kwargs)
+
+    def plot_netlist(
+        self,
+        recursive: bool = False,
+        with_labels: bool = True,
+        font_weight: str = "normal",
+        **kwargs: Any,
+    ) -> nx.Graph:
+        """Plots a netlist graph with networkx.
+
+        Args:
+            recursive: if True, returns a recursive netlist.
+            with_labels: add label to each node.
+            font_weight: normal, bold.
+            kwargs: keyword arguments to get_netlist.
+
+        Keyword Args:
+            tolerance: tolerance in grid_factor to consider two ports connected.
+            exclude_port_types: optional list of port types to exclude from netlisting.
+            get_instance_name: function to get instance name.
+            allow_multiple: False to raise an error if more than two ports share the same connection. \
+                    if True, will return key: [value] pairs with [value] a list of all connected instances.
+        """
+        import matplotlib.pyplot as plt
+        import networkx as nx
+
+        from gdsfactory.get_netlist import nets_to_connections
+
+        plt.figure()
+        netlist = self.get_netlist(recursive=recursive, **kwargs)
+        G = nx.Graph()
+
+        if recursive:
+            pos: dict[str, tuple[float, float]] = {}
+            labels: dict[str, str] = {}
+            for net in netlist.values():
+                nets = net.get("nets", [])
+                connections = net.get("connections", {})
+                connections = nets_to_connections(nets, connections)
+                placements = net["placements"]
+                G.add_edges_from(
+                    [
+                        (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                        for k, v in connections.items()
+                    ]
+                )
+                pos |= {k: (v["x"], v["y"]) for k, v in placements.items()}
+                labels |= {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
+
+        else:
+            nets = netlist.get("nets", [])
+            connections = netlist.get("connections", {})
+            connections = nets_to_connections(nets, connections)
+            placements = netlist["placements"]
+            G.add_edges_from(
+                [
+                    (",".join(k.split(",")[:-1]), ",".join(v.split(",")[:-1]))
+                    for k, v in connections.items()
+                ]
+            )
+            pos = {k: (v["x"], v["y"]) for k, v in placements.items()}
+            labels = {k: ",".join(k.split(",")[:1]) for k in placements.keys()}
+
+        nx.draw(
+            G,
+            with_labels=with_labels,
+            font_weight=font_weight,
+            labels=labels,
+            pos=pos,
+        )
+        return G
+
+    def plot_netlist_graphviz(
+        self, recursive: bool = False, interactive: bool = False, splines: str = "ortho"
+    ) -> None:
+        """Plots a netlist graph with graphviz.
+
+        Args:
+            recursive: if True, returns a recursive netlist.
+            interactive: if True, opens the graph in a browser.
+            splines: ortho, spline, polyline, line, curved.
+        """
+        from gdsfactory.schematic import plot_graphviz
+
+        n = self.to_graphviz(
+            recursive=recursive,
+        )
+        plot_graphviz(n, splines=splines, interactive=interactive)
+
+    def to_graphviz(self, recursive: bool = False) -> Digraph:
+        """Returns a netlist graph with graphviz.
+
+        Args:
+            recursive: if True, returns a recursive netlist.
+        """
+        from gdsfactory.schematic import to_graphviz
+
+        netlist = self.get_netlist(recursive=recursive)
+        return to_graphviz(
+            netlist["instances"],
+            placements=netlist["placements"],
+            nets=netlist["nets"],
+        )
 
 
 class ComponentAllAngle(ComponentBase, kf.VKCell):  # type: ignore

--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -219,10 +218,8 @@ def get_min_sbend_size(
 
     # Guess sizes, iterate over them until we cannot achieve the min radius
     # the max size corresponds to an ellipsoid
-    max_size = 2.5 * np.sqrt(np.abs(min_radius * known_s))
-    sizes: Iterable[float] = np.linspace(max_size, 0.1 * max_size, num_points)  # type: ignore
-
-    assert isinstance(sizes, Iterable)
+    max_size = float(np.sqrt(np.abs(min_radius * known_s)) * 2.5)
+    sizes = np.linspace(max_size, 0.1 * max_size, num_points)
 
     for s in sizes:
         sz = size_list

--- a/gdsfactory/components/containers/pack_doe.py
+++ b/gdsfactory/components/containers/pack_doe.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools as it
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import gdsfactory as gf
@@ -13,7 +13,7 @@ from gdsfactory.typings import CellSpec, ComponentSpec
 
 def generate_doe(
     doe: ComponentSpec,
-    settings: dict[str, Sequence[Any]],
+    settings: Mapping[str, Sequence[Any]],
     do_permutations: bool = False,
     function: CellSpec | None = None,
 ) -> tuple[list[Component], list[dict[str, Any]]]:
@@ -34,8 +34,6 @@ def generate_doe(
 
     if function:
         function = gf.get_cell(function)
-        if not callable(function):
-            raise ValueError(f"Error {function!r} needs to be callable.")
         component_list = [
             function(gf.get_component(doe, **settings)) for settings in settings_list
         ]
@@ -50,7 +48,7 @@ def generate_doe(
 @gf.cell
 def pack_doe(
     doe: ComponentSpec,
-    settings: dict[str, Sequence[Any]],
+    settings: Mapping[str, Sequence[Any]],
     do_permutations: bool = False,
     function: CellSpec | None = None,
     **kwargs: Any,
@@ -91,6 +89,7 @@ def pack_doe(
         raise ValueError(
             f"failed to pack in one Component, it created {len(components)} Components"
         )
+
     component = components[0]
     component.info["doe_names"] = [component.name for component in component_list]
     component.info["doe_settings"] = settings_list  # type: ignore
@@ -100,7 +99,7 @@ def pack_doe(
 @gf.cell
 def pack_doe_grid(
     doe: ComponentSpec,
-    settings: dict[str, Sequence[Any]],
+    settings: Mapping[str, Sequence[Any]],
     do_permutations: bool = False,
     function: CellSpec | None = None,
     with_text: bool = False,
@@ -138,8 +137,6 @@ def pack_doe_grid(
 
     if function:
         function = gf.get_cell(function)
-        if not callable(function):
-            raise ValueError(f"Error {function!r} needs to be callable.")
         component_list = [
             function(gf.get_component(doe, **settings)) for settings in settings_list
         ]
@@ -170,5 +167,4 @@ if __name__ == "__main__":
     )
 
     c = pack_doe(doe="mmi1x2", settings=dict(length_mmi=(2, 100), width_mmi=(4, 10)))
-    # c = pack_doe()
     c.show()

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -13,7 +13,7 @@ from numpy import cos, float64, sin
 import gdsfactory as gf
 
 if TYPE_CHECKING:
-    from gdsfactory.component import Component
+    from gdsfactory.component import Component, ComponentReference
     from gdsfactory.typings import LayerSpec, LayerSpecs
 
 RAD2DEG = 180.0 / np.pi
@@ -126,7 +126,7 @@ GetPolygonsResult: TypeAlias = "dict[LayerSpec, list[kf.kdb.Polygon]]"
 
 
 def get_polygons(
-    component_or_instance: "Component | kf.Instance",
+    component_or_instance: "Component | ComponentReference",
     merge: bool = False,
     by: Literal["index", "name", "tuple"] = "index",
     layers: LayerSpecs | None = None,
@@ -180,7 +180,7 @@ def get_polygons(
 
 
 def get_polygons_points(
-    component_or_instance: "Component | kf.Instance",
+    component_or_instance: "Component | ComponentReference",
     merge: bool = False,
     scale: float | None = None,
     by: Literal["index", "name", "tuple"] = "index",
@@ -228,7 +228,7 @@ def get_polygons_points(
 
 
 def get_point_inside(
-    component_or_instance: Component | kf.Instance, layer: LayerSpec
+    component_or_instance: "Component | ComponentReference", layer: LayerSpec
 ) -> npt.NDArray[np.floating[Any]]:
     """Returns a point inside the component or instance.
 

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -24,12 +24,16 @@ from pprint import pprint
 from typing import Any, Protocol
 from warnings import warn
 
-import kfactory as kf
 import numpy as np
 from kfactory import LayerEnum
 
 from gdsfactory import Port, typings
-from gdsfactory.component import Component, ComponentReference, ComponentReferences
+from gdsfactory.component import (
+    Component,
+    ComponentBase,
+    ComponentReference,
+    ComponentReferences,
+)
 from gdsfactory.name import clean_name
 from gdsfactory.serialization import clean_dict, clean_value_json
 from gdsfactory.typings import LayerSpec
@@ -131,7 +135,7 @@ def _is_orthogonal_array_reference(ref: ComponentReference) -> bool:
 
 
 def get_netlist(
-    component: kf.DKCell,
+    component: ComponentBase,
     exclude_port_types: Sequence[str] | None = (
         "placement",
         "pad",
@@ -502,16 +506,16 @@ def difference_between_angles(angle2: float, angle1: float) -> float:
     return diff
 
 
-def _get_references_to_netlist(component: kf.DKCell) -> ComponentReferences:
+def _get_references_to_netlist(component: Component) -> ComponentReferences:
     return component.insts
 
 
 class GetNetlistFunc(Protocol):
-    def __call__(self, component: kf.DKCell, **kwargs: Any) -> dict[str, Any]: ...
+    def __call__(self, component: Component, **kwargs: Any) -> dict[str, Any]: ...
 
 
 def get_netlist_recursive(
-    component: kf.DKCell,
+    component: Component,
     component_suffix: str = "",
     get_netlist_func: GetNetlistFunc = get_netlist,  # type: ignore
     get_instance_name: Callable[..., str] = get_instance_name_from_alias,

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -25,12 +25,11 @@ from typing import Any, Protocol
 from warnings import warn
 
 import numpy as np
-from kfactory import LayerEnum
+from kfactory import DKCell, LayerEnum
 
 from gdsfactory import Port, typings
 from gdsfactory.component import (
     Component,
-    ComponentBase,
     ComponentReference,
     ComponentReferences,
 )
@@ -135,7 +134,7 @@ def _is_orthogonal_array_reference(ref: ComponentReference) -> bool:
 
 
 def get_netlist(
-    component: ComponentBase,
+    component: Component,
     exclude_port_types: Sequence[str] | None = (
         "placement",
         "pad",
@@ -506,16 +505,16 @@ def difference_between_angles(angle2: float, angle1: float) -> float:
     return diff
 
 
-def _get_references_to_netlist(component: Component) -> ComponentReferences:
+def _get_references_to_netlist(component: DKCell) -> ComponentReferences:
     return component.insts
 
 
 class GetNetlistFunc(Protocol):
-    def __call__(self, component: Component, **kwargs: Any) -> dict[str, Any]: ...
+    def __call__(self, component: DKCell, **kwargs: Any) -> dict[str, Any]: ...
 
 
 def get_netlist_recursive(
-    component: Component,
+    component: DKCell,
     component_suffix: str = "",
     get_netlist_func: GetNetlistFunc = get_netlist,  # type: ignore
     get_instance_name: Callable[..., str] = get_instance_name_from_alias,

--- a/gdsfactory/pack.py
+++ b/gdsfactory/pack.py
@@ -5,7 +5,6 @@ Adapted from PHIDL https://github.com/amccaugh/phidl/ by Adam McCaughan
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from typing import Any, Protocol
 
@@ -247,10 +246,6 @@ def pack(
                     )
 
         components_packed_list.append(packed)
-
-    if len(components_packed_list) > 1:
-        groups = len(components_packed_list)
-        warnings.warn(f"unable to pack in one component, creating {groups} components")
 
     return components_packed_list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ exclude = [
 ]
 python_version = "3.11"
 strict = true
-warn_unused_ignores = false
 
 [tool.pylsp-mypy]
 enabled = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ exclude = [
 ]
 python_version = "3.11"
 strict = true
+warn_unused_ignores = false
 
 [tool.pylsp-mypy]
 enabled = true

--- a/tests/components/containers/test_extension.py
+++ b/tests/components/containers/test_extension.py
@@ -74,6 +74,14 @@ def test_line_function() -> None:
     assert p3 is not None
 
 
+def test_line_function_coordinates() -> None:
+    p0, p1, p2, p3 = extension.line((0, 0), (10, 0), width=0.5)
+    assert p0 is not None
+    assert p1 is not None
+    assert p2 is not None
+    assert p3 is not None
+
+
 def test_move_polar_rad_copy_function() -> None:
     pos = (0, 0)
     angle = np.pi / 4

--- a/tests/components/containers/test_pack_doe.py
+++ b/tests/components/containers/test_pack_doe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import gdsfactory as gf
 from gdsfactory.components.containers.pack_doe import (
     generate_doe,
     pack_doe,
@@ -17,6 +18,30 @@ def test_generate_doe() -> None:
     )
     assert len(component_list) == 4
     assert len(settings_list) == 4
+
+
+def test_generate_doe_with_function() -> None:
+    doe = "mmi1x2"
+    settings = dict(length_mmi=(2.5, 100), width_mmi=(4, 10))
+
+    def i(c: gf.Component) -> gf.Component:
+        return c
+
+    component_list, settings_list = generate_doe(
+        doe=doe, settings=settings, do_permutations=True, function=i
+    )
+    assert len(component_list) == 4
+    assert len(settings_list) == 4
+
+
+def test_pack_doe_grid_with_function() -> None:
+    doe = "mmi1x2"
+    settings = dict(length_mmi=(2.5, 100), width_mmi=(4, 10))
+
+    def i(c: gf.Component) -> gf.Component:
+        return c
+
+    pack_doe_grid(doe=doe, settings=settings, do_permutations=True, function=i)
 
 
 def test_pack_doe() -> None:
@@ -60,5 +85,18 @@ def test_pack_doe_grid_without_text() -> None:
     assert len(component.info["doe_settings"]) == 4
 
 
+def test_pack_doe_error() -> None:
+    doe = "mmi1x2"
+    settings = dict(length_mmi=(2.5, 100), width_mmi=(4, 10))
+    with pytest.raises(ValueError):
+        pack_doe(
+            doe=doe,
+            settings=settings,
+            do_permutations=True,
+            max_size=(135, 135),
+            precision=1,
+        )
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    pytest.main([__file__, "-s"])

--- a/tests/components/couplers/test_coupler.py
+++ b/tests/components/couplers/test_coupler.py
@@ -4,12 +4,15 @@ import gdsfactory as gf
 
 
 def test_coupler_min_radius() -> None:
+    cross_section = gf.cross_section.strip(radius=1)
+
     with pytest.raises(ValueError, match="min_bend_radius 1"):
-        cross_section = gf.cross_section.strip(radius=1)
         gf.components.coupler(
             cross_section=cross_section, allow_min_radius_violation=False
         )
+    cross_section = gf.cross_section.strip(radius=10)
+    gf.components.coupler(cross_section=cross_section, allow_min_radius_violation=True)
 
 
 if __name__ == "__main__":
-    test_coupler_min_radius()
+    pytest.main([__file__, "-s"])

--- a/tests/components/couplers/test_coupler_broadband.py
+++ b/tests/components/couplers/test_coupler_broadband.py
@@ -1,0 +1,13 @@
+import pytest
+
+import gdsfactory as gf
+
+
+def test_coupler_broadband() -> None:
+    cross_section = gf.cross_section.rib()
+
+    gf.components.coupler_broadband(cross_section=cross_section, radius=25)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])

--- a/tests/components/couplers/test_coupler_full.py
+++ b/tests/components/couplers/test_coupler_full.py
@@ -1,0 +1,12 @@
+import pytest
+
+import gdsfactory as gf
+
+
+def test_coupler_full() -> None:
+    gf.components.coupler_full(cross_section="strip")
+    gf.components.coupler_full(cross_section="strip", width=10)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])

--- a/tests/components/dies/test_align.py
+++ b/tests/components/dies/test_align.py
@@ -1,0 +1,15 @@
+import pytest
+
+import gdsfactory as gf
+
+
+def test_align() -> None:
+    c = gf.components.align_wafer(layer_cladding=(3, 0))
+    assert not c.bbox(gf.get_layer((3, 0))).empty()
+
+    c = gf.components.align_wafer()
+    assert c.bbox(gf.get_layer((3, 0))).empty()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])

--- a/tests/components/dies/test_die.py
+++ b/tests/components/dies/test_die.py
@@ -1,0 +1,14 @@
+import pytest
+
+import gdsfactory as gf
+
+
+@pytest.mark.parametrize("draw_corners", [True, False])
+def test_die(draw_corners: bool) -> None:
+    c = gf.components.die(layer=(4, 0), bbox_layer=(5, 0), draw_corners=draw_corners)
+    assert not c.bbox(gf.get_layer((4, 0))).empty()
+    assert not c.bbox(gf.get_layer((5, 0))).empty()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-s"])

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -59,3 +59,14 @@ def test_boolean_array(c1: gf.Component, c2: gf.Component) -> None:
     d = gf.boolean(ref_a, ref_b, "not", layer1=(1, 0), layer2=(2, 0), layer=(1, 0))
 
     assert d.area((1, 0)) == 500 * 500 - 90_000
+
+
+def test_invalid_operation() -> None:
+    a = gf.Component()
+    a.shapes(a.kcl.layer(1, 0)).insert(gf.kdb.DBox(0, 0, 500, 500))
+
+    b = gf.Component()
+    b.shapes(b.kcl.layer(2, 0)).insert(gf.kdb.DBox(0, 0, 100, 100))
+
+    with pytest.raises(ValueError):
+        gf.boolean(a, b, "invalid", layer=(1, 0))

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -151,7 +151,7 @@ def test_locked_cell() -> None:
         c.absorb(c.add_ref(gf.Component()))
 
     with pytest.raises(LockedError):
-        c.add(gf.Instance(gf.Component().kcl, kdb.Instance()))
+        c.add(kf.DInstance(gf.Component().kcl, kdb.Instance()))
 
 
 def test_locked_cell_all_angle() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Refactor netlisting, plotting, and component sequence functionalities. Improve testing and add support for generating design of experiments (DOE) with custom functions.

Bug Fixes:
- Fix `add_port` to allow adding ports without orientation if the component is a `ComponentAllAngle`.
- Fix `copy_child_info` to copy all the child info and not just the first element.
- Fix `get_netlist` to accept `Component` instead of `kf.DKCell`.
- Fix `pack` to avoid warning when it creates multiple components.
- Fix `bend_s` to avoid type errors when calculating the minimum size.
- Fix `component_sequence` to raise the correct error when a port is not found.
- Fix `_flip_ref` to flip the reference around the correct axis.
- Fix boolean operations to raise an error if the operation is invalid.
- Fix `Component.add` to accept `Iterable[ComponentReference]` instead of `list[Instance]` or `Instance`.
- Fix `Component.layers` to return a list of layers instead of a set.
- Fix `Component.get_netlist` to return the correct netlist when called recursively.
- Fix `Component.plot_netlist` to plot the netlist correctly when called recursively.
- Fix `Component.plot_netlist_graphviz` to plot the netlist correctly when called recursively.
- Fix `Component.to_graphviz` to return the correct graph when called recursively.
- Fix `Component.pprint_ports` to print the ports correctly.
- Fix `Component.absorb` to absorb the reference correctly.
- Fix `Component.bbox` to return the correct bounding box.
- Fix `Component.write_gds` to write the GDS file correctly.
- Fix `Component.write_oas` to write the OAS file correctly.
- Fix `Component.write_sparameters` to write the Sparameters file correctly.
- Fix `Component.write_netlist` to write the netlist file correctly.
- Fix `Component.plot` to plot the component correctly.
- Fix `Component.show` to show the component correctly.
- Fix `Component.gds` to return the correct GDS file.
- Fix `Component.oas` to return the correct OAS file.
- Fix `Component.sparameters` to return the correct Sparameters file.
- Fix `Component.netlist` to return the correct netlist file.
- Fix `Component.to_dict` to return the correct dictionary.
- Fix `Component.from_dict` to return the correct component.
- Fix `Component.copy` to copy the component correctly.
- Fix `Component.mirror` to mirror the component correctly.
- Fix `Component.rotate` to rotate the component correctly.
- Fix `Component.move` to move the component correctly.
- Fix `Component.translate` to translate the component correctly.
- Fix `Component.ports` to return the correct ports.
- Fix `Component.ports_layer` to return the correct ports.
- Fix `Component.port_by_orientation_and_layer` to return the correct port.
- Fix `Component.port_by_orientation_and_width` to return the correct port.
- Fix `Component.get_ports_xsize` to return the correct size.
- Fix `Component.get_ports_ysize` to return the correct size.
- Fix `Component.get_ports_x` to return the correct positions.
- Fix `Component.get_ports_y` to return the correct positions.
- Fix `Component.get_ports_x_between` to return the correct positions.
- Fix `Component.get_ports_y_between` to return the correct positions.
- Fix `Component.get_ports_on_grid` to return the correct ports.
- Fix `Component.get_ports_by_type` to return the correct ports.
- Fix `Component.get_ports_by_layer` to return the correct ports.
- Fix `Component.get_ports_by_width` to return the correct ports.
- Fix `Component.get_ports_by_orientation` to return the correct ports.
- Fix `Component.get_ports_xsize` to return the correct size.
- Fix `Component.get_ports_ysize` to return the correct size.
- Fix `Component.get_ports_x` to return the correct positions.
- Fix `Component.get_ports_y` to return the correct positions.
- Fix `Component.get_ports_x_between` to return the correct positions.
- Fix `Component.get_ports_y_between` to return the correct positions.
- Fix `Component.get_ports_on_grid` to return the correct ports.
- Fix `Component.get_ports_by_type` to return the correct ports.
- Fix `Component.get_ports_by_layer` to return the correct ports.
- Fix `Component.get_ports_by_width` to return the correct ports.
- Fix `Component.get_ports_by_orientation` to return the correct ports.

Enhancements:
- Refactor `bend_circular_heater` to accept `angle` and `allow_min_radius_violation` parameters.
- Add `plot_netlist` method to `Component` to plot the netlist graph using NetworkX.
- Add `plot_netlist_graphviz` method to `Component` to plot the netlist graph using Graphviz.
- Add `to_graphviz` method to `Component` to convert the component to a Graphviz graph.
- Add `layers` property to `Component` to return a list of all layers used in the component.
- Add `pprint_ports` method to `Component` to pretty-print the component's ports.
- Add `get_netlist_recursive` function to recursively generate netlists for components.
- Add `line` function to `extension` module to create a line between two points.
- Add `test_line_function_coordinates` test to verify the coordinates of the line created by the `line` function.
- Add `test_bend_circular_heater_valid_radius` test to verify the radius of the `bend_circular_heater` component.
- Add `test_bend_circular_heater` test to verify the `bend_circular_heater` component.
- Add `test_invalid_operation` test to verify that an error is raised when an invalid boolean operation is performed.
- Add `test_component_sequence_errors` test to verify that errors are raised when invalid sequences are used in `component_sequence`.
- Add `test_component_sequence_different_sequence` test to verify that `component_sequence` works with different sequences.
- Add `test_generate_doe_with_function` test to verify that `generate_doe` works with a function.
- Add `test_pack_doe_grid_with_function` test to verify that `pack_doe_grid` works with a function.
- Add `test_pack_doe_error` test to verify that an error is raised when `pack_doe` fails to pack components.

Tests:
- Add more tests for bends, component sequence, pack DOE, boolean operations, and component functionalities.