### PR TITLE
Update litho_ruler.py

### DIFF
--- a/gdsfactory/components/pcms/litho_ruler.py
+++ b/gdsfactory/components/pcms/litho_ruler.py
@@ -32,7 +32,7 @@ def litho_ruler(
     for n in range(num_marks):
         h = height * scale[n % len(scale)]
         ref = D << gf.components.rectangle(size=(width, h), layer=layer)
-        ref.movex((n - num_marks / 2) * pitch)
+        ref.movex((n - num_marks / 2) * pitch + spacing/2.0)
 
     return D
 


### PR DESCRIPTION
The ruler is off-centre, but adding half of 'spacing' makes it centered at the centre tick, as I think was intended.

## Summary by Sourcery

Bug Fixes:
- Offset ruler tick placement by spacing/2 to center marks at the central tick