### PR TITLE
Meander resistance: Fix name collision

### DIFF
--- a/gdsfactory/components/pcms/resistance_meander.py
+++ b/gdsfactory/components/pcms/resistance_meander.py
@@ -9,6 +9,7 @@ from gdsfactory.typings import LayerSpec, Size
 
 @gf.cell_with_module_name
 def resistance_meander(
+	name = "net",
     pad_size: Size = (50.0, 50.0),
     num_squares: int = 1000,
     width: float = 1.0,
@@ -66,7 +67,7 @@ def resistance_meander(
     col.move((length_row - width, -width))
 
     # Creating entire straight net
-    N = Component(name="net")
+    N = Component(name=name)
     n = 1
     for i in range(num_rows):
         d = N.add_ref(T) if i != num_rows - 1 else N.add_ref(Row)

--- a/gdsfactory/components/pcms/resistance_meander.py
+++ b/gdsfactory/components/pcms/resistance_meander.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec, Size
 
 @gf.cell_with_module_name
 def resistance_meander(
-	name = "net",
+    name: str = "net",
     pad_size: Size = (50.0, 50.0),
     num_squares: int = 1000,
     width: float = 1.0,


### PR DESCRIPTION
Allow for a custome name to be set when creating a meander resistor

## Summary by Sourcery

New Features:
- Allow specifying a custom name for the net component in resistance_meander to avoid name collisions