### PR TITLE
Expose coupler ring length extension

### DIFF
--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -42,7 +42,13 @@ def layermap_to_dataclass(
 
 
 @app.command()
-def write_cells(gdspath: str, dirpath: str = "", recursively: bool = True) -> None:
+def write_cells(
+    gdspath: str,
+    dirpath: str = typer.Option(
+        "", "--dirpath", help="Directory path to write GDS files to"
+    ),
+    recursively: bool = typer.Option(True, help="Write cells recursively"),
+) -> None:
     """Write each all level cells into separate GDS files."""
     from gdsfactory.write_cells import write_cells as write_cells_top_cells
     from gdsfactory.write_cells import write_cells_recursively
@@ -54,12 +60,19 @@ def write_cells(gdspath: str, dirpath: str = "", recursively: bool = True) -> No
 
 
 @app.command()
-def merge_gds(dirpath: str = "", gdspath: str = "") -> None:
+def merge_gds(
+    dirpath: str = typer.Option(
+        "", "--dirpath", help="Directory containing GDS files to merge"
+    ),
+    gdspath: str = typer.Option("", "--gdspath", help="Output GDS file path"),
+) -> None:
     """Merges GDS cells from a directory into a single GDS."""
     from gdsfactory.read.from_gdspaths import from_gdsdir
 
-    dirpath_path = pathlib.Path(dirpath) or pathlib.Path.cwd()
-    gdspath_path = pathlib.Path(gdspath) or pathlib.Path.cwd() / "merged.gds"
+    dirpath_path = pathlib.Path(dirpath) if dirpath else pathlib.Path.cwd()
+    gdspath_path = (
+        pathlib.Path(gdspath) if gdspath else pathlib.Path.cwd() / "merged.gds"
+    )
     c = from_gdsdir(dirpath=dirpath_path)
     c.write_gds(gdspath=gdspath_path)
     c.show()
@@ -67,7 +80,7 @@ def merge_gds(dirpath: str = "", gdspath: str = "") -> None:
 
 @app.command()
 def watch(
-    path: str = str(pathlib.Path.cwd()),
+    path: str = typer.Argument(str(pathlib.Path.cwd()), help="Folder to watch"),
     pdk: str = typer.Option(None, "--pdk", "-pdk", help="PDK name"),
     run_main: bool = typer.Option(False, "--run-main", "-rm", help="Run main"),
     run_cells: bool = typer.Option(False, "--run-cells", "-rc", help="Run cells"),
@@ -129,16 +142,19 @@ def version() -> None:
 
 
 @app.command(name="from-updk")
-def from_updk_command(filepath: str, filepath_out: str = "") -> None:
+def from_updk_command(
+    filepath: str,
+    filepath_out: str = typer.Option(
+        "", "--output", "-o", help="Output Python file path"
+    ),
+) -> None:
     """Writes a PDK in python from uPDK YAML spec."""
     filepath_path = pathlib.Path(filepath)
-    filepath_out_path = filepath_out or filepath_path.with_suffix(".py")
+    filepath_out_path = (
+        pathlib.Path(filepath_out) if filepath_out else filepath_path.with_suffix(".py")
+    )
     from_updk(filepath, filepath_out=filepath_out_path)
 
 
 if __name__ == "__main__":
-    import sys
-
-    if len(sys.argv) == 1:  # No arguments provided
-        sys.argv.append("--help")
     app()

--- a/gdsfactory/components/couplers/coupler90.py
+++ b/gdsfactory/components/couplers/coupler90.py
@@ -15,6 +15,7 @@ def coupler90(
     straight: ComponentSpec = "straight",
     cross_section: CrossSectionSpec = "strip",
     cross_section_bend: CrossSectionSpec | None = None,
+    length_straight: float | None = None,
 ) -> Component:
     r"""Straight coupled to a bend.
 
@@ -25,6 +26,7 @@ def coupler90(
         bend: bend spec.
         cross_section: cross_section spec.
         cross_section_bend: optional bend cross_section spec.
+        length_straight: optional length of the straight waveguide.
 
     .. code::
 
@@ -47,10 +49,14 @@ def coupler90(
     )
     bend_ref = c << bend90
     bend90_ports = bend_ref.ports.filter(port_type="optical")
+
+    if length_straight is None:
+        length_straight = bend90_ports[1].center[0] - bend90_ports[0].center[0]
+
     straight_component = gf.get_component(
         straight,
         cross_section=cross_section,
-        length=bend90_ports[1].center[0] - bend90_ports[0].center[0],
+        length=length_straight,
     )
     wg_ref = c << straight_component
     width = x.width
@@ -67,5 +73,5 @@ coupler90circular = partial(coupler90, bend="bend_circular")
 
 
 if __name__ == "__main__":
-    c = coupler90(cross_section_bend="strip_heater_metal")
+    c = coupler90(cross_section_bend="strip_heater_metal", length_straight=0)
     c.show()

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -16,7 +16,7 @@ def coupler_ring(
     straight: ComponentSpec = "straight",
     cross_section: CrossSectionSpec = "strip",
     cross_section_bend: CrossSectionSpec | None = None,
-    length_extension: float = 3,
+    length_extension: float = 3.0,
 ) -> Component:
     r"""Coupler for ring.
 
@@ -28,7 +28,7 @@ def coupler_ring(
         straight: straight spec.
         cross_section: cross_section spec.
         cross_section_bend: optional bend cross_section spec.
-        length_extension: for the ports.
+        length_extension: straight length extension at the end of the coupler bottom ports.
 
     .. code::
 
@@ -50,8 +50,10 @@ def coupler_ring(
                          │gap
                  o1──────▼─────────◄──────────────► o4
                                     length_extension
-
     """
+    if length_extension is None:
+        length_extension = 3 + radius
+
     c = Component()
     gap = gf.snap.snap_to_grid(gap, grid_factor=2)
     cross_section_bend = cross_section_bend or cross_section
@@ -100,5 +102,5 @@ def coupler_ring(
 
 
 if __name__ == "__main__":
-    c = coupler_ring(length_extension=3, length_x=0)
+    c = coupler_ring()
     c.show()

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -39,6 +39,18 @@ def coupler_ring(
            ---=========---
         o1    length_x   o4
 
+          o2                              o3
+          xx                              xx
+          xx                             xx
+           xx          length_x          x
+            xx     ◄───────────────►    x
+             xx                       xxx
+               xx                   xxx
+                xxx──────▲─────────xxx
+                         │gap
+                 o1──────▼─────────◄──────────────► o4
+                                    length_extension
+
     """
     c = Component()
     gap = gf.snap.snap_to_grid(gap, grid_factor=2)
@@ -53,6 +65,7 @@ def coupler_ring(
         straight=straight,
         cross_section=cross_section,
         cross_section_bend=cross_section_bend,
+        length_straight=length_extension,
     )
     coupler_straight_component = gf.get_component(
         coupler_straight,
@@ -70,17 +83,10 @@ def coupler_ring(
     cs.connect(port="o4", other=cbr.ports["o1"])
     cbl.connect(port="o2", other=cs.ports["o2"], mirror=True)
 
-    s = gf.get_component(straight, length=length_extension, cross_section=cross_section)
-    s1 = c << s
-    s2 = c << s
-
-    s1.connect("o2", cbl.ports["o4"])
-    s2.connect("o1", cbr.ports["o4"])
-
-    c.add_port("o1", port=s1.ports["o1"])
+    c.add_port("o1", port=cbl.ports["o4"])
     c.add_port("o2", port=cbl.ports["o3"])
     c.add_port("o3", port=cbr.ports["o3"])
-    c.add_port("o4", port=s2.ports["o2"])
+    c.add_port("o4", port=cbr.ports["o4"])
 
     c.add_ports(
         gf.port.select_ports_list(ports=cbl.ports, port_type="electrical"), prefix="cbl"
@@ -94,5 +100,5 @@ def coupler_ring(
 
 
 if __name__ == "__main__":
-    c = coupler_ring()
+    c = coupler_ring(length_extension=3, length_x=0)
     c.show()

--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-import numpy.typing as npt
 from numpy import cos, pi, sin
 
 import gdsfactory as gf
@@ -30,8 +29,7 @@ def ring(
     inner_radius = radius - width / 2
     outer_radius = radius + width / 2
     n = int(np.round(360 / angle_resolution))
-    t: npt.NDArray[np.float64] = np.linspace(0, angle, n + 1) * pi / 180
-    assert isinstance(t, np.ndarray)
+    t = np.linspace(0, angle, n + 1) * pi / 180
     inner_points_x = inner_radius * cos(t)
     inner_points_y = inner_radius * sin(t)
     outer_points_x = outer_radius * cos(t)

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -18,6 +18,7 @@ def ring_double(
     coupler_ring: ComponentSpec = "coupler_ring",
     coupler_ring_top: ComponentSpec | None = None,
     cross_section: CrossSectionSpec = "strip",
+    length_extension: float = 3.0,
 ) -> Component:
     """Returns a double bus ring.
 
@@ -36,6 +37,7 @@ def ring_double(
         coupler_ring: ring coupler spec.
         coupler_ring_top: top ring coupler spec. Defaults to coupler_ring.
         cross_section: cross_section spec.
+        length_extension: length extension for the coupler ring.
 
     .. code::
 
@@ -68,6 +70,7 @@ def ring_double(
         cross_section=cross_section,
         straight=straight,
         bend=bend,
+        length_extension=length_extension,
     )
     coupler_component_top = gf.get_component(
         coupler_ring_top or coupler_ring,
@@ -77,6 +80,7 @@ def ring_double(
         cross_section=cross_section,
         straight=straight,
         bend=bend,
+        length_extension=length_extension,
     )
     straight_component = gf.get_component(
         straight,
@@ -105,5 +109,5 @@ def ring_double(
 
 
 if __name__ == "__main__":
-    c = ring_double(length_y=2, bend="bend_circular", gap_top=0.4)
+    c = ring_double(length_y=2, bend="bend_circular", gap_top=0.4, length_extension=0)
     c.show()

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -37,7 +37,7 @@ def ring_double(
         coupler_ring: ring coupler spec.
         coupler_ring_top: top ring coupler spec. Defaults to coupler_ring.
         cross_section: cross_section spec.
-        length_extension: length extension for the coupler ring.
+        length_extension: straight length extension at the end of the coupler bottom ports.
 
     .. code::
 
@@ -58,7 +58,8 @@ def ring_double(
            xx                   xxx
             xxx──────▲─────────xxx
                      │gap
-             o1──────▼─────────o4
+             o1──────▼─────────◄──────────────► o4
+                                length_extension
     """
     gap_top = gap_top or gap
     gap_bot = gap_bot or gap

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -26,6 +26,7 @@ def ring_double_heater(
     port_orientation: AngleInDegrees | None = None,
     via_stack_offset: Float2 = (1, 0),
     with_drop: bool = True,
+    length_extension: float = 3.0,
 ) -> Component:
     """Returns a double bus ring with heater on top.
 
@@ -50,6 +51,7 @@ def ring_double_heater(
         port_orientation: for electrical ports to promote from via_stack.
         via_stack_offset: x,y offset for via_stack.
         with_drop: adds drop ports.
+        length_extension: straight length extension at the end of the coupler bottom ports.
 
     .. code::
 
@@ -89,6 +91,7 @@ def ring_double_heater(
         bend=bend,
         cross_section=cross_section,
         cross_section_bend=cross_section_waveguide_heater,
+        length_extension=length_extension,
     )
     coupler_component_top = gf.get_component(
         coupler_ring_top,
@@ -98,6 +101,7 @@ def ring_double_heater(
         bend=bend,
         cross_section=cross_section,
         cross_section_bend=cross_section_waveguide_heater,
+        length_extension=length_extension,
     )
     straight_component = gf.get_component(
         straight,
@@ -177,6 +181,6 @@ ring_single_heater = partial(ring_double_heater, with_drop=False)
 
 
 if __name__ == "__main__":
-    c = ring_double_heater(gap_top=0.4, length_y=2)
+    c = ring_double_heater(gap_top=0.4, length_y=2, length_extension=10)
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -14,6 +14,7 @@ def ring_single(
     straight: ComponentSpec = "straight",
     coupler_ring: ComponentSpec = "coupler_ring",
     cross_section: CrossSectionSpec = "strip",
+    length_extension: float = 3.0,
 ) -> gf.Component:
     """Returns a single ring resonator with a directional coupler.
 
@@ -38,6 +39,7 @@ def ring_single(
         straight: Component spec for the straight waveguides. Default is "straight".
         coupler_ring: Component spec for the ring coupler. Default is "coupler_ring".
         cross_section: Cross section spec for all waveguides. Default is "strip".
+        length_extension: Optional length extension for the coupler ring (μm).
 
     Returns:
         Component: A gdsfactory Component containing the ring resonator with:
@@ -47,6 +49,7 @@ def ring_single(
 
     Raises:
         ValueError: If length_x or length_y is negative.
+
 
     .. code::
 
@@ -66,7 +69,8 @@ def ring_single(
                xx                   xxx
                 xxx──────▲─────────xxx
                          │gap
-                 o1──────▼─────────o2
+                 o1──────▼─────────o2◄──────────────►
+                                     length_extension
     """
     if length_y < 0:
         raise ValueError(f"length_y={length_y} must be >= 0")
@@ -77,9 +81,7 @@ def ring_single(
     # Create main component
     c = gf.Component()
 
-    # Create and place the directional coupler
-    cb = c << gf.get_component(
-        coupler_ring,
+    settings = dict(
         gap=gap,
         radius=radius,
         length_x=length_x,
@@ -87,6 +89,12 @@ def ring_single(
         bend=bend,
         straight=straight,
     )
+
+    if length_extension is not None:
+        settings["length_extension"] = length_extension
+
+    # Create and place the coupler
+    cb = c << gf.get_component(coupler_ring, settings=settings)
 
     # Create waveguide components
     sy = gf.get_component(straight, length=length_y, cross_section=cross_section)
@@ -117,7 +125,14 @@ def ring_single(
 if __name__ == "__main__":
     # c = ring_single(layer=(2, 0), cross_section_factory=gf.cross_section.pin, width=1)
     # c = ring_single(width=2, gap=1, layer=(2, 0), radius=7, length_y=1)
-    c = ring_single(radius=5, gap=0.111, bend="bend_circular", length_x=0, length_y=0)
+    c = ring_single(
+        radius=5,
+        gap=0.111,
+        bend="bend_circular",
+        length_x=0,
+        length_y=0,
+        length_extension=0,
+    )
     n = c.get_netlist()
     # print(c.ports)
 

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -39,7 +39,7 @@ def ring_single(
         straight: Component spec for the straight waveguides. Default is "straight".
         coupler_ring: Component spec for the ring coupler. Default is "coupler_ring".
         cross_section: Cross section spec for all waveguides. Default is "strip".
-        length_extension: Optional length extension for the coupler ring (μm).
+        length_extension: straight length extension at the end of the coupler bottom ports.
 
     Returns:
         Component: A gdsfactory Component containing the ring resonator with:

--- a/gdsfactory/components/rings/ring_single_array.py
+++ b/gdsfactory/components/rings/ring_single_array.py
@@ -15,14 +15,14 @@ _list_of_dicts: tuple[dict[str, Any], ...] = (
 @gf.cell_with_module_name
 def ring_single_array(
     ring: ComponentSpec = "ring_single",
-    spacing: float = 5.0,
+    spacing: float = 15.0,
     list_of_dicts: tuple[dict[str, Any], ...] | None = None,
     cross_section: CrossSectionSpec = "strip",
 ) -> Component:
     """Ring of single bus connected with straights.
 
     Args:
-        ring: ring function.
+        ring: ring spec.
         spacing: between rings.
         list_of_dicts: settings for each ring.
         cross_section: spec.

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -19,6 +19,7 @@ def ring_single_dut(
     bend: ComponentSpec = "bend_euler",
     with_component: bool = True,
     port_name: str = "o1",
+    length_extension: float | None = None,
     **kwargs: Any,
 ) -> Component:
     """Single bus ring made of two couplers (ct: top, cb: bottom) connected.
@@ -36,6 +37,7 @@ def ring_single_dut(
         bend: bend function.
         with_component: True adds component. False adds waveguide.
         port_name: for component input.
+        length_extension: optional length extension for the coupler bottom ports.
         kwargs: cross_section settings.
 
     Args:
@@ -55,7 +57,12 @@ def ring_single_dut(
     assert_on_2x_grid(gap)
 
     coupler = gf.get_component(
-        coupler, gap=gap, length_x=length_x, radius=radius, **kwargs
+        coupler,
+        gap=gap,
+        length_x=length_x,
+        radius=radius,
+        length_extension=length_extension,
+        **kwargs,
     )
 
     component_xsize = component.xsize

--- a/test-data-regression/test_netlists_coupler90_.yml
+++ b/test-data-regression/test_netlists_coupler90_.yml
@@ -37,7 +37,7 @@ instances:
       length: 10
       npoints: 2
       width: null
-name: coupler90_gdsfactorypco_36298ee4
+name: coupler90_gdsfactorypco_9253bfe3
 nets: []
 placements:
   bend_euler_gdsfactorypc_c35a91db_0_700:

--- a/test-data-regression/test_netlists_coupler90circular_.yml
+++ b/test-data-regression/test_netlists_coupler90circular_.yml
@@ -34,7 +34,7 @@ instances:
       length: 10
       npoints: 2
       width: null
-name: coupler90_gdsfactorypco_7a423c76
+name: coupler90_gdsfactorypco_393cec8e
 nets: []
 placements:
   bend_circular_gdsfactor_9f5f0004_0_700:

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -51,7 +51,7 @@ instances:
       length: 0.01
       npoints: 2
       width: null
-name: ring_double_gdsfactoryp_c961dbbf
+name: ring_double_gdsfactoryp_0922feda
 nets:
 - p1: coupler_ring_gdsfactory_0dce5cf1_0_0,o2
   p2: straight_gdsfactorypcom_05377f40_m10010_10700_A90,o1

--- a/test-data-regression/test_netlists_ring_double_heater_.yml
+++ b/test-data-regression/test_netlists_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_gdsf_97fd82da
+name: ring_double_heater_gdsf_1cb4fda3
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -101,7 +101,7 @@ instances:
       length: 4
       npoints: 2
       width: null
-name: ring_single_gdsfactoryp_0384f741
+name: ring_single_gdsfactoryp_d74ed1d8
 nets:
 - p1: bend_euler_gdsfactorypc_e95a7a4d_10000_11300_A90,o1
   p2: straight_gdsfactorypcom_058e2168_10000_11300_A270,o1

--- a/test-data-regression/test_netlists_ring_single_array_.yml
+++ b/test-data-regression/test_netlists_ring_single_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  ring_single_gdsfactoryp_89ce1377_0_0:
+  ring_single_gdsfactoryp_36f99320_41000_0:
     component: ring_single
     info: {}
     settings:
@@ -7,58 +7,60 @@ instances:
       coupler_ring: coupler_ring
       cross_section: strip
       gap: 0.2
-      length_x: 10
-      length_y: 0.6
-      radius: 5
-      straight: straight
-  ring_single_gdsfactoryp_c1dcd193_46000_0:
-    component: ring_single
-    info: {}
-    settings:
-      bend: bend_euler
-      coupler_ring: coupler_ring
-      cross_section: strip
-      gap: 0.2
+      length_extension: 3
       length_x: 20
       length_y: 0.6
       radius: 10
       straight: straight
-  straight_gdsfactorypcom_32b584f5_8000_0:
+  ring_single_gdsfactoryp_7576c664_0_0:
+    component: ring_single
+    info: {}
+    settings:
+      bend: bend_euler
+      coupler_ring: coupler_ring
+      cross_section: strip
+      gap: 0.2
+      length_extension: 3
+      length_x: 10
+      length_y: 0.6
+      radius: 5
+      straight: straight
+  straight_gdsfactorypcom_aa481ca5_3000_0:
     component: straight
     info:
-      length: 5
-      route_info_length: 5
-      route_info_strip_length: 5
+      length: 15
+      route_info_length: 15
+      route_info_strip_length: 15
       route_info_type: strip
-      route_info_weight: 5
+      route_info_weight: 15
       width: 0.5
     settings:
       cross_section: strip
-      length: 5
+      length: 15
       npoints: 2
       width: null
-name: ring_single_array_gdsfa_616e5436
+name: ring_single_array_gdsfa_54fe30c4
 nets:
-- p1: ring_single_gdsfactoryp_89ce1377_0_0,o2
-  p2: straight_gdsfactorypcom_32b584f5_8000_0,o1
-- p1: ring_single_gdsfactoryp_c1dcd193_46000_0,o1
-  p2: straight_gdsfactorypcom_32b584f5_8000_0,o2
+- p1: ring_single_gdsfactoryp_36f99320_41000_0,o1
+  p2: straight_gdsfactorypcom_aa481ca5_3000_0,o2
+- p1: ring_single_gdsfactoryp_7576c664_0_0,o2
+  p2: straight_gdsfactorypcom_aa481ca5_3000_0,o1
 placements:
-  ring_single_gdsfactoryp_89ce1377_0_0:
+  ring_single_gdsfactoryp_36f99320_41000_0:
+    mirror: false
+    rotation: 0
+    x: 41
+    y: 0
+  ring_single_gdsfactoryp_7576c664_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  ring_single_gdsfactoryp_c1dcd193_46000_0:
+  straight_gdsfactorypcom_aa481ca5_3000_0:
     mirror: false
     rotation: 0
-    x: 46
-    y: 0
-  straight_gdsfactorypcom_32b584f5_8000_0:
-    mirror: false
-    rotation: 0
-    x: 8
+    x: 3
     y: 0
 ports:
-  o1: ring_single_gdsfactoryp_89ce1377_0_0,o1
-  o2: ring_single_gdsfactoryp_c1dcd193_46000_0,o2
+  o1: ring_single_gdsfactoryp_7576c664_0_0,o1
+  o2: ring_single_gdsfactoryp_36f99320_41000_0,o2

--- a/test-data-regression/test_netlists_ring_single_dut_.yml
+++ b/test-data-regression/test_netlists_ring_single_dut_.yml
@@ -47,7 +47,7 @@ instances:
       radius: 5
       width: null
       with_arc_floorplan: true
-  coupler_ring_gdsfactory_8af83332_0_0:
+  coupler_ring_gdsfactory_e57d2f45_0_0:
     component: coupler_ring
     info: {}
     settings:
@@ -55,7 +55,7 @@ instances:
       cross_section: strip
       cross_section_bend: null
       gap: 0.2
-      length_extension: 3
+      length_extension: null
       length_x: 4
       radius: 5
       straight: straight
@@ -101,7 +101,7 @@ instances:
       length: 10
       npoints: 2
       width: null
-name: ring_single_dut_gdsfact_8e89b00d
+name: ring_single_dut_gdsfact_9fdbcb54
 nets:
 - p1: bend_euler_gdsfactorypc_56602939_5000_15700_A90,o1
   p2: straight_gdsfactorypcom_f2286423_5000_15700_A270,o1
@@ -111,9 +111,9 @@ nets:
   p2: straight_gdsfactorypcom_a6eac62c_m4000_20700,o1
 - p1: bend_euler_gdsfactorypc_56602939_m4000_20700_A180,o2
   p2: straight_gdsfactorypcom_f2286423_m9000_15700_A270,o1
-- p1: coupler_ring_gdsfactory_8af83332_0_0,o2
+- p1: coupler_ring_gdsfactory_e57d2f45_0_0,o2
   p2: straight_gdsfactorypcom_f2286423_m9000_15700_A270,o2
-- p1: coupler_ring_gdsfactory_8af83332_0_0,o3
+- p1: coupler_ring_gdsfactory_e57d2f45_0_0,o3
   p2: straight_gdsfactorypcom_f2286423_5000_15700_A270,o2
 placements:
   bend_euler_gdsfactorypc_56602939_5000_15700_A90:
@@ -126,7 +126,7 @@ placements:
     rotation: 180
     x: -4
     y: 20.7
-  coupler_ring_gdsfactory_8af83332_0_0:
+  coupler_ring_gdsfactory_e57d2f45_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -147,5 +147,5 @@ placements:
     x: -9
     y: 15.7
 ports:
-  o1: coupler_ring_gdsfactory_8af83332_0_0,o1
-  o2: coupler_ring_gdsfactory_8af83332_0_0,o4
+  o1: coupler_ring_gdsfactory_e57d2f45_0_0,o1
+  o2: coupler_ring_gdsfactory_e57d2f45_0_0,o4

--- a/test-data-regression/test_netlists_ring_single_heater_.yml
+++ b/test-data-regression/test_netlists_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_gdsf_562492d7
+name: ring_double_heater_gdsf_6e5a093d
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_coupler90_.yml
+++ b/test-data-regression/test_settings_coupler90_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: coupler90_gdsfactorypco_36298ee4
+name: coupler90_gdsfactorypco_9253bfe3
 settings:
   bend: bend_euler
   cross_section: strip

--- a/test-data-regression/test_settings_coupler90circular_.yml
+++ b/test-data-regression/test_settings_coupler90circular_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: coupler90_gdsfactorypco_7a423c76
+name: coupler90_gdsfactorypco_393cec8e
 settings:
   bend: bend_circular
   cross_section: strip

--- a/test-data-regression/test_settings_ring_double_.yml
+++ b/test-data-regression/test_settings_ring_double_.yml
@@ -1,10 +1,11 @@
 info: {}
-name: ring_double_gdsfactoryp_c961dbbf
+name: ring_double_gdsfactoryp_0922feda
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
   cross_section: strip
   gap: 0.2
+  length_extension: 3
   length_x: 0.01
   length_y: 0.01
   radius: 10

--- a/test-data-regression/test_settings_ring_double_heater_.yml
+++ b/test-data-regression/test_settings_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_gdsf_97fd82da
+name: ring_double_heater_gdsf_1cb4fda3
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
@@ -7,6 +7,7 @@ settings:
   cross_section_heater: heater_metal
   cross_section_waveguide_heater: strip_heater_metal
   gap: 0.2
+  length_extension: 3
   length_x: 1
   length_y: 0.01
   radius: 10

--- a/test-data-regression/test_settings_ring_single_.yml
+++ b/test-data-regression/test_settings_ring_single_.yml
@@ -1,10 +1,11 @@
 info: {}
-name: ring_single_gdsfactoryp_0384f741
+name: ring_single_gdsfactoryp_d74ed1d8
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
   cross_section: strip
   gap: 0.2
+  length_extension: 3
   length_x: 4
   length_y: 0.6
   radius: 10

--- a/test-data-regression/test_settings_ring_single_array_.yml
+++ b/test-data-regression/test_settings_ring_single_array_.yml
@@ -1,6 +1,6 @@
 info: {}
-name: ring_single_array_gdsfa_616e5436
+name: ring_single_array_gdsfa_54fe30c4
 settings:
   cross_section: strip
   ring: ring_single
-  spacing: 5
+  spacing: 15

--- a/test-data-regression/test_settings_ring_single_dut_.yml
+++ b/test-data-regression/test_settings_ring_single_dut_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_single_dut_gdsfact_8e89b00d
+name: ring_single_dut_gdsfact_9fdbcb54
 settings:
   bend: bend_euler
   component: straight

--- a/test-data-regression/test_settings_ring_single_heater_.yml
+++ b/test-data-regression/test_settings_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_gdsf_562492d7
+name: ring_double_heater_gdsf_6e5a093d
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
@@ -7,6 +7,7 @@ settings:
   cross_section_heater: heater_metal
   cross_section_waveguide_heater: strip_heater_metal
   gap: 0.2
+  length_extension: 3
   length_x: 1
   length_y: 0.01
   radius: 10

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,474 @@
+import os
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from gdsfactory.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_dir() -> Generator[Path, None, None]:
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def sample_gds_file(temp_dir: Path) -> Path:
+    """Create a sample GDS file for testing."""
+    import gdsfactory as gf
+
+    c = gf.components.rectangle()
+    gds_path = temp_dir / "sample.gds"
+    c.write_gds(gds_path)
+    return gds_path
+
+
+@pytest.fixture
+def sample_lyp_file(temp_dir: Path) -> Path:
+    """Create a sample LYP file for testing."""
+    lyp_content = """<?xml version="1.0" encoding="utf-8"?>
+<layer-properties>
+  <properties>
+    <frame-color>#ff0000</frame-color>
+    <fill-color>#ff0000</fill-color>
+    <frame-brightness>0</frame-brightness>
+    <fill-brightness>0</fill-brightness>
+    <dither-pattern>I9</dither-pattern>
+    <line-style/>
+    <valid>true</valid>
+    <visible>true</visible>
+    <transparent>false</transparent>
+    <width>1</width>
+    <marked>false</marked>
+    <xfill>false</xfill>
+    <animation>0</animation>
+    <name>layer1/0@*</name>
+    <source>1/0@*</source>
+  </properties>
+</layer-properties>"""
+    lyp_path = temp_dir / "sample.lyp"
+    lyp_path.write_text(lyp_content)
+    return lyp_path
+
+
+class TestCLIHelp:
+    """Test CLI help functionality."""
+
+    def test_app_help(self, runner: CliRunner) -> None:
+        """Test main help command."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+        assert "Commands" in result.stdout
+
+    def test_individual_command_help(self, runner: CliRunner) -> None:
+        """Test help for individual commands."""
+        commands = [
+            "layermap-to-dataclass",
+            "write-cells",
+            "merge-gds",
+            "watch",
+            "show",
+            "gds-diff",
+            "install-klayout-genericpdk",
+            "install-git-diff",
+            "version",
+            "from-updk",
+        ]
+
+        for command in commands:
+            result = runner.invoke(app, [command, "--help"])
+            assert result.exit_code == 0, f"Help failed for command: {command}"
+            assert "Usage:" in result.stdout
+
+
+class TestLayermapToDataclass:
+    """Test layermap-to-dataclass command."""
+
+    def test_layermap_to_dataclass_success(
+        self, runner: CliRunner, sample_lyp_file: Path, temp_dir: Path
+    ) -> None:
+        """Test successful conversion of LYP to dataclass."""
+        with patch("gdsfactory.technology.lyp_to_dataclass") as mock_convert:
+            result = runner.invoke(app, ["layermap-to-dataclass", str(sample_lyp_file)])
+            assert result.exit_code == 0
+            mock_convert.assert_called_once()
+
+    def test_layermap_to_dataclass_file_not_found(self, runner: CliRunner) -> None:
+        """Test error when LYP file doesn't exist."""
+        result = runner.invoke(app, ["layermap-to-dataclass", "nonexistent.lyp"])
+        assert result.exit_code == 1
+        # Check that the exception was raised (typer catches it and sets exit code to 1)
+        assert "FileNotFoundError" in str(result.exception) or "not found" in str(
+            result.exception
+        )
+
+    def test_layermap_to_dataclass_file_exists_no_force(
+        self, runner: CliRunner, sample_lyp_file: Path
+    ) -> None:
+        """Test error when output file exists and --force not used."""
+        py_file = sample_lyp_file.with_suffix(".py")
+        py_file.write_text("# existing file")
+
+        result = runner.invoke(app, ["layermap-to-dataclass", str(sample_lyp_file)])
+        assert result.exit_code == 1
+        # Check that the exception was raised
+        assert "FileExistsError" in str(result.exception) or "found" in str(
+            result.exception
+        )
+
+    def test_layermap_to_dataclass_force_overwrite(
+        self, runner: CliRunner, sample_lyp_file: Path
+    ) -> None:
+        """Test successful overwrite with --force flag."""
+        py_file = sample_lyp_file.with_suffix(".py")
+        py_file.write_text("# existing file")
+
+        with patch("gdsfactory.technology.lyp_to_dataclass") as mock_convert:
+            result = runner.invoke(
+                app, ["layermap-to-dataclass", str(sample_lyp_file), "--force"]
+            )
+            assert result.exit_code == 0
+            mock_convert.assert_called_once()
+
+
+class TestWriteCells:
+    """Test write-cells command."""
+
+    def test_write_cells_recursive(
+        self, runner: CliRunner, sample_gds_file: Path, temp_dir: Path
+    ) -> None:
+        """Test write-cells with recursive option."""
+        output_dir = temp_dir / "output"
+
+        with patch("gdsfactory.write_cells.write_cells_recursively") as mock_write:
+            result = runner.invoke(
+                app,
+                [
+                    "write-cells",
+                    str(sample_gds_file),
+                    "--dirpath",
+                    str(output_dir),
+                    "--recursively",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_write.assert_called_once_with(
+                gdspath=str(sample_gds_file), dirpath=str(output_dir)
+            )
+
+    def test_write_cells_non_recursive(
+        self, runner: CliRunner, sample_gds_file: Path, temp_dir: Path
+    ) -> None:
+        """Test write-cells without recursive option."""
+        output_dir = temp_dir / "output"
+
+        with patch("gdsfactory.write_cells.write_cells") as mock_write:
+            result = runner.invoke(
+                app,
+                [
+                    "write-cells",
+                    str(sample_gds_file),
+                    "--dirpath",
+                    str(output_dir),
+                    "--no-recursively",
+                ],
+            )
+            assert result.exit_code == 0
+            mock_write.assert_called_once_with(
+                gdspath=str(sample_gds_file), dirpath=str(output_dir)
+            )
+
+
+class TestMergeGds:
+    """Test merge-gds command."""
+
+    def test_merge_gds_default_paths(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test merge-gds with default paths."""
+        # Create some sample GDS files in the directory
+        import gdsfactory as gf
+
+        for i in range(2):
+            c = gf.components.rectangle(size=(i + 1, i + 1))
+            c.write_gds(temp_dir / f"rect_{i}.gds")
+
+        with patch("gdsfactory.read.from_gdspaths.from_gdsdir") as mock_from_gdsdir:
+            mock_component = Mock()
+            mock_from_gdsdir.return_value = mock_component
+
+            # Change to temp directory to test default behavior
+            original_cwd = Path.cwd()
+            os.chdir(temp_dir)
+            try:
+                result = runner.invoke(app, ["merge-gds"])
+                assert result.exit_code == 0
+                mock_from_gdsdir.assert_called_once()
+                mock_component.write_gds.assert_called_once()
+                mock_component.show.assert_called_once()
+            finally:
+                os.chdir(original_cwd)
+
+    def test_merge_gds_custom_paths(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test merge-gds with custom input and output paths."""
+        input_dir = temp_dir / "input"
+        input_dir.mkdir()
+        output_file = temp_dir / "merged_custom.gds"
+
+        with patch("gdsfactory.read.from_gdspaths.from_gdsdir") as mock_from_gdsdir:
+            mock_component = Mock()
+            mock_from_gdsdir.return_value = mock_component
+
+            result = runner.invoke(
+                app,
+                [
+                    "merge-gds",
+                    "--dirpath",
+                    str(input_dir),
+                    "--gdspath",
+                    str(output_file),
+                ],
+            )
+            assert result.exit_code == 0
+            mock_from_gdsdir.assert_called_once_with(dirpath=input_dir)
+            mock_component.write_gds.assert_called_once_with(gdspath=output_file)
+
+
+class TestWatch:
+    """Test watch command."""
+
+    def test_watch_default_options(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test watch command with default options."""
+        with patch("gdsfactory.cli._watch") as mock_watch:
+            result = runner.invoke(app, ["watch", str(temp_dir)])
+            assert result.exit_code == 0
+            mock_watch.assert_called_once_with(
+                str(temp_dir.absolute()),
+                pdk=None,
+                run_main=False,
+                run_cells=False,
+                pre_run=False,
+            )
+
+    def test_watch_with_options(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test watch command with various options."""
+        with patch("gdsfactory.cli._watch") as mock_watch:
+            with patch("gdsfactory.CONF") as mock_conf:
+                result = runner.invoke(
+                    app,
+                    [
+                        "watch",
+                        str(temp_dir),
+                        "--pdk",
+                        "test_pdk",
+                        "--run-main",
+                        "--run-cells",
+                        "--pre-run",
+                        "--overwrite",
+                    ],
+                )
+                assert result.exit_code == 0
+                mock_watch.assert_called_once_with(
+                    str(temp_dir.absolute()),
+                    pdk="test_pdk",
+                    run_main=True,
+                    run_cells=True,
+                    pre_run=True,
+                )
+                assert mock_conf.cell_overwrite_existing is True
+
+
+class TestShow:
+    """Test show command."""
+
+    def test_show_gds_file(self, runner: CliRunner, sample_gds_file: Path) -> None:
+        """Test showing a GDS file."""
+        with patch("gdsfactory.cli._show") as mock_show:
+            result = runner.invoke(app, ["show", str(sample_gds_file)])
+            assert result.exit_code == 0
+            mock_show.assert_called_once_with(str(sample_gds_file))
+
+
+class TestGdsDiff:
+    """Test gds-diff command."""
+
+    def test_gds_diff_basic(
+        self, runner: CliRunner, sample_gds_file: Path, temp_dir: Path
+    ) -> None:
+        """Test basic GDS diff functionality."""
+        # Create a second GDS file
+        import gdsfactory as gf
+
+        c2 = gf.components.rectangle(size=(2, 2))
+        gds2_path = temp_dir / "sample2.gds"
+        c2.write_gds(gds2_path)
+
+        with patch("gdsfactory.cli.diff") as mock_diff:
+            result = runner.invoke(
+                app, ["gds-diff", str(sample_gds_file), str(gds2_path)]
+            )
+            assert result.exit_code == 0
+            mock_diff.assert_called_once_with(
+                str(sample_gds_file), str(gds2_path), xor=False
+            )
+
+    def test_gds_diff_with_xor(
+        self, runner: CliRunner, sample_gds_file: Path, temp_dir: Path
+    ) -> None:
+        """Test GDS diff with XOR option."""
+        import gdsfactory as gf
+
+        c2 = gf.components.rectangle(size=(2, 2))
+        gds2_path = temp_dir / "sample2.gds"
+        c2.write_gds(gds2_path)
+
+        with patch("gdsfactory.cli.diff") as mock_diff:
+            result = runner.invoke(
+                app, ["gds-diff", str(sample_gds_file), str(gds2_path), "--xor"]
+            )
+            assert result.exit_code == 0
+            mock_diff.assert_called_once_with(
+                str(sample_gds_file), str(gds2_path), xor=True
+            )
+
+
+class TestInstallCommands:
+    """Test installation commands."""
+
+    def test_install_klayout_genericpdk(self, runner: CliRunner) -> None:
+        """Test installing KLayout generic PDK."""
+        with patch("gdsfactory.cli.install_klayout_package") as mock_install:
+            result = runner.invoke(app, ["install-klayout-genericpdk"])
+            assert result.exit_code == 0
+            mock_install.assert_called_once()
+
+    def test_install_git_diff(self, runner: CliRunner) -> None:
+        """Test installing git diff."""
+        with patch("gdsfactory.cli.install_gdsdiff") as mock_install:
+            result = runner.invoke(app, ["install-git-diff"])
+            assert result.exit_code == 0
+            mock_install.assert_called_once()
+
+
+class TestVersion:
+    """Test version command."""
+
+    def test_version_command(self, runner: CliRunner) -> None:
+        """Test version command output."""
+        with patch("gdsfactory.cli.print_version_plugins") as mock_print:
+            result = runner.invoke(app, ["version"])
+            assert result.exit_code == 0
+            mock_print.assert_called_once()
+
+
+class TestFromUpdk:
+    """Test from-updk command."""
+
+    def test_from_updk_basic(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test basic from-updk functionality."""
+        input_file = temp_dir / "test.yaml"
+        input_file.write_text("blocks: {}")
+
+        with patch("gdsfactory.cli.from_updk") as mock_from_updk:
+            result = runner.invoke(app, ["from-updk", str(input_file)])
+            assert result.exit_code == 0
+            expected_output = input_file.with_suffix(".py")
+            mock_from_updk.assert_called_once_with(
+                str(input_file), filepath_out=expected_output
+            )
+
+    def test_from_updk_custom_output(self, runner: CliRunner, temp_dir: Path) -> None:
+        """Test from-updk with custom output path."""
+        input_file = temp_dir / "test.yaml"
+        output_file = temp_dir / "custom_output.py"
+        input_file.write_text("blocks: {}")
+
+        with patch("gdsfactory.cli.from_updk") as mock_from_updk:
+            result = runner.invoke(
+                app, ["from-updk", str(input_file), "--output", str(output_file)]
+            )
+            assert result.exit_code == 0
+            mock_from_updk.assert_called_once_with(
+                str(input_file), filepath_out=output_file
+            )
+
+
+class TestBuildCommand:
+    """Test build command from kfactory."""
+
+    def test_build_command_exists(self, runner: CliRunner) -> None:
+        """Test that build command is available."""
+        result = runner.invoke(app, ["build", "--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+
+
+class TestCLIEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_invalid_command(self, runner: CliRunner) -> None:
+        """Test behavior with invalid command."""
+        result = runner.invoke(app, ["invalid-command"])
+        assert result.exit_code != 0
+
+    def test_missing_required_args(self, runner: CliRunner) -> None:
+        """Test behavior when required arguments are missing."""
+        # Test commands that require arguments
+        commands_requiring_args = [
+            "layermap-to-dataclass",
+            "write-cells",
+            "show",
+            "gds-diff",
+            "from-updk",
+        ]
+
+        for command in commands_requiring_args:
+            result = runner.invoke(app, [command])
+            assert result.exit_code != 0, (
+                f"Command {command} should fail without required args"
+            )
+
+
+# Test CLI path handling fixes
+class TestCLIPathHandling:
+    """Test that path handling issues are fixed."""
+
+    def test_merge_gds_empty_string_paths(
+        self, runner: CliRunner, temp_dir: Path
+    ) -> None:
+        """Test that empty strings are handled correctly in merge_gds."""
+        import gdsfactory as gf
+
+        # Create a test GDS file in temp directory
+        c = gf.components.rectangle()
+        c.write_gds(temp_dir / "test.gds")
+
+        with patch("gdsfactory.read.from_gdspaths.from_gdsdir") as mock_from_gdsdir:
+            mock_component = Mock()
+            mock_from_gdsdir.return_value = mock_component
+
+            # Change to temp directory
+            original_cwd = Path.cwd()
+            os.chdir(temp_dir)
+            try:
+                # Test with empty strings (should use current directory)
+                result = runner.invoke(
+                    app, ["merge-gds", "--dirpath", "", "--gdspath", ""]
+                )
+                assert result.exit_code == 0
+            finally:
+                os.chdir(original_cwd)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary by Sourcery

Expose a new length_extension option in ring couplers and related components, extend coupler90 with a length_straight parameter, refine CLI command options and defaults, and add a full suite of CLI tests while updating regression fixtures.

New Features:
- Expose length_extension parameter (straight length extension at coupler bottom ports) in coupler_ring and make it configurable in ring_single, ring_double, ring_double_heater, ring_single_dut, and ring_single_array components
- Add optional length_straight parameter to coupler90 to customize the straight segment length

Enhancements:
- Refine CLI commands (write-cells, merge-gds, watch, from-updk) to use typer.Option, improve help text, argument parsing, and default path handling
- Bump default spacing between rings in ring_single_array from 5.0 to 15.0
- Simplify ring geometry code by removing redundant type checks and assertion on numpy arrays

Tests:
- Add comprehensive CLI test suite under tests/test_cli.py covering all commands, options, and edge cases

Chores:
- Update test-data-regression YAML fixtures to reflect new parameter names, defaults, and component signatures