### PR TITLE
udpdate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 <!-- towncrier release notes start -->
 
+- replace `auto_taper_taper` with `layer_transitions` in `get_bundle` [#4043](https://github.com/gdsfactory/gdsfactory/pull/4043)
+
 ## [9.11.2](https://github.com/gdsfactory/gdsfactory/releases/tag/v9.11.2) - 2025-07-20
 
 - Passing kwargs to connect from component_sequence [#4040](https://github.com/gdsfactory/gdsfactory/pull/4040)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add changelog entry for replacing `auto_taper_taper` with `layer_transitions` in `get_bundle`