### PR TITLE
bump kfactory to 1.5.2 at least

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.5,<1.6",
+  "kfactory[ipy]>=1.5.2,<1.6",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Update the kfactory dependency to version 1.5.2 or higher