### PR TITLE
fix netlist-tests

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -82,19 +82,19 @@ jobs:
       - run: make install
       - run: uv run mypy gdsfactory/
 
-  run-ty:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version:
-          - "3.11"
-          - "3.13"
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - name: Install dependencies
-        run: |
-          uv sync --extra dev
-      - name: Run ty check
-        run: uv run ty check gdsfactory || true
+  # run-ty:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       python-version:
+  #         - "3.11"
+  #         - "3.13"
+  #       os: [ubuntu-latest]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: astral-sh/setup-uv@v6
+  #     - name: Install dependencies
+  #       run: |
+  #         uv sync --extra dev
+  #     - name: Run ty check
+  #       run: uv run ty check gdsfactory || true

--- a/test-data-regression/test_netlists_awg_.yml
+++ b/test-data-regression/test_netlists_awg_.yml
@@ -507,7 +507,7 @@ instances:
       wg_width: 0.5
       width1: 10
       width2: 20
-  straight_gdsfactorypcom_09b87fdc_53250_29000_A270:
+  straight_gdsfactorypcom_09b87fdc_53250_20000_A90:
     component: straight
     info:
       length: 9
@@ -535,7 +535,7 @@ instances:
       length: 9
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_1504ef4a_15417_33000:
+  straight_gdsfactorypcom_1504ef4a_34583_33000_A180:
     component: straight
     info:
       length: 19.166
@@ -549,7 +549,7 @@ instances:
       length: 19.166
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_193ce81f_17583_31500:
+  straight_gdsfactorypcom_193ce81f_32417_31500_A180:
     component: straight
     info:
       length: 14.834
@@ -563,7 +563,7 @@ instances:
       length: 14.834
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_27783c1e_42417_21500_A270:
+  straight_gdsfactorypcom_27783c1e_42417_20000_A90:
     component: straight
     info:
       length: 1.5
@@ -591,7 +591,7 @@ instances:
       length: 1.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_3d0cd97c_51083_27500_A270:
+  straight_gdsfactorypcom_3d0cd97c_51083_20000_A90:
     component: straight
     info:
       length: 7.5
@@ -619,7 +619,7 @@ instances:
       length: 7.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_5d7bad5d_59750_33500_A270:
+  straight_gdsfactorypcom_5d7bad5d_59750_20000_A90:
     component: straight
     info:
       length: 13.5
@@ -647,7 +647,7 @@ instances:
       length: 13.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_67f97490_4583_40500:
+  straight_gdsfactorypcom_67f97490_45417_40500_A180:
     component: straight
     info:
       length: 40.834
@@ -675,7 +675,7 @@ instances:
       length: 6
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_702d0d58_48917_26000_A270:
+  straight_gdsfactorypcom_702d0d58_48917_20000_A90:
     component: straight
     info:
       length: 6
@@ -689,7 +689,7 @@ instances:
       length: 6
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_76e47883_44583_23000_A270:
+  straight_gdsfactorypcom_76e47883_44583_20000_A90:
     component: straight
     info:
       length: 3
@@ -717,7 +717,7 @@ instances:
       length: 3
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_807addbc_8917_37500:
+  straight_gdsfactorypcom_807addbc_41083_37500_A180:
     component: straight
     info:
       length: 32.166
@@ -731,7 +731,7 @@ instances:
       length: 32.166
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_827597b2_13250_34500:
+  straight_gdsfactorypcom_827597b2_36750_34500_A180:
     component: straight
     info:
       length: 23.5
@@ -745,7 +745,7 @@ instances:
       length: 23.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_83262ea0_250_43500:
+  straight_gdsfactorypcom_83262ea0_49750_43500_A180:
     component: straight
     info:
       length: 49.5
@@ -759,7 +759,7 @@ instances:
       length: 49.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_9630dc72_11083_36000:
+  straight_gdsfactorypcom_9630dc72_38917_36000_A180:
     component: straight
     info:
       length: 27.834
@@ -787,7 +787,7 @@ instances:
       length: 4.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_99671446_46750_24500_A270:
+  straight_gdsfactorypcom_99671446_46750_20000_A90:
     component: straight
     info:
       length: 4.5
@@ -801,7 +801,7 @@ instances:
       length: 4.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_bdf181a4_2417_42000:
+  straight_gdsfactorypcom_bdf181a4_47583_42000_A180:
     component: straight
     info:
       length: 45.166
@@ -815,7 +815,7 @@ instances:
       length: 45.166
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_da623fc9_19750_30000:
+  straight_gdsfactorypcom_da623fc9_30250_30000_A180:
     component: straight
     info:
       length: 10.5
@@ -829,7 +829,7 @@ instances:
       length: 10.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_da623fc9_55417_30500_A270:
+  straight_gdsfactorypcom_da623fc9_55417_20000_A90:
     component: straight
     info:
       length: 10.5
@@ -857,7 +857,7 @@ instances:
       length: 10.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_da8cfc5e_6750_39000:
+  straight_gdsfactorypcom_da8cfc5e_43250_39000_A180:
     component: straight
     info:
       length: 36.5
@@ -871,7 +871,7 @@ instances:
       length: 36.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_f3e780f9_57583_32000_A270:
+  straight_gdsfactorypcom_f3e780f9_57583_20000_A90:
     component: straight
     info:
       length: 12
@@ -904,83 +904,83 @@ nets:
 - p1: bend_euler_gdsfactorypc_af2c9296_1083_26000_A90_M,o1
   p2: straight_gdsfactorypcom_702d0d58_1083_26000_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_1083_26000_A90_M,o2
-  p2: straight_gdsfactorypcom_9630dc72_11083_36000,o1
+  p2: straight_gdsfactorypcom_9630dc72_38917_36000_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_30250_30000_M,o1
-  p2: straight_gdsfactorypcom_da623fc9_19750_30000,o2
+  p2: straight_gdsfactorypcom_da623fc9_30250_30000_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_30250_30000_M,o2
   p2: free_propagation_region_e953b677_50000_0_A90,E9
 - p1: bend_euler_gdsfactorypc_af2c9296_32417_31500_M,o1
-  p2: straight_gdsfactorypcom_193ce81f_17583_31500,o2
+  p2: straight_gdsfactorypcom_193ce81f_32417_31500_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_32417_31500_M,o2
-  p2: straight_gdsfactorypcom_27783c1e_42417_21500_A270,o1
+  p2: straight_gdsfactorypcom_27783c1e_42417_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_3250_24500_A90_M,o1
   p2: straight_gdsfactorypcom_99671446_3250_24500_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_3250_24500_A90_M,o2
