### PR TITLE
automatic_name_cladding_layer_sections

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -603,13 +603,19 @@ def cross_section(
     ):
         s += [
             Section(
-                width=width + 2 * offset, layer=layer, simplify=simplify, offset=center
+                width=width + 2 * offset,
+                layer=layer,
+                simplify=simplify,
+                offset=center,
+                name=f"cladding_{i}",
             )
-            for layer, offset, simplify, center in zip(
-                cladding_layers,
-                cladding_offsets_not_none,
-                cladding_simplify_not_none,
-                cladding_centers_not_none,
+            for i, (layer, offset, simplify, center) in enumerate(
+                zip(
+                    cladding_layers,
+                    cladding_offsets_not_none,
+                    cladding_simplify_not_none,
+                    cladding_centers_not_none,
+                )
             )
         ]
     return CrossSection(


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3693

![image](https://github.com/user-attachments/assets/640bfe95-4efb-45b1-a0f5-1e4c8a956c47)


## Summary 

Bug Fixes:
- Fixes an issue where cladding layers were not automatically named, which could lead to problems when manipulating the layers.