### PR TITLE
Skip diffing on same file instead of crashing

### DIFF
--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -231,8 +231,12 @@ def diff(
         show: shows diff in klayout.
         stagger: if True, staggers the old/new/xor views. If False, all three are overlaid.
     """
-    old = read_top_cell(pathlib.Path(ref_file))
-    new = read_top_cell(pathlib.Path(run_file))
+    ref_file, run_file = pathlib.Path(ref_file), pathlib.Path(run_file)
+    if ref_file == run_file:
+        return False
+
+    old = read_top_cell(ref_file)
+    new = read_top_cell(run_file)
 
     if ignore_sliver_differences is None:
         ignore_sliver_differences = CONF.difftest_ignore_sliver_differences
@@ -245,7 +249,7 @@ def diff(
 
     if old.kcl.dbu != new.kcl.dbu:
         raise ValueError(
-            f"dbu is different in old {old.kcl.dbu} {ref_file!r} and new {new.kcl.dbu} {run_file!r} files"
+            f"dbu is different in old {old.kcl.dbu} {ref_file} and new {new.kcl.dbu} {run_file} files"
         )
 
     equivalent = True


### PR DESCRIPTION
Closes https://github.com/gdsfactory/gdsfactory/issues/3988

## Summary by Sourcery

Prevent crashes by skipping diff operation when the reference and run files are identical and improve path handling and error messaging.

Bug Fixes:
- Skip diffing when the reference and run file paths are the same to avoid crashing.

Enhancements:
- Convert input file arguments to pathlib.Path upfront for consistency.
- Refine database unit mismatch error message to use clean formatting without repr artifacts.