### PR TITLE
Center and fix fiducial squares when offset is an int

### DIFF
--- a/gdsfactory/components/shapes/fiducial_squares.py
+++ b/gdsfactory/components/shapes/fiducial_squares.py
@@ -8,7 +8,7 @@ from gdsfactory.typings import Float2, LayerSpecs
 
 @gf.cell_with_module_name
 def fiducial_squares(
-    layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 0.14
+    layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 1
 ) -> gf.Component:
     """Returns fiducials with two squares.
 
@@ -18,12 +18,16 @@ def fiducial_squares(
         offset: in um.
     """
     c = gf.Component()
-    for layer in layers:
-        r = c << gf.c.rectangle(size=size, layer=layer)
+
+    dx, dy = (np.array(size) + np.array([offset, offset])) / 2
 
     for layer in layers:
-        r = c << gf.c.rectangle(size=size, layer=layer)
-        r.move(-np.array(size) - np.array([offset, offset]))
+        r = c << gf.c.rectangle(size=size, layer=layer, centered=True)
+        r.move((dx, dy))
+
+    for layer in layers:
+        r = c << gf.c.rectangle(size=size, layer=layer, centered=True)
+        r.move((-dx, -dy))
 
     return c
 

--- a/gdsfactory/components/shapes/fiducial_squares.py
+++ b/gdsfactory/components/shapes/fiducial_squares.py
@@ -8,14 +8,14 @@ from gdsfactory.typings import Float2, LayerSpecs
 
 @gf.cell_with_module_name
 def fiducial_squares(
-    layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 1
+    layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 0.14
 ) -> gf.Component:
     """Returns fiducials with two squares.
 
     Args:
-        layers: list of layers.
-        size: in um.
-        offset: in um.
+        layers: list of layers to draw the squares.
+        size: size of each square in um.
+        offset: space between squares in x and y.
     """
     c = gf.Component()
 

--- a/test-data-regression/test_netlists_fiducial_squares_.yml
+++ b/test-data-regression/test_netlists_fiducial_squares_.yml
@@ -1,9 +1,9 @@
 instances:
-  rectangle_gdsfactorypco_8a1fdb9b_0_0:
+  rectangle_gdsfactorypco_68f9f59d_2570_2570:
     component: rectangle
     info: {}
     settings:
-      centered: false
+      centered: true
       layer: WG
       port_orientations:
       - 180
@@ -14,11 +14,11 @@ instances:
       size:
       - 5
       - 5
-  rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140:
+  rectangle_gdsfactorypco_68f9f59d_m2570_m2570:
     component: rectangle
     info: {}
     settings:
-      centered: false
+      centered: true
       layer: WG
       port_orientations:
       - 180
@@ -32,44 +32,44 @@ instances:
 name: fiducial_squares_gdsfac_9aab5a27
 nets: []
 placements:
-  rectangle_gdsfactorypco_8a1fdb9b_0_0:
+  rectangle_gdsfactorypco_68f9f59d_2570_2570:
     mirror: false
     rotation: 0
-    x: 0
-    y: 0
-  rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140:
+    x: 2.57
+    y: 2.57
+  rectangle_gdsfactorypco_68f9f59d_m2570_m2570:
     mirror: false
     rotation: 0
-    x: -5.14
-    y: -5.14
+    x: -2.57
+    y: -2.57
 ports: {}
 warnings:
   electrical:
     unconnected_ports:
     - message: 8 unconnected electrical ports!
       ports:
-      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e1
-      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e2
-      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e3
-      - rectangle_gdsfactorypco_8a1fdb9b_0_0,e4
-      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e1
-      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e2
-      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e3
-      - rectangle_gdsfactorypco_8a1fdb9b_m5140_m5140,e4
+      - rectangle_gdsfactorypco_68f9f59d_2570_2570,e1
+      - rectangle_gdsfactorypco_68f9f59d_2570_2570,e2
+      - rectangle_gdsfactorypco_68f9f59d_2570_2570,e3
+      - rectangle_gdsfactorypco_68f9f59d_2570_2570,e4
+      - rectangle_gdsfactorypco_68f9f59d_m2570_m2570,e1
+      - rectangle_gdsfactorypco_68f9f59d_m2570_m2570,e2
+      - rectangle_gdsfactorypco_68f9f59d_m2570_m2570,e3
+      - rectangle_gdsfactorypco_68f9f59d_m2570_m2570,e4
       values:
-      - - 0
-        - 2.5
-      - - 2.5
-        - 5
-      - - 5
-        - 2.5
-      - - 2.5
-        - 0
-      - - -5.14
-        - -2.64
-      - - -2.64
-        - -0.14
-      - - -0.14
-        - -2.64
-      - - -2.64
-        - -5.14
+      - - 0.07
+        - 2.57
+      - - 2.57
+        - 5.07
+      - - 5.07
+        - 2.57
+      - - 2.57
+        - 0.07
+      - - -5.07
+        - -2.57
+      - - -2.57
+        - -0.07
+      - - -0.07
+        - -2.57
+      - - -2.57
+        - -5.07


### PR DESCRIPTION
Closes https://github.com/gdsfactory/gdsfactory/issues/3991

Needs tests

## Summary by Sourcery

Center and properly offset the fiducial squares by default and update tests to match the new positions.

Bug Fixes:
- Fix misalignment of fiducial squares when offset is an integer by adjusting centering and movement logic.

Enhancements:
- Refactor fiducial_squares to use centered rectangles and compute dx, dy as (size + offset)/2 for placement.

Tests:
- Update regression netlist tests to expect the new centered positions and adjusted coordinates.