-  p2: straight_gdsfactorypcom_827597b2_13250_34500,o1
+  p2: straight_gdsfactorypcom_827597b2_36750_34500_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_34583_33000_M,o1
-  p2: straight_gdsfactorypcom_1504ef4a_15417_33000,o2
+  p2: straight_gdsfactorypcom_1504ef4a_34583_33000_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_34583_33000_M,o2
-  p2: straight_gdsfactorypcom_76e47883_44583_23000_A270,o1
+  p2: straight_gdsfactorypcom_76e47883_44583_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_36750_34500_M,o1
-  p2: straight_gdsfactorypcom_827597b2_13250_34500,o2
+  p2: straight_gdsfactorypcom_827597b2_36750_34500_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_36750_34500_M,o2
-  p2: straight_gdsfactorypcom_99671446_46750_24500_A270,o1
+  p2: straight_gdsfactorypcom_99671446_46750_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_38917_36000_M,o1
-  p2: straight_gdsfactorypcom_9630dc72_11083_36000,o2
+  p2: straight_gdsfactorypcom_9630dc72_38917_36000_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_38917_36000_M,o2
-  p2: straight_gdsfactorypcom_702d0d58_48917_26000_A270,o1
+  p2: straight_gdsfactorypcom_702d0d58_48917_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_41083_37500_M,o1
-  p2: straight_gdsfactorypcom_807addbc_8917_37500,o2
+  p2: straight_gdsfactorypcom_807addbc_41083_37500_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_41083_37500_M,o2
-  p2: straight_gdsfactorypcom_3d0cd97c_51083_27500_A270,o1
+  p2: straight_gdsfactorypcom_3d0cd97c_51083_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_43250_39000_M,o1
-  p2: straight_gdsfactorypcom_da8cfc5e_6750_39000,o2
+  p2: straight_gdsfactorypcom_da8cfc5e_43250_39000_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_43250_39000_M,o2
-  p2: straight_gdsfactorypcom_09b87fdc_53250_29000_A270,o1
+  p2: straight_gdsfactorypcom_09b87fdc_53250_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_45417_40500_M,o1
-  p2: straight_gdsfactorypcom_67f97490_4583_40500,o2
+  p2: straight_gdsfactorypcom_67f97490_45417_40500_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_45417_40500_M,o2
-  p2: straight_gdsfactorypcom_da623fc9_55417_30500_A270,o1
+  p2: straight_gdsfactorypcom_da623fc9_55417_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_47583_42000_M,o1
-  p2: straight_gdsfactorypcom_bdf181a4_2417_42000,o2
+  p2: straight_gdsfactorypcom_bdf181a4_47583_42000_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_47583_42000_M,o2
-  p2: straight_gdsfactorypcom_f3e780f9_57583_32000_A270,o1
+  p2: straight_gdsfactorypcom_f3e780f9_57583_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_49750_43500_M,o1
-  p2: straight_gdsfactorypcom_83262ea0_250_43500,o2
+  p2: straight_gdsfactorypcom_83262ea0_49750_43500_A180,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_49750_43500_M,o2
-  p2: straight_gdsfactorypcom_5d7bad5d_59750_33500_A270,o1
+  p2: straight_gdsfactorypcom_5d7bad5d_59750_20000_A90,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_5417_23000_A90_M,o1
   p2: straight_gdsfactorypcom_76e47883_5417_23000_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_5417_23000_A90_M,o2
-  p2: straight_gdsfactorypcom_1504ef4a_15417_33000,o1
+  p2: straight_gdsfactorypcom_1504ef4a_34583_33000_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_7583_21500_A90_M,o1
   p2: straight_gdsfactorypcom_27783c1e_7583_21500_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_7583_21500_A90_M,o2
-  p2: straight_gdsfactorypcom_193ce81f_17583_31500,o1
+  p2: straight_gdsfactorypcom_193ce81f_32417_31500_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_9750_20000_A90_M,o1
   p2: free_propagation_region_5ff2a5ce_0_0_A90,E0
 - p1: bend_euler_gdsfactorypc_af2c9296_9750_20000_A90_M,o2
-  p2: straight_gdsfactorypcom_da623fc9_19750_30000,o1
+  p2: straight_gdsfactorypcom_da623fc9_30250_30000_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_m1083_27500_A90_M,o1
   p2: straight_gdsfactorypcom_3d0cd97c_m1083_27500_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_m1083_27500_A90_M,o2
-  p2: straight_gdsfactorypcom_807addbc_8917_37500,o1
+  p2: straight_gdsfactorypcom_807addbc_41083_37500_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_m3250_29000_A90_M,o1
   p2: straight_gdsfactorypcom_09b87fdc_m3250_29000_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_m3250_29000_A90_M,o2
-  p2: straight_gdsfactorypcom_da8cfc5e_6750_39000,o1
+  p2: straight_gdsfactorypcom_da8cfc5e_43250_39000_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_m5417_30500_A90_M,o1
   p2: straight_gdsfactorypcom_da623fc9_m5417_30500_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_m5417_30500_A90_M,o2
-  p2: straight_gdsfactorypcom_67f97490_4583_40500,o1
+  p2: straight_gdsfactorypcom_67f97490_45417_40500_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_m7583_32000_A90_M,o1
   p2: straight_gdsfactorypcom_f3e780f9_m7583_32000_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_m7583_32000_A90_M,o2
-  p2: straight_gdsfactorypcom_bdf181a4_2417_42000,o1
+  p2: straight_gdsfactorypcom_bdf181a4_47583_42000_A180,o2
 - p1: bend_euler_gdsfactorypc_af2c9296_m9750_33500_A90_M,o1
   p2: straight_gdsfactorypcom_5d7bad5d_m9750_33500_A270,o1
 - p1: bend_euler_gdsfactorypc_af2c9296_m9750_33500_A90_M,o2
-  p2: straight_gdsfactorypcom_83262ea0_250_43500,o1
+  p2: straight_gdsfactorypcom_83262ea0_49750_43500_A180,o2
 - p1: free_propagation_region_5ff2a5ce_0_0_A90,E1
   p2: straight_gdsfactorypcom_27783c1e_7583_21500_A270,o2
 - p1: free_propagation_region_5ff2a5ce_0_0_A90,E2
