### PR TITLE
improve pads

### DIFF
--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -100,7 +100,7 @@ def pad_array(
     row_pitch: float = 150.0,
     port_orientation: AngleInDegrees = 0,
     size: Float2 | None = None,
-    layer: LayerSpec | None = None,
+    layer: LayerSpec | None = "MTOP",
     centered_ports: bool = False,
     auto_rename_ports: bool = False,
 ) -> Component:
@@ -145,7 +145,7 @@ def pad_array(
         column_pitch=column_pitch,
         row_pitch=row_pitch,
     )
-    width = size[0] if port_orientation in {90, 270} else size[1]
+    width = size[0] if int(port_orientation) in {90, 270} else size[1]
 
     for col in range(columns):
         for row in range(rows):
@@ -185,8 +185,14 @@ pad_array180 = partial(pad_array, port_orientation=180, columns=1, rows=3)
 
 
 if __name__ == "__main__":
-    c = pad_array()
+    # c = pad_array(port_orientation=270.)
     # c = pad_array(columns=3, centered_ports=True, port_orientation=90)
     # c = pad(port_orientations=[270])
-    c.pprint_ports()
+    pad = gf.components.pad
+    # c = gf.get_component(pad)
+
+    c = gf.components.pad_array(
+        port_orientation=270, pad=pad, size=(10, 10), column_pitch=15
+    )
+    # c.pprint_ports()
     c.show()

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -99,8 +99,8 @@ def pad_array(
     column_pitch: float = 150.0,
     row_pitch: float = 150.0,
     port_orientation: AngleInDegrees = 0,
-    size: Float2 = (100.0, 100.0),
-    layer: LayerSpec = "MTOP",
+    size: Float2 | None = None,
+    layer: LayerSpec | None = None,
     centered_ports: bool = False,
     auto_rename_ports: bool = False,
 ) -> Component:
