### PR TITLE
Update makefile documentation

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -33,7 +33,7 @@ jobs:
           make install test-data
       - name: Test with pytest
         run: |
-          make uv-test
+          make test
 
   test_code_coverage:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.terminal.activateEnvironment": true,
   "python.venvPath": "${workspaceFolder}",
-  "python.venvFolders": [".venv"]
+  "python.venvFolders": [
+    ".venv"
+  ],
+  "makefile.configureOnOpen": false
 }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
+UV_INSTALLED := $(shell command -v uv)
+
 .PHONY: uv
 uv: ## install uv
+uv: ## install uv if not installed
+ifndef UV_INSTALLED
 	curl -LsSf https://astral.sh/uv/install.sh | sh
+endif
 
 .PHONY: install
-install: ## Install all dependencies using uv
+install: uv ## Install all dependencies using uv
 	uv sync --all-extras --no-extra full
 
 .PHONY: dev
-dev: ## Set up dev environment and install pre-commit
+
+dev: uv ## Set up dev environment and install pre-commit
 	uv venv -p 3.12
 	uv sync --all-extras --no-extra full
 	uv pip install -e .
@@ -23,11 +29,9 @@ install-kfactory-dev: ## Force-reinstall kfactory from GitHub
 update-pre: ## Update pre-commit hooks
 	pre-commit autoupdate
 
-.PHONY: test-data
 test-data: ## Clone test data from GitHub (HTTPS)
 	git clone https://github.com/gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
-.PHONY: test-data-gds
 test-data-gds: ## Clone test data from GitHub (SSH)
 	git clone git@github.com:gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ cov: ## Run tests with coverage
 	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered
 
 .PHONY: dev-cov
-dev-cov: ### Run tests in parallel with coverage
+dev-cov: ## Run tests in parallel with coverage
 	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered --durations=10
 
 .PHONY: test-samples

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+.PHONY: uv
 uv: ## install uv
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 
+.PHONY: install
 install: ## Install all dependencies using uv
 	uv sync --all-extras --no-extra full
 
+.PHONY: dev
 dev: ## Set up dev environment and install pre-commit
 	uv venv -p 3.12
 	uv sync --all-extras --no-extra full
@@ -12,39 +15,51 @@ dev: ## Set up dev environment and install pre-commit
 	uv run gf install-klayout-genericpdk
 	uv run gf install-git-diff
 
+.PHONY: install-kfactory-dev
 install-kfactory-dev: ## Force-reinstall kfactory from GitHub
 	uv pip install git+https://github.com/gdsfactory/kfactory --force-reinstall
 
+.PHONY: update-pre
 update-pre: ## Update pre-commit hooks
 	pre-commit autoupdate
 
+.PHONY: test-data
 test-data: ## Clone test data from GitHub (HTTPS)
 	git clone https://github.com/gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
+.PHONY: test-data-gds
 test-data-gds: ## Clone test data from GitHub (SSH)
 	git clone git@github.com:gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
+.PHONY: test
 test: test-data-gds ## Run tests
 	uv run pytest -s
 
+.PHONY: test-force
 test-force: ## Run tests with force-regen
 	uv run pytest -n logical --force-regen -s
 
+.PHONY: cov
 cov: ## Run tests with coverage
 	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered
 
+.PHONY: dev-cov
 dev-cov: ### Run tests in parallel with coverage
 	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered --durations=10
 
+.PHONY: test-samples
 test-samples: ## Test that samples run without error
 	uv run pytest tests/test_samples.py
 
+.PHONY: docker-debug
 docker-debug: ## Start a debug shell in Docker
 	docker run -it joamatab/gdsfactory sh
 
+.PHONY: docker-build
 docker-build: ## Build Docker image
 	docker build -t joamatab/gdsfactory .
 
+.PHONY: docker-run
 docker-run: ## Run Docker container
 	docker run \
 		-p 8888:8888 \
@@ -52,32 +67,40 @@ docker-run: ## Run Docker container
 		-e JUPYTER_ENABLE_LAB=yes \
 		joamatab/gdsfactory:latest
 
+.PHONY: build
 build: ## Build python package
 	rm -rf dist
 	pip install build
 	python -m build
 
+.PHONY: upload-devpi
 upload-devpi: ## Upload package to devpi
 	pip install devpi-client wheel
 	devpi upload --format=bdist_wheel,sdist.tgz
 
+.PHONY: upload-twine
 upload-twine: build ## Upload package to PyPI using twine
 	pip install twine
 	twine upload dist/*
 
+.PHONY: autopep8
 autopep8: ## Format python files with autopep8
 	autopep8 --in-place --aggressive --aggressive **/*.py
 
+.PHONY: docs
 docs: ## Build documentation
 	uv run python docs/write_cells.py
 	uv run jb build docs
 
+.PHONY: git-rm-merged
 git-rm-merged: ## Delete merged git branches
 	git branch -D `git branch --merged | grep -v \* | xargs`
 
