### PR TITLE
Remove snap

### DIFF
--- a/gdsfactory/components/shapes/compass.py
+++ b/gdsfactory/components/shapes/compass.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import valid_port_orientations
-from gdsfactory.snap import snap_to_grid2x
 from gdsfactory.typings import Ints, LayerSpec, Size
 
 
@@ -27,7 +26,7 @@ def compass(
         auto_rename_ports: auto rename ports.
     """
     c = gf.Component()
-    dx, dy = snap_to_grid2x(size)
+    dx, dy = size
     port_orientations = port_orientations or []
 
     if dx <= 0 or dy <= 0:
@@ -93,6 +92,6 @@ def compass(
 
 if __name__ == "__main__":
     # c = compass(size=(10, 4), port_type="electrical")
-    c = compass(port_orientations=[270])
+    c = compass(size=((0.101, 0.1)), port_orientations=[0])
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/superconductors/optimal_hairpin.py
+++ b/gdsfactory/components/superconductors/optimal_hairpin.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import LayerSpec
 
 
@@ -84,8 +83,8 @@ def optimal_hairpin(
     xpts.append(xpts[0])
     ypts.append(ypts[0])
 
-    xpts_np = snap_to_grid(xpts)
-    ypts_np = snap_to_grid(ypts)
+    xpts_np = np.array(xpts)
+    ypts_np = np.array(ypts)
 
     # ==========================================================================
     #  Create a blank device, add the geometry, and define the ports


### PR DESCRIPTION

## Summary

Remove grid snapping for component geometry calculations

Enhancements:
- Remove snap_to_grid2x in compass and use raw size tuples
- Replace snap_to_grid calls in optimal_hairpin with direct numpy arrays

Inspired by @reed-foster

https://github.com/gdsfactory/gdsfactory/pull/3816#pullrequestreview-2894282283