@@ -119,9 +119,24 @@ def pad_array(
         auto_rename_ports: True to auto rename ports.
     """
     c = Component()
-    pad_component = gf.get_component(
-        pad, size=size, layer=layer, port_orientations=None, port_orientation=None
-    )
+
+    if layer and size:
+        pad_component = gf.get_component(
+            pad, size=size, layer=layer, port_orientations=None, port_orientation=None
+        )
+    elif layer:
+        pad_component = gf.get_component(
+            pad, layer=layer, port_orientations=None, port_orientation=None
+        )
+    elif size:
+        pad_component = gf.get_component(
+            pad, size=size, port_orientations=None, port_orientation=None
+        )
+    else:
+        pad_component = gf.get_component(pad)
+
+    size = size or pad_component.info["size"]
+    layer = layer or pad_component.ports[0].layer
 
     c.add_ref(
         pad_component,
@@ -170,8 +185,8 @@ pad_array180 = partial(pad_array, port_orientation=180, columns=1, rows=3)
 
 
 if __name__ == "__main__":
-    c = pad_rectangular()
+    c = pad_array()
     # c = pad_array(columns=3, centered_ports=True, port_orientation=90)
     # c = pad(port_orientations=[270])
-    # c.pprint_ports()
+    c.pprint_ports()
     c.show()

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 from pathlib import Path
 from typing import Any, Self
 
@@ -10,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import PATH
+from gdsfactory.serialization import convert_tuples_to_lists
 from gdsfactory.typings import Anchor, Delta, Port, Ports
 from gdsfactory.utils import is_component_spec
 
@@ -420,6 +422,22 @@ class Schematic(BaseModel):
         """
         dot = self.to_graphviz()
         plot_graphviz(dot, interactive=interactive, splines=splines)
+
+    def write_netlist(
+        self, netlist: dict[str, Any], filepath: str | pathlib.Path | None = None
+    ) -> str:
+        """Returns netlist as YAML string.
+
+        Args:
+            netlist: netlist to write.
+            filepath: Optional file path to write to.
+        """
+        netlist_converted = convert_tuples_to_lists(netlist)
+        yaml_string = yaml.dump(netlist_converted)
+        if filepath:
+            filepath = pathlib.Path(filepath)
+            filepath.write_text(yaml_string)
+        return str(yaml_string)
 
 
 def plot_graphviz(

--- a/test-data-regression/test_netlists_pad_array0_.yml
+++ b/test-data-regression/test_netlists_pad_array0_.yml
@@ -23,7 +23,7 @@ instances:
       size:
       - 100
       - 100
-name: pad_array_Ppad_C1_R3_CP_91545b40
+name: pad_array_Ppad_C1_R3_CP_8f43394f
 nets: []
 placements:
   pad_S100_100_LMTOP_BLNo_23f16118_0_0:

--- a/test-data-regression/test_netlists_pad_array180_.yml
+++ b/test-data-regression/test_netlists_pad_array180_.yml
@@ -23,7 +23,7 @@ instances:
       size:
       - 100
       - 100
-name: pad_array_Ppad_C1_R3_CP_a8428924
+name: pad_array_Ppad_C1_R3_CP_707f34aa
 nets: []
 placements:
   pad_S100_100_LMTOP_BLNo_23f16118_0_0:

--- a/test-data-regression/test_netlists_pad_array270_.yml
+++ b/test-data-regression/test_netlists_pad_array270_.yml
@@ -23,7 +23,7 @@ instances:
       size:
       - 100
       - 100
-name: pad_array_Ppad_C6_R1_CP_e1ca63f5
+name: pad_array_Ppad_C6_R1_CP_a9e1290d
 nets: []
 placements:
   pad_S100_100_LMTOP_BLNo_23f16118_0_0:

--- a/test-data-regression/test_netlists_pad_array90_.yml
+++ b/test-data-regression/test_netlists_pad_array90_.yml
@@ -23,7 +23,7 @@ instances:
       size:
       - 100
       - 100
-name: pad_array_Ppad_C6_R1_CP_eac4a503
+name: pad_array_Ppad_C6_R1_CP_0a01cde6
 nets: []
 placements:
   pad_S100_100_LMTOP_BLNo_23f16118_0_0:

--- a/test-data-regression/test_netlists_pad_array_.yml
+++ b/test-data-regression/test_netlists_pad_array_.yml
@@ -23,7 +23,7 @@ instances:
       size:
       - 100
       - 100
-name: pad_array_Ppad_C6_R1_CP_935e7f93
+name: pad_array_Ppad_C6_R1_CP_686e97b5
 nets: []
 placements:
   pad_S100_100_LMTOP_BLNo_23f16118_0_0:

--- a/test-data-regression/test_settings_pad_array0_.yml
+++ b/test-data-regression/test_settings_pad_array0_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pad_array_Ppad_C1_R3_CP_91545b40
+name: pad_array_Ppad_C1_R3_CP_8f43394f
 settings:
   auto_rename_ports: false
   centered_ports: false
@@ -10,6 +10,3 @@ settings:
   port_orientation: 0
   row_pitch: 150
   rows: 3
-  size:
-  - 100
-  - 100

--- a/test-data-regression/test_settings_pad_array180_.yml
+++ b/test-data-regression/test_settings_pad_array180_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pad_array_Ppad_C1_R3_CP_a8428924
+name: pad_array_Ppad_C1_R3_CP_707f34aa
 settings:
   auto_rename_ports: false
   centered_ports: false
@@ -10,6 +10,3 @@ settings:
   port_orientation: 180
   row_pitch: 150
   rows: 3
-  size:
-  - 100
-  - 100

--- a/test-data-regression/test_settings_pad_array270_.yml
+++ b/test-data-regression/test_settings_pad_array270_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pad_array_Ppad_C6_R1_CP_e1ca63f5
+name: pad_array_Ppad_C6_R1_CP_a9e1290d
 settings:
   auto_rename_ports: false
   centered_ports: false
@@ -10,6 +10,3 @@ settings:
   port_orientation: 270
   row_pitch: 150
   rows: 1
-  size:
-  - 100
-  - 100

--- a/test-data-regression/test_settings_pad_array90_.yml
+++ b/test-data-regression/test_settings_pad_array90_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pad_array_Ppad_C6_R1_CP_eac4a503
+name: pad_array_Ppad_C6_R1_CP_0a01cde6
 settings:
   auto_rename_ports: false
   centered_ports: false
@@ -10,6 +10,3 @@ settings:
   port_orientation: 90
   row_pitch: 150
   rows: 1
-  size:
-  - 100
-  - 100

--- a/test-data-regression/test_settings_pad_array_.yml
+++ b/test-data-regression/test_settings_pad_array_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: pad_array_Ppad_C6_R1_CP_935e7f93
+name: pad_array_Ppad_C6_R1_CP_686e97b5
 settings:
   auto_rename_ports: false
   centered_ports: false
@@ -10,6 +10,3 @@ settings:
   port_orientation: 0
   row_pitch: 150
   rows: 1
-  size:
-  - 100
-  - 100

--- a/tests/routing/test_routing_route_bundle_west_to_north.py
+++ b/tests/routing/test_routing_route_bundle_west_to_north.py
@@ -87,5 +87,5 @@ def test_route_bundle_west_to_north2(
 
 
 if __name__ == "__main__":
-    # test_route_bundle_west_to_north(None, check=False)
-    test_route_bundle_west_to_north2(None, check=False)
+    test_route_bundle_west_to_north(None, check=False)
+    # test_route_bundle_west_to_north2(None, check=False)


### PR DESCRIPTION
## Summary by Sourcery

Make pad size and layer optional in pad_array function. Add write_netlist method to Schematic class to write netlist as YAML string.

Enhancements:
- Make pad size and layer optional in pad_array function, falling back to the pad component's default values if not specified.
- Add write_netlist method to Schematic class to write netlist as YAML string.