@@ -1000,23 +1000,23 @@ nets:
 - p1: free_propagation_region_5ff2a5ce_0_0_A90,E9
   p2: straight_gdsfactorypcom_5d7bad5d_m9750_33500_A270,o2
 - p1: free_propagation_region_e953b677_50000_0_A90,E0
-  p2: straight_gdsfactorypcom_5d7bad5d_59750_33500_A270,o2
+  p2: straight_gdsfactorypcom_5d7bad5d_59750_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E1
-  p2: straight_gdsfactorypcom_f3e780f9_57583_32000_A270,o2
+  p2: straight_gdsfactorypcom_f3e780f9_57583_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E2
-  p2: straight_gdsfactorypcom_da623fc9_55417_30500_A270,o2
+  p2: straight_gdsfactorypcom_da623fc9_55417_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E3
-  p2: straight_gdsfactorypcom_09b87fdc_53250_29000_A270,o2
+  p2: straight_gdsfactorypcom_09b87fdc_53250_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E4
-  p2: straight_gdsfactorypcom_3d0cd97c_51083_27500_A270,o2
+  p2: straight_gdsfactorypcom_3d0cd97c_51083_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E5
-  p2: straight_gdsfactorypcom_702d0d58_48917_26000_A270,o2
+  p2: straight_gdsfactorypcom_702d0d58_48917_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E6
-  p2: straight_gdsfactorypcom_99671446_46750_24500_A270,o2
+  p2: straight_gdsfactorypcom_99671446_46750_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E7
-  p2: straight_gdsfactorypcom_76e47883_44583_23000_A270,o2
+  p2: straight_gdsfactorypcom_76e47883_44583_20000_A90,o1
 - p1: free_propagation_region_e953b677_50000_0_A90,E8
-  p2: straight_gdsfactorypcom_27783c1e_42417_21500_A270,o2
+  p2: straight_gdsfactorypcom_27783c1e_42417_20000_A90,o1
 placements:
   bend_euler_gdsfactorypc_af2c9296_1083_26000_A90_M:
     mirror: true
@@ -1128,141 +1128,141 @@ placements:
     rotation: 90
     x: 50
     y: 0
-  straight_gdsfactorypcom_09b87fdc_53250_29000_A270:
+  straight_gdsfactorypcom_09b87fdc_53250_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 53.25
-    y: 29
+    y: 20
   straight_gdsfactorypcom_09b87fdc_m3250_29000_A270:
     mirror: false
     rotation: 270
     x: -3.25
     y: 29
-  straight_gdsfactorypcom_1504ef4a_15417_33000:
+  straight_gdsfactorypcom_1504ef4a_34583_33000_A180:
     mirror: false
-    rotation: 0
-    x: 15.417
+    rotation: 180
+    x: 34.583
     y: 33
-  straight_gdsfactorypcom_193ce81f_17583_31500:
+  straight_gdsfactorypcom_193ce81f_32417_31500_A180:
     mirror: false
-    rotation: 0
-    x: 17.583
+    rotation: 180
+    x: 32.417
     y: 31.5
-  straight_gdsfactorypcom_27783c1e_42417_21500_A270:
+  straight_gdsfactorypcom_27783c1e_42417_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 42.417
-    y: 21.5
+    y: 20
   straight_gdsfactorypcom_27783c1e_7583_21500_A270:
     mirror: false
     rotation: 270
     x: 7.583
     y: 21.5
-  straight_gdsfactorypcom_3d0cd97c_51083_27500_A270:
+  straight_gdsfactorypcom_3d0cd97c_51083_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 51.083
-    y: 27.5
+    y: 20
   straight_gdsfactorypcom_3d0cd97c_m1083_27500_A270:
     mirror: false
     rotation: 270
     x: -1.083
     y: 27.5
-  straight_gdsfactorypcom_5d7bad5d_59750_33500_A270:
+  straight_gdsfactorypcom_5d7bad5d_59750_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 59.75
-    y: 33.5
+    y: 20
   straight_gdsfactorypcom_5d7bad5d_m9750_33500_A270:
     mirror: false
     rotation: 270
     x: -9.75
     y: 33.5
-  straight_gdsfactorypcom_67f97490_4583_40500:
+  straight_gdsfactorypcom_67f97490_45417_40500_A180:
     mirror: false
-    rotation: 0
-    x: 4.583
+    rotation: 180
+    x: 45.417
     y: 40.5
   straight_gdsfactorypcom_702d0d58_1083_26000_A270:
     mirror: false
     rotation: 270
     x: 1.083
     y: 26
-  straight_gdsfactorypcom_702d0d58_48917_26000_A270:
+  straight_gdsfactorypcom_702d0d58_48917_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 48.917
-    y: 26
-  straight_gdsfactorypcom_76e47883_44583_23000_A270:
+    y: 20
+  straight_gdsfactorypcom_76e47883_44583_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 44.583
-    y: 23
+    y: 20
   straight_gdsfactorypcom_76e47883_5417_23000_A270:
     mirror: false
     rotation: 270
     x: 5.417
     y: 23
-  straight_gdsfactorypcom_807addbc_8917_37500:
+  straight_gdsfactorypcom_807addbc_41083_37500_A180:
     mirror: false
-    rotation: 0
-    x: 8.917
+    rotation: 180
+    x: 41.083
     y: 37.5
-  straight_gdsfactorypcom_827597b2_13250_34500:
+  straight_gdsfactorypcom_827597b2_36750_34500_A180:
     mirror: false
-    rotation: 0
-    x: 13.25
+    rotation: 180
+    x: 36.75
     y: 34.5
-  straight_gdsfactorypcom_83262ea0_250_43500:
+  straight_gdsfactorypcom_83262ea0_49750_43500_A180:
     mirror: false
-    rotation: 0
-    x: 0.25
+    rotation: 180
+    x: 49.75
     y: 43.5
-  straight_gdsfactorypcom_9630dc72_11083_36000:
+  straight_gdsfactorypcom_9630dc72_38917_36000_A180:
     mirror: false
-    rotation: 0
-    x: 11.083
+    rotation: 180
+    x: 38.917
     y: 36
   straight_gdsfactorypcom_99671446_3250_24500_A270:
     mirror: false
     rotation: 270
     x: 3.25
     y: 24.5
