### PR TITLE
Fix pytest warnings

### DIFF
--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -40,7 +40,7 @@ def neff_TE1550SOI_220nm(w: float) -> float:
             -1.12666286e00,
         ]
     )
-    return float(np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w))
+    return float(np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w).item())
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -827,9 +827,11 @@ def _load_yaml_str(yaml_str: Any) -> dict[str, Any]:
     elif (isinstance(yaml_str, str) and "\n" in yaml_str) or isinstance(yaml_str, IO):
         dct = yaml.load(yaml_str, Loader=yaml.FullLoader)
     elif isinstance(yaml_str, str):
-        dct = yaml.load(open(yaml_str), Loader=yaml.FullLoader)
+        with open(yaml_str) as f:
+            dct = yaml.load(f, Loader=yaml.FullLoader)
     elif isinstance(yaml_str, pathlib.Path):
-        dct = yaml.load(open(yaml_str), Loader=yaml.FullLoader)
+        with open(yaml_str) as f:
+            dct = yaml.load(f, Loader=yaml.FullLoader)
     else:
         raise ValueError("Invalid format for 'yaml_str'.")
     return dct

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -1184,7 +1184,7 @@ class LayerViews(BaseModel):
         """
         layer_file = pathlib.Path(layer_file)
 
-        properties = yaml.safe_load(layer_file.open())
+        properties = yaml.safe_load(layer_file.read_text())
         lvs = {}
         for name, lv in properties["LayerViews"].items():
             if "group_members" in lv:


### PR DESCRIPTION
There's still warnings about bend_euler being used with angles other than 90 or 180 degrees. This PR corrects a numpy warning and some warnings about un-closed files.

## Summary by Sourcery

Suppress resource and numpy warnings by closing YAML files properly and converting numpy scalar outputs to Python floats

Bug Fixes:
- Use context managers when opening YAML files to ensure file handles are closed
- Load YAML from file using read_text() instead of open() to avoid unclosed file warnings
- Extract Python scalar via .item() from numpy polynomial output to suppress numpy warnings