### PR TITLE
fix overloads

### DIFF
--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -24,6 +24,7 @@ def _bend_euler(
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
     all_angle: Literal[False] = False,
+    angular_step: float | None = None,
 ) -> Component: ...
 
 
@@ -39,6 +40,7 @@ def _bend_euler(
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
     all_angle: Literal[True] = True,
+    angular_step: float | None = None,
 ) -> ComponentAllAngle: ...
 
 


### PR DESCRIPTION
## Summary by Sourcery

Include the angular_step parameter in the overload signatures for bend_euler to match the implementation

Enhancements:
- Add optional angular_step parameter to the false-angle _bend_euler overload
- Add optional angular_step parameter to the all-angle _bend_euler overload