-  straight_gdsfactorypcom_99671446_46750_24500_A270:
+  straight_gdsfactorypcom_99671446_46750_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 46.75
-    y: 24.5
-  straight_gdsfactorypcom_bdf181a4_2417_42000:
+    y: 20
+  straight_gdsfactorypcom_bdf181a4_47583_42000_A180:
     mirror: false
-    rotation: 0
-    x: 2.417
+    rotation: 180
+    x: 47.583
     y: 42
-  straight_gdsfactorypcom_da623fc9_19750_30000:
+  straight_gdsfactorypcom_da623fc9_30250_30000_A180:
     mirror: false
-    rotation: 0
-    x: 19.75
+    rotation: 180
+    x: 30.25
     y: 30
-  straight_gdsfactorypcom_da623fc9_55417_30500_A270:
+  straight_gdsfactorypcom_da623fc9_55417_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 55.417
-    y: 30.5
+    y: 20
   straight_gdsfactorypcom_da623fc9_m5417_30500_A270:
     mirror: false
     rotation: 270
     x: -5.417
     y: 30.5
-  straight_gdsfactorypcom_da8cfc5e_6750_39000:
+  straight_gdsfactorypcom_da8cfc5e_43250_39000_A180:
     mirror: false
-    rotation: 0
-    x: 6.75
+    rotation: 180
+    x: 43.25
     y: 39
-  straight_gdsfactorypcom_f3e780f9_57583_32000_A270:
+  straight_gdsfactorypcom_f3e780f9_57583_20000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 57.583
-    y: 32
+    y: 20
   straight_gdsfactorypcom_f3e780f9_m7583_32000_A270:
     mirror: false
     rotation: 270

--- a/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -113,7 +113,7 @@ instances:
       - o1
       - o2
       port_type: optical
-  straight_gdsfactorypcom_602f5a09_m30000_859000_A270:
+  straight_gdsfactorypcom_602f5a09_m30000_792000_A90:
     component: straight
     info:
       length: 67
@@ -127,7 +127,7 @@ instances:
       length: 67
       npoints: 2
       width: null
-  straight_gdsfactorypcom_602f5a09_m31000_97000_A270:
+  straight_gdsfactorypcom_602f5a09_m31000_30000_A90:
     component: straight
     info:
       length: 67
@@ -146,17 +146,17 @@ nets:
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_0_889000_A180,o1
   p2: extend_ports_gdsfactory_a22b19de_0_0,o8
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_0_889000_A180,o2
-  p2: straight_gdsfactorypcom_602f5a09_m30000_859000_A270,o1
+  p2: straight_gdsfactorypcom_602f5a09_m30000_792000_A90,o2
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m1000_127000_A180,o1
   p2: extend_ports_gdsfactory_a22b19de_0_0,o2
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m1000_127000_A180,o2
-  p2: straight_gdsfactorypcom_602f5a09_m31000_97000_A270,o1
+  p2: straight_gdsfactorypcom_602f5a09_m31000_30000_A90,o2
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m30000_792000_A270,o1
-  p2: straight_gdsfactorypcom_602f5a09_m30000_859000_A270,o2
+  p2: straight_gdsfactorypcom_602f5a09_m30000_792000_A90,o1
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m30000_792000_A270,o2
   p2: extend_ports_gdsfactory_a22b19de_0_0,o7
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m31000_30000_A270,o1
-  p2: straight_gdsfactorypcom_602f5a09_m31000_97000_A270,o2
+  p2: straight_gdsfactorypcom_602f5a09_m31000_30000_A90,o1
 - p1: bend_euler_gdsfactorypc_ecb0ec9a_m31000_30000_A270,o2
   p2: extend_ports_gdsfactory_a22b19de_0_0,o1
 placements:
@@ -185,16 +185,16 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcom_602f5a09_m30000_859000_A270:
+  straight_gdsfactorypcom_602f5a09_m30000_792000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: -30
-    y: 859
-  straight_gdsfactorypcom_602f5a09_m31000_97000_A270:
+    y: 792
+  straight_gdsfactorypcom_602f5a09_m31000_30000_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: -31
-    y: 97
+    y: 30
 ports:
   '1': extend_ports_gdsfactory_a22b19de_0_0,0o2
   '11': extend_ports_gdsfactory_a22b19de_0_0,5o2

--- a/test-data-regression/test_netlists_grating_coupler_loss_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_loss_.yml
@@ -367,7 +367,7 @@ instances:
       taper_length: 16.6
       trenches_extra_angle: 9
       wavelength: 1.53
-  straight_gdsfactorypcom_046a924a_1586204_49529_A180:
+  straight_gdsfactorypcom_046a924a_844204_49529:
     component: straight
     info:
       length: 742
@@ -381,7 +381,7 @@ instances:
       length: 742
       npoints: 2
       width: null
-  straight_gdsfactorypcom_18b99f0e_244000_49529_A180:
+  straight_gdsfactorypcom_18b99f0e_10000_49529:
     component: straight
     info:
       length: 234
@@ -395,7 +395,7 @@ instances:
       length: 234
       npoints: 2
       width: null
-  straight_gdsfactorypcom_92237c63_0_39529_A270:
+  straight_gdsfactorypcom_92237c63_0_m471_A90:
     component: straight
     info:
       length: 40
@@ -423,7 +423,7 @@ instances:
       length: 40
       npoints: 2
       width: null
-  straight_gdsfactorypcom_92237c63_1632306_39529_A270:
+  straight_gdsfactorypcom_92237c63_1632306_m471_A90:
     component: straight
     info:
       length: 40
@@ -465,7 +465,7 @@ instances:
       length: 40
       npoints: 2
       width: null
-  straight_gdsfactorypcom_92237c63_290102_39529_A270:
+  straight_gdsfactorypcom_92237c63_290102_m471_A90:
     component: straight
     info:
       length: 40
@@ -493,7 +493,7 @@ instances:
       length: 40
       npoints: 2
       width: null
-  straight_gdsfactorypcom_92237c63_834204_39529_A270:
+  straight_gdsfactorypcom_92237c63_834204_m471_A90:
     component: straight
     info:
       length: 40
@@ -507,7 +507,7 @@ instances:
       length: 40
       npoints: 2
       width: null
-  straight_gdsfactorypcom_ef17e3a4_2638306_49529_A180:
+  straight_gdsfactorypcom_ef17e3a4_1642306_49529:
     component: straight
     info:
       length: 996
