### PR TITLE
Remove typing changes from migration docs

### DIFF
--- a/notebooks/22_migration_8.ipynb
+++ b/notebooks/22_migration_8.ipynb
@@ -43,36 +43,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### gdsfactory.typings\n",
-    "\n",
-    "Some of the type aliases have been removed, you can now use the following:\n",
-    "\n",
-    "Moved from gdsfactory.typings to gdsfactory.cross_section:\n",
-    "- `MultiCrossSectionAngleSpec`\n",
-    "- `CrossSectionFactory`\n",
-    "- `CrossSectionSpec`\n",
-    "\n",
-    "Moved from gdsfactory.typings to gdsfactory.component:\n",
-    "- `AnyComponent`\n",
-    "- `AnyComponentT`\n",
-    "- `AnyComponentFactory`\n",
-    "- `AnyComponentPostProcess`\n",
-    "- `ComponentFactory`\n",
-    "- `ComponentAllAngleFactory`\n",
-    "- `ComponentFactoryDict`\n",
-    "- `ComponentFactories` \n",
-    "- `ComponentSpecOrList`\n",
-    "- `CellSpec`\n",
-    "\n",
-    "Removed from gdsfactory.typings:\n",
-    "- `NameToFunctionDict`\n",
-    "- `ComponentBaseFactory`"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -134,13 +104,6 @@
    "source": [
     "c"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Removes the section about typing changes in gdsfactory from the migration documentation.