### PR TITLE
prevent container conflicts

### DIFF
--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -67,7 +67,7 @@ def get_generic_pdk() -> Pdk:
     return Pdk(
         name="generic",
         version=__version__,
-        cells=cells,
+        cells={c: cells[c] for c in cells if c not in containers_dict},
         containers=containers_dict,
         cross_sections=cross_sections,
         layers=LAYER,

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -335,7 +335,16 @@ class Pdk(BaseModel):
         **kwargs: Any,
     ) -> Component:
         """Returns component from a component spec."""
-        cells = {**self.cells, **self.containers} if include_containers else self.cells
+        if include_containers:
+            conflicting_names = set(self.cells.keys()).intersection(self.containers.keys())
+            if conflicting_names:
+                raise ValueError(
+                    f"PDK {self.name!r} has overlapping cell names between cells and containers: {list(conflicting_names)}. "
+                )
+            cells = {**self.cells, **self.containers}
+        else:
+            cells = self.cells
+            
         return self._get_component(
             component=component, cells=cells, settings=settings, **kwargs
         )

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -336,7 +336,9 @@ class Pdk(BaseModel):
     ) -> Component:
         """Returns component from a component spec."""
         if include_containers:
-            conflicting_names = set(self.cells.keys()).intersection(self.containers.keys())
+            conflicting_names = set(self.cells.keys()).intersection(
+                self.containers.keys()
+            )
             if conflicting_names:
                 raise ValueError(
                     f"PDK {self.name!r} has overlapping cell names between cells and containers: {list(conflicting_names)}. "
@@ -344,7 +346,7 @@ class Pdk(BaseModel):
             cells = {**self.cells, **self.containers}
         else:
             cells = self.cells
-            
+
         return self._get_component(
             component=component, cells=cells, settings=settings, **kwargs
         )

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,6 +1,8 @@
+import pytest
+
 import gdsfactory as gf
 from gdsfactory.generic_tech import LAYER
-import pytest
+
 
 def test_get_cross_section() -> None:
     assert gf.pdk.get_cross_section("strip") == gf.cross_section.strip()
@@ -24,8 +26,10 @@ def test_container_cell_conflict_raises_error() -> None:
         name="test",
         layers=LAYER,
         cross_sections={"strip": gf.cross_section.strip},
-        cells={"straight": gf.components.straight,
-                    "add_pads_top": gf.containers.add_pads_top},
+        cells={
+            "straight": gf.components.straight,
+            "add_pads_top": gf.containers.add_pads_top,
+        },
         containers={"add_pads_top": gf.containers.add_pads_top},
     )
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,6 +1,6 @@
 import gdsfactory as gf
 from gdsfactory.generic_tech import LAYER
-
+import pytest
 
 def test_get_cross_section() -> None:
     assert gf.pdk.get_cross_section("strip") == gf.cross_section.strip()
@@ -16,3 +16,18 @@ def test_get_layer() -> None:
     assert gf.get_layer(1) == LAYER.WG
     assert gf.get_layer((1, 0)) == LAYER.WG
     assert gf.get_layer("WG") == LAYER.WG
+
+
+def test_container_cell_conflict_raises_error() -> None:
+    """Test that a cell with the same name as a container raises an error."""
+    pdk = gf.Pdk(
+        name="test",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+        cells={"straight": gf.components.straight,
+                    "add_pads_top": gf.containers.add_pads_top},
+        containers={"add_pads_top": gf.containers.add_pads_top},
+    )
+
+    with pytest.raises(ValueError, match=".* overlapping cell names .*add_pads_top.*"):
+        pdk.get_component("add_pads_top")


### PR DESCRIPTION
raises an error if there are naming conflicts between cells and containers in the pdk

## Summary by Sourcery

Bug Fixes:
- Raise an error when cell and container names overlap in get_component to prevent silent conflicts.