### PR TITLE
bend_circular_all_angle fails with angle small and negative

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1454,8 +1454,8 @@ def arc(
     if not radius:
         raise ValueError("arc() requires a radius argument")
 
-    npoints = npoints or abs(int(angle / 360 * radius / PDK.bend_points_distance / 2))
-    npoints = max(int(npoints), int(360 / angle) + 1)
+    npoints = npoints or int(abs(angle) / 360 * radius / PDK.bend_points_distance / 2)
+    npoints = max(int(npoints), int(360 / abs(angle)) + 1)
 
     t = np.linspace(
         start_angle * np.pi / 180, (angle + start_angle) * np.pi / 180, npoints


### PR DESCRIPTION
`bend_circular_all_angle` was failing when the angle was small and negative:
```python
gf.c.bend_circular_all_angle(angle=-1.0)
```

I updated `path.arc` to use the absolute value of the angle when determining the number of points in the path.

## Summary by Sourcery

Bug Fixes:
- Use absolute value of angle when calculating the number of points in path.arc to support small negative angles