@@ -521,7 +521,7 @@ instances:
       length: 996
       npoints: 2
       width: null
-  straight_gdsfactorypcom_f5f7f076_788102_49529_A180:
+  straight_gdsfactorypcom_f5f7f076_300102_49529:
     component: straight
     info:
       length: 488
@@ -538,53 +538,53 @@ instances:
 name: grating_coupler_loss_gd_e0b001ca
 nets:
 - p1: bend_euler_gdsfactorypc_e95a7a4d_10000_49529_A180,o1
-  p2: straight_gdsfactorypcom_18b99f0e_244000_49529_A180,o2
+  p2: straight_gdsfactorypcom_18b99f0e_10000_49529,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_10000_49529_A180,o2
-  p2: straight_gdsfactorypcom_92237c63_0_39529_A270,o1
+  p2: straight_gdsfactorypcom_92237c63_0_m471_A90,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_1596204_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_1596204_39529_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_1596204_39529_A90,o2
-  p2: straight_gdsfactorypcom_046a924a_1586204_49529_A180,o1
+  p2: straight_gdsfactorypcom_046a924a_844204_49529,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_1642306_49529_A180,o1
-  p2: straight_gdsfactorypcom_ef17e3a4_2638306_49529_A180,o2
+  p2: straight_gdsfactorypcom_ef17e3a4_1642306_49529,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_1642306_49529_A180,o2
-  p2: straight_gdsfactorypcom_92237c63_1632306_39529_A270,o1
+  p2: straight_gdsfactorypcom_92237c63_1632306_m471_A90,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_254000_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_254000_39529_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_254000_39529_A90,o2
-  p2: straight_gdsfactorypcom_18b99f0e_244000_49529_A180,o1
+  p2: straight_gdsfactorypcom_18b99f0e_10000_49529,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_2648306_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_2648306_39529_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_2648306_39529_A90,o2
-  p2: straight_gdsfactorypcom_ef17e3a4_2638306_49529_A180,o1
+  p2: straight_gdsfactorypcom_ef17e3a4_1642306_49529,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_300102_49529_A180,o1
-  p2: straight_gdsfactorypcom_f5f7f076_788102_49529_A180,o2
+  p2: straight_gdsfactorypcom_f5f7f076_300102_49529,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_300102_49529_A180,o2
-  p2: straight_gdsfactorypcom_92237c63_290102_39529_A270,o1
+  p2: straight_gdsfactorypcom_92237c63_290102_m471_A90,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_798102_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_798102_39529_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_798102_39529_A90,o2
-  p2: straight_gdsfactorypcom_f5f7f076_788102_49529_A180,o1
+  p2: straight_gdsfactorypcom_f5f7f076_300102_49529,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_844204_49529_A180,o1
-  p2: straight_gdsfactorypcom_046a924a_1586204_49529_A180,o2
+  p2: straight_gdsfactorypcom_046a924a_844204_49529,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_844204_49529_A180,o2
-  p2: straight_gdsfactorypcom_92237c63_834204_39529_A270,o1
+  p2: straight_gdsfactorypcom_92237c63_834204_m471_A90,o2
 - p1: grating_coupler_ellipti_6c1e46af_0_0_A270,o1
-  p2: straight_gdsfactorypcom_92237c63_0_39529_A270,o2
+  p2: straight_gdsfactorypcom_92237c63_0_m471_A90,o1
 - p1: grating_coupler_ellipti_6c1e46af_1596204_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_1596204_39529_A270,o2
 - p1: grating_coupler_ellipti_6c1e46af_1632306_0_A270,o1
-  p2: straight_gdsfactorypcom_92237c63_1632306_39529_A270,o2
+  p2: straight_gdsfactorypcom_92237c63_1632306_m471_A90,o1
 - p1: grating_coupler_ellipti_6c1e46af_254000_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_254000_39529_A270,o2
 - p1: grating_coupler_ellipti_6c1e46af_2648306_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_2648306_39529_A270,o2
 - p1: grating_coupler_ellipti_6c1e46af_290102_0_A270,o1
-  p2: straight_gdsfactorypcom_92237c63_290102_39529_A270,o2
+  p2: straight_gdsfactorypcom_92237c63_290102_m471_A90,o1
 - p1: grating_coupler_ellipti_6c1e46af_798102_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_798102_39529_A270,o2
 - p1: grating_coupler_ellipti_6c1e46af_834204_0_A270,o1
-  p2: straight_gdsfactorypcom_92237c63_834204_39529_A270,o2
+  p2: straight_gdsfactorypcom_92237c63_834204_m471_A90,o1
 placements:
   bend_euler_gdsfactorypc_e95a7a4d_10000_49529_A180:
     mirror: false
@@ -666,31 +666,31 @@ placements:
     rotation: 270
     x: 834.204
     y: 0
-  straight_gdsfactorypcom_046a924a_1586204_49529_A180:
+  straight_gdsfactorypcom_046a924a_844204_49529:
     mirror: false
-    rotation: 180
-    x: 1586.204
+    rotation: 0
+    x: 844.204
     y: 49.529
-  straight_gdsfactorypcom_18b99f0e_244000_49529_A180:
+  straight_gdsfactorypcom_18b99f0e_10000_49529:
     mirror: false
-    rotation: 180
-    x: 244
+    rotation: 0
+    x: 10
     y: 49.529
-  straight_gdsfactorypcom_92237c63_0_39529_A270:
+  straight_gdsfactorypcom_92237c63_0_m471_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 0
-    y: 39.529
+    y: -0.471
   straight_gdsfactorypcom_92237c63_1596204_39529_A270:
     mirror: false
     rotation: 270
     x: 1596.204
     y: 39.529
-  straight_gdsfactorypcom_92237c63_1632306_39529_A270:
+  straight_gdsfactorypcom_92237c63_1632306_m471_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 1632.306
-    y: 39.529
+    y: -0.471
   straight_gdsfactorypcom_92237c63_254000_39529_A270:
     mirror: false
     rotation: 270
@@ -701,30 +701,30 @@ placements:
     rotation: 270
     x: 2648.306
     y: 39.529
-  straight_gdsfactorypcom_92237c63_290102_39529_A270:
+  straight_gdsfactorypcom_92237c63_290102_m471_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 290.102
-    y: 39.529
+    y: -0.471
   straight_gdsfactorypcom_92237c63_798102_39529_A270:
     mirror: false
     rotation: 270
     x: 798.102
     y: 39.529
