### PR TITLE
try to fix codeflash github actions

### DIFF
--- a/.github/workflows/codeflash.yaml
+++ b/.github/workflows/codeflash.yaml
@@ -20,11 +20,11 @@ jobs:
       CODEFLASH_PR_NUMBER: ${{ github.event.number }}
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: 🐍 Setup UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - name: 📦 Install Dependencies


### PR DESCRIPTION
## Summary by Sourcery

Update CodeFlash GitHub Actions workflow to use the latest versions of checkout and UV setup actions

CI:
- Upgrade actions/checkout to v6
- Upgrade astral-sh/setup-uv to v6