### PR TITLE
fix autotaper in fiber array routing

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -111,7 +111,7 @@ def route_bundle(
     straight: ComponentSpec = "straight",
     auto_taper: bool = True,
     auto_taper_taper: ComponentSpec | None = None,
-    waypoints: Coordinates | None = None,
+    waypoints: Coordinates | Sequence[gf.kdb.DPoint] | None = None,
     steps: Sequence[Mapping[str, int | float]] | None = None,
     start_angles: float | list[float] | None = None,
     end_angles: float | list[float] | None = None,
@@ -297,13 +297,14 @@ def route_bundle(
                 )
             x = d.get("x", x) + d.get("dx", 0)
             y = d.get("y", y) + d.get("dy", 0)
-            waypoints += [(x, y)]
+            waypoints += [(x, y)]  # type: ignore[arg-type]
     if waypoints is not None and not isinstance(waypoints[0], kf.kdb.DPoint):
         waypoints_: list[kf.kdb.DPoint] | None = [
-            kf.kdb.DPoint(p[0], p[1]) for p in waypoints
+            kf.kdb.DPoint(p[0], p[1])  # type: ignore[index]
+            for p in waypoints
         ]
     else:
-        waypoints_ = waypoints
+        waypoints_ = waypoints  # type: ignore[assignment]
 
     router = router or "electrical" if port_type == "electrical" else "optical"
     if router == "electrical":

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -10,7 +10,6 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.port import select_ports_optical
 from gdsfactory.routing.route_bundle import get_min_spacing, route_bundle
-from gdsfactory.routing.route_single import route_single
 from gdsfactory.routing.utils import direction_ports_from_list_ports
 from gdsfactory.typings import (
     BoundingBoxes,
@@ -388,10 +387,20 @@ def route_fiber_array(
             bend, cross_section=cross_section, radius=radius_loopback
         )
 
-        route_single(
+        sign = 1 if with_loopback_inside else -1
+        wp_start = waypoints_loopback_[0]
+        wp_end = waypoints_loopback_[-1]
+        waypoints_loopback_[0:3] = [
+            gf.kdb.DPoint(wp_start.x - sign * radius * 2, wp_start.y)
+        ]
+        waypoints_loopback_[-3:] = [
+            gf.kdb.DPoint(wp_end.x + sign * radius * 2, wp_end.y)
+        ]
+
+        route_bundle(
             component,
-            port1=port0,
-            port2=port1,
+            [port0],
+            [port1],
             waypoints=waypoints_loopback_,
             straight=straight,
             bend=bend90,

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -391,10 +391,10 @@ def route_fiber_array(
         wp_start = waypoints_loopback_[0]
         wp_end = waypoints_loopback_[-1]
         waypoints_loopback_[:3] = [
-            gf.kdb.DPoint(wp_start.x - sign * radius * 2, wp_start.y)
+            gf.kdb.DPoint(wp_start.x + sign * radius * 2, wp_start.y)
         ]
         waypoints_loopback_[-3:] = [
-            gf.kdb.DPoint(wp_end.x + sign * radius * 2, wp_end.y)
+            gf.kdb.DPoint(wp_end.x - sign * radius * 2, wp_end.y)
         ]
 
         route_bundle(

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -390,7 +390,7 @@ def route_fiber_array(
         sign = 1 if with_loopback_inside else -1
         wp_start = waypoints_loopback_[0]
         wp_end = waypoints_loopback_[-1]
-        waypoints_loopback_[0:3] = [
+        waypoints_loopback_[:3] = [
             gf.kdb.DPoint(wp_start.x - sign * radius * 2, wp_start.y)
         ]
         waypoints_loopback_[-3:] = [


### PR DESCRIPTION
## Summary by Sourcery

Fix loopback autotaper in fiber array routing by adjusting waypoints and switching to route_bundle

Enhancements:
- Offset the first and last waypoints by twice the bend radius based on loopback orientation to correct tapering
- Replace the call to route_single with route_bundle and pass ports as lists for proper fiber bundle routing