### PR TITLE
Add warning stacklevels

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -86,7 +86,7 @@ if sys.version_info[:2] == (3, 10):
         "to continue using the latest features and improvements. "
         "To get the latest gdsfactory, upgrading your Python version is required.",
         DeprecationWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
 

--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -86,6 +86,7 @@ if sys.version_info[:2] == (3, 10):
         "to continue using the latest features and improvements. "
         "To get the latest gdsfactory, upgrading your Python version is required.",
         DeprecationWarning,
+        stacklevel=2,
     )
 
 

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -493,7 +493,7 @@ def add_instance_label(
         layer = layer or gf.get_layer("LABEL_INSTANCE")
     except ValueError:
         warnings.warn(
-            "Layer LABEL_INSTANCE not found in PDK.layers, using (1, 0)", stacklevel=2
+            "Layer LABEL_INSTANCE not found in PDK.layers, using (1, 0)", stacklevel=3
         )
         layer = (1, 0)
     instance_name = (

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -492,7 +492,9 @@ def add_instance_label(
     try:
         layer = layer or gf.get_layer("LABEL_INSTANCE")
     except ValueError:
-        warnings.warn("Layer LABEL_INSTANCE not found in PDK.layers, using (1, 0)")
+        warnings.warn(
+            "Layer LABEL_INSTANCE not found in PDK.layers, using (1, 0)", stacklevel=2
+        )
         layer = (1, 0)
     instance_name = (
         instance_name or f"{reference.cell.name},{int(reference.x)},{int(reference.y)}"

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -172,7 +172,7 @@ def add_ports_from_markers_center(
     polygons = component.get_polygons(by="index")
     if pin_layer not in polygons:
         warnings.warn(
-            f"no pin layer {pin_layer} found in {component.layers}", stacklevel=2
+            f"no pin layer {pin_layer} found in {component.layers}", stacklevel=3
         )
         return component
 

--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -171,7 +171,9 @@ def add_ports_from_markers_center(
 
     polygons = component.get_polygons(by="index")
     if pin_layer not in polygons:
-        warnings.warn(f"no pin layer {pin_layer} found in {component.layers}")
+        warnings.warn(
+            f"no pin layer {pin_layer} found in {component.layers}", stacklevel=2
+        )
         return component
 
     port_markers = polygons[pin_layer]

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -199,7 +199,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             warnings.warn(
                 f"Port type {port_type} not in {CONF.port_types}. "
                 "Please add it to the port_types list in the config gf.CONF.port_types.",
-                stacklevel=2,
+                stacklevel=3,
             )
 
         if layer is None:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -198,7 +198,8 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if port_type not in CONF.port_types:
             warnings.warn(
                 f"Port type {port_type} not in {CONF.port_types}. "
-                "Please add it to the port_types list in the config gf.CONF.port_types."
+                "Please add it to the port_types list in the config gf.CONF.port_types.",
+                stacklevel=2,
             )
 
         if layer is None:

--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -125,7 +125,7 @@ def bend_circular(
         warnings.warn(
             f"bend_euler angle should be 90 or 180. Got {angle}. Use bend_euler_all_angle instead.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
     return _bend_circular(
         radius=radius,

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -223,7 +223,7 @@ def bend_euler(
         warnings.warn(
             f"bend_euler angle should be 90 or 180. Got {angle}. Use bend_euler_all_angle instead.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
     return _bend_euler(

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -59,7 +59,8 @@ def text_freetype(
                 else:
                     valid_chars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~µ"
                     warnings.warn(
-                        f'text(): Warning, some characters ignored, no geometry for character "{chr(ascii_val)}" with ascii value {ascii_val}. Valid characters: {valid_chars}'
+                        f'text(): Warning, some characters ignored, no geometry for character "{chr(ascii_val)}" with ascii value {ascii_val}. Valid characters: {valid_chars}',
+                        stacklevel=2,
                     )
             ref = t.add_ref(char)
             yoffset -= 1500 * scaling

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -60,7 +60,7 @@ def text_freetype(
                     valid_chars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~µ"
                     warnings.warn(
                         f'text(): Warning, some characters ignored, no geometry for character "{chr(ascii_val)}" with ascii value {ascii_val}. Valid characters: {valid_chars}',
-                        stacklevel=2,
+                        stacklevel=3,
                     )
             ref = t.add_ref(char)
             yoffset -= 1500 * scaling

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -241,7 +241,7 @@ class CrossSection(BaseModel):
                 raise ValueError(message)
 
             elif error_type == ErrorType.WARNING:
-                warnings.warn(message)
+                warnings.warn(message, stacklevel=2)
 
     @property
     def name(self) -> str:

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -241,7 +241,7 @@ class CrossSection(BaseModel):
                 raise ValueError(message)
 
             elif error_type == ErrorType.WARNING:
-                warnings.warn(message, stacklevel=2)
+                warnings.warn(message, stacklevel=3)
 
     @property
     def name(self) -> str:

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -83,7 +83,8 @@ def extract(
     for layer_tuple in layer_tuples:
         if layer_tuple not in component_layers:
             warnings.warn(
-                f"Layer {layer_tuple} not found in component {component.name!r} layers. {component_layers}"
+                f"Layer {layer_tuple} not found in component {component.name!r} layers. {component_layers}",
+                stacklevel=2,
             )
 
     for layer_tuple in component_layers:

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -84,7 +84,7 @@ def extract(
         if layer_tuple not in component_layers:
             warnings.warn(
                 f"Layer {layer_tuple} not found in component {component.name!r} layers. {component_layers}",
-                stacklevel=2,
+                stacklevel=3,
             )
 
     for layer_tuple in component_layers:

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -402,7 +402,7 @@ def _extract_connections(
 
         elif not allow_multiple:
             warnings["multiple_connections"].append(ports_at_xy)
-            warn(f"Found multiple connections at {xy}:{ports_at_xy}")
+            warn(f"Found multiple connections at {xy}:{ports_at_xy}", stacklevel=2)
 
         else:
             # Iterates over the list of multiple ports to create related two-port connectivity
@@ -437,7 +437,7 @@ def _extract_connections(
 
     if critical_warnings and raise_error_for_warnings:
         pprint(critical_warnings)
-        warn("Found critical warnings while extracting netlist")
+        warn("Found critical warnings while extracting netlist", stacklevel=2)
     return connections, dict(warnings)
 
 

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -402,7 +402,7 @@ def _extract_connections(
 
         elif not allow_multiple:
             warnings["multiple_connections"].append(ports_at_xy)
-            warn(f"Found multiple connections at {xy}:{ports_at_xy}", stacklevel=2)
+            warn(f"Found multiple connections at {xy}:{ports_at_xy}", stacklevel=3)
 
         else:
             # Iterates over the list of multiple ports to create related two-port connectivity
@@ -437,7 +437,7 @@ def _extract_connections(
 
     if critical_warnings and raise_error_for_warnings:
         pprint(critical_warnings)
-        warn("Found critical warnings while extracting netlist", stacklevel=2)
+        warn("Found critical warnings while extracting netlist", stacklevel=3)
     return connections, dict(warnings)
 
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -232,7 +232,7 @@ class Pdk(BaseModel):
                     "cells functions that return a Component"
                 )
             if name in self.cells:
-                warnings.warn(f"Overwriting cell {name!r}", stacklevel=2)
+                warnings.warn(f"Overwriting cell {name!r}", stacklevel=3)
 
             self.cells[name] = cell
 
@@ -245,7 +245,7 @@ class Pdk(BaseModel):
                     "cross_section functions that return a CrossSection"
                 )
             if name in self.cross_sections:
-                warnings.warn(f"Overwriting cross_section {name!r}", stacklevel=2)
+                warnings.warn(f"Overwriting cross_section {name!r}", stacklevel=3)
             self.cross_sections[name] = cross_section
 
     def register_cells_yaml(

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -232,7 +232,7 @@ class Pdk(BaseModel):
                     "cells functions that return a Component"
                 )
             if name in self.cells:
-                warnings.warn(f"Overwriting cell {name!r}")
+                warnings.warn(f"Overwriting cell {name!r}", stacklevel=2)
 
             self.cells[name] = cell
 
@@ -245,7 +245,7 @@ class Pdk(BaseModel):
                     "cross_section functions that return a CrossSection"
                 )
             if name in self.cross_sections:
-                warnings.warn(f"Overwriting cross_section {name!r}")
+                warnings.warn(f"Overwriting cross_section {name!r}", stacklevel=2)
             self.cross_sections[name] = cross_section
 
     def register_cells_yaml(

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -404,7 +404,7 @@ def flipped(port: typings.Port) -> typings.Port:
 def move_copy(port: typings.Port, x: int = 0, y: int = 0) -> typings.Port:
     warnings.warn(
         "Port.move_copy(...) should be used instead of move_copy(Port, ...).",
-        stacklevel=2,
+        stacklevel=3,
     )
     _port = port.copy()
     _port.center = (port.center[0] + x, port.center[1] + y)

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -404,6 +404,7 @@ def flipped(port: typings.Port) -> typings.Port:
 def move_copy(port: typings.Port, x: int = 0, y: int = 0) -> typings.Port:
     warnings.warn(
         "Port.move_copy(...) should be used instead of move_copy(Port, ...).",
+        stacklevel=2,
     )
     _port = port.copy()
     _port.center = (port.center[0] + x, port.center[1] + y)

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -112,7 +112,7 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
         if "parameters" in block:
             parameters = block["parameters"]
         else:
-            warnings.warn(f"{block_name=} does not have parameters", stacklevel=2)
+            warnings.warn(f"{block_name=} does not have parameters", stacklevel=3)
             continue
 
         parameters_string = (

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -112,7 +112,7 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
         if "parameters" in block:
             parameters = block["parameters"]
         else:
-            warnings.warn(f"{block_name=} does not have parameters")
+            warnings.warn(f"{block_name=} does not have parameters", stacklevel=2)
             continue
 
         parameters_string = (

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -1229,7 +1229,7 @@ def _split_route_link(s: str) -> tuple[str, list[str], str]:
         if s.count(":") == 2:
             s = s.replace(":", "", 1)
             s = s.replace(":", "-", 1)
-            warnings.warn(warning)
+            warnings.warn(warning, stacklevel=2)
         else:
             raise error
 

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -995,7 +995,6 @@ def _add_routes(
             ports2=ports2,
             **bundle.settings,
         )
-        c.plot()
         routes_dict.update(dict(zip(route_names, routes_list)))
         c.routes = routes_dict
     return c

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -1229,7 +1229,7 @@ def _split_route_link(s: str) -> tuple[str, list[str], str]:
         if s.count(":") == 2:
             s = s.replace(":", "", 1)
             s = s.replace(":", "-", 1)
-            warnings.warn(warning, stacklevel=2)
+            warnings.warn(warning, stacklevel=3)
         else:
             raise error
 

--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -69,7 +69,8 @@ def auto_taper_to_cross_section(
             taper = layer_transitions[port_layer]
         except KeyError:
             warnings.warn(
-                f"No registered width taper for layer {port_layer}. Skipping."
+                f"No registered width taper for layer {port_layer}. Skipping.",
+                stacklevel=2,
             )
             return port
     else:

--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -70,7 +70,7 @@ def auto_taper_to_cross_section(
         except KeyError:
             warnings.warn(
                 f"No registered width taper for layer {port_layer}. Skipping.",
-                stacklevel=3,
+                stacklevel=4,
             )
             return port
     else:

--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -70,7 +70,7 @@ def auto_taper_to_cross_section(
         except KeyError:
             warnings.warn(
                 f"No registered width taper for layer {port_layer}. Skipping.",
-                stacklevel=2,
+                stacklevel=3,
             )
             return port
     else:

--- a/gdsfactory/routing/validation.py
+++ b/gdsfactory/routing/validation.py
@@ -26,7 +26,7 @@ def make_error_traces(
     """
     import gdsfactory as gf
 
-    warn(message, RouteWarning)
+    warn(message, RouteWarning, stacklevel=2)
     for port1, port2 in zip(ports1, ports2):
         path = gf.path.Path(np.array([port1.center, port2.center]))
         error_component = gf.path.extrude(path, layer=CONF.layer_error_path, width=1)

--- a/gdsfactory/routing/validation.py
+++ b/gdsfactory/routing/validation.py
@@ -26,7 +26,7 @@ def make_error_traces(
     """
     import gdsfactory as gf
 
-    warn(message, RouteWarning, stacklevel=2)
+    warn(message, RouteWarning, stacklevel=3)
     for port1, port2 in zip(ports1, ports2):
         path = gf.path.Path(np.array([port1.center, port2.center]))
         error_component = gf.path.extrude(path, layer=CONF.layer_error_path, width=1)

--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -26,7 +26,7 @@ def is_on_grid(
 
 def warn_if_not_on_grid(x: Value) -> None:
     if not is_on_grid(x):
-        warnings.warn(f"{x} is not on grid", stacklevel=2)
+        warnings.warn(f"{x} is not on grid", stacklevel=3)
 
 
 def assert_on_grid(

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -572,7 +572,8 @@ class LayerView(BaseModel):
             dither_pattern = f"C{list(custom_hatch_patterns).index(str(hatch_name))}"
         else:
             warnings.warn(
-                f"Dither pattern {hatch_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead."
+                f"Dither pattern {hatch_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead.",
+                stacklevel=2,
             )
             dither_pattern = "I3"
 
@@ -586,7 +587,8 @@ class LayerView(BaseModel):
             line_style = f"C{list(custom_line_styles).index(str(ls_name))}"
         else:
             warnings.warn(
-                f"Line style {ls_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead."
+                f"Line style {ls_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead.",
+                stacklevel=2,
             )
             line_style = "I3"
 
@@ -1087,7 +1089,8 @@ class LayerViews(BaseModel):
 
             if name in dither_patterns:
                 warnings.warn(
-                    f"Dither pattern named {name!r} already exists. Keeping only the first defined."
+                    f"Dither pattern named {name!r} already exists. Keeping only the first defined.",
+                    stacklevel=2,
                 )
                 continue
 
@@ -1106,7 +1109,8 @@ class LayerViews(BaseModel):
 
             if name in line_styles:
                 warnings.warn(
-                    f"Line style named {name!r} already exists. Keeping only the first defined."
+                    f"Line style named {name!r} already exists. Keeping only the first defined.",
+                    stacklevel=2,
                 )
                 continue
 

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -573,7 +573,7 @@ class LayerView(BaseModel):
         else:
             warnings.warn(
                 f"Dither pattern {hatch_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead.",
-                stacklevel=2,
+                stacklevel=3,
             )
             dither_pattern = "I3"
 
@@ -588,7 +588,7 @@ class LayerView(BaseModel):
         else:
             warnings.warn(
                 f"Line style {ls_name!r} does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead.",
-                stacklevel=2,
+                stacklevel=3,
             )
             line_style = "I3"
 
@@ -1090,7 +1090,7 @@ class LayerViews(BaseModel):
             if name in dither_patterns:
                 warnings.warn(
                     f"Dither pattern named {name!r} already exists. Keeping only the first defined.",
-                    stacklevel=2,
+                    stacklevel=3,
                 )
                 continue
 
@@ -1110,7 +1110,7 @@ class LayerViews(BaseModel):
             if name in line_styles:
                 warnings.warn(
                     f"Line style named {name!r} already exists. Keeping only the first defined.",
-                    stacklevel=2,
+                    stacklevel=3,
                 )
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ fix = true
 [tool.ruff.lint]
 ignore = [
   "B008",  # do not perform function calls in argument defaults
-  "B028",  # stacklevel
   "B904",
   "B905",  # `zip()` without an explicit `strict=` parameter
   "C408",  # C408 Unnecessary `dict` call (rewrite as a literal)


### PR DESCRIPTION
increasing the stacklevel will give better info on where the warning was generated.

## Summary by Sourcery

Increase stacklevel for warnings to provide more accurate source information when warnings are generated

Enhancements:
- Updated multiple warning calls across the project to use stacklevel=3 to improve warning trace accuracy

Chores:
- Removed 'B028' stacklevel warning from ruff linter configuration