### PR TITLE
bump kfactory to 1.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.10,<1.11",
+  "kfactory[ipy]>=1.10.1,<1.11",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump kfactory[ipy] dependency from >=1.10,<1.11 to >=1.10.1,<1.11