### PR TITLE
add_quantum

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -9,6 +9,7 @@ from gdsfactory.components import (
     mzis,
     pads,
     pcms,
+    quantum,
     rings,
     shapes,
     spirals,

--- a/gdsfactory/components/quantum/__init__.py
+++ b/gdsfactory/components/quantum/__init__.py
@@ -1,0 +1,31 @@
+from gdsfactory.components.quantum.coupler_capacitive import (
+    coupler_capacitive,
+    coupler_interdigital,
+    coupler_tunable,
+)
+from gdsfactory.components.quantum.flux_qubit import (
+    flux_qubit,
+    flux_qubit_asymmetric,
+)
+from gdsfactory.components.quantum.resonator import (
+    resonator_cpw,
+    resonator_lumped,
+    resonator_quarter_wave,
+)
+from gdsfactory.components.quantum.transmon import (
+    transmon,
+    transmon_circular,
+)
+
+__all__ = [
+    "coupler_capacitive",
+    "coupler_interdigital",
+    "coupler_tunable",
+    "flux_qubit",
+    "flux_qubit_asymmetric",
+    "resonator_cpw",
+    "resonator_lumped",
+    "resonator_quarter_wave",
+    "transmon",
+    "transmon_circular",
+]

--- a/gdsfactory/components/quantum/flux_qubit.py
+++ b/gdsfactory/components/quantum/flux_qubit.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import numpy as np
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.typings import LayerSpec
+
+
+@gf.cell_with_module_name
+def flux_qubit(
+    loop_width: float = 50.0,
+    loop_height: float = 50.0,
+    junction_width: float = 0.15,
+    junction_height: float = 0.3,
+    alpha_junction_width: float = 0.12,
+    alpha_junction_height: float = 0.25,
+    wire_width: float = 2.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_junction: LayerSpec = (2, 0),
+    layer_alpha_junction: LayerSpec = (3, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a flux qubit (persistent current qubit).
+
+    A flux qubit consists of a superconducting loop interrupted by three Josephson junctions.
+    Two junctions are identical (β junctions) while the third is smaller (α junction)
+    with roughly 0.5-0.8 times the critical current.
+
+    Args:
+        loop_width: Width of the superconducting loop in μm.
+        loop_height: Height of the superconducting loop in μm.
+        junction_width: Width of the β Josephson junctions in μm.
+        junction_height: Height of the β Josephson junctions in μm.
+        alpha_junction_width: Width of the α Josephson junction in μm.
+        alpha_junction_height: Height of the α Josephson junction in μm.
+        wire_width: Width of the superconducting wires in μm.
+        layer_metal: Layer for the metal wires.
+        layer_junction: Layer for the β Josephson junctions.
+        layer_alpha_junction: Layer for the α Josephson junction.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the flux qubit geometry.
+    """
+    c = Component()
+
+    # Create the superconducting loop as a hollow rectangle
+    outer_rect = gf.components.rectangle(
+        size=(loop_width, loop_height),
+        layer=layer_metal,
+    )
+
+    inner_rect = gf.components.rectangle(
+        size=(loop_width - 2 * wire_width, loop_height - 2 * wire_width),
+        layer=layer_metal,
+    )
+
+    # Create the loop by boolean difference
+    loop = gf.boolean(
+        outer_rect,
+        inner_rect,
+        operation="not",
+        layer=layer_metal,
+    )
+
+    loop_ref = c.add_ref(loop)
+    loop_ref.move((-loop_width / 2, -loop_height / 2))
+
+    # Create gaps for junctions
+    # Bottom gap for α junction
+    alpha_gap = gf.components.rectangle(
+        size=(alpha_junction_width + 0.1, wire_width + 0.1),
+        layer=layer_metal,
+    )
+    alpha_gap_ref = c.add_ref(alpha_gap)
+    alpha_gap_ref.move((-alpha_junction_width / 2 - 0.05, -loop_height / 2 - 0.05))
+
+    # Left gap for β junction
+    beta_gap_left = gf.components.rectangle(
+        size=(wire_width + 0.1, junction_height + 0.1),
+        layer=layer_metal,
+    )
+    beta_gap_left_ref = c.add_ref(beta_gap_left)
+    beta_gap_left_ref.move((-loop_width / 2 - 0.05, -junction_height / 2 - 0.05))
+
+    # Right gap for β junction
+    beta_gap_right = gf.components.rectangle(
+        size=(wire_width + 0.1, junction_height + 0.1),
+        layer=layer_metal,
+    )
+    beta_gap_right_ref = c.add_ref(beta_gap_right)
+    beta_gap_right_ref.move(
+        (loop_width / 2 - wire_width - 0.05, -junction_height / 2 - 0.05)
+    )
+
+    # Remove gaps from the loop
+    loop_with_gaps = gf.boolean(
+        loop_ref,
+        [alpha_gap_ref, beta_gap_left_ref, beta_gap_right_ref],
+        operation="not",
+        layer=layer_metal,
+    )
+
+    # Create the α junction (smaller)
+    alpha_junction = gf.components.rectangle(
+        size=(alpha_junction_width, alpha_junction_height),
+        layer=layer_alpha_junction,
+    )
+    alpha_junction_ref = c.add_ref(alpha_junction)
+    alpha_junction_ref.move(
+        (
+            -alpha_junction_width / 2,
+            -loop_height / 2 + wire_width / 2 - alpha_junction_height / 2,
+        )
+    )
+
+    # Create the β junctions (larger, identical)
+    beta_junction_left = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    beta_junction_left_ref = c.add_ref(beta_junction_left)
+    beta_junction_left_ref.move(
+        (-loop_width / 2 + wire_width / 2 - junction_width / 2, -junction_height / 2)
+    )
+
+    beta_junction_right = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    beta_junction_right_ref = c.add_ref(beta_junction_right)
+    beta_junction_right_ref.move(
+        (loop_width / 2 - wire_width / 2 - junction_width / 2, -junction_height / 2)
+    )
+
+    # Add control lines for flux bias
+    control_line_left = gf.components.rectangle(
+        size=(20.0, 2.0),
+        layer=layer_metal,
+    )
+    control_line_left_ref = c.add_ref(control_line_left)
+    control_line_left_ref.move((-loop_width / 2 - 30.0, -1.0))
+
+    control_line_right = gf.components.rectangle(
+        size=(20.0, 2.0),
+        layer=layer_metal,
+    )
+    control_line_right_ref = c.add_ref(control_line_right)
+    control_line_right_ref.move((loop_width / 2 + 10.0, -1.0))
+
+    # Add ports for flux control
+    c.add_port(
+        name="flux_control_left",
+        center=(-loop_width / 2 - 40.0, 0),
+        width=2.0,
+        orientation=180,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="flux_control_right",
+        center=(loop_width / 2 + 40.0, 0),
+        width=2.0,
+        orientation=0,
+        layer=layer_metal,
+    )
+
+    # Add readout connection
+    c.add_port(
+        name="readout",
+        center=(0, loop_height / 2 + 10.0),
+        width=wire_width,
+        orientation=90,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["qubit_type"] = "flux_qubit"
+    c.info["loop_width"] = loop_width
+    c.info["loop_height"] = loop_height
+    c.info["beta_junction_area"] = junction_width * junction_height
+    c.info["alpha_junction_area"] = alpha_junction_width * alpha_junction_height
+    c.info["alpha_beta_ratio"] = (alpha_junction_width * alpha_junction_height) / (
+        junction_width * junction_height
+    )
+
+    return c
+
+
+@gf.cell_with_module_name
+def flux_qubit_asymmetric(
+    loop_width: float = 60.0,
+    loop_height: float = 40.0,
+    junction_width: float = 0.15,
+    junction_height: float = 0.3,
+    alpha_junction_width: float = 0.12,
+    alpha_junction_height: float = 0.25,
+    wire_width: float = 2.0,
+    asymmetry_angle: float = 15.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_junction: LayerSpec = (2, 0),
+    layer_alpha_junction: LayerSpec = (3, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates an asymmetric flux qubit for reduced flux noise sensitivity.
+
+    An asymmetric flux qubit has a loop geometry that is not perfectly symmetric,
+    which can help reduce sensitivity to flux noise while maintaining controllability.
+
+    Args:
+        loop_width: Width of the superconducting loop in μm.
+        loop_height: Height of the superconducting loop in μm.
+        junction_width: Width of the β Josephson junctions in μm.
+        junction_height: Height of the β Josephson junctions in μm.
+        alpha_junction_width: Width of the α Josephson junction in μm.
+        alpha_junction_height: Height of the α Josephson junction in μm.
+        wire_width: Width of the superconducting wires in μm.
+        asymmetry_angle: Angle of asymmetry in degrees.
+        layer_metal: Layer for the metal wires.
+        layer_junction: Layer for the β Josephson junctions.
+        layer_alpha_junction: Layer for the α Josephson junction.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the asymmetric flux qubit geometry.
+    """
+    c = Component()
+
+    # Create the main loop structure
+    points = []
+    angle_rad = np.radians(asymmetry_angle)
+
+    # Create asymmetric loop shape
+    # Bottom side
+    points.extend(
+        [
+            (-loop_width / 2, -loop_height / 2),
+            (loop_width / 2, -loop_height / 2),
+            (loop_width / 2, -loop_height / 2 + wire_width),
+            (-loop_width / 2, -loop_height / 2 + wire_width),
+        ]
+    )
+
+    # Right side with angle
+    x_offset = loop_height / 2 * np.tan(angle_rad)
+    points.extend(
+        [
+            (loop_width / 2 - wire_width, -loop_height / 2 + wire_width),
+            (loop_width / 2 - wire_width, loop_height / 2 - wire_width),
+            (loop_width / 2 - wire_width + x_offset, loop_height / 2 - wire_width),
+            (loop_width / 2 + x_offset, loop_height / 2 - wire_width),
+            (loop_width / 2 + x_offset, loop_height / 2),
+            (loop_width / 2, loop_height / 2),
+            (loop_width / 2, -loop_height / 2),
+        ]
+    )
+
+    # Top side
+    points.extend(
+        [
+            (loop_width / 2 + x_offset, loop_height / 2),
+            (-loop_width / 2, loop_height / 2),
+            (-loop_width / 2, loop_height / 2 - wire_width),
+            (loop_width / 2 + x_offset, loop_height / 2 - wire_width),
+        ]
+    )
+
+    # Left side
+    points.extend(
+        [
+            (-loop_width / 2 + wire_width, loop_height / 2 - wire_width),
+            (-loop_width / 2 + wire_width, -loop_height / 2 + wire_width),
+            (-loop_width / 2, -loop_height / 2 + wire_width),
+            (-loop_width / 2, loop_height / 2),
+        ]
+    )
+
+    # Create the loop polygon
+    c.add_polygon(points, layer=layer_metal)
+
+    # Create junctions in the gaps
+    # α junction at bottom
+    alpha_junction = gf.components.rectangle(
+        size=(alpha_junction_width, alpha_junction_height),
+        layer=layer_alpha_junction,
+    )
+    alpha_junction_ref = c.add_ref(alpha_junction)
+    alpha_junction_ref.move(
+        (
+            -alpha_junction_width / 2,
+            -loop_height / 2 + wire_width / 2 - alpha_junction_height / 2,
+        )
+    )
+
+    # β junctions at sides
+    beta_junction_left = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    beta_junction_left_ref = c.add_ref(beta_junction_left)
+    beta_junction_left_ref.move(
+        (-loop_width / 2 + wire_width / 2 - junction_width / 2, 0)
+    )
+
+    beta_junction_right = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    beta_junction_right_ref = c.add_ref(beta_junction_right)
+    beta_junction_right_ref.move(
+        (loop_width / 2 - wire_width / 2 - junction_width / 2, 0)
+    )
+
+    # Add control and readout ports
+    c.add_port(
+        name="flux_control",
+        center=(0, loop_height / 2 + 10.0),
+        width=wire_width,
+        orientation=90,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="readout",
+        center=(loop_width / 2 + x_offset + 10.0, 0),
+        width=wire_width,
+        orientation=0,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["qubit_type"] = "flux_qubit_asymmetric"
+    c.info["loop_width"] = loop_width
+    c.info["loop_height"] = loop_height
+    c.info["asymmetry_angle"] = asymmetry_angle
+    c.info["beta_junction_area"] = junction_width * junction_height
+    c.info["alpha_junction_area"] = alpha_junction_width * alpha_junction_height
+    c.info["alpha_beta_ratio"] = (alpha_junction_width * alpha_junction_height) / (
+        junction_width * junction_height
+    )
+
+    return c
+
+
+if __name__ == "__main__":
+    c1 = flux_qubit()
+    c1.show()
+
+    c2 = flux_qubit_asymmetric()
+    c2.show()

--- a/gdsfactory/components/quantum/resonator.py
+++ b/gdsfactory/components/quantum/resonator.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.typings import LayerSpec
+
+
+@gf.cell_with_module_name
+def resonator_cpw(
+    length: float = 1000.0,
+    width: float = 10.0,
+    gap: float = 6.0,
+    meander_pitch: float = 50.0,
+    meander_width: float = 200.0,
+    coupling_gap: float = 5.0,
+    coupling_length: float = 100.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_gap: LayerSpec = (2, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a coplanar waveguide (CPW) resonator.
+
+    A CPW resonator consists of a meandered coplanar waveguide with coupling gaps
+    for capacitive coupling to feedlines or qubits.
+
+    Args:
+        length: Total length of the resonator in μm.
+        width: Width of the center conductor in μm.
+        gap: Gap width on each side of the center conductor in μm.
+        meander_pitch: Pitch between meander segments in μm.
+        meander_width: Width of each meander section in μm.
+        coupling_gap: Gap for capacitive coupling in μm.
+        coupling_length: Length of the coupling region in μm.
+        layer_metal: Layer for the metal conductor.
+        layer_gap: Layer for the gaps (ground plane).
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the CPW resonator geometry.
+    """
+    c = Component()
+
+    # Calculate number of meander sections needed
+    num_meanders = int(length / meander_width) if meander_width > 0 else 1
+    actual_length = num_meanders * meander_width
+
+    # Create meander path
+    path_points = []
+    x, y = 0, 0
+
+    for i in range(num_meanders):
+        if i == 0:
+            # First segment
+            path_points.extend([(x, y), (x + meander_width, y)])
+            x += meander_width
+        else:
+            # Alternate up and down
+            if i % 2 == 1:
+                y += meander_pitch
+                path_points.extend([(x, y), (x - meander_width, y)])
+                x -= meander_width
+            else:
+                y += meander_pitch
+                path_points.extend([(x, y), (x + meander_width, y)])
+                x += meander_width
+
+    # Create the CPW path
+    path = gf.Path(path_points)
+
+    # Create cross section for CPW
+    cpw_xs = gf.cross_section.strip(width=width, layer=layer_metal)
+
+    # Create the resonator structure
+    resonator_path = gf.path.extrude(path, cpw_xs)
+    resonator_ref = c.add_ref(resonator_path)
+
+    # Create ground plane with gaps
+    total_width = meander_width + 2 * meander_pitch
+    total_height = (num_meanders - 1) * meander_pitch + width + 2 * gap
+
+    # Ground plane
+    ground_plane = gf.components.rectangle(
+        size=(total_width + 2 * gap, total_height + 2 * gap),
+        layer=layer_metal,
+    )
+    ground_ref = c.add_ref(ground_plane)
+    ground_ref.move((-gap, -gap))
+
+    # Create gaps by boolean subtraction
+    gap_width = width + 2 * gap
+
+    # Create gap path along the resonator
+    gap_path = gf.Path(path_points)
+    gap_xs = gf.cross_section.strip(width=gap_width, layer=layer_gap)
+    gap_structure = gf.path.extrude(gap_path, gap_xs)
+
+    # Subtract gaps from ground plane
+    cpw_structure = gf.boolean(
+        ground_ref,
+        gap_structure,
+        operation="not",
+        layer=layer_metal,
+    )
+
+    # Add coupling regions
+    # Input coupling
+    coupling_in = gf.components.rectangle(
+        size=(coupling_length, coupling_gap),
+        layer=layer_gap,
+    )
+    coupling_in_ref = c.add_ref(coupling_in)
+    coupling_in_ref.move((-coupling_length / 2, -width / 2 - gap - coupling_gap / 2))
+
+    # Output coupling
+    coupling_out = gf.components.rectangle(
+        size=(coupling_length, coupling_gap),
+        layer=layer_gap,
+    )
+    coupling_out_ref = c.add_ref(coupling_out)
+    coupling_out_ref.move(
+        (x - coupling_length / 2, y + width / 2 + gap + coupling_gap / 2)
+    )
+
+    # Add ports for coupling
+    c.add_port(
+        name="input",
+        center=(0, -width / 2 - gap - coupling_gap),
+        width=coupling_length,
+        orientation=270,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="output",
+        center=(x, y + width / 2 + gap + coupling_gap),
+        width=coupling_length,
+        orientation=90,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["resonator_type"] = "cpw"
+    c.info["length"] = actual_length
+    c.info["width"] = width
+    c.info["gap"] = gap
+    c.info["frequency_estimate"] = (
+        3e8 / (2 * actual_length * 1e-6) / 1e9
+    )  # GHz, rough estimate
+
+    return c
+
+
+@gf.cell_with_module_name
+def resonator_lumped(
+    capacitor_fingers: int = 4,
+    capacitor_finger_length: float = 20.0,
+    capacitor_finger_gap: float = 2.0,
+    capacitor_thickness: float = 5.0,
+    inductor_width: float = 2.0,
+    inductor_turns: int = 3,
+    inductor_radius: float = 20.0,
+    coupling_gap: float = 5.0,
+    layer_metal: LayerSpec = (1, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a lumped element resonator with interdigital capacitor and spiral inductor.
+
+    A lumped resonator consists of a capacitive element (interdigital capacitor)
+    and an inductive element (spiral inductor) forming an LC circuit.
+
+    Args:
+        capacitor_fingers: Number of fingers in the interdigital capacitor.
+        capacitor_finger_length: Length of each capacitor finger in μm.
+        capacitor_finger_gap: Gap between capacitor fingers in μm.
+        capacitor_thickness: Thickness of capacitor fingers in μm.
+        inductor_width: Width of the inductor wire in μm.
+        inductor_turns: Number of turns in the spiral inductor.
+        inductor_radius: Radius of the spiral inductor in μm.
+        coupling_gap: Gap for capacitive coupling in μm.
+        layer_metal: Layer for the metal structures.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the lumped resonator geometry.
+    """
+    c = Component()
+
+    # Create interdigital capacitor
+    capacitor = gf.components.interdigital_capacitor(
+        fingers=capacitor_fingers,
+        finger_length=capacitor_finger_length,
+        finger_gap=capacitor_finger_gap,
+        thickness=capacitor_thickness,
+        layer=layer_metal,
+    )
+    cap_ref = c.add_ref(capacitor)
+
+    # Create spiral inductor
+    inductor = gf.components.spiral(
+        n_loops=inductor_turns,
+        width=inductor_width,
+        layer=layer_metal,
+    )
+    ind_ref = c.add_ref(inductor)
+
+    # Position inductor next to capacitor
+    cap_width = 2 * capacitor_thickness + capacitor_finger_length + capacitor_finger_gap
+    ind_ref.move((cap_width + 20.0, 0))
+
+    # Connect capacitor and inductor
+    connection = gf.components.rectangle(
+        size=(20.0, inductor_width),
+        layer=layer_metal,
+    )
+    conn_ref = c.add_ref(connection)
+    conn_ref.move((cap_width, -inductor_width / 2))
+
+    # Connect to inductor input
+    connection2 = gf.components.rectangle(
+        size=(inductor_width, 20.0),
+        layer=layer_metal,
+    )
+    conn2_ref = c.add_ref(connection2)
+    conn2_ref.move((cap_width + 20.0 - inductor_width / 2, -20.0))
+
+    # Add coupling elements for input/output
+    coupling_cap_in = gf.components.rectangle(
+        size=(capacitor_thickness, coupling_gap),
+        layer=layer_metal,
+    )
+    coupling_in_ref = c.add_ref(coupling_cap_in)
+    coupling_in_ref.move(
+        (
+            -coupling_gap - capacitor_thickness,
+            capacitor_fingers * capacitor_thickness / 2,
+        )
+    )
+
+    coupling_cap_out = gf.components.rectangle(
+        size=(capacitor_thickness, coupling_gap),
+        layer=layer_metal,
+    )
+    coupling_out_ref = c.add_ref(coupling_cap_out)
+    coupling_out_ref.move(
+        (cap_width + coupling_gap, capacitor_fingers * capacitor_thickness / 2)
+    )
+
+    # Add ports
+    c.add_port(
+        name="input",
+        center=(
+            -coupling_gap - capacitor_thickness / 2,
+            capacitor_fingers * capacitor_thickness / 2,
+        ),
+        width=coupling_gap,
+        orientation=180,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="output",
+        center=(
+            cap_width + coupling_gap + capacitor_thickness / 2,
+            capacitor_fingers * capacitor_thickness / 2,
+        ),
+        width=coupling_gap,
+        orientation=0,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["resonator_type"] = "lumped"
+    c.info["capacitor_fingers"] = capacitor_fingers
+    c.info["inductor_turns"] = inductor_turns
+    c.info["inductor_radius"] = inductor_radius
+
+    return c
+
+
+@gf.cell_with_module_name
+def resonator_quarter_wave(
+    length: float = 2500.0,
+    width: float = 10.0,
+    gap: float = 6.0,
+    short_stub_length: float = 50.0,
+    coupling_gap: float = 5.0,
+    coupling_length: float = 100.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_gap: LayerSpec = (2, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a quarter-wave coplanar waveguide resonator.
+
+    A quarter-wave resonator is shorted at one end and has maximum electric field
+    at the open end, making it suitable for capacitive coupling.
+
+    Args:
+        length: Length of the quarter-wave resonator in μm.
+        width: Width of the center conductor in μm.
+        gap: Gap width on each side of the center conductor in μm.
+        short_stub_length: Length of the shorting stub in μm.
+        coupling_gap: Gap for capacitive coupling in μm.
+        coupling_length: Length of the coupling region in μm.
+        layer_metal: Layer for the metal conductor.
+        layer_gap: Layer for the gaps.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the quarter-wave resonator geometry.
+    """
+    c = Component()
+
+    # Create main resonator line
+    main_line = gf.components.rectangle(
+        size=(length, width),
+        layer=layer_metal,
+    )
+    main_ref = c.add_ref(main_line)
+
+    # Create shorting stub at one end
+    short_stub = gf.components.rectangle(
+        size=(short_stub_length, width + 2 * gap),
+        layer=layer_metal,
+    )
+    short_ref = c.add_ref(short_stub)
+    short_ref.move((length, -gap))
+
+    # Create ground planes
+    ground_top = gf.components.rectangle(
+        size=(length + short_stub_length + 2 * gap, gap),
+        layer=layer_metal,
+    )
+    ground_top_ref = c.add_ref(ground_top)
+    ground_top_ref.move((-gap, width))
+
+    ground_bottom = gf.components.rectangle(
+        size=(length + short_stub_length + 2 * gap, gap),
+        layer=layer_metal,
+    )
+    ground_bottom_ref = c.add_ref(ground_bottom)
+    ground_bottom_ref.move((-gap, -gap))
+
+    # Create coupling region at open end
+    coupling_region = gf.components.rectangle(
+        size=(coupling_length, coupling_gap),
+        layer=layer_gap,
+    )
+    coupling_ref = c.add_ref(coupling_region)
+    coupling_ref.move((-coupling_length, width / 2 - coupling_gap / 2))
+
+    # Add port for coupling
+    c.add_port(
+        name="coupling",
+        center=(-coupling_length / 2, width / 2),
+        width=coupling_gap,
+        orientation=180,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["resonator_type"] = "quarter_wave"
+    c.info["length"] = length
+    c.info["width"] = width
+    c.info["gap"] = gap
+    c.info["frequency_estimate"] = (
+        3e8 / (4 * length * 1e-6) / 1e9
+    )  # GHz, rough estimate
+
+    return c
+
+
+if __name__ == "__main__":
+    c1 = resonator_cpw()
+    c1.show()
+
+    c2 = resonator_lumped()
+    c2.show()
+
+    c3 = resonator_quarter_wave()
+    c3.show()

--- a/gdsfactory/components/quantum/transmon.py
+++ b/gdsfactory/components/quantum/transmon.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.typings import LayerSpec
+
+
+@gf.cell_with_module_name
+def transmon(
+    pad_width: float = 200.0,
+    pad_height: float = 100.0,
+    pad_gap: float = 6.0,
+    junction_width: float = 0.15,
+    junction_height: float = 0.3,
+    island_width: float = 10.0,
+    island_height: float = 4.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_junction: LayerSpec = (2, 0),
+    layer_island: LayerSpec = (1, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a transmon qubit with Josephson junction.
+
+    A transmon qubit consists of two capacitor pads connected by a Josephson junction.
+    The junction creates an anharmonic oscillator that can be used as a qubit.
+
+    Args:
+        pad_width: Width of each capacitor pad in μm.
+        pad_height: Height of each capacitor pad in μm.
+        pad_gap: Gap between the two pads in μm.
+        junction_width: Width of the Josephson junction in μm.
+        junction_height: Height of the Josephson junction in μm.
+        island_width: Width of the central island in μm.
+        island_height: Height of the central island in μm.
+        layer_metal: Layer for the metal pads.
+        layer_junction: Layer for the Josephson junction.
+        layer_island: Layer for the central island.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the transmon geometry.
+    """
+    c = Component()
+
+    # Create left capacitor pad
+    left_pad = gf.components.rectangle(
+        size=(pad_width, pad_height),
+        layer=layer_metal,
+        port_type=port_type,
+    )
+    left_pad_ref = c.add_ref(left_pad)
+    left_pad_ref.move((-pad_width - pad_gap / 2, -pad_height / 2))
+
+    # Create right capacitor pad
+    right_pad = gf.components.rectangle(
+        size=(pad_width, pad_height),
+        layer=layer_metal,
+        port_type=port_type,
+    )
+    right_pad_ref = c.add_ref(right_pad)
+    right_pad_ref.move((pad_gap / 2, -pad_height / 2))
+
+    # Create central island
+    island = gf.components.rectangle(
+        size=(island_width, island_height),
+        layer=layer_island,
+    )
+    island_ref = c.add_ref(island)
+    island_ref.move((-island_width / 2, -island_height / 2))
+
+    # Create Josephson junction
+    junction = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    junction_ref = c.add_ref(junction)
+    junction_ref.move((-junction_width / 2, -junction_height / 2))
+
+    # Add connection lines from pads to island
+    left_connection = gf.components.rectangle(
+        size=(pad_gap / 2 - island_width / 2, junction_height / 2),
+        layer=layer_metal,
+    )
+    left_conn_ref = c.add_ref(left_connection)
+    left_conn_ref.move((-pad_gap / 2, -junction_height / 4))
+
+    right_connection = gf.components.rectangle(
+        size=(pad_gap / 2 - island_width / 2, junction_height / 2),
+        layer=layer_metal,
+    )
+    right_conn_ref = c.add_ref(right_connection)
+    right_conn_ref.move((island_width / 2, -junction_height / 4))
+
+    # Add ports for connections
+    c.add_port(
+        name="left_pad",
+        center=(-pad_width - pad_gap / 2, 0),
+        width=pad_height,
+        orientation=180,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="right_pad",
+        center=(pad_width + pad_gap / 2, 0),
+        width=pad_height,
+        orientation=0,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["qubit_type"] = "transmon"
+    c.info["pad_width"] = pad_width
+    c.info["pad_height"] = pad_height
+    c.info["pad_gap"] = pad_gap
+    c.info["junction_area"] = junction_width * junction_height
+
+    return c
+
+
+@gf.cell_with_module_name
+def transmon_circular(
+    pad_radius: float = 100.0,
+    pad_gap: float = 6.0,
+    junction_width: float = 0.15,
+    junction_height: float = 0.3,
+    island_radius: float = 5.0,
+    layer_metal: LayerSpec = (1, 0),
+    layer_junction: LayerSpec = (2, 0),
+    layer_island: LayerSpec = (1, 0),
+    port_type: str = "electrical",
+) -> Component:
+    """Creates a circular transmon qubit with Josephson junction.
+
+    A circular variant of the transmon qubit with circular capacitor pads.
+
+    Args:
+        pad_radius: Radius of each circular capacitor pad in μm.
+        pad_gap: Gap between the two pads in μm.
+        junction_width: Width of the Josephson junction in μm.
+        junction_height: Height of the Josephson junction in μm.
+        island_radius: Radius of the central circular island in μm.
+        layer_metal: Layer for the metal pads.
+        layer_junction: Layer for the Josephson junction.
+        layer_island: Layer for the central island.
+        port_type: Type of port to add to the component.
+
+    Returns:
+        Component: A gdsfactory component with the circular transmon geometry.
+    """
+    c = Component()
+
+    # Create left circular pad
+    left_pad = gf.components.circle(
+        radius=pad_radius,
+        layer=layer_metal,
+    )
+    left_pad_ref = c.add_ref(left_pad)
+    left_pad_ref.move((-pad_radius - pad_gap / 2, 0))
+
+    # Create right circular pad
+    right_pad = gf.components.circle(
+        radius=pad_radius,
+        layer=layer_metal,
+    )
+    right_pad_ref = c.add_ref(right_pad)
+    right_pad_ref.move((pad_radius + pad_gap / 2, 0))
+
+    # Create central circular island
+    island = gf.components.circle(
+        radius=island_radius,
+        layer=layer_island,
+    )
+    island_ref = c.add_ref(island)
+
+    # Create Josephson junction
+    junction = gf.components.rectangle(
+        size=(junction_width, junction_height),
+        layer=layer_junction,
+    )
+    junction_ref = c.add_ref(junction)
+    junction_ref.move((-junction_width / 2, -junction_height / 2))
+
+    # Add connection lines from pads to island
+    left_connection = gf.components.rectangle(
+        size=(pad_gap / 2 - island_radius, junction_height / 2),
+        layer=layer_metal,
+    )
+    left_conn_ref = c.add_ref(left_connection)
+    left_conn_ref.move((-pad_gap / 2, -junction_height / 4))
+
+    right_connection = gf.components.rectangle(
+        size=(pad_gap / 2 - island_radius, junction_height / 2),
+        layer=layer_metal,
+    )
+    right_conn_ref = c.add_ref(right_connection)
+    right_conn_ref.move((island_radius, -junction_height / 4))
+
+    # Add ports for connections
+    c.add_port(
+        name="left_pad",
+        center=(-2 * pad_radius - pad_gap / 2, 0),
+        width=2 * pad_radius,
+        orientation=180,
+        layer=layer_metal,
+    )
+
+    c.add_port(
+        name="right_pad",
+        center=(2 * pad_radius + pad_gap / 2, 0),
+        width=2 * pad_radius,
+        orientation=0,
+        layer=layer_metal,
+    )
+
+    # Add metadata
+    c.info["qubit_type"] = "transmon_circular"
+    c.info["pad_radius"] = pad_radius
+    c.info["pad_gap"] = pad_gap
+    c.info["junction_area"] = junction_width * junction_height
+
+    return c
+
+
+if __name__ == "__main__":
+    c1 = transmon()
+    c1.show()
+
+    c2 = transmon_circular()
+    c2.show()


### PR DESCRIPTION
Needs some fixes

@Jelly298

## Summary by Sourcery

Add a new quantum component submodule to gdsfactory, providing a suite of superconducting resonators, couplers, and qubit layouts.

New Features:
- Introduce CPW, lumped, and quarter-wave resonators under components.quantum.resonator
- Add capacitive, interdigital, and tunable couplers in components.quantum.coupler_capacitive/interdigital/tunable
- Implement flux qubit and asymmetric flux qubit layouts in components.quantum.flux_qubit
- Provide transmon and circular transmon qubit designs in components.quantum.transmon