### PR TITLE
Simpler spiral definition

### DIFF
--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -47,6 +47,7 @@ def spiral_racetrack(
 
     xs = gf.get_cross_section(cross_section)
     min_radius = min_radius or xs.radius
+    assert min_radius
 
     _bend_s = gf.get_component(
         bend_s,
@@ -237,6 +238,7 @@ def _req_straight_len(
 
     xs = gf.get_cross_section(cross_section)
     min_radius = min_radius or xs.radius
+    assert min_radius
 
     # "Brute force" approach - sweep length and save total length
     lens: list[float] = []

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 import gdsfactory as gf
-from gdsfactory.component import Component, ComponentReference
+from gdsfactory.component import Component
 from gdsfactory.components.bends.bend_euler import bend_euler
 from gdsfactory.components.bends.bend_s import get_min_sbend_size
 from gdsfactory.components.waveguides.straight import straight
@@ -49,7 +49,7 @@ def spiral_racetrack(
     c = gf.Component()
 
     if with_inner_ports:
-        bend_s: ComponentReference | Component = gf.get_component(
+        bend_s = gf.get_component(
             bend_s,
             size=(straight_length, -min_radius * 2 + 1 * spacings[0]),
             cross_section=cross_section_s or cross_section,
@@ -124,8 +124,8 @@ def spiral_racetrack_fixed_length(
     n_straight_sections: int = 8,
     min_radius: float = 5,
     min_spacing: float = 5.0,
-    straight: ComponentFactory = straight,
-    bend: ComponentFactory = "bend_circular",
+    straight: ComponentSpec = straight,
+    bend: ComponentSpec = "bend_circular",
     bend_s: ComponentSpec = "bend_s",
     cross_section: CrossSectionSpec = "strip",
     cross_section_s: CrossSectionSpec | None = None,

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -18,7 +18,7 @@ from gdsfactory.typings import (
 
 @gf.cell
 def spiral_racetrack(
-    min_radius: float = 5,
+    min_radius: float | None = None,
     straight_length: float = 20.0,
     spacings: Floats = (2, 2, 3, 3, 2, 2),
     straight: ComponentSpec = straight,
@@ -44,6 +44,9 @@ def spiral_racetrack(
         allow_min_radius_violation: if True, will allow the s-bend to have a smaller radius than the minimum radius.
     """
     c = gf.Component()
+
+    xs = gf.get_cross_section(cross_section)
+    min_radius = min_radius or xs.radius
 
     _bend_s = gf.get_component(
         bend_s,
@@ -98,7 +101,7 @@ def spiral_racetrack_fixed_length(
     length: float = 1000,
     in_out_port_spacing: float = 150,
     n_straight_sections: int = 8,
-    min_radius: float = 5,
+    min_radius: float | None = None,
     min_spacing: float = 5.0,
     straight: ComponentSpec = straight,
     bend: ComponentSpec = "bend_circular",
@@ -127,6 +130,8 @@ def spiral_racetrack_fixed_length(
     c = gf.Component()
 
     xs_s_bend = cross_section_s or cross_section
+    xs = gf.get_cross_section(xs_s_bend)
+    min_radius = min_radius or xs.radius
 
     if np.mod(n_straight_sections, 2) != 0:
         raise ValueError("The number of straight sections has to be even!")
@@ -209,7 +214,7 @@ def spiral_racetrack_fixed_length(
 def _req_straight_len(
     length: float = 1000,
     in_out_port_spacing: float = 100,
-    min_radius: float = 5,
+    min_radius: float | None = None,
     spacings: Floats = (1.0, 1.0),
     bend: ComponentSpec = bend_euler,
     bend_s: ComponentSpec = "bend_s",
@@ -221,7 +226,7 @@ def _req_straight_len(
     Args:
         length: total length of the spiral from input to output ports in um.
         in_out_port_spacing: spacing between input and output ports of the spiral in um.
-        min_radius: smallest radius in um.
+        min_radius: smallest radius in um. Defaults to the radius of the cross-section.
         spacings: spacings between adjacent waveguides.
         bend: factory to generate the bend segments.
         bend_s: factory to generate the s-bend segments.
@@ -230,8 +235,10 @@ def _req_straight_len(
     """
     from scipy.interpolate import interp1d  # type: ignore
 
-    # "Brute force" approach - sweep length and save total length
+    xs = gf.get_cross_section(cross_section)
+    min_radius = min_radius or xs.radius
 
+    # "Brute force" approach - sweep length and save total length
     lens: list[float] = []
 
     # Figure out the min straight for the spiral so that the inner
@@ -313,7 +320,7 @@ def spiral_racetrack_heater_metal(
     based on https://doi.org/10.1364/OL.400230 .
 
     Args:
-        min_radius: smallest radius.
+        min_radius: smallest radius. Defaults to the radius of the cross-section.
         straight_length: length of the straight segments.
         spacing: space between the center of neighboring waveguides.
         num: number of loops.
@@ -419,7 +426,7 @@ def spiral_racetrack_heater_doped(
     based on https://doi.org/10.1364/OL.400230 but with the heater between the loops.
 
     Args:
-        min_radius: smallest radius in um.
+        min_radius: smallest radius in um. Defaults to the radius of the cross-section.
         straight_length: length of the straight segments in um.
         spacing: space between the center of neighboring waveguides in um.
         num: number.
@@ -480,7 +487,7 @@ if __name__ == "__main__":
     # test_length_spiral_racetrack()
 
     # c = spiral_racetrack(cross_section="rib")
-    c = spiral_racetrack(cross_section="nitride")
+    c = spiral_racetrack(cross_section="nitride", straight_length=54)
     # c = spiral_racetrack()
     # c = spiral_racetrack_fixed_length()
     # c = spiral_racetrack_heater_metal()

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -487,9 +487,11 @@ if __name__ == "__main__":
     # test_length_spiral_racetrack()
 
     # c = spiral_racetrack(cross_section="rib")
-    c = spiral_racetrack(cross_section="nitride", straight_length=54)
+    # c = spiral_racetrack(cross_section="nitride", straight_length=54)
     # c = spiral_racetrack()
     # c = spiral_racetrack_fixed_length()
-    # c = spiral_racetrack_heater_metal()
+    c = spiral_racetrack_heater_metal(
+        waveguide_cross_section="nitride", straight_length=54
+    )
     # c = spiral_racetrack_heater_doped()
     c.show()

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -27,10 +27,9 @@ def spiral_racetrack(
     bend_s_factory: ComponentFactory = bend_s,
     cross_section: CrossSectionSpec = "strip",
     cross_section_s: CrossSectionSpec | None = None,
-    n_bend_points: int = 99,
     with_inner_ports: bool = False,
     extra_90_deg_bend: bool = False,
-    allow_min_radius_violation: bool = True,
+    allow_min_radius_violation: bool = False,
 ) -> Component:
     """Returns Racetrack-Spiral.
 
@@ -43,7 +42,6 @@ def spiral_racetrack(
         bend_s_factory: factory to generate the s-bend segments.
         cross_section: cross-section of the waveguides.
         cross_section_s: cross-section of the s bend waveguide (optional).
-        n_bend_points: optional bend points.
         with_inner_ports: if True, will build the spiral, but expose the inner ports where the S-bend would be.
         extra_90_deg_bend: if True, we add an additional straight + 90 degree bent at the output, so the output port is looking down.
         allow_min_radius_violation: if True, will allow the s-bend to have a smaller radius than the minimum radius.
@@ -55,7 +53,6 @@ def spiral_racetrack(
             bend_s_factory,
             size=(straight_length, -min_radius * 2 + 1 * spacings[0]),
             cross_section=cross_section_s or cross_section,
-            npoints=n_bend_points,
         )
         c.info["length"] = 0
 
@@ -76,7 +73,6 @@ def spiral_racetrack(
             bend_s_factory,
             size=(straight_length, -min_radius * 2 + 1 * spacings[0]),
             cross_section=cross_section_s or cross_section,
-            npoints=n_bend_points,
             allow_min_radius_violation=allow_min_radius_violation,
         )
         bend_s = c << _bend_s
@@ -89,9 +85,7 @@ def spiral_racetrack(
                 bend_factory,
                 angle=180,
                 radius=min_radius + np.sum(spacings[:i]),
-                p=0,
                 cross_section=cross_section,
-                npoints=n_bend_points,
             )
             bend = c << _bend
             bend.connect("o1", port)
@@ -113,9 +107,7 @@ def spiral_racetrack(
             bend_factory,
             angle=90,
             radius=min_radius + np.sum(spacings),
-            p=0,
             cross_section=cross_section,
-            npoints=n_bend_points,
         )
         bend.connect("o1", ports[1])
         c.add_port("o2", port=bend.ports["o2"])
@@ -137,7 +129,6 @@ def spiral_racetrack_fixed_length(
     bend_s_factory: ComponentFactory = bend_s,
     cross_section: CrossSectionSpec = "strip",
     cross_section_s: CrossSectionSpec | None = None,
-    n_bend_points: int = 99,
     with_inner_ports: bool = False,
 ) -> Component:
     """Returns Racetrack-Spiral with a specified total length.
@@ -157,7 +148,6 @@ def spiral_racetrack_fixed_length(
         bend_s_factory: factory to generate the s-bend segments.
         cross_section: cross-section of the waveguides.
         cross_section_s: cross-section of the s bend waveguide (optional).
-        n_bend_points: optional bend points.
         with_inner_ports: if True, will build the spiral, but expose the inner ports where the S-bend would be.
     """
     c = gf.Component()
@@ -190,7 +180,6 @@ def spiral_racetrack_fixed_length(
         bend_s_factory=bend_s_factory,
         cross_section=cross_section,
         cross_section_s=cross_section_s,
-        n_bend_points=n_bend_points,
         with_inner_ports=with_inner_ports,
         extra_90_deg_bend=True,
     )
@@ -352,7 +341,7 @@ def spiral_racetrack_heater_metal(
         min_radius: smallest radius.
         straight_length: length of the straight segments.
         spacing: space between the center of neighboring waveguides.
-        num: number.
+        num: number of loops.
         straight_factory: factory to generate the straight segments.
         bend_factory: factory to generate the bend segments.
         bend_s_factory: factory to generate the s-bend segments.
@@ -397,7 +386,8 @@ def spiral_racetrack_heater_metal(
     )
     heater_bot.dmovey(-spacing * num // 2)
 
-    heater_bend = c << gf.components.bend_circular(
+    heater_bend = c << gf.get_component(
+        bend_factory,
         angle=180,
         radius=min_radius + spacing * (num // 2 + 1),
         cross_section=heater_cross_section,
@@ -517,7 +507,7 @@ if __name__ == "__main__":
     # c = spiral_racetrack(cross_section="rib")
     # c = spiral_racetrack()
     # c = spiral_racetrack()
-    c = spiral_racetrack_fixed_length()
-    # c = spiral_racetrack_heater_metal()
+    # c = spiral_racetrack_fixed_length()
+    c = spiral_racetrack_heater_metal()
     # c = spiral_racetrack_heater_doped()
     c.show()

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -49,7 +49,7 @@ def _simplify(
 
 
 def reflect_points(
-    points: npt.NDArray[np.float64],
+    points: npt.NDArray[np.floating[Any]],
     p1: tuple[float, float] = (0, 0),
     p2: tuple[float, float] = (1, 0),
 ) -> npt.NDArray[np.float64]:

--- a/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
@@ -1,17 +1,16 @@
 instances:
-  spiral_racetrack_MR10_S_2cd856ae_0_0:
+  spiral_racetrack_MR10_S_b35ed17b_0_0:
     component: spiral_racetrack
     info:
-      length: 1402.314
+      length: 1723.876
     settings:
-      allow_min_radius_violation: true
-      bend_factory: bend_euler
-      bend_s_factory: bend_s
+      allow_min_radius_violation: false
+      bend: bend_euler
+      bend_s: bend_s
       cross_section: strip
       cross_section_s: null
       extra_90_deg_bend: false
       min_radius: 10
-      n_bend_points: 99
       spacings:
       - 2
       - 2
@@ -21,7 +20,7 @@ instances:
       - 3
       - 2
       - 2
-      straight_factory: straight
+      straight: straight
       straight_length: 30
       with_inner_ports: false
   straight_L30_N2_CSnpp_WNone_0_12000:
@@ -52,10 +51,10 @@ instances:
       length: 30
       npoints: 2
       width: null
-name: spiral_racetrack_heater_b997422e
+name: spiral_racetrack_heater_c5c52dbc
 nets: []
 placements:
-  spiral_racetrack_MR10_S_2cd856ae_0_0:
+  spiral_racetrack_MR10_S_b35ed17b_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -73,7 +72,7 @@ placements:
 ports:
   bot_e1: straight_L30_N2_CSnpp_WNone_0_12000,e1
   bot_e2: straight_L30_N2_CSnpp_WNone_0_12000,e2
-  o1: spiral_racetrack_MR10_S_2cd856ae_0_0,o1
-  o2: spiral_racetrack_MR10_S_2cd856ae_0_0,o2
+  o1: spiral_racetrack_MR10_S_b35ed17b_0_0,o1
+  o2: spiral_racetrack_MR10_S_b35ed17b_0_0,o2
   top_e1: straight_L30_N2_CSnpp_WNone_30000_m30000,e1
   top_e2: straight_L30_N2_CSnpp_WNone_30000_m30000,e2

--- a/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
+++ b/test-data-regression/test_netlists_spiral_racetrack_heater_doped_.yml
@@ -1,5 +1,5 @@
 instances:
-  spiral_racetrack_MR10_S_b35ed17b_0_0:
+  spiral_racetrack_MR10_S_2a52360f_0_0:
     component: spiral_racetrack
     info:
       length: 1723.876
@@ -22,7 +22,6 @@ instances:
       - 2
       straight: straight
       straight_length: 30
-      with_inner_ports: false
   straight_L30_N2_CSnpp_WNone_0_12000:
     component: straight
     info:
@@ -54,7 +53,7 @@ instances:
 name: spiral_racetrack_heater_c5c52dbc
 nets: []
 placements:
-  spiral_racetrack_MR10_S_b35ed17b_0_0:
+  spiral_racetrack_MR10_S_2a52360f_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -72,7 +71,7 @@ placements:
 ports:
   bot_e1: straight_L30_N2_CSnpp_WNone_0_12000,e1
   bot_e2: straight_L30_N2_CSnpp_WNone_0_12000,e2
-  o1: spiral_racetrack_MR10_S_b35ed17b_0_0,o1
-  o2: spiral_racetrack_MR10_S_b35ed17b_0_0,o2
+  o1: spiral_racetrack_MR10_S_2a52360f_0_0,o1
+  o2: spiral_racetrack_MR10_S_2a52360f_0_0,o2
   top_e1: straight_L30_N2_CSnpp_WNone_30000_m30000,e1
   top_e2: straight_L30_N2_CSnpp_WNone_30000_m30000,e2

--- a/test-data-regression/test_settings_spiral_racetrack_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_.yml
@@ -1,14 +1,13 @@
 info:
-  length: 670.464
-name: spiral_racetrack_MR5_SL_dd5880dc
+  length: 818.7
+name: spiral_racetrack_MR5_SL_7ab1ec43
 settings:
-  allow_min_radius_violation: true
-  bend_factory: bend_euler
-  bend_s_factory: bend_s
+  allow_min_radius_violation: false
+  bend: bend_euler
+  bend_s: bend_s
   cross_section: strip
   extra_90_deg_bend: false
   min_radius: 5
-  n_bend_points: 99
   spacings:
   - 2
   - 2
@@ -16,6 +15,6 @@ settings:
   - 3
   - 2
   - 2
-  straight_factory: straight
+  straight: straight
   straight_length: 20
   with_inner_ports: false

--- a/test-data-regression/test_settings_spiral_racetrack_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_.yml
@@ -1,13 +1,12 @@
 info:
-  length: 818.7
-name: spiral_racetrack_MR5_SL_7ab1ec43
+  length: 1081.925
+name: spiral_racetrack_MRNone_05d4c3d3
 settings:
   allow_min_radius_violation: false
   bend: bend_euler
   bend_s: bend_s
   cross_section: strip
   extra_90_deg_bend: false
-  min_radius: 5
   spacings:
   - 2
   - 2
@@ -17,4 +16,3 @@ settings:
   - 2
   straight: straight
   straight_length: 20
-  with_inner_ports: false

--- a/test-data-regression/test_settings_spiral_racetrack_fixed_length_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_fixed_length_.yml
@@ -1,15 +1,13 @@
 info:
   length: 1000
-  straight_length: 66.292
-name: spiral_racetrack_fixed__e6b03613
+  straight_length: 50.869
+name: spiral_racetrack_fixed__0024322a
 settings:
   bend: bend_circular
   bend_s: bend_s
   cross_section: strip
   in_out_port_spacing: 150
   length: 1000
-  min_radius: 5
   min_spacing: 5
   n_straight_sections: 8
   straight: straight
-  with_inner_ports: false

--- a/test-data-regression/test_settings_spiral_racetrack_fixed_length_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_fixed_length_.yml
@@ -1,16 +1,15 @@
 info:
-  length: 1000.001
+  length: 1000
   straight_length: 66.292
-name: spiral_racetrack_fixed__e95fe6cc
+name: spiral_racetrack_fixed__e6b03613
 settings:
-  bend_factory: bend_euler
-  bend_s_factory: bend_s
+  bend: bend_circular
+  bend_s: bend_s
   cross_section: strip
   in_out_port_spacing: 150
   length: 1000
   min_radius: 5
   min_spacing: 5
-  n_bend_points: 99
   n_straight_sections: 8
-  straight_factory: straight
+  straight: straight
   with_inner_ports: false

--- a/test-data-regression/test_settings_spiral_racetrack_heater_doped_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_heater_doped_.yml
@@ -1,11 +1,11 @@
 info: {}
-name: spiral_racetrack_heater_b997422e
+name: spiral_racetrack_heater_c5c52dbc
 settings:
-  bend_factory: bend_euler
-  bend_s_factory: bend_s
+  bend: bend_euler
+  bend_s: bend_s
   heater_cross_section: npp
   num: 8
   spacing: 2
-  straight_factory: straight
+  straight: straight
   straight_length: 30
   waveguide_cross_section: strip

--- a/test-data-regression/test_settings_spiral_racetrack_heater_metal_.yml
+++ b/test-data-regression/test_settings_spiral_racetrack_heater_metal_.yml
@@ -1,12 +1,12 @@
 info: {}
-name: spiral_racetrack_heater_19482d4b
+name: spiral_racetrack_heater_def19831
 settings:
-  bend_factory: bend_euler
-  bend_s_factory: bend_s
+  bend: bend_euler
+  bend_s: bend_s
   heater_cross_section: heater_metal
   num: 8
   spacing: 2
-  straight_factory: straight
+  straight: straight
   straight_length: 30
   via_stack: via_stack_heater_mtop
   waveguide_cross_section: strip


### PR DESCRIPTION
## Summary 

Simplify spiral definition by removing the `n_bend_points` parameter and replacing `*_factory` with component specs.

Enhancements:
- Simplify spiral definition by removing the `n_bend_points` parameter.
- Replace `*_factory` with component specs for bend, straight and bend_s.
- Use min_radius as the default from cross_section parameter