### PR TITLE
fix tests

### DIFF
--- a/gdsfactory/components/pcms/litho_ruler.py
+++ b/gdsfactory/components/pcms/litho_ruler.py
@@ -32,7 +32,7 @@ def litho_ruler(
     for n in range(num_marks):
         h = height * scale[n % len(scale)]
         ref = D << gf.components.rectangle(size=(width, h), layer=layer)
-        ref.movex((n - num_marks / 2) * pitch + spacing/2.0)
+        ref.movex((n - num_marks / 2) * pitch + spacing / 2.0)
 
     return D
 

--- a/test-data-regression/test_netlists_litho_ruler_.yml
+++ b/test-data-regression/test_netlists_litho_ruler_.yml
@@ -1,5 +1,5 @@
 instances:
-  rectangle_gdsfactorypco_04850913_1250_0:
+  rectangle_gdsfactorypco_04850913_14750_0:
     component: rectangle
     info: {}
     settings:
@@ -14,7 +14,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_13750_0:
+  rectangle_gdsfactorypco_04850913_17250_0:
     component: rectangle
     info: {}
     settings:
@@ -29,7 +29,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_16250_0:
+  rectangle_gdsfactorypco_04850913_19750_0:
     component: rectangle
     info: {}
     settings:
@@ -44,7 +44,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_18750_0:
+  rectangle_gdsfactorypco_04850913_22250_0:
     component: rectangle
     info: {}
     settings:
@@ -59,7 +59,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_21250_0:
+  rectangle_gdsfactorypco_04850913_2250_0:
     component: rectangle
     info: {}
     settings:
@@ -74,7 +74,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_3750_0:
+  rectangle_gdsfactorypco_04850913_4750_0:
     component: rectangle
     info: {}
     settings:
@@ -89,7 +89,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_6250_0:
+  rectangle_gdsfactorypco_04850913_7250_0:
     component: rectangle
     info: {}
     settings:
@@ -104,7 +104,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_8750_0:
+  rectangle_gdsfactorypco_04850913_9750_0:
     component: rectangle
     info: {}
     settings:
@@ -119,7 +119,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m11250_0:
+  rectangle_gdsfactorypco_04850913_m10250_0:
     component: rectangle
     info: {}
     settings:
@@ -134,7 +134,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m16250_0:
+  rectangle_gdsfactorypco_04850913_m15250_0:
     component: rectangle
     info: {}
     settings:
@@ -149,7 +149,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m18750_0:
+  rectangle_gdsfactorypco_04850913_m17750_0:
     component: rectangle
     info: {}
     settings:
@@ -164,7 +164,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m21250_0:
+  rectangle_gdsfactorypco_04850913_m20250_0:
     component: rectangle
     info: {}
     settings:
@@ -179,7 +179,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m23750_0:
+  rectangle_gdsfactorypco_04850913_m22750_0:
     component: rectangle
     info: {}
     settings:
@@ -194,7 +194,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m3750_0:
+  rectangle_gdsfactorypco_04850913_m2750_0:
     component: rectangle
     info: {}
     settings:
@@ -209,7 +209,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m6250_0:
+  rectangle_gdsfactorypco_04850913_m5250_0:
     component: rectangle
     info: {}
     settings:
@@ -224,7 +224,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_04850913_m8750_0:
+  rectangle_gdsfactorypco_04850913_m7750_0:
     component: rectangle
     info: {}
     settings:
@@ -239,7 +239,7 @@ instances:
       size:
       - 0.5
       - 2
-  rectangle_gdsfactorypco_b315d65e_11250_0:
+  rectangle_gdsfactorypco_b315d65e_12250_0:
     component: rectangle
     info: {}
     settings:
@@ -254,7 +254,7 @@ instances:
       size:
       - 0.5
       - 4
-  rectangle_gdsfactorypco_b315d65e_m13750_0:
+  rectangle_gdsfactorypco_b315d65e_m12750_0:
     component: rectangle
     info: {}
     settings:
@@ -269,7 +269,7 @@ instances:
       size:
       - 0.5
       - 4
-  rectangle_gdsfactorypco_c88bb9ce_23750_0:
+  rectangle_gdsfactorypco_c88bb9ce_24750_0:
     component: rectangle
     info: {}
     settings:
@@ -284,7 +284,7 @@ instances:
       size:
       - 0.5
       - 6
-  rectangle_gdsfactorypco_c88bb9ce_m1250_0:
+  rectangle_gdsfactorypco_c88bb9ce_m250_0:
     component: rectangle
     info: {}
     settings:
@@ -299,7 +299,7 @@ instances:
       size:
       - 0.5
       - 6
-  rectangle_gdsfactorypco_c88bb9ce_m26250_0:
+  rectangle_gdsfactorypco_c88bb9ce_m25250_0:
     component: rectangle
     info: {}
     settings:
@@ -317,110 +317,110 @@ instances:
 name: litho_ruler_gdsfactoryp_498cf36f
 nets: []
 placements:
-  rectangle_gdsfactorypco_04850913_1250_0:
+  rectangle_gdsfactorypco_04850913_14750_0:
     mirror: false
     rotation: 0
-    x: 1.25
+    x: 14.75
     y: 0
-  rectangle_gdsfactorypco_04850913_13750_0:
+  rectangle_gdsfactorypco_04850913_17250_0:
     mirror: false
     rotation: 0
-    x: 13.75
+    x: 17.25
     y: 0
-  rectangle_gdsfactorypco_04850913_16250_0:
+  rectangle_gdsfactorypco_04850913_19750_0:
     mirror: false
     rotation: 0
-    x: 16.25
+    x: 19.75
     y: 0
-  rectangle_gdsfactorypco_04850913_18750_0:
+  rectangle_gdsfactorypco_04850913_22250_0:
     mirror: false
     rotation: 0
-    x: 18.75
+    x: 22.25
     y: 0
-  rectangle_gdsfactorypco_04850913_21250_0:
+  rectangle_gdsfactorypco_04850913_2250_0:
     mirror: false
     rotation: 0
-    x: 21.25
+    x: 2.25
     y: 0
-  rectangle_gdsfactorypco_04850913_3750_0:
+  rectangle_gdsfactorypco_04850913_4750_0:
     mirror: false
     rotation: 0
-    x: 3.75
+    x: 4.75
     y: 0
-  rectangle_gdsfactorypco_04850913_6250_0:
+  rectangle_gdsfactorypco_04850913_7250_0:
     mirror: false
     rotation: 0
-    x: 6.25
+    x: 7.25
     y: 0
-  rectangle_gdsfactorypco_04850913_8750_0:
+  rectangle_gdsfactorypco_04850913_9750_0:
     mirror: false
     rotation: 0
-    x: 8.75
+    x: 9.75
     y: 0
-  rectangle_gdsfactorypco_04850913_m11250_0:
+  rectangle_gdsfactorypco_04850913_m10250_0:
     mirror: false
     rotation: 0
-    x: -11.25
+    x: -10.25
     y: 0
-  rectangle_gdsfactorypco_04850913_m16250_0:
+  rectangle_gdsfactorypco_04850913_m15250_0:
     mirror: false
     rotation: 0
-    x: -16.25
+    x: -15.25
     y: 0
-  rectangle_gdsfactorypco_04850913_m18750_0:
+  rectangle_gdsfactorypco_04850913_m17750_0:
     mirror: false
     rotation: 0
-    x: -18.75
+    x: -17.75
     y: 0
-  rectangle_gdsfactorypco_04850913_m21250_0:
+  rectangle_gdsfactorypco_04850913_m20250_0:
     mirror: false
     rotation: 0
-    x: -21.25
+    x: -20.25
     y: 0
-  rectangle_gdsfactorypco_04850913_m23750_0:
+  rectangle_gdsfactorypco_04850913_m22750_0:
     mirror: false
     rotation: 0
-    x: -23.75
+    x: -22.75
     y: 0
-  rectangle_gdsfactorypco_04850913_m3750_0:
+  rectangle_gdsfactorypco_04850913_m2750_0:
     mirror: false
     rotation: 0
-    x: -3.75
+    x: -2.75
     y: 0
-  rectangle_gdsfactorypco_04850913_m6250_0:
+  rectangle_gdsfactorypco_04850913_m5250_0:
     mirror: false
     rotation: 0
-    x: -6.25
+    x: -5.25
     y: 0
-  rectangle_gdsfactorypco_04850913_m8750_0:
+  rectangle_gdsfactorypco_04850913_m7750_0:
     mirror: false
     rotation: 0
-    x: -8.75
+    x: -7.75
     y: 0
-  rectangle_gdsfactorypco_b315d65e_11250_0:
+  rectangle_gdsfactorypco_b315d65e_12250_0:
     mirror: false
     rotation: 0
-    x: 11.25
+    x: 12.25
     y: 0
-  rectangle_gdsfactorypco_b315d65e_m13750_0:
+  rectangle_gdsfactorypco_b315d65e_m12750_0:
     mirror: false
     rotation: 0
-    x: -13.75
+    x: -12.75
     y: 0
-  rectangle_gdsfactorypco_c88bb9ce_23750_0:
+  rectangle_gdsfactorypco_c88bb9ce_24750_0:
     mirror: false
     rotation: 0
-    x: 23.75
+    x: 24.75
     y: 0
-  rectangle_gdsfactorypco_c88bb9ce_m1250_0:
+  rectangle_gdsfactorypco_c88bb9ce_m250_0:
     mirror: false
     rotation: 0
-    x: -1.25
+    x: -0.25
     y: 0
-  rectangle_gdsfactorypco_c88bb9ce_m26250_0:
+  rectangle_gdsfactorypco_c88bb9ce_m25250_0:
     mirror: false
     rotation: 0
-    x: -26.25
+    x: -25.25
     y: 0
 ports: {}
 warnings:
@@ -428,256 +428,256 @@ warnings:
     unconnected_ports:
     - message: 84 unconnected electrical ports!
       ports:
-      - rectangle_gdsfactorypco_c88bb9ce_m26250_0,e1
-      - rectangle_gdsfactorypco_c88bb9ce_m26250_0,e2
-      - rectangle_gdsfactorypco_c88bb9ce_m26250_0,e3
-      - rectangle_gdsfactorypco_c88bb9ce_m26250_0,e4
-      - rectangle_gdsfactorypco_04850913_m23750_0,e1
-      - rectangle_gdsfactorypco_04850913_m23750_0,e2
-      - rectangle_gdsfactorypco_04850913_m23750_0,e3
-      - rectangle_gdsfactorypco_04850913_m23750_0,e4
-      - rectangle_gdsfactorypco_04850913_m21250_0,e1
-      - rectangle_gdsfactorypco_04850913_m21250_0,e2
-      - rectangle_gdsfactorypco_04850913_m21250_0,e3
-      - rectangle_gdsfactorypco_04850913_m21250_0,e4
-      - rectangle_gdsfactorypco_04850913_m18750_0,e1
-      - rectangle_gdsfactorypco_04850913_m18750_0,e2
-      - rectangle_gdsfactorypco_04850913_m18750_0,e3
-      - rectangle_gdsfactorypco_04850913_m18750_0,e4
-      - rectangle_gdsfactorypco_04850913_m16250_0,e1
-      - rectangle_gdsfactorypco_04850913_m16250_0,e2
-      - rectangle_gdsfactorypco_04850913_m16250_0,e3
-      - rectangle_gdsfactorypco_04850913_m16250_0,e4
-      - rectangle_gdsfactorypco_b315d65e_m13750_0,e1
-      - rectangle_gdsfactorypco_b315d65e_m13750_0,e2
-      - rectangle_gdsfactorypco_b315d65e_m13750_0,e3
-      - rectangle_gdsfactorypco_b315d65e_m13750_0,e4
-      - rectangle_gdsfactorypco_04850913_m11250_0,e1
-      - rectangle_gdsfactorypco_04850913_m11250_0,e2
-      - rectangle_gdsfactorypco_04850913_m11250_0,e3
-      - rectangle_gdsfactorypco_04850913_m11250_0,e4
-      - rectangle_gdsfactorypco_04850913_m8750_0,e1
-      - rectangle_gdsfactorypco_04850913_m8750_0,e2
-      - rectangle_gdsfactorypco_04850913_m8750_0,e3
-      - rectangle_gdsfactorypco_04850913_m8750_0,e4
-      - rectangle_gdsfactorypco_04850913_m6250_0,e1
-      - rectangle_gdsfactorypco_04850913_m6250_0,e2
-      - rectangle_gdsfactorypco_04850913_m6250_0,e3
-      - rectangle_gdsfactorypco_04850913_m6250_0,e4
-      - rectangle_gdsfactorypco_04850913_m3750_0,e1
-      - rectangle_gdsfactorypco_04850913_m3750_0,e2
-      - rectangle_gdsfactorypco_04850913_m3750_0,e3
-      - rectangle_gdsfactorypco_04850913_m3750_0,e4
-      - rectangle_gdsfactorypco_c88bb9ce_m1250_0,e1
-      - rectangle_gdsfactorypco_c88bb9ce_m1250_0,e2
-      - rectangle_gdsfactorypco_c88bb9ce_m1250_0,e3
-      - rectangle_gdsfactorypco_c88bb9ce_m1250_0,e4
-      - rectangle_gdsfactorypco_04850913_1250_0,e1
-      - rectangle_gdsfactorypco_04850913_1250_0,e2
-      - rectangle_gdsfactorypco_04850913_1250_0,e3
-      - rectangle_gdsfactorypco_04850913_1250_0,e4
-      - rectangle_gdsfactorypco_04850913_3750_0,e1
-      - rectangle_gdsfactorypco_04850913_3750_0,e2
-      - rectangle_gdsfactorypco_04850913_3750_0,e3
-      - rectangle_gdsfactorypco_04850913_3750_0,e4
-      - rectangle_gdsfactorypco_04850913_6250_0,e1
-      - rectangle_gdsfactorypco_04850913_6250_0,e2
-      - rectangle_gdsfactorypco_04850913_6250_0,e3
-      - rectangle_gdsfactorypco_04850913_6250_0,e4
-      - rectangle_gdsfactorypco_04850913_8750_0,e1
-      - rectangle_gdsfactorypco_04850913_8750_0,e2
-      - rectangle_gdsfactorypco_04850913_8750_0,e3
-      - rectangle_gdsfactorypco_04850913_8750_0,e4
-      - rectangle_gdsfactorypco_b315d65e_11250_0,e1
-      - rectangle_gdsfactorypco_b315d65e_11250_0,e2
-      - rectangle_gdsfactorypco_b315d65e_11250_0,e3
-      - rectangle_gdsfactorypco_b315d65e_11250_0,e4
-      - rectangle_gdsfactorypco_04850913_13750_0,e1
-      - rectangle_gdsfactorypco_04850913_13750_0,e2
-      - rectangle_gdsfactorypco_04850913_13750_0,e3
-      - rectangle_gdsfactorypco_04850913_13750_0,e4
-      - rectangle_gdsfactorypco_04850913_16250_0,e1
-      - rectangle_gdsfactorypco_04850913_16250_0,e2
-      - rectangle_gdsfactorypco_04850913_16250_0,e3
-      - rectangle_gdsfactorypco_04850913_16250_0,e4
-      - rectangle_gdsfactorypco_04850913_18750_0,e1
-      - rectangle_gdsfactorypco_04850913_18750_0,e2
-      - rectangle_gdsfactorypco_04850913_18750_0,e3
-      - rectangle_gdsfactorypco_04850913_18750_0,e4
-      - rectangle_gdsfactorypco_04850913_21250_0,e1
-      - rectangle_gdsfactorypco_04850913_21250_0,e2
-      - rectangle_gdsfactorypco_04850913_21250_0,e3
-      - rectangle_gdsfactorypco_04850913_21250_0,e4
-      - rectangle_gdsfactorypco_c88bb9ce_23750_0,e1
-      - rectangle_gdsfactorypco_c88bb9ce_23750_0,e2
-      - rectangle_gdsfactorypco_c88bb9ce_23750_0,e3
-      - rectangle_gdsfactorypco_c88bb9ce_23750_0,e4
+      - rectangle_gdsfactorypco_c88bb9ce_m25250_0,e1
+      - rectangle_gdsfactorypco_c88bb9ce_m25250_0,e2
+      - rectangle_gdsfactorypco_c88bb9ce_m25250_0,e3
+      - rectangle_gdsfactorypco_c88bb9ce_m25250_0,e4
+      - rectangle_gdsfactorypco_04850913_m22750_0,e1
+      - rectangle_gdsfactorypco_04850913_m22750_0,e2
+      - rectangle_gdsfactorypco_04850913_m22750_0,e3
+      - rectangle_gdsfactorypco_04850913_m22750_0,e4
+      - rectangle_gdsfactorypco_04850913_m20250_0,e1
+      - rectangle_gdsfactorypco_04850913_m20250_0,e2
+      - rectangle_gdsfactorypco_04850913_m20250_0,e3
+      - rectangle_gdsfactorypco_04850913_m20250_0,e4
+      - rectangle_gdsfactorypco_04850913_m17750_0,e1
+      - rectangle_gdsfactorypco_04850913_m17750_0,e2
+      - rectangle_gdsfactorypco_04850913_m17750_0,e3
+      - rectangle_gdsfactorypco_04850913_m17750_0,e4
+      - rectangle_gdsfactorypco_04850913_m15250_0,e1
+      - rectangle_gdsfactorypco_04850913_m15250_0,e2
+      - rectangle_gdsfactorypco_04850913_m15250_0,e3
+      - rectangle_gdsfactorypco_04850913_m15250_0,e4
+      - rectangle_gdsfactorypco_b315d65e_m12750_0,e1
+      - rectangle_gdsfactorypco_b315d65e_m12750_0,e2
+      - rectangle_gdsfactorypco_b315d65e_m12750_0,e3
+      - rectangle_gdsfactorypco_b315d65e_m12750_0,e4
+      - rectangle_gdsfactorypco_04850913_m10250_0,e1
+      - rectangle_gdsfactorypco_04850913_m10250_0,e2
+      - rectangle_gdsfactorypco_04850913_m10250_0,e3
+      - rectangle_gdsfactorypco_04850913_m10250_0,e4
+      - rectangle_gdsfactorypco_04850913_m7750_0,e1
+      - rectangle_gdsfactorypco_04850913_m7750_0,e2
+      - rectangle_gdsfactorypco_04850913_m7750_0,e3
+      - rectangle_gdsfactorypco_04850913_m7750_0,e4
+      - rectangle_gdsfactorypco_04850913_m5250_0,e1
+      - rectangle_gdsfactorypco_04850913_m5250_0,e2
+      - rectangle_gdsfactorypco_04850913_m5250_0,e3
+      - rectangle_gdsfactorypco_04850913_m5250_0,e4
+      - rectangle_gdsfactorypco_04850913_m2750_0,e1
+      - rectangle_gdsfactorypco_04850913_m2750_0,e2
+      - rectangle_gdsfactorypco_04850913_m2750_0,e3
+      - rectangle_gdsfactorypco_04850913_m2750_0,e4
+      - rectangle_gdsfactorypco_c88bb9ce_m250_0,e1
+      - rectangle_gdsfactorypco_c88bb9ce_m250_0,e2
+      - rectangle_gdsfactorypco_c88bb9ce_m250_0,e3
+      - rectangle_gdsfactorypco_c88bb9ce_m250_0,e4
+      - rectangle_gdsfactorypco_04850913_2250_0,e1
+      - rectangle_gdsfactorypco_04850913_2250_0,e2
+      - rectangle_gdsfactorypco_04850913_2250_0,e3
+      - rectangle_gdsfactorypco_04850913_2250_0,e4
+      - rectangle_gdsfactorypco_04850913_4750_0,e1
+      - rectangle_gdsfactorypco_04850913_4750_0,e2
+      - rectangle_gdsfactorypco_04850913_4750_0,e3
+      - rectangle_gdsfactorypco_04850913_4750_0,e4
+      - rectangle_gdsfactorypco_04850913_7250_0,e1
+      - rectangle_gdsfactorypco_04850913_7250_0,e2
+      - rectangle_gdsfactorypco_04850913_7250_0,e3
+      - rectangle_gdsfactorypco_04850913_7250_0,e4
+      - rectangle_gdsfactorypco_04850913_9750_0,e1
+      - rectangle_gdsfactorypco_04850913_9750_0,e2
+      - rectangle_gdsfactorypco_04850913_9750_0,e3
+      - rectangle_gdsfactorypco_04850913_9750_0,e4
+      - rectangle_gdsfactorypco_b315d65e_12250_0,e1
+      - rectangle_gdsfactorypco_b315d65e_12250_0,e2
+      - rectangle_gdsfactorypco_b315d65e_12250_0,e3
+      - rectangle_gdsfactorypco_b315d65e_12250_0,e4
+      - rectangle_gdsfactorypco_04850913_14750_0,e1
+      - rectangle_gdsfactorypco_04850913_14750_0,e2
+      - rectangle_gdsfactorypco_04850913_14750_0,e3
+      - rectangle_gdsfactorypco_04850913_14750_0,e4
+      - rectangle_gdsfactorypco_04850913_17250_0,e1
+      - rectangle_gdsfactorypco_04850913_17250_0,e2
+      - rectangle_gdsfactorypco_04850913_17250_0,e3
+      - rectangle_gdsfactorypco_04850913_17250_0,e4
+      - rectangle_gdsfactorypco_04850913_19750_0,e1
+      - rectangle_gdsfactorypco_04850913_19750_0,e2
+      - rectangle_gdsfactorypco_04850913_19750_0,e3
+      - rectangle_gdsfactorypco_04850913_19750_0,e4
+      - rectangle_gdsfactorypco_04850913_22250_0,e1
+      - rectangle_gdsfactorypco_04850913_22250_0,e2
+      - rectangle_gdsfactorypco_04850913_22250_0,e3
+      - rectangle_gdsfactorypco_04850913_22250_0,e4
+      - rectangle_gdsfactorypco_c88bb9ce_24750_0,e1
+      - rectangle_gdsfactorypco_c88bb9ce_24750_0,e2
+      - rectangle_gdsfactorypco_c88bb9ce_24750_0,e3
+      - rectangle_gdsfactorypco_c88bb9ce_24750_0,e4
       values:
-      - - -26.25
+      - - -25.25
         - 3
-      - - -26
+      - - -25
         - 6
-      - - -25.75
+      - - -24.75
         - 3
-      - - -26
+      - - -25
         - 0
-      - - -23.75
+      - - -22.75
         - 1
-      - - -23.5
+      - - -22.5
         - 2
-      - - -23.25
+      - - -22.25
         - 1
-      - - -23.5
+      - - -22.5
         - 0
-      - - -21.25
+      - - -20.25
         - 1
-      - - -21
+      - - -20
         - 2
-      - - -20.75
+      - - -19.75
         - 1
-      - - -21
+      - - -20
         - 0
-      - - -18.75
+      - - -17.75
         - 1
-      - - -18.5
+      - - -17.5
         - 2
-      - - -18.25
+      - - -17.25
         - 1
-      - - -18.5
+      - - -17.5
         - 0
-      - - -16.25
+      - - -15.25
         - 1
-      - - -16
+      - - -15
         - 2
-      - - -15.75
+      - - -14.75
         - 1
-      - - -16
+      - - -15
         - 0
-      - - -13.75
+      - - -12.75
         - 2
-      - - -13.5
+      - - -12.5
         - 4
-      - - -13.25
+      - - -12.25
         - 2
-      - - -13.5
+      - - -12.5
         - 0
-      - - -11.25
+      - - -10.25
         - 1
-      - - -11
+      - - -10
         - 2
-      - - -10.75
+      - - -9.75
         - 1
-      - - -11
+      - - -10
         - 0
-      - - -8.75
+      - - -7.75
         - 1
-      - - -8.5
+      - - -7.5
         - 2
-      - - -8.25
+      - - -7.25
         - 1
-      - - -8.5
+      - - -7.5
         - 0
-      - - -6.25
+      - - -5.25
         - 1
-      - - -6
+      - - -5
         - 2
-      - - -5.75
+      - - -4.75
         - 1
-      - - -6
+      - - -5
         - 0
-      - - -3.75
+      - - -2.75
         - 1
-      - - -3.5
+      - - -2.5
         - 2
-      - - -3.25
+      - - -2.25
         - 1
-      - - -3.5
+      - - -2.5
         - 0
-      - - -1.25
+      - - -0.25
         - 3
-      - - -1
+      - - 0
         - 6
-      - - -0.75
+      - - 0.25
         - 3
-      - - -1
+      - - 0
         - 0
-      - - 1.25
+      - - 2.25
         - 1
-      - - 1.5
+      - - 2.5
         - 2
-      - - 1.75
+      - - 2.75
         - 1
-      - - 1.5
+      - - 2.5
         - 0
-      - - 3.75
+      - - 4.75
         - 1
-      - - 4
+      - - 5
         - 2
-      - - 4.25
+      - - 5.25
         - 1
-      - - 4
+      - - 5
         - 0
-      - - 6.25
+      - - 7.25
         - 1
-      - - 6.5
+      - - 7.5
         - 2
-      - - 6.75
+      - - 7.75
         - 1
-      - - 6.5
+      - - 7.5
         - 0
-      - - 8.75
+      - - 9.75
         - 1
-      - - 9
+      - - 10
         - 2
-      - - 9.25
+      - - 10.25
         - 1
-      - - 9
+      - - 10
         - 0
-      - - 11.25
+      - - 12.25
         - 2
-      - - 11.5
+      - - 12.5
         - 4
-      - - 11.75
+      - - 12.75
         - 2
-      - - 11.5
+      - - 12.5
         - 0
-      - - 13.75
+      - - 14.75
         - 1
-      - - 14
+      - - 15
         - 2
-      - - 14.25
+      - - 15.25
         - 1
-      - - 14
+      - - 15
         - 0
-      - - 16.25
+      - - 17.25
         - 1
-      - - 16.5
+      - - 17.5
         - 2
-      - - 16.75
+      - - 17.75
         - 1
-      - - 16.5
+      - - 17.5
         - 0
-      - - 18.75
+      - - 19.75
         - 1
-      - - 19
+      - - 20
         - 2
-      - - 19.25
+      - - 20.25
         - 1
-      - - 19
+      - - 20
         - 0
-      - - 21.25
+      - - 22.25
         - 1
-      - - 21.5
+      - - 22.5
         - 2
-      - - 21.75
+      - - 22.75
         - 1
-      - - 21.5
+      - - 22.5
         - 0
-      - - 23.75
+      - - 24.75
         - 3
-      - - 24
+      - - 25
         - 6
-      - - 24.25
+      - - 25.25
         - 3
-      - - 24
+      - - 25
         - 0


### PR DESCRIPTION
## Summary by Sourcery

Regenerate litho ruler regression test data to align instance IDs, placement coordinates, and expected unconnected port values with updated rectangle positions

Tests:
- Update test-data-regression/test_netlists_litho_ruler_.yml by renaming instances to match new x-coordinates
- Adjust placement x-values for all rectangle instances
- Refresh expected warning values for unconnected electrical ports to correspond with updated positions