### PR TITLE
fix pre-commit

### DIFF
--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -97,8 +97,8 @@ def ring_single(
     sl = c << sy  # Left vertical straight
     sr = c << sy  # Right vertical straight
     st = c << sx  # Top horizontal straight
-    bl = c << b   # Left bend
-    br = c << b   # Right bend
+    bl = c << b  # Left bend
+    br = c << b  # Right bend
 
     # Connect all components
     sl.connect(port="o1", other=cb.ports["o2"])

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -33,10 +33,10 @@ def spiral_inductor(
     Example:
         ```python
         import gdsfactory as gf
-        
+
         # Create a standard spiral inductor
         inductor = gf.components.spiral_inductor()
-        
+
         # Create a custom spiral inductor with specific parameters
         custom_inductor = gf.components.spiral_inductor(
             width=2.0,

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -20,9 +20,9 @@ def get_cells(
 
     Args:
         modules: A module or an iterable of modules.
-        ignore_non_decorated: only include functions that are decorated with gf.cell
-        ignore_underscored: only include functions that do not start with '_'
-        ignore_partials: only include functions, not partials
+        ignore_non_decorated: only include functions that are decorated with gf.cell.
+        ignore_underscored: only include functions that do not start with '_'.
+        ignore_partials: only include functions, not partials.
     """
     modules = modules if isinstance(modules, Iterable) else [modules]
     cells: dict[str, ComponentFactory] = {}
@@ -50,6 +50,15 @@ def is_cell(
     ignore_partials: bool = False,
     name: str = "",
 ) -> bool:
+    """Checks if a function is a GDSFactory cell.
+
+    Args:
+        func: The function to check.
+        ignore_non_decorated: only include functions that are decorated with gf.cell.
+        ignore_underscored: only include functions that do not start with '_'.
+        ignore_partials: only include functions, not partials.
+        name: The name of the function.
+    """
     try:
         # Fast fail for non-callable
         if not callable(func):
@@ -133,7 +142,7 @@ def get_cells_from_dict(
     return valid_cells
 
 
-# Cache signatures to avoid repeated work.
 @lru_cache(maxsize=2048)
-def _get_signature(obj):
+def _get_signature(obj: Any) -> Any:
+    """Cache signatures to avoid repeated work."""
     return signature(obj)


### PR DESCRIPTION
## Summary by Sourcery

Standardize docstrings and code formatting across utilities and component implementations by adding missing docstrings and type hints, aligning punctuation, and removing trailing whitespace.

Chores:
- Standardize and complete docstrings: add punctuation to parameter descriptions, insert missing docstrings for is_cell and _get_signature, and add type hints to _get_signature
- Remove trailing whitespace in ring_single and spiral_inductor component definitions for consistent formatting