### PR TITLE
Run ty in ci

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
-change-template: '- $TITLE [#$NUMBER](https://github.com/gdsfactory/gdsfactory/pull/$NUMBER)'
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE [#$NUMBER](https://github.com/gdsfactory/gdsfactory/pull/$NUMBER)"
 template: |
   # What's Changed
 
@@ -8,60 +8,67 @@ template: |
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
-  - title: 'Breaking'
-    label: 'breaking'
-  - title: 'New'
+  - title: "Breaking"
+    label: "breaking"
+  - title: "New"
     labels:
-      - 'feature'
-      - 'enhancement'
-  - title: 'Bug Fixes'
-    label: 'bug'
-  - title: 'Maintenance'
+      - "feature"
+      - "enhancement"
+  - title: "Bug Fixes"
+    label: "bug"
+  - title: "Maintenance"
     labels:
-      - 'maintenance'
-      - 'github_actions'
-      - 'codeflash'
-  - title: 'Documentation'
-    label: 'documentation'
-  - title: 'Other changes'
-  - title: 'Dependency Updates'
-    label: 'dependencies'
+      - "maintenance"
+      - "github_actions"
+      - "codeflash"
+  - title: "Documentation"
+    label: "documentation"
+  - title: "Typing"
+    label: "typing"
+  - title: "Other changes"
+  - title: "Dependency Updates"
+    label: "dependencies"
     collapse-after: 5
 version-resolver:
   major:
     labels:
-      - 'breaking'
-      - 'major'
+      - "breaking"
+      - "major"
   minor:
     labels:
-      - 'feature'
-      - 'minor'
-      - 'enhancement'
+      - "feature"
+      - "minor"
+      - "enhancement"
   patch:
     labels:
-      - 'bug'
-      - 'maintenance'
-      - 'github_actions'
-      - 'documentation'
-      - 'dependencies'
-      - 'security'
+      - "bug"
+      - "maintenance"
+      - "github_actions"
+      - "documentation"
+      - "dependencies"
+      - "security"
   default: patch
 exclude-labels:
-  - 'skip-changelog'
+  - "skip-changelog"
 autolabeler:
-  - label: 'documentation'
+  - label: "documentation"
     files:
-      - '*.md'
+      - "*.md"
     branch:
-      - '/docs-.+/'
-  - label: 'bug'
+      - "/docs-.+/"
+  - label: "bug"
     branch:
-      - '/fix-.+/'
+      - "/fix-.+/"
     title:
-      - '/fix/i'
-  - label: 'enhancement'
+      - "/fix/i"
+  - label: "enhancement"
     branch:
-      - '/feature-.+/'
-      - '/add-.+/'
+      - "/feature-.+/"
+      - "/add-.+/"
     title:
       - '/^add\s/i'
+  - label: "typing"
+    branch:
+      - "/^typing-.+/"
+    title:
+      - "/^typing/i"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "breaking, bug, github_actions, documentation, dependencies, enhancement, feature, maintenance, security"
+          labels: "breaking, bug, github_actions, documentation, dependencies, enhancement, feature, maintenance, security, typing"
           add_comment: true

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -97,4 +97,4 @@ jobs:
         run: |
           uv sync --extra dev
       - name: Run ty check
-        run: uv run ty check src/kfactory || true
+        run: uv run ty check gdsfactory || true

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
   test_samples:
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +73,7 @@ jobs:
       - name: Test with pytest
         run: |
           make test-samples
+
   type_consistency:
     runs-on: ubuntu-latest
     steps:
@@ -79,3 +81,20 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: make install
       - run: uv run mypy gdsfactory/
+
+  run-ty:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.13"
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+      - name: Run ty check
+        run: uv run ty check src/kfactory || true

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -56,7 +56,7 @@ import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from functools import partial
-from typing import IO, TYPE_CHECKING, Any, Literal, Protocol
+from typing import IO, TYPE_CHECKING, Any, Literal, Protocol, cast
 
 import kfactory as kf
 import networkx as nx
@@ -160,7 +160,7 @@ def _get_anchor_point_from_name(
     ref: ComponentReference, anchor_name: str
 ) -> tuple[float, float] | None:
     if anchor_name in VALID_ANCHOR_POINT_KEYWORDS:
-        return getattr(ref.dsize_info, anchor_name)
+        return cast("tuple[float, float] | None", getattr(ref.dsize_info, anchor_name))
     elif anchor_name in ref.ports:
         return ref.ports[anchor_name].center
     return None

--- a/gdsfactory/technology/yaml_utils.py
+++ b/gdsfactory/technology/yaml_utils.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from typing import Any
 
 import yaml
+import yaml.representer as yaml_representer
 from pydantic_extra_types.color import Color
 
 from gdsfactory.technology.color_utils import ensure_six_digit_hex_color
@@ -15,7 +16,7 @@ def add_color_yaml_representer(prefer_named_color: bool = True) -> None:
     """Add a custom YAML presenter for Color objects."""
 
     def _color_presenter(
-        dumper: yaml.representer.SafeRepresenter, data: Color
+        dumper: yaml_representer.SafeRepresenter, data: Color
     ) -> yaml.Node:
         data_str = data.as_named(fallback=True) if prefer_named_color else data.as_hex()
         return dumper.represent_scalar(
@@ -29,7 +30,7 @@ def add_tuple_yaml_representer() -> None:
     """Add a custom YAML presenter for tuple objects."""
 
     def _tuple_presenter(
-        dumper: yaml.representer.SafeRepresenter, data: Iterable[Any]
+        dumper: yaml_representer.SafeRepresenter, data: Iterable[Any]
     ) -> yaml.Node:
         return dumper.represent_sequence("tag:yaml.org,2002:seq", data, flow_style=True)
 
@@ -40,7 +41,7 @@ def add_multiline_str_yaml_representer() -> None:
     """Add a custom YAML presenter for multiline strings."""
 
     def _str_presenter(
-        dumper: yaml.representer.SafeRepresenter, data: str
+        dumper: yaml_representer.SafeRepresenter, data: str
     ) -> yaml.Node:
         if "\n" in data:  # check for multiline string
             return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,8 @@ dev = [
   "types-cachetools",
   "pytest-github-actions-annotate-failures",
   "pytest-randomly",
-  "pytest-xdist"
+  "pytest-xdist",
+  "ty"
 ]
 docs = [
   "autodoc_pydantic>=2.0.1,<3",


### PR DESCRIPTION
Resolves #3860

## Summary by Sourcery

Add Ty static type checking to CI and include Ty in the development dependencies

Build:
- Add Ty to the dev dependencies in pyproject.toml

CI:
- Introduce a new run-ty job in GitHub Actions to perform Ty checks on src/kfactory across Python 3.11 and 3.13