-  straight_gdsfactorypcom_92237c63_834204_39529_A270:
+  straight_gdsfactorypcom_92237c63_834204_m471_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 834.204
-    y: 39.529
-  straight_gdsfactorypcom_ef17e3a4_2638306_49529_A180:
+    y: -0.471
+  straight_gdsfactorypcom_ef17e3a4_1642306_49529:
     mirror: false
-    rotation: 180
-    x: 2638.306
+    rotation: 0
+    x: 1642.306
     y: 49.529
-  straight_gdsfactorypcom_f5f7f076_788102_49529_A180:
+  straight_gdsfactorypcom_f5f7f076_300102_49529:
     mirror: false
-    rotation: 180
-    x: 788.102
+    rotation: 0
+    x: 300.102
     y: 49.529
 ports: {}
 warnings:

--- a/test-data-regression/test_netlists_grating_coupler_tree_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_tree_.yml
@@ -395,7 +395,7 @@ instances:
       length: 64
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_32999c45_185500_4500_A180:
+  straight_gdsfactorypcom_32999c45_0_4500_A180:
     component: straight
     info:
       length: 175.5
@@ -409,7 +409,7 @@ instances:
       length: 175.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_32999c45_m175500_4500:
+  straight_gdsfactorypcom_32999c45_10000_4500:
     component: straight
     info:
       length: 175.5
@@ -423,7 +423,7 @@ instances:
       length: 175.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_3f34bc4c_439500_13500_A180:
+  straight_gdsfactorypcom_3f34bc4c_0_13500_A180:
     component: straight
     info:
       length: 429.5
@@ -437,7 +437,7 @@ instances:
       length: 429.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_3f34bc4c_m429500_13500:
+  straight_gdsfactorypcom_3f34bc4c_10000_13500:
     component: straight
     info:
       length: 429.5
@@ -507,7 +507,7 @@ instances:
       length: 73
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_91443128_312500_9000_A180:
+  straight_gdsfactorypcom_91443128_0_9000_A180:
     component: straight
     info:
       length: 302.5
@@ -521,7 +521,7 @@ instances:
       length: 302.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_91443128_m302500_9000:
+  straight_gdsfactorypcom_91443128_10000_9000:
     component: straight
     info:
       length: 302.5
@@ -563,7 +563,7 @@ instances:
       length: 68.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_dbb2297b_58500_0_A180:
+  straight_gdsfactorypcom_dbb2297b_0_0_A180:
     component: straight
     info:
       length: 48.5
@@ -577,7 +577,7 @@ instances:
       length: 48.5
       npoints: 2
       width: 0.5
-  straight_gdsfactorypcom_dbb2297b_m48500_0:
+  straight_gdsfactorypcom_dbb2297b_10000_0:
     component: straight
     info:
       length: 48.5
@@ -596,35 +596,35 @@ nets:
 - p1: bend_euler_gdsfactorypc_c35a91db_195500_m5500_A90,o1
   p2: straight_gdsfactorypcom_1d439041_195500_m5500_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_195500_m5500_A90,o2
-  p2: straight_gdsfactorypcom_32999c45_185500_4500_A180,o1
+  p2: straight_gdsfactorypcom_32999c45_10000_4500,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_322500_m1000_A90,o1
   p2: straight_gdsfactorypcom_aaf4282c_322500_m1000_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_322500_m1000_A90,o2
-  p2: straight_gdsfactorypcom_91443128_312500_9000_A180,o1
+  p2: straight_gdsfactorypcom_91443128_10000_9000,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_449500_3500_A90,o1
   p2: straight_gdsfactorypcom_7e7d1e79_449500_3500_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_449500_3500_A90,o2
-  p2: straight_gdsfactorypcom_3f34bc4c_439500_13500_A180,o1
+  p2: straight_gdsfactorypcom_3f34bc4c_10000_13500,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_68500_m10000_A90,o1
   p2: straight_gdsfactorypcom_5a080edd_68500_m10000_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_68500_m10000_A90,o2
-  p2: straight_gdsfactorypcom_dbb2297b_58500_0_A180,o1
+  p2: straight_gdsfactorypcom_dbb2297b_10000_0,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_m185500_m5500_A90_M,o1
   p2: straight_gdsfactorypcom_1d439041_m185500_m5500_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_m185500_m5500_A90_M,o2
-  p2: straight_gdsfactorypcom_32999c45_m175500_4500,o1
+  p2: straight_gdsfactorypcom_32999c45_0_4500_A180,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_m312500_m1000_A90_M,o1
   p2: straight_gdsfactorypcom_aaf4282c_m312500_m1000_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_m312500_m1000_A90_M,o2
-  p2: straight_gdsfactorypcom_91443128_m302500_9000,o1
+  p2: straight_gdsfactorypcom_91443128_0_9000_A180,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_m439500_3500_A90_M,o1
   p2: straight_gdsfactorypcom_7e7d1e79_m439500_3500_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_m439500_3500_A90_M,o2
-  p2: straight_gdsfactorypcom_3f34bc4c_m429500_13500,o1
+  p2: straight_gdsfactorypcom_3f34bc4c_0_13500_A180,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_m58500_m10000_A90_M,o1
   p2: straight_gdsfactorypcom_5a080edd_m58500_m10000_A270,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_m58500_m10000_A90_M,o2
-  p2: straight_gdsfactorypcom_dbb2297b_m48500_0,o1
+  p2: straight_gdsfactorypcom_dbb2297b_0_0_A180,o2
 - p1: grating_coupler_ellipti_2f9b04be_195500_m69500_A270,o1
   p2: straight_gdsfactorypcom_1d439041_195500_m5500_A270,o2
 - p1: grating_coupler_ellipti_2f9b04be_322500_m69500_A270,o1
