### PR TITLE
customize ring_double to accept gap_top and gap_top

### DIFF
--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -8,6 +8,8 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 @gf.cell
 def ring_double(
     gap: float = 0.2,
+    gap_top: float | None = None,
+    gap_bot: float | None = None,
     radius: float = 10.0,
     length_x: float = 0.01,
     length_y: float = 0.01,
@@ -23,6 +25,8 @@ def ring_double(
 
     Args:
         gap: gap between for coupler.
+        gap_top: gap for the top coupler. Defaults to gap.
+        gap_bot: gap for the bottom coupler. Defaults to gap.
         radius: for the bend and coupler.
         length_x: ring coupler length.
         length_y: vertical straight length.
@@ -52,9 +56,20 @@ def ring_double(
                      │gap
              o1──────▼─────────o4
     """
-    coupler_component = gf.get_component(
+    gap_top = gap_top or gap
+    gap_bot = gap_bot or gap
+    coupler_component_bot = gf.get_component(
         coupler_ring,
-        gap=gap,
+        gap=gap_bot,
+        radius=radius,
+        length_x=length_x,
+        cross_section=cross_section,
+        straight=straight,
+        bend=bend,
+    )
+    coupler_component_top = gf.get_component(
+        coupler_ring,
+        gap=gap_top,
         radius=radius,
         length_x=length_x,
         cross_section=cross_section,
@@ -68,8 +83,8 @@ def ring_double(
     )
 
     c = Component()
-    cb = c.add_ref(coupler_component)
-    ct = c.add_ref(coupler_component)
+    cb = c.add_ref(coupler_component_bot)
+    ct = c.add_ref(coupler_component_top)
 
     length_y = length_y or 0.001
 
@@ -88,5 +103,5 @@ def ring_double(
 
 
 if __name__ == "__main__":
-    c = ring_double(length_y=2, bend="bend_circular")
+    c = ring_double(length_y=2, bend="bend_circular", gap_top=0.4)
     c.show()

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -10,6 +10,8 @@ from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, 
 @gf.cell
 def ring_double_heater(
     gap: float = 0.2,
+    gap_top: float | None = None,
+    gap_bot: float | None = None,
     radius: float = 10.0,
     length_x: float = 1.0,
     length_y: float = 0.01,
@@ -32,6 +34,8 @@ def ring_double_heater(
 
     Args:
         gap: gap between for coupler.
+        gap_top: gap for the top coupler. Defaults to gap.
+        gap_bot: gap for the bottom coupler. Defaults to gap.
         radius: for the bend and coupler.
         length_x: ring coupler length.
         length_y: vertical straight length.
@@ -68,13 +72,18 @@ def ring_double_heater(
                      │gap
              o1──────▼─────────o4
     """
+    gap_top = gap_top or gap
+    gap_bot = gap_bot or gap
+
     gap = gf.snap.snap_to_grid(gap, grid_factor=2)
+    gap_top = gf.snap.snap_to_grid(gap_top, grid_factor=2)
+    gap_bot = gf.snap.snap_to_grid(gap_bot, grid_factor=2)
 
     coupler_ring_top = coupler_ring_top or coupler_ring
 
     coupler_component = gf.get_component(
         coupler_ring,
-        gap=gap,
+        gap=gap_bot,
         radius=radius,
         length_x=length_x,
         bend=bend,
@@ -83,7 +92,7 @@ def ring_double_heater(
     )
     coupler_component_top = gf.get_component(
         coupler_ring_top,
-        gap=gap,
+        gap=gap_top,
         radius=radius,
         length_x=length_x,
         bend=bend,
@@ -168,6 +177,6 @@ ring_single_heater = partial(ring_double_heater, with_drop=False)
 
 
 if __name__ == "__main__":
-    c = ring_double_heater()
+    c = ring_double_heater(gap_top=0.4, length_y=2)
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -67,8 +67,8 @@ def ring_double_pn(
     """Returns add-drop pn ring with optional doped heater.
 
     Args:
-        add_gap: gap to add waveguide.
-        drop_gap: gap to drop waveguide.
+        add_gap: gap to add waveguide. Bottom gap.
+        drop_gap: gap to drop waveguide. Top gap.
         radius: for the bend and coupler.
         doping_angle: angle in degrees representing portion of ring that is doped.
         length_x: ring coupler length.

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -51,7 +51,7 @@ instances:
       length: 0.01
       npoints: 2
       width: null
-name: ring_double_G0p2_R10_LX_07be0fa3
+name: ring_double_G0p2_GTNone_9ee873d5
 nets:
 - p1: coupler_ring_G0p2_R10_L_f700a51f_0_0,o2
   p2: straight_L0p01_N2_CSstrip_WNone_m10010_10700,o1

--- a/test-data-regression/test_netlists_ring_double_heater_.yml
+++ b/test-data-regression/test_netlists_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_G0p2_26d47ff1
+name: ring_double_heater_G0p2_8e89bf2a
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_ring_single_heater_.yml
+++ b/test-data-regression/test_netlists_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_G0p2_113fb173
+name: ring_double_heater_G0p2_d60b09da
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_ring_double_.yml
+++ b/test-data-regression/test_settings_ring_double_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_G0p2_R10_LX_07be0fa3
+name: ring_double_G0p2_GTNone_9ee873d5
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring

--- a/test-data-regression/test_settings_ring_double_heater_.yml
+++ b/test-data-regression/test_settings_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_G0p2_26d47ff1
+name: ring_double_heater_G0p2_8e89bf2a
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring

--- a/test-data-regression/test_settings_ring_single_heater_.yml
+++ b/test-data-regression/test_settings_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_G0p2_113fb173
+name: ring_double_heater_G0p2_d60b09da
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Customize ring_double and ring_double_heater components to accept gap_top and gap_bot parameters.