### PR TITLE
use cross_section in route_bundle for electrical cases

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -261,26 +261,53 @@ def route_bundle(
 
     router = router or "electrical" if port_type == "electrical" else "optical"
     if router == "electrical":
-        return kf.routing.electrical.route_bundle(
-            component,
-            ports1_,
-            ports2_,
-            separation=separation,
-            starts=start_straight_length,
-            ends=end_straight_length,
-            collision_check_layers=[
-                c.kcl.layout.get_info(layer) for layer in collision_check_layer_enums
-            ]
-            if collision_check_layer_enums is not None
-            else None,
-            on_collision=on_collision,
-            bboxes=bboxes,
-            route_width=width,
-            sort_ports=sort_ports,
-            waypoints=waypoints_,
-            end_angles=end_angles,
-            start_angles=start_angles,
-        )
+        if cross_section is not None:
+            xs = gf.get_cross_section(cross_section)
+            print(xs.name)
+            return kf.routing.electrical.route_bundle(
+                component,
+                ports1_,
+                ports2_,
+                separation=separation,
+                starts=start_straight_length,
+                ends=end_straight_length,
+                collision_check_layers=[
+                    c.kcl.layout.get_info(layer)
+                    for layer in collision_check_layer_enums
+                ]
+                if collision_check_layer_enums is not None
+                else None,
+                on_collision=on_collision,
+                bboxes=bboxes,
+                route_width=width,
+                sort_ports=sort_ports,
+                waypoints=waypoints_,
+                end_angles=end_angles,
+                start_angles=start_angles,
+                place_layer=gf.kcl.get_info(gf.get_layer(xs.sections[0].layer)),
+            )
+        else:
+            return kf.routing.electrical.route_bundle(
+                component,
+                ports1_,
+                ports2_,
+                separation=separation,
+                starts=start_straight_length,
+                ends=end_straight_length,
+                collision_check_layers=[
+                    c.kcl.layout.get_info(layer)
+                    for layer in collision_check_layer_enums
+                ]
+                if collision_check_layer_enums is not None
+                else None,
+                on_collision=on_collision,
+                bboxes=bboxes,
+                route_width=width,
+                sort_ports=sort_ports,
+                waypoints=waypoints_,
+                end_angles=end_angles,
+                start_angles=start_angles,
+            )
 
     bend90 = (
         bend

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -263,51 +263,32 @@ def route_bundle(
     if router == "electrical":
         if cross_section is not None:
             xs = gf.get_cross_section(cross_section)
-            print(xs.name)
-            return kf.routing.electrical.route_bundle(
-                component,
-                ports1_,
-                ports2_,
-                separation=separation,
-                starts=start_straight_length,
-                ends=end_straight_length,
-                collision_check_layers=[
-                    c.kcl.layout.get_info(layer)
-                    for layer in collision_check_layer_enums
-                ]
-                if collision_check_layer_enums is not None
-                else None,
-                on_collision=on_collision,
-                bboxes=bboxes,
-                route_width=width,
-                sort_ports=sort_ports,
-                waypoints=waypoints_,
-                end_angles=end_angles,
-                start_angles=start_angles,
-                place_layer=gf.kcl.get_info(gf.get_layer(xs.sections[0].layer)),
+            layer_: gf.kdb.LayerInfo | None = gf.kcl.get_info(
+                gf.get_layer(xs.sections[0].layer)
             )
         else:
-            return kf.routing.electrical.route_bundle(
-                component,
-                ports1_,
-                ports2_,
-                separation=separation,
-                starts=start_straight_length,
-                ends=end_straight_length,
-                collision_check_layers=[
-                    c.kcl.layout.get_info(layer)
-                    for layer in collision_check_layer_enums
-                ]
-                if collision_check_layer_enums is not None
-                else None,
-                on_collision=on_collision,
-                bboxes=bboxes,
-                route_width=width,
-                sort_ports=sort_ports,
-                waypoints=waypoints_,
-                end_angles=end_angles,
-                start_angles=start_angles,
-            )
+            layer_ = None
+        return kf.routing.electrical.route_bundle(
+            component,
+            ports1_,
+            ports2_,
+            separation=separation,
+            starts=start_straight_length,
+            ends=end_straight_length,
+            collision_check_layers=[
+                c.kcl.layout.get_info(layer) for layer in collision_check_layer_enums
+            ]
+            if collision_check_layer_enums is not None
+            else None,
+            on_collision=on_collision,
+            bboxes=bboxes,
+            route_width=width,
+            sort_ports=sort_ports,
+            waypoints=waypoints_,
+            end_angles=end_angles,
+            start_angles=start_angles,
+            place_layer=layer_,
+        )
 
     bend90 = (
         bend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.5.2,<1.6",
+  "kfactory[ipy]>=1.5.4,<1.6",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Add support for using cross_section in electrical route_bundle routing

New Features:
- Add optional cross_section parameter for electrical route_bundle routing

Enhancements:
- Modify electrical route_bundle to use cross_section layer when provided

Chores:
- Update kfactory dependency to version >=1.5.4