### PR TITLE
Remove notimplemented error

### DIFF
--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -383,8 +383,6 @@ def route_sharp(
         if layer is None:
             raise ValueError("layer is required for width")
         d = p.extrude(width=width, layer=layer)
-        if not isinstance(width, CrossSection):
-            raise NotImplementedError("TODO")
 
     component << d
 


### PR DESCRIPTION
I added this 6 months ago, not exactly sure why

## Summary by Sourcery

Remove obsolete NotImplementedError check in route_sharp to allow width extrusion regardless of type

Bug Fixes:
- Prevent route_sharp from throwing NotImplementedError for non-CrossSection width values

Enhancements:
- Simplify route_sharp by eliminating redundant instance check for width