@@ -642,21 +642,21 @@ nets:
 - p1: grating_coupler_ellipti_2f9b04be_m58500_m69500_A270,o1
   p2: straight_gdsfactorypcom_5a080edd_m58500_m10000_A270,o2
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o1
-  p2: straight_gdsfactorypcom_dbb2297b_m48500_0,o2
+  p2: straight_gdsfactorypcom_dbb2297b_0_0_A180,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o2
-  p2: straight_gdsfactorypcom_32999c45_m175500_4500,o2
+  p2: straight_gdsfactorypcom_32999c45_0_4500_A180,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o3
-  p2: straight_gdsfactorypcom_91443128_m302500_9000,o2
+  p2: straight_gdsfactorypcom_91443128_0_9000_A180,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o4
-  p2: straight_gdsfactorypcom_3f34bc4c_m429500_13500,o2
+  p2: straight_gdsfactorypcom_3f34bc4c_0_13500_A180,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o5
-  p2: straight_gdsfactorypcom_3f34bc4c_439500_13500_A180,o2
+  p2: straight_gdsfactorypcom_3f34bc4c_10000_13500,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o6
-  p2: straight_gdsfactorypcom_91443128_312500_9000_A180,o2
+  p2: straight_gdsfactorypcom_91443128_10000_9000,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o7
-  p2: straight_gdsfactorypcom_32999c45_185500_4500_A180,o2
+  p2: straight_gdsfactorypcom_32999c45_10000_4500,o1
 - p1: straight_array_gdsfacto_4d2a5b84_0_0,o8
-  p2: straight_gdsfactorypcom_dbb2297b_58500_0_A180,o2
+  p2: straight_gdsfactorypcom_dbb2297b_10000_0,o1
 placements:
   bend_euler_gdsfactorypc_c35a91db_195500_m5500_A90:
     mirror: false
@@ -753,25 +753,25 @@ placements:
     rotation: 270
     x: -185.5
     y: -5.5
-  straight_gdsfactorypcom_32999c45_185500_4500_A180:
+  straight_gdsfactorypcom_32999c45_0_4500_A180:
     mirror: false
     rotation: 180
-    x: 185.5
+    x: 0
     y: 4.5
-  straight_gdsfactorypcom_32999c45_m175500_4500:
+  straight_gdsfactorypcom_32999c45_10000_4500:
     mirror: false
     rotation: 0
-    x: -175.5
+    x: 10
     y: 4.5
-  straight_gdsfactorypcom_3f34bc4c_439500_13500_A180:
+  straight_gdsfactorypcom_3f34bc4c_0_13500_A180:
     mirror: false
     rotation: 180
-    x: 439.5
+    x: 0
     y: 13.5
-  straight_gdsfactorypcom_3f34bc4c_m429500_13500:
+  straight_gdsfactorypcom_3f34bc4c_10000_13500:
     mirror: false
     rotation: 0
-    x: -429.5
+    x: 10
     y: 13.5
   straight_gdsfactorypcom_5a080edd_68500_m10000_A270:
     mirror: false
@@ -793,15 +793,15 @@ placements:
     rotation: 270
     x: -439.5
     y: 3.5
-  straight_gdsfactorypcom_91443128_312500_9000_A180:
+  straight_gdsfactorypcom_91443128_0_9000_A180:
     mirror: false
     rotation: 180
-    x: 312.5
+    x: 0
     y: 9
-  straight_gdsfactorypcom_91443128_m302500_9000:
+  straight_gdsfactorypcom_91443128_10000_9000:
     mirror: false
     rotation: 0
-    x: -302.5
+    x: 10
     y: 9
   straight_gdsfactorypcom_aaf4282c_322500_m1000_A270:
     mirror: false
@@ -813,15 +813,15 @@ placements:
     rotation: 270
     x: -312.5
     y: -1
-  straight_gdsfactorypcom_dbb2297b_58500_0_A180:
+  straight_gdsfactorypcom_dbb2297b_0_0_A180:
     mirror: false
     rotation: 180
-    x: 58.5
+    x: 0
     y: 0
-  straight_gdsfactorypcom_dbb2297b_m48500_0:
+  straight_gdsfactorypcom_dbb2297b_10000_0:
     mirror: false
     rotation: 0
-    x: -48.5
+    x: 10
     y: 0
 ports:
   o1: grating_coupler_ellipti_2f9b04be_m439500_m69500_A270,o2

--- a/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/test-data-regression/test_netlists_loop_mirror_.yml
@@ -122,7 +122,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_gdsfactorypcom_b215014a_45500_m9375_A270:
+  straight_gdsfactorypcom_b215014a_45500_m10625_A90:
     component: straight
     info:
       length: 1.25
@@ -145,11 +145,11 @@ nets:
 - p1: bend_euler_gdsfactorypc_c35a91db_35500_625_M,o1
   p2: straight_gdsfactorypcom_31a8c163_35500_625_A180,o1
 - p1: bend_euler_gdsfactorypc_c35a91db_35500_625_M,o2
-  p2: straight_gdsfactorypcom_b215014a_45500_m9375_A270,o1
+  p2: straight_gdsfactorypcom_b215014a_45500_m10625_A90,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_35500_m20625_A180_M,o1
   p2: bend_euler_gdsfactorypc_c35a91db_45500_m10625_A270_M,o2
 - p1: bend_euler_gdsfactorypc_c35a91db_45500_m10625_A270_M,o1
-  p2: straight_gdsfactorypcom_b215014a_45500_m9375_A270,o2
+  p2: straight_gdsfactorypcom_b215014a_45500_m10625_A90,o1
 - p1: mmi1x2_gdsfactorypcompo_1f097353_0_0,o2
   p2: straight_gdsfactorypcom_31a8c163_35500_625_A180,o2
 placements:
@@ -183,10 +183,10 @@ placements:
     rotation: 180
     x: 35.5
     y: 0.625
-  straight_gdsfactorypcom_b215014a_45500_m9375_A270:
+  straight_gdsfactorypcom_b215014a_45500_m10625_A90:
     mirror: false
-    rotation: 270
+    rotation: 90
     x: 45.5
-    y: -9.375
+    y: -10.625
 ports:
   o1: mmi1x2_gdsfactorypcompo_1f097353_0_0,o1

--- a/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/test-data-regression/test_netlists_splitter_tree_.yml
@@ -218,7 +218,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_gdsfactorypcom_94881c7f_25500_15000_A270:
+  straight_gdsfactorypcom_94881c7f_25500_10625_A90:
     component: straight
     info:
       length: 4.375
@@ -232,7 +232,7 @@ instances:
       length: 4.375
       npoints: 2
       width: null
-  straight_gdsfactorypcom_94881c7f_25500_m15000_A90:
+  straight_gdsfactorypcom_94881c7f_25500_m10625_A270:
     component: straight
     info:
       length: 4.375
