### PR TITLE
remove add_padding default

### DIFF
--- a/gdsfactory/add_padding.py
+++ b/gdsfactory/add_padding.py
@@ -42,7 +42,7 @@ def get_padding_points(
 
 
 def add_padding(
-    component: ComponentSpec = "mmi2x2",
+    component: ComponentSpec,
     layers: LayerSpecs = ("PADDING",),
     default: float = 50.0,
     top: float | None = None,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove default `mmi2x2` value for the `component` parameter in `add_padding`, making it a required argument.