### PR TITLE
fix grating_coupler_array when the routing cross section does not match ports

### DIFF
--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -4,6 +4,7 @@ import kfactory as kf
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
@@ -77,6 +78,9 @@ def grating_coupler_array(
             ]
         )
         d_loop = c.kcl.to_dbu(d_loop_um) + radius_dbu
+
+        port0 = add_auto_tapers(c, [port0], cross_section)[0]
+        port1 = add_auto_tapers(c, [port1], cross_section)[0]
         waypoints = kf.routing.optical.route_loopback(
             port0.to_itype(),
             port1.to_itype(),


### PR DESCRIPTION
before this PR, `grating_coupler_array` would break if transitions were needed between the ports and the routing cross section (proper space was not allocated). this PR fixes that problem

## Summary by Sourcery

Bug Fixes:
- Automatically insert auto tapers on ports in grating_coupler_array when the routing cross section differs to avoid breakage