### PR TITLE
bump kfactory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.2.4,<1.3",
+  "kfactory[ipy]>=1.2.5,<1.3",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update kfactory dependency to version 1.2.5 or higher but less than 1.3.