### PR TITLE
Widen Component function arguments

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -329,7 +329,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         for key, value in kwargs.items():
             info[f"route_info_{key}"] = value
 
-    def copy_child_info(self, component: ProtoKCell[Any, Any]) -> None:
+    def copy_child_info(self, component: kf.ProtoTKCell[Any]) -> None:
         """Copy and settings info from child component into parent.
 
         Parent components can access child cells settings.
@@ -531,7 +531,7 @@ class Component(ComponentBase, kf.DKCell):
 
     def add_ref(
         self,
-        component: ProtoKCell[Any, Any],
+        component: kf.ProtoTKCell[Any],
         name: str | None = None,
         columns: int = 1,
         rows: int = 1,

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -329,7 +329,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         for key, value in kwargs.items():
             info[f"route_info_{key}"] = value
 
-    def copy_child_info(self, component: Component) -> None:
+    def copy_child_info(self, component: ProtoKCell[Any, Any]) -> None:
         """Copy and settings info from child component into parent.
 
         Parent components can access child cells settings.
@@ -531,7 +531,7 @@ class Component(ComponentBase, kf.DKCell):
 
     def add_ref(
         self,
-        component: Component,
+        component: ProtoKCell[Any, Any],
         name: str | None = None,
         columns: int = 1,
         rows: int = 1,


### PR DESCRIPTION
## Summary by Sourcery

Widen the typed argument for component methods to accept generic cells rather than only Component instances

Enhancements:
- Use ProtoKCell[Any, Any] instead of Component for the component parameter in copy_child_info
- Use ProtoKCell[Any, Any] instead of Component for the component parameter in add_ref