### PR TITLE
improve docs

### DIFF
--- a/notebooks/00_geometry.ipynb
+++ b/notebooks/00_geometry.ipynb
@@ -84,17 +84,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "c = gf.Component()\n",
-    "p1 = gf.kdb.DPolygon([(-8, -6), (6, 8), (7, 17), (9, 5)])  # DPolygons are in um\n",
-    "p2 = p1.sized(2)\n",
-    "\n",
-    "c.add_polygon(p1, layer=(1, 0))\n",
-    "c.add_polygon(p2, layer=(2, 0))\n",
+    "p1 = c.add_polygon(\n",
+    "    [(-8, -6), (6, 8), (7, 17), (9, 5)], layer=(1, 0)\n",
+    ")  # DPolygons are in um\n",
+    "p2 = c.get_region(layer=(1, 0))  # Get the region of the polygon\n",
+    "p3 = p2.size(2000)  # Regions are in nm!\n",
+    "c.add_polygon(p3, layer=(2, 0))  # Add the region to the component\n",
     "c.plot()"
    ]
   },
@@ -116,12 +115,14 @@
    "outputs": [],
    "source": [
     "c = gf.Component()\n",
-    "p1 = gf.kdb.DPolygon([(-8, -6), (6, 8), (7, 17), (9, 5)])\n",
-    "r1 = gf.Region(p1.to_itype(gf.kcl.dbu))  # convert from um to DBU\n",
-    "r2 = r1.sized(2000)  # in DBU\n",
+    "p1 = c.add_polygon(\n",
+    "    [(-8, -6), (6, 8), (7, 17), (9, 5)], layer=(1, 0)\n",
+    ")  # Polygons are in um\n",
+    "r1 = c.get_region(layer=(1,0))  # Regions are in DBU (1 nm in this case)\n",
+    "r2 = r1.sized(2000)  # Regions are in DBU\n",
     "r3 = r2 - r1\n",
     "\n",
-    "c.add_polygon(r3, layer=(2, 0))\n",
+    "c.add_polygon(r3, layer=(2, 0))  # Add the region to the component\n",
     "c.plot()"
    ]
   },
@@ -143,8 +144,27 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "p1 = [(-8, -6), (6, 8), (7, 17), (9, 5)]\n",
+    "s1 = c.add_polygon(p1, layer=(1, 0))\n",
+    "r1 = gf.Region(s1.polygon)\n",
+    "r2 = r1.sized(2000)  # in DBU, 1 DBU = 1 nm, size it by 2000 nm = 2um\n",
+    "r3 = r2 - r1\n",
+    "\n",
+    "c2 = gf.Component()\n",
+    "c2.add_polygon(r3, layer=(2, 0))\n",
+    "c2.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -161,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "Now we can connect everything together using the ports:\n",
@@ -215,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "Ports can be added by copying existing ports. In the example below, ports are added at the component-level on c from the existing ports of children wg1 and wg3\n",
@@ -241,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "You can show the ports by adding port pins with triangular shape or using the show_ports plugin\n",
@@ -263,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "Also you can visualize ports in klayout as the ports are stored in the GDS cell metadata."
@@ -281,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Move and rotate Instances\n",
@@ -297,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +338,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "You can also define the positions relative to other references."
@@ -327,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Ports\n",
@@ -360,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "You can access the ports of a Component or ComponentReference"
@@ -369,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## References\n",
@@ -414,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Labels\n",
@@ -455,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +493,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "Another simple example"
@@ -482,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +520,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Boolean shapes\n",
@@ -517,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,7 +561,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Move Reference by port"
@@ -550,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Mirror reference\n",
@@ -584,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Write\n",
@@ -614,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "You can see the GDS file in Klayout viewer.\n",
@@ -638,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +667,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "⚠️ **Warning!**  \n",
@@ -663,7 +683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "OASIS is a newer format that can store CAD files and that reduces the size."
@@ -672,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "You can also save it as STL for 3D printing or for device level simulations. For that you need to extrude the polygons using the information in the LayerStack."
@@ -690,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +749,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Update the 00_geometry tutorial notebook to modernize API usage, improve clarity around unit conversions, and clean up cell metadata and numbering

Documentation:
- Modernize geometry notebook examples to use Component.add_polygon and get_region workflows
- Clarify units for polygons (µm) and regions (DBU/nm) in documentation cells
- Replace obsolete cell metadata and simplify code snippets for clarity

Chores:
- Renumber all notebook cell IDs and remove redundant metadata
- Update notebook kernel version from Python 3.11.8 to 3.12.9