### PR TITLE
Update extension.py to correctly allow for non-optical extensions

### DIFF
--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -181,6 +181,7 @@ def extend_ports(
                     cross_section_extension = cross_section or cross_section_function(
                         layer=gf.get_layer_tuple(port.layer),
                         width=port.width,
+                        port_types=(port_type, port_type),
                     )
 
                 extension_component = gf.components.straight(


### PR DESCRIPTION
Fixes for #4000. I believe this is all that is required to address this bug, but if there are other changes necessary let me know.

## Summary by Sourcery

Bug Fixes:
- Add port_types parameter when extending ports to enable correct non-optical extension support