### PR TITLE
improve docs for avoiding colisions

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -212,9 +212,29 @@ def route_bundle(
     else:
         collision_check_layer_enums = None
 
+    bboxes = bboxes or []
+
     if auto_taper:
+        bbox1 = gf.kdb.DBox()
+        bbox2 = gf.kdb.DBox()
+        for port in ports1_:
+            bbox1 += port.dcplx_trans.disp.to_p()
+
+        for port in ports2_:
+            bbox2 += port.dcplx_trans.disp.to_p()
+
         ports1_ = add_auto_tapers(component, ports1_, cross_section)
         ports2_ = add_auto_tapers(component, ports2_, cross_section)
+
+        for port in ports1_:
+            bbox1 += port.dcplx_trans.disp.to_p()
+
+        for port in ports2_:
+            bbox2 += port.dcplx_trans.disp.to_p()
+
+        bboxes.append(bbox1)
+        bboxes.append(bbox2)
+        # component.shapes(component.kcl.layer(1,0)).insert(bbox)
 
     if steps and waypoints:
         raise ValueError("Cannot have both steps and waypoints")

--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -1180,7 +1180,7 @@
     "## route_bundle with collisions\n",
     "\n",
     "\n",
-    "The route bundle with collision avoidance is not yet supported."
+    "The route bundle alsos supports avoiding obstacles."
    ]
   },
   {
@@ -1215,7 +1215,7 @@
     "        obstacle.bbox(),\n",
     "        pbot.bbox(),\n",
     "        ptop.bbox(),\n",
-    "    ],  # obstacles to avoid\n",
+    "    ],  # obstacles to avoid need to be touching the initial or end ports\n",
     "    sort_ports=True,\n",
     ")\n",
     "\n",
@@ -1223,9 +1223,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "43",
+   "metadata": {},
+   "source": [
+    "If the obstacle does not intersect the initial or end ports, the router does not attempt to avoid it."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,9 +1250,52 @@
     "obstacle.ymin = pbot.ymax - 10\n",
     "obstacle.xmin = pbot.xmax + 10\n",
     "\n",
-    "c2 = gf.Component()  # create a dummy component to get the size of the obstacle\n",
-    "obstacle_sized = c2 << gf.c.rectangle(size=(340, 140), layer=\"M3\", centered=True)\n",
-    "obstacle_sized.dcenter = obstacle.dcenter\n",
+    "\n",
+    "routes = gf.routing.route_bundle_electrical(\n",
+    "    c,\n",
+    "    pbot.ports,\n",
+    "    ptop.ports,\n",
+    "    start_straight_length=100,\n",
+    "    separation=20,\n",
+    "    cross_section=\"metal_routing\",\n",
+    "    bboxes=[\n",
+    "        obstacle.bbox(), \n",
+    "        pbot.bbox(),\n",
+    "        ptop.bbox(),\n",
+    "    ],  \n",
+    "    sort_ports=True,\n",
+    ")\n",
+    "\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45",
+   "metadata": {},
+   "source": [
+    "However you can enlarge it to avoid it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "c = gf.Component()\n",
+    "columns = 2\n",
+    "ptop = c << gf.components.pad_array(columns=columns, port_orientation=270)\n",
+    "pbot = c << gf.components.pad_array(port_orientation=270, columns=columns)\n",
+    "ptop.movex(300)\n",
+    "ptop.movey(300)\n",
+    "\n",
+    "obstacle = c << gf.c.rectangle(size=(300, 100), layer=\"M3\", centered=True)\n",
+    "obstacle.ymin = pbot.ymax - 10\n",
+    "obstacle.xmin = pbot.xmax + 10\n",
     "\n",
     "\n",
     "routes = gf.routing.route_bundle_electrical(\n",
@@ -1255,10 +1306,10 @@
     "    separation=20,\n",
     "    cross_section=\"metal_routing\",\n",
     "    bboxes=[\n",
-    "        obstacle_sized.bbox(),\n",
+    "        obstacle.bbox().enlarge(10), # Otherwise you need to enlarge the bbox by 10 um\n",
     "        pbot.bbox(),\n",
     "        ptop.bbox(),\n",
-    "    ],  # obstacles to avoid not working yet\n",
+    "    ],  \n",
     "    sort_ports=True,\n",
     ")\n",
     "\n",
@@ -1267,7 +1318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "47",
    "metadata": {},
    "source": [
     "## route_bundle_all_angle\n",
@@ -1278,7 +1329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,7 +1358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "49",
    "metadata": {},
    "source": [
     "You can also use it to connect rotated components that do not have a manhattan orientation (0, 90, 180, 270)"
@@ -1316,7 +1367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1340,7 +1391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "51",
    "metadata": {},
    "source": [
     "## Dubins paths\n",
@@ -1355,7 +1406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1382,7 +1433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,7 +1462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "54",
    "metadata": {},
    "source": [
     "## auto_taper\n",
@@ -1450,7 +1501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1471,7 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1500,7 +1551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Update `route_bundle` documentation and examples for obstacle avoidance, and ensure auto-tapers are considered obstacles.

Enhancements:
- Automatically include the bounding boxes of auto-tapers in the obstacle list for `route_bundle`.

Documentation:
- Clarify that `route_bundle` avoids obstacles touching ports by default.
- Add examples demonstrating how to handle obstacles not touching ports by enlarging their bounding boxes.

Chores:
- Automatically include the bounding boxes of auto-tapers in the obstacle list for `route_bundle`.