### PR TITLE
replace `auto_taper_taper` with `layer_transitions` in `get_bundle`

### DIFF
--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -14,6 +14,7 @@ def add_auto_tapers(
     component: Component,
     ports: Ports,
     cross_section: CrossSectionSpec,
+    layer_transitions: LayerTransitions | None = None,
 ) -> list[Port]:
     """Adds tapers to the ports of a component (to be used for routing) and returns the new lists of ports.
 
@@ -21,6 +22,7 @@ def add_auto_tapers(
         component: the component to add tapers to
         ports: the list of ports
         cross_section: the cross section to route to
+        layer_transitions: the layer transitions dictionary to use (use the pdk default if None)
 
     Returns:
         The new list of ports, on the opposite end of the tapers
@@ -29,7 +31,6 @@ def add_auto_tapers(
     cs_layer = gf.get_layer(cross_section_obj.layer)
     cs_width = cross_section_obj.width
 
-    layer_transitions = None
     _pdk = None
 
     def get_layer_transitions() -> LayerTransitions:

--- a/tests/routing/test_routing_route_bundle_auto_taper.py
+++ b/tests/routing/test_routing_route_bundle_auto_taper.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from functools import partial
+
+import gdsfactory as gf
+from gdsfactory import Port
+from gdsfactory.components.tapers import taper
+from gdsfactory.difftest import difftest
+from gdsfactory.generic_tech import LAYER
+from gdsfactory.routing.route_bundle import route_bundle
+
+
+def test_route_bundle_auto_taper_layer_transitions() -> None:
+    """Tests route_bundle with auto_taper and layer transitions."""
+    layer = LAYER.WG
+    transition = partial(taper, length=13.5)
+    layer_transitions = {LAYER.WG: transition}
+    pitch = 127.0
+    xs_top = [0, 50, 100]
+    N = len(xs_top)
+    xs_bottom = [(i - N / 2) * pitch for i in range(N)]
+    layer = 1
+
+    top_ports = [
+        Port(
+            name=f"top_{i}",
+            center=(xs_top[i], 0),
+            width=2.7 - i * 0.2,
+            orientation=270,
+            layer=layer,
+        )
+        for i in range(N)
+    ]
+
+    bot_ports = [
+        Port(
+            name=f"bot_{i}",
+            center=(xs_bottom[i], -400),
+            width=2.1 - i * 0.1,
+            orientation=90,
+            layer=layer,
+        )
+        for i in range(N)
+    ]
+
+    c = gf.Component(name="test_route_bundle_auto_taper_layer_transitions")
+    route_bundle(
+        c,
+        top_ports,
+        bot_ports,
+        start_straight_length=5,
+        end_straight_length=10,
+        cross_section="strip",
+        auto_taper=True,
+        layer_transitions=layer_transitions,
+    )
+    # lengths = {i: route.length for i, route in enumerate(routes)}
+    difftest(c)


### PR DESCRIPTION
currently the `auto_taper_taper` argument of `get_bundle` only works in a very narrow set of circumstances. namely
- all the input **and** output ports must **all** be the same width
- the taper component must **exactly** have the correct input width (the port width) **and** output width (the cross section width)

there is also quite a bit of code duplication for this specific case.

i propose replacing with a `layer_transitions` argument, which will override the PDK's default `layer_transitions`, if provided. this solution is much more flexible in that
- tapers are parametric: supports varied input/output widths
- supports different taper components for different layers/layer-pairs

it also reduces code duplication and offers more consistent behavior

## Summary by Sourcery

Replace the deprecated auto_taper_taper parameter with a new layer_transitions argument in routing to support custom parametric tapers per layer, emit a deprecation warning for the old parameter, and add tests to validate the new behavior.

New Features:
- Add layer_transitions argument to route_bundle and add_auto_tapers for specifying custom tapers per layer
- Support parametric input/output widths and varied taper components through layer_transitions

Enhancements:
- Deprecate auto_taper_taper in route_bundle with a warning and remove its specific width constraints
- Refactor route_bundle to forward layer_transitions to add_auto_tapers, eliminating duplicate taper logic

Tests:
- Introduce test_route_bundle_auto_taper_layer_transitions to verify routing uses custom layer_transitions