### PR TITLE
Make small change to clarify first use of PCell as "Parameterized Cell".

### DIFF
--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -299,7 +299,7 @@
     "\n",
     "### partial\n",
     "\n",
-    "Partial is an easy way to modify the default arguments of a function. This is useful in gdsfactory because we define PCells using functions. `from functools import partial`\n",
+    "Partial is an easy way to modify the default arguments of a function. This is useful in gdsfactory because we define Parametric Cells (PCells) using functions. `from functools import partial`\n",
     "\n",
     "You can use partial to create a new function with some default arguments.\n",
     "\n",
@@ -351,7 +351,7 @@
    "source": [
     "### compose\n",
     "\n",
-    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we define PCells using functions and functions are easier to combine than classes. You can also import compose from the toolz package `from toolz import compose`"
+    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we define DOn\"T COMMIT ME. PCells using functions and functions are easier to combine than classes. You can also import compose from the toolz package `from toolz import compose`"
    ]
   },
   {
@@ -577,7 +577,7 @@
    "main_language": "python"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -591,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -351,7 +351,7 @@
    "source": [
     "### compose\n",
     "\n",
-    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we define DOn\"T COMMIT ME. PCells using functions and functions are easier to combine than classes. You can also import compose from the toolz package `from toolz import compose`"
+    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we define PCells using functions and functions are easier to combine than classes. You can also import compose from the toolz package `from toolz import compose`"
    ]
   },
   {


### PR DESCRIPTION
Make small change to clarify first use of PCell as "Parameterized Cell".

## Summary by Sourcery

Clarify the first use of “PCell” in the Python tutorial notebook and update notebook metadata to reflect the correct kernel settings.

Documentation:
- Expand “PCells” to “Parametric Cells (PCells)” on first mention in the partial section.
- Insert a “DOn'T COMMIT ME.” placeholder in the compose section.

Chores:
- Change notebook kernel display_name to “.venv” and adjust the version metadata from 3.12.4 to 3.12.3.