### PR TITLE
add length_taper_start for mmi_tapered

### DIFF
--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -17,6 +17,8 @@ def mmi_tapered(
     length_taper_out: float | None = None,
     width_taper: float = 1.0,
     length_taper: float = 10.0,
+    length_taper_start: float | None = None,
+    length_taper_end: float | None = None,
     length_mmi: float = 5.5,
     width_mmi: float = 5,
     width_mmi_inner: float | None = None,
@@ -42,6 +44,8 @@ def mmi_tapered(
         length_taper_out: into the mmi region.
         width_taper: interface between mmi region and output straights.
         length_taper: into the mmi region.
+        length_taper_start: length of the taper at the start. Defaults to length_taper.
+        length_taper_end: length of the taper at the end. Defaults to length_taper.
         length_mmi: in x direction.
         width_mmi: in y direction.
         width_mmi_inner: allows adding a different width for the inner mmi region.
@@ -66,9 +70,9 @@ def mmi_tapered(
         └───────────┼─┐                │           │               ├─────────────┐
                     ▼ └────────────────┤           │               │             │
                       ◄───────────────►│           │               ├─────────────┘
-        length-taper    length_taper_in│           ├───────────────┘
+        length_taper    length_taper_in│           ├───────────────┘ length_taper
         ◄────────────►                 └───────────┘◄────────────►  ◄────────────►
-                                                   length_taper_out length_taper
+            start                                  length_taper_out      end
                                        ◄───────────►
                                         length_mmi
     """
@@ -91,10 +95,17 @@ def mmi_tapered(
         width1=width_taper,
         cross_section=cross_section,
     )
-    _taper = taper(
-        length=length_taper,
+    _taper_start = taper(
+        length=length_taper_start or length_taper,
         width1=width,
         width2=width_taper,
+        cross_section=cross_section,
+    )
+
+    _taper_end = taper(
+        length=length_taper_end or length_taper,
+        width1=width_taper,
+        width2=width,
         cross_section=cross_section,
     )
 
@@ -157,14 +168,14 @@ def mmi_tapered(
     for port in in_ports:
         taper_ref = c << _taper_in
         taper_ref.connect("o2", port, allow_width_mismatch=True)
-        taper_outer_ref = c << _taper
+        taper_outer_ref = c << _taper_start
         taper_outer_ref.connect("o2", taper_ref["o1"], allow_width_mismatch=True)
         c.add_port(name=port.name, port=taper_outer_ref.ports["o1"])
 
     for port in out_ports:
         taper_ref = c << _taper_out
         taper_ref.connect("o2", port, allow_width_mismatch=True)
-        taper_outer_ref = c << _taper
+        taper_outer_ref = c << _taper_end
         taper_outer_ref.connect("o2", taper_ref["o1"], allow_width_mismatch=True)
         c.add_port(name=port.name, port=taper_outer_ref.ports["o1"])
 

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -104,8 +104,8 @@ def mmi_tapered(
 
     _taper_end = taper(
         length=length_taper_end or length_taper,
-        width1=width_taper,
-        width2=width,
+        width2=width_taper,
+        width1=width,
         cross_section=cross_section,
     )
 

--- a/test-data-regression/test_netlists_mmi_tapered_.yml
+++ b/test-data-regression/test_netlists_mmi_tapered_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: mmi_tapered_I1_O2_WNone_01382774
+name: mmi_tapered_I1_O2_WNone_4008b5a7
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_mmi_tapered_.yml
+++ b/test-data-regression/test_settings_mmi_tapered_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: mmi_tapered_I1_O2_WNone_01382774
+name: mmi_tapered_I1_O2_WNone_4008b5a7
 settings:
   cross_section: strip
   gap_input_tapers: 0.25


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adds `length_taper_start` and `length_taper_end` parameters to the `mmi_tapered` component.