### PR TITLE
Replace usage of Layers by LayerSpecs in fiducial_squares

### DIFF
--- a/gdsfactory/components/shapes/fiducial_squares.py
+++ b/gdsfactory/components/shapes/fiducial_squares.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import numpy as np
 
 import gdsfactory as gf
-from gdsfactory.typings import Float2, Layers
+from gdsfactory.typings import Float2, LayerSpecs
 
 
 @gf.cell_with_module_name
 def fiducial_squares(
-    layers: Layers = ((1, 0),), size: Float2 = (5, 5), offset: float = 0.14
+    layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 0.14
 ) -> gf.Component:
     """Returns fiducials with two squares.
 

--- a/test-data-regression/test_netlists_fiducial_squares_.yml
+++ b/test-data-regression/test_netlists_fiducial_squares_.yml
@@ -1,12 +1,10 @@
 instances:
-  rectangle_gdsfactorypco_68f8d919_0_0:
+  rectangle_gdsfactorypco_8a1fdb9b_0_0:
     component: rectangle
     info: {}
     settings:
       centered: false
-      layer:
-      - 1
-      - 0
+      layer: WG
       port_orientations:
       - 180
       - 90
@@ -16,14 +14,12 @@ instances:
       size:
       - 5
       - 5
-  rectangle_gdsfactorypco_68f8d919_m5140_m5140:
+  rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140:
     component: rectangle
     info: {}
     settings:
       centered: false
-      layer:
-      - 1
-      - 0
+      layer: WG
       port_orientations:
       - 180
       - 90
@@ -33,15 +29,15 @@ instances:
       size:
       - 5
       - 5
-name: fiducial_squares_gdsfac_8cf4f5ad
+name: fiducial_squares_gdsfac_9aab5a27
 nets: []
 placements:
-  rectangle_gdsfactorypco_68f8d919_0_0:
+  rectangle_gdsfactorypco_8a1fdb9b_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  rectangle_gdsfactorypco_68f8d919_m5140_m5140:
+  rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140:
     mirror: false
     rotation: 0
     x: -5.14
@@ -52,14 +48,14 @@ warnings:
     unconnected_ports:
     - message: 8 unconnected electrical ports!
       ports:
-      - rectangle_gdsfactorypco_68f8d919_0_0,e1
-      - rectangle_gdsfactorypco_68f8d919_0_0,e2
-      - rectangle_gdsfactorypco_68f8d919_0_0,e3
-      - rectangle_gdsfactorypco_68f8d919_0_0,e4
-      - rectangle_gdsfactorypco_68f8d919_m5140_m5140,e1
-      - rectangle_gdsfactorypco_68f8d919_m5140_m5140,e2
-      - rectangle_gdsfactorypco_68f8d919_m5140_m5140,e3
-      - rectangle_gdsfactorypco_68f8d919_m5140_m5140,e4
+      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e1
+      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e2
+      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e3
+      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e4
+      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e1
+      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e2
+      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e3
+      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e4
       values:
       - - 0
         - 2.5

--- a/test-data-regression/test_settings_fiducial_squares_.yml
+++ b/test-data-regression/test_settings_fiducial_squares_.yml
@@ -1,9 +1,8 @@
 info: {}
-name: fiducial_squares_gdsfac_8cf4f5ad
+name: fiducial_squares_gdsfac_9aab5a27
 settings:
   layers:
-  - - 1
-    - 0
+  - WG
   offset: 0.14
   size:
   - 5


### PR DESCRIPTION
More in line with rest of API

## Summary by Sourcery

Replace usage of Layers with LayerSpecs in the fiducial_squares component to align with the rest of the API

Enhancements:
- Switch the layers parameter type from Layers to LayerSpecs in fiducial_squares
- Update default layers value to use a named LayerSpec