### PR TITLE
enabling extruding with a cross section and a width

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -902,6 +902,7 @@ def extrude(
     """
     from gdsfactory.pdk import get_cross_section, get_layer
 
+    x = None
     if cross_section is None and layer is None:
         raise ValueError("CrossSection or layer needed")
 
@@ -910,7 +911,10 @@ def extrude(
 
     if layer is not None and width is None:
         raise ValueError("Need to define layer width")
-    elif width:
+    elif width and cross_section:
+        x = get_cross_section(cross_section, width=width)
+
+    elif width and layer:
         assert layer is not None
         s = Section(
             width=width,
@@ -925,7 +929,8 @@ def extrude(
 
     assert cross_section is not None
 
-    x = get_cross_section(cross_section)
+    if x is None:
+        x = get_cross_section(cross_section)
 
     layer = layer or x.layer
     layer = get_layer(layer)

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -169,5 +169,10 @@ def test_extrude_cross_section_list_of_sections() -> None:
     assert c
 
 
+def test_extrude_cross_section_width() -> None:
+    c = gf.path.extrude(gf.path.straight(length=10), cross_section="strip", width=2.4)
+    assert c.ports["o1"].width == 2.4
+
+
 if __name__ == "__main__":
     test_transition_cross_section_different_layers()


### PR DESCRIPTION
This PR allows the case of `gf.extrude` where both a cross section and width are passed, so long as the cross section is either a string or function.

Fixes #4012

## Summary by Sourcery

Enable the case where gf.extrude is called with both a cross_section and width by adjusting the extrude function logic and adding a corresponding test

New Features:
- Allow extrude to accept both a cross_section and width simultaneously when cross_section is a string or function

Enhancements:
- Refactor extrude logic to handle the cross_section and width combination and properly initialize the cross_section object

Tests:
- Add test to verify extrude works with cross_section and width inputs