### PR TITLE
less branches inside pad_array function

### DIFF
--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -120,24 +120,14 @@ def pad_array(
     """
     c = Component()
 
-    if layer and size:
-        pad_component = gf.get_component(
-            pad,
-            size=size,
-            layer=layer,
-            port_orientations=None,
-            port_orientation=port_orientation,
-        )
-    elif layer:
-        pad_component = gf.get_component(
-            pad, layer=layer, port_orientations=None, port_orientation=port_orientation
-        )
-    elif size:
-        pad_component = gf.get_component(
-            pad, size=size, port_orientations=None, port_orientation=port_orientation
-        )
-    else:
-        pad_component = gf.get_component(pad)
+    pad_kwargs = {}
+    if layer is not None:
+        pad_kwargs["layer"] = layer
+    if size is not None:
+        pad_kwargs["size"] = size
+    pad_component = gf.get_component(
+        pad, port_orientations=None, port_orientation=port_orientation, **pad_kwargs
+    )
 
     size = size or pad_component.info["size"]
     layer = layer or pad_component.ports[0].layer


### PR DESCRIPTION
the pad_array function is currently prone to be buggy with so many logical branches. this PR simplifies the function to have one consistent behavior

## Summary by Sourcery

Enhancements:
- Replace multiple if/elif branches in pad_array with a single component instantiation using a pad_kwargs dictionary to handle optional size and layer parameters