### PR TITLE
Fixed [Bug] wrong port in `gdsfactory.components.filters.terminator_s…

### DIFF
--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -49,11 +49,13 @@ def terminator_spiral(
     spiral = extrude_transition(path, transition=xs)
     c = gf.Component()
     ref = c << spiral
-    c.add_port("o1", port=ref["o1"])
+    c.add_port("o1", port=ref["o2"])
+    c.add_port("o2", port=ref["o1"])
     c.flatten()
     return c
 
 
 if __name__ == "__main__":
     c = terminator_spiral(number_of_loops=3)
+    c.draw_ports()
     c.show()


### PR DESCRIPTION
Fixed #3956 - name the optical ports at both the input and termination correctly

## Summary by Sourcery

Fix port naming in terminator_spiral component and update example to visualize ports

Bug Fixes:
- Correct input and termination port assignments by swapping o1 and o2 in terminator_spiral

Enhancements:
- Add draw_ports() call in the terminator_spiral example for port visualization