### PR TITLE
fix docs

### DIFF
--- a/notebooks/07_mask.ipynb
+++ b/notebooks/07_mask.ipynb
@@ -297,8 +297,6 @@
    },
    "outputs": [],
    "source": [
-    "pdk = gf.get_active_pdk()\n",
-    "pdk.register_cells(add_fiber_array=gf.routing.add_fiber_array)\n",
     "\n",
     "c = gf.read.from_yaml(\n",
     "    \"\"\"\n",
@@ -693,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Remove manual PDK registration lines from the mask tutorial notebook and update its kernel version to Python 3.12.9.

Documentation:
- Remove explicit PDK registration commands from the example notebook
- Update notebook metadata to use Python 3.12.9 kernel