@@ -277,21 +277,21 @@ instances:
 name: splitter_tree_gdsfactor_b6d59c93
 nets:
 - p1: bend_euler_gdsfactorypc_e95a7a4d_25500_10625_A270_M,o1
-  p2: straight_gdsfactorypcom_94881c7f_25500_15000_A270,o2
+  p2: straight_gdsfactorypcom_94881c7f_25500_10625_A90,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_25500_10625_A270_M,o2
   p2: coupler_0_0,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_25500_m10625_A90,o1
-  p2: straight_gdsfactorypcom_94881c7f_25500_m15000_A90,o2
+  p2: straight_gdsfactorypcom_94881c7f_25500_m10625_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_25500_m10625_A90,o2
   p2: coupler_0_0,o3
 - p1: bend_euler_gdsfactorypc_e95a7a4d_35500_25000_A180,o1
   p2: straight_gdsfactorypcom_eefd19f7_35500_25000,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_35500_25000_A180,o2
-  p2: straight_gdsfactorypcom_94881c7f_25500_15000_A270,o1
+  p2: straight_gdsfactorypcom_94881c7f_25500_10625_A90,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_35500_m25000_A180_M,o1
   p2: straight_gdsfactorypcom_eefd19f7_35500_m25000,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_35500_m25000_A180_M,o2
-  p2: straight_gdsfactorypcom_94881c7f_25500_m15000_A90,o1
+  p2: straight_gdsfactorypcom_94881c7f_25500_m10625_A270,o2
 - p1: bend_s_gdsfactorypcompo_bd3e5121_105500_24375_M,o1
   p2: coupler_1_1,o3
 - p1: bend_s_gdsfactorypcompo_bd3e5121_105500_25625,o1
@@ -360,16 +360,16 @@ placements:
     rotation: 0
     x: 90
     y: 25
-  straight_gdsfactorypcom_94881c7f_25500_15000_A270:
-    mirror: false
-    rotation: 270
-    x: 25.5
-    y: 15
-  straight_gdsfactorypcom_94881c7f_25500_m15000_A90:
+  straight_gdsfactorypcom_94881c7f_25500_10625_A90:
     mirror: false
     rotation: 90
     x: 25.5
-    y: -15
+    y: 10.625
+  straight_gdsfactorypcom_94881c7f_25500_m10625_A270:
+    mirror: false
+    rotation: 270
+    x: 25.5
+    y: -10.625
   straight_gdsfactorypcom_eefd19f7_35500_25000:
     mirror: false
     rotation: 0

--- a/test-data-regression/test_netlists_switch_tree_.yml
+++ b/test-data-regression/test_netlists_switch_tree_.yml
@@ -294,7 +294,7 @@ instances:
       length: 69
       npoints: 2
       width: null
-  straight_gdsfactorypcom_9857e1e1_411000_40000_A270:
+  straight_gdsfactorypcom_9857e1e1_411000_10625_A90:
     component: straight
     info:
       length: 29.375
@@ -308,7 +308,7 @@ instances:
       length: 29.375
       npoints: 2
       width: null
-  straight_gdsfactorypcom_9857e1e1_411000_m40000_A90:
+  straight_gdsfactorypcom_9857e1e1_411000_m10625_A270:
     component: straight
     info:
       length: 29.375
@@ -325,21 +325,21 @@ instances:
 name: splitter_tree_gdsfactor_dfaf2fb9
 nets:
 - p1: bend_euler_gdsfactorypc_e95a7a4d_411000_10625_A270_M,o1
-  p2: straight_gdsfactorypcom_9857e1e1_411000_40000_A270,o2
+  p2: straight_gdsfactorypcom_9857e1e1_411000_10625_A90,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_411000_10625_A270_M,o2
   p2: coupler_0_0,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_411000_m10625_A90,o1
-  p2: straight_gdsfactorypcom_9857e1e1_411000_m40000_A90,o2
+  p2: straight_gdsfactorypcom_9857e1e1_411000_m10625_A270,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_411000_m10625_A90,o2
   p2: coupler_0_0,o3
 - p1: bend_euler_gdsfactorypc_e95a7a4d_421000_50000_A180,o1
   p2: straight_gdsfactorypcom_11566f47_421000_50000,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_421000_50000_A180,o2
-  p2: straight_gdsfactorypcom_9857e1e1_411000_40000_A270,o1
+  p2: straight_gdsfactorypcom_9857e1e1_411000_10625_A90,o2
 - p1: bend_euler_gdsfactorypc_e95a7a4d_421000_m50000_A180_M,o1
   p2: straight_gdsfactorypcom_11566f47_421000_m50000,o1
 - p1: bend_euler_gdsfactorypc_e95a7a4d_421000_m50000_A180_M,o2
-  p2: straight_gdsfactorypcom_9857e1e1_411000_m40000_A90,o1
+  p2: straight_gdsfactorypcom_9857e1e1_411000_m10625_A270,o2
 - p1: bend_s_gdsfactorypcompo_23c8b359_901000_49375_M,o1
   p2: coupler_1_1,o3
 - p1: bend_s_gdsfactorypcompo_23c8b359_901000_50625,o1
@@ -418,16 +418,16 @@ placements:
     rotation: 0
     x: 421
     y: -50
-  straight_gdsfactorypcom_9857e1e1_411000_40000_A270:
-    mirror: false
-    rotation: 270
-    x: 411
-    y: 40
-  straight_gdsfactorypcom_9857e1e1_411000_m40000_A90:
+  straight_gdsfactorypcom_9857e1e1_411000_10625_A90:
     mirror: false
     rotation: 90
     x: 411
-    y: -40
+    y: 10.625
+  straight_gdsfactorypcom_9857e1e1_411000_m10625_A270:
+    mirror: false
+    rotation: 270
+    x: 411
+    y: -10.625
 ports:
   e1_0_1: coupler_0_0,e1
   e1_1_19: coupler_1_1,e1


### PR DESCRIPTION
mirror flags are swapped with new placer modularization for some cases, no gds diffs

## Summary by Sourcery

Update netlist regression test fixtures to reflect the swapped mirror flags and new orientation/placement parameters introduced by the placer modularization refactor.

Bug Fixes:
- Correct swapped mirror flags and orientation values in test netlist YAML files after placer modularization changes.

Tests:
- Refresh expected YAML fixtures for AWG, grating coupler loss/tree, edge coupler array, splitter tree, switch tree, and loop mirror cases to use updated component naming, rotation, mirror flags, and placement coordinates.