### PR TITLE
fix pad array size

### DIFF
--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -122,15 +122,19 @@ def pad_array(
 
     if layer and size:
         pad_component = gf.get_component(
-            pad, size=size, layer=layer, port_orientations=None, port_orientation=None
+            pad,
+            size=size,
+            layer=layer,
+            port_orientations=None,
+            port_orientation=port_orientation,
         )
     elif layer:
         pad_component = gf.get_component(
-            pad, layer=layer, port_orientations=None, port_orientation=None
+            pad, layer=layer, port_orientations=None, port_orientation=port_orientation
         )
     elif size:
         pad_component = gf.get_component(
-            pad, size=size, port_orientations=None, port_orientation=None
+            pad, size=size, port_orientations=None, port_orientation=port_orientation
         )
     else:
         pad_component = gf.get_component(pad)

--- a/test-data-regression/test_netlists_pad_array0_.yml
+++ b/test-data-regression/test_netlists_pad_array0_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_8da24944_0_0:
     array:
       column_pitch: 150
       columns: 1
@@ -17,7 +17,7 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
+      port_orientation: 0
       port_orientations: null
       port_type: pad
       size:
@@ -26,7 +26,7 @@ instances:
 name: pad_array_gdsfactorypco_70dcc787
 nets: []
 placements:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_8da24944_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_pad_array180_.yml
+++ b/test-data-regression/test_netlists_pad_array180_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_14496117_0_0:
     array:
       column_pitch: 150
       columns: 1
@@ -17,7 +17,7 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
+      port_orientation: 180
       port_orientations: null
       port_type: pad
       size:
@@ -26,7 +26,7 @@ instances:
 name: pad_array_gdsfactorypco_dc726c53
 nets: []
 placements:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_14496117_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_pad_array270_.yml
+++ b/test-data-regression/test_netlists_pad_array270_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_3a395e77_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -17,7 +17,7 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
+      port_orientation: 270
       port_orientations: null
       port_type: pad
       size:
@@ -26,7 +26,7 @@ instances:
 name: pad_array_gdsfactorypco_4ce3fbcf
 nets: []
 placements:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_3a395e77_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_pad_array90_.yml
+++ b/test-data-regression/test_netlists_pad_array90_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_553ba667_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -17,7 +17,7 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
+      port_orientation: 90
       port_orientations: null
       port_type: pad
       size:
@@ -26,7 +26,7 @@ instances:
 name: pad_array_gdsfactorypco_c1dae302
 nets: []
 placements:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_553ba667_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_netlists_pad_array_.yml
+++ b/test-data-regression/test_netlists_pad_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_8da24944_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -17,7 +17,7 @@ instances:
       bbox_offsets: null
       layer: MTOP
       port_inclusion: 0
-      port_orientation: null
+      port_orientation: 0
       port_orientations: null
       port_type: pad
       size:
@@ -26,7 +26,7 @@ instances:
 name: pad_array_gdsfactorypco_7cada612
 nets: []
 placements:
-  pad_gdsfactorypcomponen_6a189aa4_0_0:
+  pad_gdsfactorypcomponen_8da24944_0_0:
     mirror: false
     rotation: 0
     x: 0

--- a/test-data-regression/test_settings_pad_array_layer_.yml
+++ b/test-data-regression/test_settings_pad_array_layer_.yml
@@ -1,0 +1,12 @@
+info: {}
+name: pad_array_gdsfactorypco_66bf5d0b
+settings:
+  auto_rename_ports: false
+  centered_ports: false
+  column_pitch: 150
+  columns: 6
+  layer: M1
+  pad: pad
+  port_orientation: 0
+  row_pitch: 150
+  rows: 1

--- a/test-data-regression/test_settings_pad_array_size_.yml
+++ b/test-data-regression/test_settings_pad_array_size_.yml
@@ -1,0 +1,15 @@
+info: {}
+name: pad_array_gdsfactorypco_e956078a
+settings:
+  auto_rename_ports: false
+  centered_ports: false
+  column_pitch: 150
+  columns: 6
+  layer: M1
+  pad: pad
+  port_orientation: 0
+  row_pitch: 150
+  rows: 1
+  size:
+  - 100
+  - 100

--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import Any
 
 import pytest
@@ -12,6 +13,18 @@ from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json
 
 cells = get_cells([gf.components])
+
+pad_array_layer = partial(gf.c.pad_array, layer="M1")
+pad_array_size = partial(gf.c.pad_array, layer="M1", size=(100, 100))
+
+
+cells.update(
+    {
+        "pad_array_layer": pad_array_layer,
+        "pad_array_size": pad_array_size,
+    }
+)
+
 
 skip_test = {
     "component_sequence",


### PR DESCRIPTION
## Summary by Sourcery

Fix pad_array size and port orientation propagation and update tests to cover layer and size configurations

Enhancements:
- Propagate the port_orientation argument to all pad_array component instantiations
- Enable explicit size parameter support in pad_array

Tests:
- Add pad_array_layer and pad_array_size variants to the component test suite
- Add new regression fixtures for pad_array size and layer settings
- Update existing regression netlists to include explicit port_orientation values and refreshed component IDs