### PR TITLE
Update python intro docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-data-gds:
 	git clone git@github.com:gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
 test: test-data-gds
-	pytest -s
+	uv run pytest -s
 
 test-force:
 	uv run pytest -n logical --force-regen -s

--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "For that you will see a `@cell` decorator on many component functions.\n",
     "\n",
-    "An example of a decorator is `validate_cell` in the pydantic library."
+    "An example of a decorator is `validate_call` in the pydantic library."
    ]
   },
   {
@@ -578,7 +578,6 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-
    "version": "3.12.9"
   }
  },

--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -35,10 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from functools import partial\n",
-    "\n",
-    "from pydantic import validate_call\n",
-    "\n",
     "import gdsfactory as gf"
    ]
   },
@@ -147,12 +143,16 @@
    "source": [
     "## Decorators\n",
     "\n",
-    "gdsfactory has many functions, and we want to do some common operations for the ones that return a Component:\n",
+    "A decorator is a special function in Python that lets you add extra functionality to other functions, without modifying their code.\n",
     "\n",
-    "- give a unique name (dependent on the input parameters) to a Component\n",
-    "- cache the Component that the function returns for speed and reuse cells.\n",
+    "In gdsfactory, decorators are used for managing functions that return a `Component`. For example, the `@cell` decorator:\n",
     "\n",
-    "For that you will see a `@cell` decorator on many component functions.\n"
+    "- Gives each `Component` a unique name based on its input parameters.\n",
+    "- Caches the returned `Component` for speed and to avoid duplicating cells.\n",
+    "\n",
+    "For that you will see a `@cell` decorator on many component functions.\n",
+    "\n",
+    "An example of a decorator is `validate_cell` in the pydantic library."
    ]
   },
   {
@@ -162,6 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pydantic import validate_call\n",
+    "\n",
     "@validate_call\n",
     "def double(x: float) -> float:\n",
     "    return 2 * x\n",
@@ -204,9 +206,6 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "The `cell` decorator also leverages that validate arguments.\n",
-    "So you should add type annotations to your component factories.\n",
-    "\n",
     "Lets try to create an error `x` and you will get a clear message the the function `double` does not work with strings"
    ]
   },
@@ -222,13 +221,13 @@
     "will raise a `ValidationError`\n",
     "\n",
     "```\n",
-    "ValidationError: 0 validation error for Double\n",
-    "x\n",
-    "  value is not a valid float (type=type_error.float)\n",
+    "ValidationError: 1 validation error for double\n",
+    "0\n",
+    "  Input should be a valid number, unable to parse string as a number ...\n",
     "\n",
     "```\n",
     "\n",
-    "It will also `cast` the input type based on the type annotation. So if you pass an `int` it will convert it to `float`"
+    "`validate_call` will also `cast` the input type based on the type annotation. So if you pass a another type it will convert it to `float`"
    ]
   },
   {
@@ -238,9 +237,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = 1\n",
-    "y = double_with_validator(x)\n",
-    "print(y, type(x), type(y))"
+    "x = \"12\"\n",
+    "print(f\"{double(x)=}\")\n",
+    "print(f\"{double_with_validator(x)=}\")"
    ]
   },
   {
@@ -299,65 +298,83 @@
     "\n",
     "### partial\n",
     "\n",
-    "Partial is an easy way to modify the default arguments of a function. This is useful in gdsfactory because we define PCells using functions. `from functools import partial`\n",
+    "The built in `functools.partial` is an easy way to reuse default arguments for a function.\n",
     "\n",
-    "You can use partial to create a new function with some default arguments.\n",
-    "\n",
-    "The following two functions are equivalent in functionality. Notice how the second one is shorter, more readable and easier to maintain thanks to `partial`:\n"
+    "The following two functions are equivalent in functionality. Notice how the second one is shorter, more readable and easier to maintain thanks to `partial`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "#### Example without partial"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
     "def ring_sc1(gap=0.3, **kwargs) -> gf.Component:\n",
     "    return gf.components.ring_single(gap=gap, **kwargs)\n",
     "\n",
-    "\n",
-    "ring_sc2 = partial(gf.components.ring_single, gap=0.3)  # shorter and easier to read"
+    "# Usage\n",
+    "c1 = ring_sc1(radius=10)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "#### Example with partial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functools import partial\n",
+    "\n",
+    "ring_sc2 = partial(gf.components.ring_single, gap=0.3)\n",
+    "\n",
+    "# Usage\n",
+    "c2 = ring_sc2(radius=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "source": [
-    "As you customize more parameters, it's more obvious that the second one is easier to maintain\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def ring_sc3(gap=0.3, radius=10, **kwargs):\n",
-    "    return gf.components.ring_single(gap=gap, radius=radius, **kwargs)\n",
-    "\n",
-    "\n",
-    "ring_sc4 = partial(gf.components.ring_single, gap=0.3, radius=10)"
+    "`partial` becomes more useful as you customize more parameters and more widely reuse functions.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "### compose\n",
     "\n",
-    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we define PCells using functions and functions are easier to combine than classes. You can also import compose from the toolz package `from toolz import compose`"
+    "`gf.compose` combines two functions into one. This is useful in gdsfactory because we\n",
+    "define PCells using functions and functions are easier to combine than classes.\n",
+    "\n",
+    "(This is the compose function in the toolz package `from toolz import compose`)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,33 +387,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ring_sc_gc20 = ring_sc_gc(radius=20)\n",
-    "ring_sc_gc20"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "26",
-   "metadata": {},
-   "source": [
-    "This is equivalent and more readable than writing"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "27",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "ring_sc_gc5 = add_gratings(ring_sc1(radius=5))\n",
-    "ring_sc_gc5"
+    "This is equivalent to calling the functions one after the other"
    ]
   },
   {
@@ -406,23 +401,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ring_sc_gc20 = add_gratings(ring_sc1(radius=20))\n",
-    "ring_sc_gc20"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "29",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(ring_sc_gc5)"
+    "ring_sc_gc5 = add_gratings(ring_sc1(radius=5))\n",
+    "ring_sc_gc5"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Ipython\n",
@@ -437,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "32",
    "metadata": {},
    "source": [
     "To see the source code of a function you can use `??`"
@@ -465,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "34",
    "metadata": {},
    "source": [
     "To time the execution time of a cell, you can add a `%time` on top of the cell"
@@ -483,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "36",
    "metadata": {},
    "source": [
     "For more Ipython tricks you can find many resources available online\n",
@@ -512,7 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +562,7 @@
    "main_language": "python"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -591,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update the intro to python notebook.

Also add a `uv run` to the test command in the makefile.

## Summary by Sourcery

Revise the Python introduction notebook for clearer explanations and examples of decorators, partial application, function composition, and IPython tips; and update the Makefile’s test target to invoke pytest via uv.

Build:
- Prefix the Makefile `test` target with `uv run` to launch pytest in the virtual environment.

Documentation:
- Restructure and clarify the decorators section with examples of `@cell` and `validate_call`.
- Split the partial application tutorial into separate ‘without’ and ‘with’ examples and improve narrative.
- Streamline the compose section by removing redundant cells and enhancing descriptions.
- Correct notebook metadata: update kernel display name to `.venv` and bump Python version.
- Fix example outputs and error messages in validation demonstrations.