### PR TITLE
optional watchdog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ version = "9.9.4"
 cad = ["kweb>=1.1.9,<2.1"]
 dev = [
   "codeflash",
+  "watchdog<7",
   "ipykernel",
   "jupyterlab",
   "jsondiff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "types-PyYAML",
   "typer<1",
   "kfactory[ipy]>=1.9.4,<1.10",
-  "watchdog<7",
   "freetype-py",
   "mapbox_earcut",
   "networkx",
@@ -94,6 +93,7 @@ maintainer = [
   "autotyping",
   "towncrier"
 ]
+watch = ["watchdog<7"]
 
 [project.scripts]
 gf = "gdsfactory.cli:app"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Extract the 'watchdog<7' requirement from the primary dependencies list into a dedicated 'watch' extras group in pyproject.toml.