### PR TITLE
Add get_cell overload

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -7,7 +7,7 @@ import pathlib
 import warnings
 from collections.abc import Callable, Mapping, Sequence
 from functools import cached_property, partial
-from typing import Any, cast
+from typing import Any, cast, overload
 
 import kfactory as kf
 import yaml
@@ -25,7 +25,9 @@ from gdsfactory.serialization import clean_value_json, convert_tuples_to_lists
 from gdsfactory.symbols import floorplan_with_block_letters
 from gdsfactory.technology import LayerStack, LayerViews, klayout_tech
 from gdsfactory.typings import (
+    CellAllAngleSpec,
     CellSpec,
+    ComponentAllAngleFactory,
     ComponentFactory,
     ComponentSpec,
     ConnectivitySpec,
@@ -289,7 +291,16 @@ class Pdk(BaseModel):
         self.cells.pop(name)
         logger.info(f"Removed cell {name!r}")
 
-    def get_cell(self, cell: CellSpec, **kwargs: Any) -> ComponentFactory:
+    @overload
+    def get_cell(self, cell: CellSpec, **kwargs: Any) -> ComponentFactory: ...
+    @overload
+    def get_cell(
+        self, cell: CellAllAngleSpec, **kwargs: Any
+    ) -> ComponentAllAngleFactory: ...
+
+    def get_cell(
+        self, cell: CellSpec | CellAllAngleSpec, **kwargs: Any
+    ) -> ComponentFactory | ComponentAllAngleFactory:
         """Returns ComponentFactory from a cell spec."""
         cells_and_containers = self._get_cells_and_containers()
 
@@ -652,7 +663,15 @@ def get_component(
     return get_active_pdk().get_component(component, settings=settings, **kwargs)
 
 
-def get_cell(cell: CellSpec, **kwargs: Any) -> ComponentFactory:
+@overload
+def get_cell(cell: CellSpec, **kwargs: Any) -> ComponentFactory: ...
+@overload
+def get_cell(cell: CellAllAngleSpec, **kwargs: Any) -> ComponentAllAngleFactory: ...
+
+
+def get_cell(
+    cell: CellSpec | CellAllAngleSpec, **kwargs: Any
+) -> ComponentFactory | ComponentAllAngleFactory:
     return get_active_pdk().get_cell(cell, **kwargs)
 
 

--- a/gdsfactory/routing/route_bundle_all_angle.py
+++ b/gdsfactory/routing/route_bundle_all_angle.py
@@ -4,7 +4,7 @@ from kfactory.routing.aa.optical import OpticalAllAngleRoute, route_bundle
 
 import gdsfactory as gf
 from gdsfactory.typings import (
-    ComponentAllAngleSpec,
+    CellAllAngleSpec,
     ComponentSpec,
     Coordinates,
     CrossSectionSpec,
@@ -19,8 +19,8 @@ def route_bundle_all_angle(
     ports2: list[Port],
     backbone: Coordinates | None = None,
     separation: list[float] | float = 3.0,
-    straight: ComponentAllAngleSpec = "straight_all_angle",
-    bend: ComponentAllAngleSpec = "bend_euler_all_angle",
+    straight: CellAllAngleSpec = "straight_all_angle",
+    bend: CellAllAngleSpec = "bend_euler_all_angle",
     bend_ports: tuple[str, str] = ("o1", "o2"),
     straight_ports: tuple[str, str] = ("o1", "o2"),
     cross_section: CrossSectionSpec | None = None,

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -209,6 +209,7 @@ ComponentSpecOrList: TypeAlias = ComponentSpec | list[ComponentSpec]
 CellSpec: TypeAlias = (
     str | ComponentFactory | dict[str, Any]  # PCell function, function name or dict
 )
+CellAllAngleSpec: TypeAlias = str | ComponentAllAngleFactory | dict[str, Any]
 ComponentSpecDict: TypeAlias = dict[str, ComponentSpec]
 
 LayerTransitions: TypeAlias = dict[LayerSpec | tuple[Layer, Layer], ComponentSpec]


### PR DESCRIPTION
## Summary by Sourcery

Add support for all-angle cell specifications by overloading the get_cell API and updating type aliases and function signatures accordingly

Enhancements:
- Add overloaded get_cell signatures to return ComponentAllAngleFactory for CellAllAngleSpec
- Introduce new CellAllAngleSpec type alias for all-angle cell specifications
- Update route_bundle_all_angle to use CellAllAngleSpec for straight and bend parameters