### PR TITLE
lint(pre-commit-config): update ruff version to v0.11.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.0"
+    rev: "v0.11.10"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]


### PR DESCRIPTION
Align local ruff version with v0.11.10

## Summary by Sourcery

CI:
- Update Ruff pre-commit hook version from v0.11.0 to v0.11.10