### PR TITLE
enable `get_netlist` for `ComponentAllAngle`

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -438,6 +438,22 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         assert isinstance(res, dict)
         return res
 
+    def get_netlist(self, recursive: bool = False, **kwargs: Any) -> dict[str, Any]:
+        """Returns a place-aware netlist for circuit simulation.
+
+        It includes not only the connectivity information (nodes and connections) but also the specific placement coordinates for each component or cell in the layout.
+
+        Args:
+            recursive: if True, returns a recursive netlist.
+            kwargs: keyword arguments to get_netlist.
+        """
+        from gdsfactory.get_netlist import get_netlist, get_netlist_recursive
+
+        if recursive:
+            return get_netlist_recursive(self, **kwargs)
+
+        return get_netlist(self, **kwargs)
+
 
 Route: TypeAlias = (
     kf.routing.generic.ManhattanRoute | kf.routing.aa.optical.OpticalAllAngleRoute
@@ -1012,22 +1028,6 @@ class Component(ComponentBase, kf.DKCell):
         )  # Remove any padding
         plt.tight_layout(pad=0)  # Ensure no space is wasted
         return fig if return_fig else None
-
-    def get_netlist(self, recursive: bool = False, **kwargs: Any) -> dict[str, Any]:
-        """Returns a place-aware netlist for circuit simulation.
-
-        It includes not only the connectivity information (nodes and connections) but also the specific placement coordinates for each component or cell in the layout.
-
-        Args:
-            recursive: if True, returns a recursive netlist.
-            kwargs: keyword arguments to get_netlist.
-        """
-        from gdsfactory.get_netlist import get_netlist, get_netlist_recursive
-
-        if recursive:
-            return get_netlist_recursive(self, **kwargs)
-
-        return get_netlist(self, **kwargs)
 
     def plot_netlist(
         self,


### PR DESCRIPTION
this PR enables `get_netlist` to be run on `ComponentAllAngle`, as well as `Component`. i am not sure if i did the best job of updating annotations. @sebastian-goeldi or @MatthewMckee4 please let me know if it should be done differently.

i also had to hack my way around `dtrans` not being implemented on `VKCell`. it would be cleaner if it were implemented

## Summary by Sourcery

Enable get_netlist on ComponentAllAngle and unify its implementation in the base class; add fallbacks for missing dtrans and array attributes on VKCell and update type annotations for wider compatibility.

New Features:
- Enable get_netlist on ComponentAllAngle by moving the method to the base class

Bug Fixes:
- Handle missing dtrans and na/nb attributes gracefully to prevent errors on VKCell during netlist generation

Enhancements:
- Refactor get_netlist placement to a common base class for reuse across component types
- Update type annotations to use AnyKCell for broader compatibility in netlist routines