### PR TITLE
propagating route_width to auto_taper in route_bundle

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -256,8 +256,8 @@ def route_bundle(
         for port in ports2_:
             bbox2 += port.dcplx_trans.disp.to_p()
 
-        ports1_ = add_auto_tapers(component, ports1_, cross_section)
-        ports2_ = add_auto_tapers(component, ports2_, cross_section)
+        ports1_ = add_auto_tapers(component, ports1_, cross_section=xs)
+        ports2_ = add_auto_tapers(component, ports2_, cross_section=xs)
 
         for port in ports1_:
             bbox1 += port.dcplx_trans.disp.to_p()


### PR DESCRIPTION
previously the `route_width` parameter of `route_bundle` was not being propagated in any way to the auto tapering functionality. this PR fixes that

## Summary by Sourcery

Bug Fixes:
- Ensure the route_width parameter is forwarded to add_auto_tapers by passing cross_section=xs for both port groups in route_bundle.