### PR TITLE
Add `auto_taper_pads` flag to route_fiber_array_pads_north

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -50,7 +50,7 @@ Then you need to fork the [GitHub repository](https://github.com/gdsfactory/gdsf
 The following lines will:
 
 - clone your gdsfactory fork (make sure you change `YourUserName` with your GitHub user name)
-- download the GDS reference files for running GDS regressions from a separate repo.
+- download the GDS reference files for running GDS regressions from a separate [repo](https://github.com/gdsfactory/gdsfactory-test-data/tree/test-data)
 - install gdsfactory on your computer in `-e` edit mode.
 - install pre-commit hooks for making sure your code syntax and style matches some basic rules.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -15,7 +15,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ```bash
-# On Windows.
+# On Windows open a PowerShell terminal and run:
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
@@ -50,7 +50,7 @@ Then you need to fork the [GitHub repository](https://github.com/gdsfactory/gdsf
 The following lines will:
 
 - clone your gdsfactory fork (make sure you change `YourUserName` with your GitHub user name)
-- download the GDS reference files for running GDS regressions from a separate [repo](https://github.com/gdsfactory/gdsfactory-test-data/tree/test-data)
+- download the GDS reference files for running GDS regressions from a separate repo.
 - install gdsfactory on your computer in `-e` edit mode.
 - install pre-commit hooks for making sure your code syntax and style matches some basic rules.
 

--- a/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
@@ -19,6 +19,7 @@ def add_fiber_array_optical_south_electrical_north(
     electrical_port_orientation: AngleInDegrees | None = 90,
     npads: int | None = None,
     port_types_grating_couplers: list[str] | None = None,
+    auto_taper_pads: bool = True,
     **kwargs: Any,
 ) -> Component:
     """Returns a fiber array with Optical gratings on South and Electrical pads on North.
@@ -38,6 +39,7 @@ def add_fiber_array_optical_south_electrical_north(
         electrical_port_orientation: orientation of electrical ports. Defaults to 90.
         npads: number of pads. Defaults to one per electrical_port_names.
         port_types_grating_couplers: port types for grating couplers. Defaults to vertical TE, TM, and dual.
+        auto_taper_pads: whether to add a taper to the pads.
         kwargs: additional arguments.
 
     Keyword Args:
@@ -121,6 +123,7 @@ def add_fiber_array_optical_south_electrical_north(
         ports2=ports2,
         cross_section=cross_section_metal,
         sort_ports=True,
+        auto_taper=auto_taper_pads,
     )
 
     c.add_ports(ports2)

--- a/test-data-regression/test_settings_add_fiber_array_optical_south_electrical_north_.yml
+++ b/test-data-regression/test_settings_add_fiber_array_optical_south_electrical_north_.yml
@@ -1,6 +1,7 @@
 info: {}
-name: add_fiber_array_optical_62c6e12d
+name: add_fiber_array_optical_fc183c6d
 settings:
+  auto_taper_pads: true
   component: Fstraight_heater_metal_undercut_Mgdsfactorypcomponentspwaveguidespstraight_heater_metal_SWUFalse_LSI0p1_LU5_LUS0
   cross_section_metal: metal_routing
   electrical_port_orientation: 90


### PR DESCRIPTION
## Summary by Sourcery

Add an option to automatically taper electrical pads in the fiber array component

New Features:
- Added an `auto_taper_pads` parameter to control automatic pad tapering in the fiber array component

Documentation:
- Updated Windows installation instructions in developer documentation