### PR TITLE
fix path rotate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - avoid double pdk activation [#3762](https://github.com/gdsfactory/gdsfactory/pull/3762)
 - Update kfactory 1.4.1 [#3761](https://github.com/gdsfactory/gdsfactory/pull/3761)
 
-
 ## [9.3.3](https://github.com/gdsfactory/gdsfactory/releases/tag/v9.3.3) - 2025-04-07
 
 - fix mypy [#3759](https://github.com/gdsfactory/gdsfactory/pull/3759)
@@ -33,7 +32,6 @@
 - Fix Naming Error: It's "Dubins" Not "Dubin". [#3740](https://github.com/gdsfactory/gdsfactory/pull/3740)
 - bump kfactory [#3743](https://github.com/gdsfactory/gdsfactory/pull/3743)
 - add kfactory cli build command [#3742](https://github.com/gdsfactory/gdsfactory/pull/3742)
-
 
 ## [9.3.0](https://github.com/gdsfactory/gdsfactory/releases/tag/v9.3.0) - 2025-03-20
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -186,6 +186,10 @@ class Path(UMGeometricObject):
             new_points[:, 1] = -new_points[:, 1]
 
         self.points = new_points
+        nx1, ny1 = self.points[1] - self.points[0]
+        self.start_angle = np.arctan2(ny1, nx1) / np.pi * 180
+        nx2, ny2 = self.points[-1] - self.points[-2]
+        self.end_angle = np.arctan2(ny2, nx2) / np.pi * 180
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
         return kdb.DBox(*self.bbox_np().flatten())
@@ -1763,8 +1767,22 @@ __all__ = [
 ]
 
 if __name__ == "__main__":
-    import gdsfactory as gf
+    # import gdsfactory as gf
+    # p = gf.path.euler(angle=-30)
+    # c = p.extrude(cross_section=gf.cross_section.strip)
+    # c.show()
 
-    p = gf.path.euler(angle=-30)
+    p = gf.path.euler(
+        radius=5,
+        angle=180,
+        p=1,
+        use_eff=True,
+    )
+
+    print(p.start_angle, p.end_angle)  # 0, 180
+    p.drotate(-90)
+    print(p.start_angle, p.end_angle)  # Still 0, 180
+
     c = p.extrude(cross_section=gf.cross_section.strip)
+    print(c.area("WG"))
     c.show()

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -451,5 +451,18 @@ def test_path_smooth() -> None:
     assert np.isclose(c.area((1, 0)), 3404.6317885)
 
 
+def test_path_angle() -> None:
+    p = gf.path.euler(
+        radius=5,
+        angle=180,
+        p=1,
+        use_eff=True,
+    )
+    p.drotate(-90)
+    c = p.extrude(cross_section=gf.cross_section.strip)
+    assert np.isclose(c.area("WG"), 11.409315999999999)
+
+
 if __name__ == "__main__":
-    pytest.main([__file__, "-s"])
+    test_path_angle()
+    # pytest.main([__file__, "-s"])


### PR DESCRIPTION
## Summary

Fix path rotation by updating start and end angles during path transformations

Bug Fixes:
- Correctly update path start and end angles when rotating or transforming paths

Enhancements:
- Improve path transformation method to maintain accurate angle information

Tests:
- Add a test case to verify path rotation and angle preservation