### PR TITLE
update kfactory for fix of vinsts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.9.3,<1.10",
+  "kfactory[ipy]>=1.9.4,<1.10",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump kfactory[ipy] requirement from >=1.9.3,<1.10 to >=1.9.4,<1.10