### PR TITLE
improve routing

### DIFF
--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -1067,85 +1067,6 @@
    "id": "39",
    "metadata": {},
    "source": [
-    "## route_bundle with low loss\n",
-    "\n",
-    "You can taper to wider widths to reduce the propagation loss, as wider widths have lower loss."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = gf.Component()\n",
-    "mmi1 = c << gf.components.mmi1x2()\n",
-    "mmi2 = c << gf.components.mmi1x2()\n",
-    "mmi2.move((100, 50))\n",
-    "route = gf.routing.route_bundle(\n",
-    "    c, [mmi1.ports[\"o2\"]], [mmi2.ports[\"o1\"]], taper=gf.components.taper(width1=0.5, width2=2), cross_section=\"strip\", min_straight_taper=20,\n",
-    ")\n",
-    "c"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "41",
-   "metadata": {},
-   "source": [
-    "## route_bundle with tapers\n",
-    "\n",
-    "You can automatically taper the routes to match the width of the ports of the route width cross_section."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "42",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = gf.Component()\n",
-    "s1 = c << gf.components.straight(width=4)\n",
-    "s2 = c << gf.components.straight(width=4)\n",
-    "s2.move((100, 50))\n",
-    "route = gf.routing.route_bundle(\n",
-    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\"\n",
-    ")\n",
-    "c"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43",
-   "metadata": {},
-   "source": [
-    "You can also pass a particular taper to the route_bundle function to automatically add tapers to the routes when needed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = gf.Component()\n",
-    "s1 = c << gf.components.straight(width=4)\n",
-    "s2 = c << gf.components.straight(width=4)\n",
-    "s2.move((100, 50))\n",
-    "route = gf.routing.route_bundle(\n",
-    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\", auto_taper_taper=gf.components.taper(width1=4, width2=0.5, length=30)\n",
-    ")\n",
-    "c"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45",
-   "metadata": {},
-   "source": [
     "## route_astar\n",
     "\n",
     "You can navigate around bounding boxes when routing if you pass the bboxes of all the objects that you want to avoid.\n",
@@ -1157,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,7 +1180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "42",
    "metadata": {},
    "source": [
     "## route_bundle with collisions\n",
@@ -1273,7 +1194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1311,7 +1232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "44",
    "metadata": {},
    "source": [
     "If the obstacle does not intersect the initial or end ports, the router does not attempt to avoid it."
@@ -1320,7 +1241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1358,7 +1279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "46",
    "metadata": {},
    "source": [
     "However you can enlarge it to avoid it."
@@ -1367,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1405,7 +1326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "48",
    "metadata": {},
    "source": [
     "## route_bundle_all_angle\n",
@@ -1416,7 +1337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1445,7 +1366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "50",
    "metadata": {},
    "source": [
     "You can also use it to connect rotated components that do not have a manhattan orientation (0, 90, 180, 270)"
@@ -1454,7 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1478,7 +1399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "52",
    "metadata": {},
    "source": [
     "## Dubins paths\n",
@@ -1495,7 +1416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1522,7 +1443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1551,14 +1472,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "55",
    "metadata": {},
    "source": [
     "## auto_taper\n",
     "\n",
     "Both `route_single` and `route_bundle` have a `auto_taper` parameter. \n",
     "\n",
-    "For auto_taper to work you need to define how to transition different between different layers and widths.\n",
+    "For auto_taper to work you need to define how to transition different between different layers and widths. Another option is to explicitly pass the `auto_taper_taper` parameter to `route_bundle`.\n",
+    "See examples in the next section.\n",
     "\n",
     "```python\n",
     "\n",
@@ -1590,7 +1512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1611,7 +1533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1640,11 +1562,90 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
     "c = silicon_nitride_strip(width_nitride=4)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59",
+   "metadata": {},
+   "source": [
+    "## route_bundle with tapers\n",
+    "\n",
+    "You can automatically taper the routes to match the width of the ports of the route width cross_section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "s1 = c << gf.components.straight(width=4)\n",
+    "s2 = c << gf.components.straight(width=4)\n",
+    "s2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\"\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61",
+   "metadata": {},
+   "source": [
+    "You can also pass a particular taper to the route_bundle function to automatically add tapers to the routes when needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "s1 = c << gf.components.straight(width=4)\n",
+    "s2 = c << gf.components.straight(width=4)\n",
+    "s2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\", auto_taper_taper=gf.components.taper(width1=4, width2=0.5, length=30)\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63",
+   "metadata": {},
+   "source": [
+    "## route_bundle with low loss\n",
+    "\n",
+    "You can taper to wider widths to reduce the propagation loss, as wider widths have lower loss."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "mmi1 = c << gf.components.mmi1x2()\n",
+    "mmi2 = c << gf.components.mmi1x2()\n",
+    "mmi2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [mmi1.ports[\"o2\"]], [mmi2.ports[\"o1\"]], taper=gf.components.taper(width1=0.5, width2=2), cross_section=\"strip\", min_straight_taper=20,\n",
+    ")\n",
     "c"
    ]
   }

--- a/notebooks/04_routing.ipynb
+++ b/notebooks/04_routing.ipynb
@@ -7,14 +7,14 @@
    "source": [
     "# Routing\n",
     "\n",
-    "Optical and high-speed RF ports have specific orientation requirements to ensure that routes avoid sharp turns, which can cause signal reflections.\n",
+    "Optical and high-speed RF ports have orientation requirements to avoid sharp turns, which can cause signal reflections.\n",
     "\n",
-    "We offer routing functions tailored for these requirements:\n",
+    "GDSFactory offers:\n",
     "\n",
     "- `route_single`: Routes a single connection between two ports.\n",
     "- `route_bundle`: Routes multiple connections between two port groups using a bundle/river/bus router. It also accommodates waypoints and routing steps.\n",
     "\n",
-    "The most versatile function is `route_bundle`, as it handles both single and grouped routes with length matching, ensuring all routes are of equal length."
+    "The most versatile function is `route_bundle`, as it handles both single and grouped routes."
    ]
   },
   {
@@ -50,7 +50,7 @@
    "source": [
     "## route_single\n",
     "\n",
-    "`route_single` returns a Manhattan route between 2 ports"
+    "`route_single` returns a Manhattan route between 2 ports."
    ]
   },
   {
@@ -90,26 +90,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "route"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7",
-   "metadata": {},
-   "source": [
-    "⚠️ **Note:** You can also get the route length, but keep the following in mind:  \n",
-    "\n",
-    "- The route length is in **DBU** (Database Units). Usually, **1 DBU = 1 nm**.  \n",
-    "- It only accounts for **straight segments**, not bends.  \n",
-    "\n",
-    "For the **total length**, including bends and straights, you can use `Component.info['length']` or `Instance.cell.info['length]`"
+    "c.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "route"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8",
+   "metadata": {},
+   "source": [
+    "⚠️ **Note:** You can also get the route length, but keep the following in mind that route length is in **DBU** (Database Units). Usually, **1 DBU = 1 nm**.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "**Problem**: route_single with obstacles\n",
@@ -160,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "**Solution**: specify the route steps\n",
@@ -189,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,12 +267,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## route_bundle\n",
     "\n",
-    "To route groups of ports avoiding waveguide collisions, you should use `route_bundle` instead of `route_single`.\n",
+    "To route groups of ports avoiding routing collisions between each route, you should use `route_bundle` instead of `route_single`.\n",
     "\n",
     "`route_bundle` uses a river/bundle/bus router.\n",
     "\n",
@@ -277,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -367,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,7 +821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +853,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +872,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "source": [
     "**Problem**\n",
@@ -878,7 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -892,7 +897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +947,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "**Solution**\n",
@@ -953,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -973,7 +978,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +994,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1024,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1059,20 +1064,100 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
+   "metadata": {},
+   "source": [
+    "## route_bundle with low loss\n",
+    "\n",
+    "You can taper to wider widths to reduce the propagation loss, as wider widths have lower loss."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "mmi1 = c << gf.components.mmi1x2()\n",
+    "mmi2 = c << gf.components.mmi1x2()\n",
+    "mmi2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [mmi1.ports[\"o2\"]], [mmi2.ports[\"o1\"]], taper=gf.components.taper(width1=0.5, width2=2), cross_section=\"strip\", min_straight_taper=20,\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41",
+   "metadata": {},
+   "source": [
+    "## route_bundle with tapers\n",
+    "\n",
+    "You can automatically taper the routes to match the width of the ports of the route width cross_section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "s1 = c << gf.components.straight(width=4)\n",
+    "s2 = c << gf.components.straight(width=4)\n",
+    "s2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\"\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43",
+   "metadata": {},
+   "source": [
+    "You can also pass a particular taper to the route_bundle function to automatically add tapers to the routes when needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "s1 = c << gf.components.straight(width=4)\n",
+    "s2 = c << gf.components.straight(width=4)\n",
+    "s2.move((100, 50))\n",
+    "route = gf.routing.route_bundle(\n",
+    "    c, [s1.ports[\"o2\"]], [s2.ports[\"o1\"]], auto_taper=True, cross_section=\"strip\", auto_taper_taper=gf.components.taper(width1=4, width2=0.5, length=30)\n",
+    ")\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45",
    "metadata": {},
    "source": [
     "## route_astar\n",
     "\n",
     "You can navigate around bounding boxes when routing if you pass the bboxes of all the objects that you want to avoid.\n",
     "\n",
-    "Currently the router only respects any (merged) bounding boxes which overlap with start or end port bundles"
+    "\n",
+    "If you want to navigate around all bounding boxes, you can also use the `route_astar` function."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1122,7 +1207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1174,19 +1259,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "48",
    "metadata": {},
    "source": [
     "## route_bundle with collisions\n",
     "\n",
     "\n",
-    "The route bundle alsos supports avoiding obstacles."
+    "The route bundle alsos supports avoiding obstacles.\n",
+    "\n",
+    "Currently the router only respects any (merged) bounding boxes which overlap with start or end port bundles."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1224,7 +1311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "50",
    "metadata": {},
    "source": [
     "If the obstacle does not intersect the initial or end ports, the router does not attempt to avoid it."
@@ -1233,7 +1320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "52",
    "metadata": {},
    "source": [
     "However you can enlarge it to avoid it."
@@ -1280,7 +1367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,7 +1405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "54",
    "metadata": {},
    "source": [
     "## route_bundle_all_angle\n",
@@ -1329,7 +1416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1358,7 +1445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "56",
    "metadata": {},
    "source": [
     "You can also use it to connect rotated components that do not have a manhattan orientation (0, 90, 180, 270)"
@@ -1367,7 +1454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1391,14 +1478,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "58",
    "metadata": {},
    "source": [
     "## Dubins paths\n",
     "\n",
-    "If you’re working with PIC layouts and looking for a straightforward way to optimize waveguide paths, Dubins paths (named after Lester Eli Dubins) offer an effective solution by ensuring the shortest path with minimal bending and loss.\n",
+    "If you’re looking for a straightforward way to optimize waveguide paths, Dubins paths (named after Lester Eli Dubins) offer an effective solution by ensuring the shortest path with minimal bending and loss.\n",
     "\n",
-    "Using Dubins paths for waveguide routing can simplify your design process significantly. Compared to traditional interconnects, Dubins paths offer shorter, more reliable routes that avoid unnecessary bending and intersections. For PIC layouts, this translates into denser, cleaner designs with improved performance.\n",
+    "Using Dubins paths for waveguide routing can simplify your design process significantly.\n",
+    "Compared to traditional interconnects, Dubins paths offer shorter, more reliable routes that avoid unnecessary bending and intersections.\n",
+    "This translates into denser, cleaner designs with improved performance.\n",
     "\n",
     "[See blog](https://quentinwach.com/blog/2024/02/15/dubins-paths-for-waveguide-routing.html)"
    ]
@@ -1406,7 +1495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1433,7 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1462,7 +1551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "61",
    "metadata": {},
    "source": [
     "## auto_taper\n",
@@ -1501,7 +1590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1522,7 +1611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1551,7 +1640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary by Sourcery

Introduce support for custom taper components in route_bundle and update documentation and examples accordingly.

New Features:
- Add auto_taper_taper parameter to allow specifying a custom taper component for auto-tapering routes.

Enhancements:
- Extend route_bundle logic to apply the custom taper to each port pair and compute updated bounding boxes when auto_taper_taper is provided.
- Clarify taper parameter descriptions in the route_bundle docstring.

Documentation:
- Update example in straight_um to demonstrate the new auto_taper_taper usage and clean up commented code.