+.PHONY: notebooks
 notebooks: ## Convert python scripts to Jupyter notebooks
 	jupytext docs/notebooks/*.py --to ipynb
 
+.PHONY: clean
 clean: ## Remove build, cache and temporary files
 	rm -rf .venv
 	find src -name "*.c" | xargs rm -rf
@@ -93,8 +116,6 @@ clean: ## Remove build, cache and temporary files
 	find . -name "build" | xargs rm -rf
 	find . -name "builds" | xargs rm -rf
 	find . -name "dist" -not -path "*node_modules*" | xargs rm -rf
-
-.PHONY: gdsdiff build conda gdslib docs doc install
 
 # This will output the help for each task
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ docs: ## Build documentation
 
 .PHONY: git-rm-merged
 git-rm-merged: ## Delete merged git branches
-	git branch -D `git branch --merged | grep -v \* | xargs`
+	git fetch --prune
+	git branch --merged origin/main | grep -v '^\*' | grep -v 'main' | xargs -n 1 git branch -d
 
 .PHONY: notebooks
 notebooks: ## Convert python scripts to Jupyter notebooks

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
-help:
-	@echo 'make install:          Install package'
-	@echo 'make test:             Run tests with pytest'
-	@echo 'make test-force:       Rebuilds regression test'
-
-uv:
+uv: ## install uv
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 
-install:
+install: ## Install all dependencies using uv
 	uv sync --all-extras --no-extra full
 
-dev:
+dev: ## Set up dev environment and install pre-commit
 	uv venv -p 3.12
 	uv sync --all-extras --no-extra full
 	uv pip install -e .
@@ -17,76 +12,73 @@ dev:
 	uv run gf install-klayout-genericpdk
 	uv run gf install-git-diff
 
-install-kfactory-dev:
+install-kfactory-dev: ## Force-reinstall kfactory from GitHub
 	uv pip install git+https://github.com/gdsfactory/kfactory --force-reinstall
 
-update-pre:
+update-pre: ## Update pre-commit hooks
 	pre-commit autoupdate
 
-test-data:
+test-data: ## Clone test data from GitHub (HTTPS)
 	git clone https://github.com/gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
-test-data-gds:
+test-data-gds: ## Clone test data from GitHub (SSH)
 	git clone git@github.com:gdsfactory/gdsfactory-test-data.git -b test_klayout test-data-gds
 
-test: test-data-gds
+test: test-data-gds ## Run tests
 	uv run pytest -s
 
-test-force:
+test-force: ## Run tests with force-regen
 	uv run pytest -n logical --force-regen -s
 
-uv-test: test-data-gds
-	uv run pytest -s -n logical
-
-cov:
+cov: ## Run tests with coverage
 	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered
 
-dev-cov:
+dev-cov: ### Run tests in parallel with coverage
 	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered --durations=10
 
-test-samples:
+test-samples: ## Test that samples run without error
 	uv run pytest tests/test_samples.py
 
-docker-debug:
+docker-debug: ## Start a debug shell in Docker
 	docker run -it joamatab/gdsfactory sh
 
-docker-build:
+docker-build: ## Build Docker image
 	docker build -t joamatab/gdsfactory .
 
-docker-run:
+docker-run: ## Run Docker container
 	docker run \
 		-p 8888:8888 \
 		-p 8082:8082 \
 		-e JUPYTER_ENABLE_LAB=yes \
 		joamatab/gdsfactory:latest
 
-build:
+build: ## Build python package
 	rm -rf dist
 	pip install build
 	python -m build
 
-upload-devpi:
+upload-devpi: ## Upload package to devpi
 	pip install devpi-client wheel
 	devpi upload --format=bdist_wheel,sdist.tgz
 
-upload-twine: build
+upload-twine: build ## Upload package to PyPI using twine
 	pip install twine
 	twine upload dist/*
 
-autopep8:
+autopep8: ## Format python files with autopep8
 	autopep8 --in-place --aggressive --aggressive **/*.py
 
-docs:
+docs: ## Build documentation
 	uv run python docs/write_cells.py
 	uv run jb build docs
 
-git-rm-merged:
+git-rm-merged: ## Delete merged git branches
 	git branch -D `git branch --merged | grep -v \* | xargs`
 
-notebooks:
+notebooks: ## Convert python scripts to Jupyter notebooks
 	jupytext docs/notebooks/*.py --to ipynb
 
-clean:
+clean: ## Remove build, cache and temporary files
 	rm -rf .venv
 	find src -name "*.c" | xargs rm -rf
 	find src -name "*.pyc" | xargs rm -rf
@@ -103,3 +95,9 @@ clean:
 	find . -name "dist" -not -path "*node_modules*" | xargs rm -rf
 
 .PHONY: gdsdiff build conda gdslib docs doc install
+
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+help: ## this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ clean: ## Remove build, cache and temporary files
 
 # This will output the help for each task
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.DEFAULT_GOAL := help
 .PHONY: help
 help: ## this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Update the Makefile documentation

Before
<img width="346" alt="Screenshot 2025-05-20 at 8 38 37 AM" src="https://github.com/user-attachments/assets/67e0a399-097e-44d1-b785-4df544ac355a" />

After
<img width="540" alt="Screenshot 2025-05-20 at 8 34 55 AM" src="https://github.com/user-attachments/assets/7e769471-ca48-4fa9-9168-f0c2d4e88e98" />

## Summary by Sourcery

Enhance Makefile with inline documentation and automated help generation, and update CI to use the unified test target

Enhancements:
- Add inline help descriptions (##) to all Makefile targets
- Introduce a default help target that auto-documents tasks via grep and awk
- Remove the manual 'help' echo block and deprecate the 'uv-test' target

CI:
- Update GitHub Actions to invoke 'make test' instead of the removed 'make uv-test'