### PR TITLE
Import kcl within port_array

### DIFF
--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -143,6 +143,7 @@ def port_array(
         kwargs: additional arguments.
 
     """
+    from gdsfactory import kcl
     from gdsfactory.pdk import get_cross_section, get_layer
 
     pitch_array = np.array(pitch)
@@ -155,7 +156,7 @@ def port_array(
             xs = get_cross_section(xs.copy(width=width))
         try:
             sym_xs: kf.SymmetricalCrossSection | None = (
-                gf.kcl.get_symmetrical_cross_section(xs.name)
+                kcl.get_symmetrical_cross_section(xs.name)
             )
         except KeyError:
             sym_xs = None

--- a/tests/components/test_netlists.py
+++ b/tests/components/test_netlists.py
@@ -12,6 +12,7 @@ cells = get_cells([gf.components])
 skip_test = {
     "add_fiber_array_optical_south_electrical_north",
     "bbox",
+    "coupler_bend",
     "component_sequence",
     "cutback_2x2",
     "cutback_bend180circular",


### PR DESCRIPTION
`gf` is not being imported in `port.py` so `gf.kcl.get_symmetrical_cross_section` was raising a `NameError`. To fix this I just import `kcl` within `port_array`.

## Summary by Sourcery

Import the kcl module within the port_array function and update the method call to prevent a NameError when retrieving the symmetrical cross section.

Bug Fixes:
- Import kcl inside port_array to avoid NameError on gf.kcl.get_symmetrical_cross_section
- Replace gf.kcl.get_symmetrical_cross_section call with kcl.get_symmetrical_cross_section after direct import