### PR TITLE
Better message errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,4 @@ Join our growing community:
 - [GitHub Discussions](https://github.com/gdsfactory/gdsfactory/discussions)
 - [Google Group](https://groups.google.com/g/gdsfactory)
 - [LinkedIn](https://www.linkedin.com/company/gdsfactory)
-- [Element Chat](https://gitter.im/gdsfactory-dev/community)
+- [Slack community channel](https://join.slack.com/t/gdsfactory-community/shared_invite/zt-3aoygv7cg-r5BH6yvL4YlHfY8~UXp0Wg)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -7,38 +7,9 @@ However we recommend python 3.11 or 3.12 as some extensions may not work on 3.13
 
 ## Installation for users in a new environment
 
-We recommend `uv` for installing GDSFactory:
-
 ```bash
-# On macOS and Linux.
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-```bash
-# On Windows open a PowerShell terminal and run:
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-Then you can install gdsfactory with:
-
-```bash
-uv venv --python 3.12
-uv pip install gdsfactory
-```
-
-
-## Installation for users in an existing environment
-
-You can install the latest released gdsfactory using the following command:
-
-```
-pip install gdsfactory --upgrade
-```
-
-If you want to install the latest pre-released version you can run:
-
-```
-pip install git+https://github.com/gdsfactory/gdsfactory --force-reinstall
+pip install gdsfactory_install
+gfi install
 ```
 
 ## Installation for contributors
@@ -148,6 +119,7 @@ Make sure you pin the version of gdsfactory that you are using in your `pyprojec
 
 You can take a look at the tests of other open source PDKs.
 
+- [Cornerstone PDK](https://github.com/gdsfactory/cspdk)
 - [SiEPIC Ebeam UBC PDK](https://gdsfactory.github.io/ubc) (open source)
 - [VTT photonics PDK](https://gdsfactory.github.io/vtt) (open source)
 - [GlobalFoundries 180nm MCU CMOS PDK](https://gdsfactory.github.io/gf180/) (open source)
@@ -190,8 +162,6 @@ def test_settings(component_name: str, data_regression: DataRegressionFixture) -
     data_regression.check(component.to_dict())
 
 ```
-
-For questions join the [![Join the chat at https://gitter.im/gdsfactory-dev/community](https://badges.gitter.im/gdsfactory-dev/community.svg)](https://gitter.im/gdsfactory-dev/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) with [element.io](https://element.io/download) or use GitHub issues or discussions.
 
 
 ## Docker container

--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -12,6 +12,7 @@ def coupler_symmetric(
     dy: Delta = 4.0,
     dx: Delta = 10.0,
     cross_section: CrossSectionSpec = "strip",
+    allow_min_radius_violation: bool = False,
 ) -> Component:
     r"""Two coupled straights with bends.
 
@@ -21,6 +22,7 @@ def coupler_symmetric(
         dy: port to port vertical spacing.
         dx: bend length in x direction.
         cross_section: section.
+        allow_min_radius_violation: if True does not check for min bend radius.
 
     .. code::
 
@@ -45,6 +47,7 @@ def coupler_symmetric(
         bend,
         size=(dx, dy),
         cross_section=cross_section,
+        allow_min_radius_violation=allow_min_radius_violation,
     )
     top_bend = c << bend_component
     bot_bend = c << bend_component
@@ -147,7 +150,12 @@ def coupler(
     """
     c = Component()
     sbend = coupler_symmetric(
-        gap=gap, dy=dy, dx=dx, cross_section=cross_section, bend=bend
+        gap=gap,
+        dy=dy,
+        dx=dx,
+        cross_section=cross_section,
+        bend=bend,
+        allow_min_radius_violation=allow_min_radius_violation,
     )
 
     sr = c << sbend

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -44,10 +44,12 @@ def coupler_ring(
                  o1──────▼─────────◄──────────────► o4
                                     length_extension
     """
-    radius = radius or gf.get_cross_section(cross_section).radius
+    if radius is None:
+        radius = gf.get_cross_section(cross_section).radius
+        assert radius is not None, "cross_section must have a radius"
 
     if length_extension is None:
-        length_extension = 3 + radius
+        length_extension = 3.0 + radius
 
     c = Component()
     gap = gf.snap.snap_to_grid(gap, grid_factor=2)

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -10,19 +10,19 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 @gf.cell_with_module_name
 def coupler_ring(
     gap: float = 0.2,
-    radius: float = 5.0,
+    radius: float | None = None,
     length_x: float = 4.0,
     bend: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
     cross_section: CrossSectionSpec = "strip",
     cross_section_bend: CrossSectionSpec | None = None,
-    length_extension: float = 3.0,
+    length_extension: float | None = None,
 ) -> Component:
     r"""Coupler for ring.
 
     Args:
         gap: spacing between parallel coupled straight waveguides.
-        radius: of the bends.
+        radius: of the bends. Default is None, which uses the default radius of the cross_section.
         length_x: length of the parallel coupled straight waveguides.
         bend: 90 degrees bend spec.
         straight: straight spec.
@@ -31,13 +31,6 @@ def coupler_ring(
         length_extension: straight length extension at the end of the coupler bottom ports.
 
     .. code::
-
-          o2            o3
-           |             |
-            \           /
-             \         /
-           ---=========---
-        o1    length_x   o4
 
           o2                              o3
           xx                              xx
@@ -51,6 +44,8 @@ def coupler_ring(
                  o1──────▼─────────◄──────────────► o4
                                     length_extension
     """
+    radius = radius or gf.get_cross_section(cross_section).radius
+
     if length_extension is None:
         length_extension = 3 + radius
 

--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -21,6 +21,7 @@ def grating_coupler_array(
     centered: bool = True,
     radius: float | None = None,
     bend: ComponentSpec = "bend_euler",
+    mirror_grating_coupler: bool = False,
 ) -> Component:
     """Array of grating couplers.
 
@@ -36,9 +37,12 @@ def grating_coupler_array(
         centered: if True, centers the array around the origin.
         radius: optional radius for routing the loopback.
         bend: ComponentSpec for the bend used in the loopback.
+        mirror_grating_coupler: if True, mirrors the grating coupler.
     """
     c = Component()
     grating_coupler = gf.get_component(grating_coupler)
+    if mirror_grating_coupler:
+        grating_coupler = gf.functions.mirror(grating_coupler)
     ports: dict[str, kf.DPort] = {}
 
     for i in range(n):

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -10,7 +10,7 @@ def ring_double(
     gap: float = 0.2,
     gap_top: float | None = None,
     gap_bot: float | None = None,
-    radius: float = 10.0,
+    radius: float | None = None,
     length_x: float = 0.01,
     length_y: float = 0.01,
     bend: ComponentSpec = "bend_euler",
@@ -18,7 +18,7 @@ def ring_double(
     coupler_ring: ComponentSpec = "coupler_ring",
     coupler_ring_top: ComponentSpec | None = None,
     cross_section: CrossSectionSpec = "strip",
-    length_extension: float = 3.0,
+    length_extension: float | None = None,
 ) -> Component:
     """Returns a double bus ring.
 
@@ -110,5 +110,5 @@ def ring_double(
 
 
 if __name__ == "__main__":
-    c = ring_double(length_y=2, bend="bend_circular", gap_top=0.4, length_extension=0)
+    c = ring_double(length_y=2, bend="bend_circular", gap_top=0.4)
     c.show()

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -12,7 +12,7 @@ def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,
     gap_bot: float | None = None,
-    radius: float = 10.0,
+    radius: float | None = None,
     length_x: float = 1.0,
     length_y: float = 0.01,
     coupler_ring: ComponentSpec = "coupler_ring",
@@ -27,7 +27,7 @@ def ring_double_heater(
     via_stack_offset: Float2 = (1, 0),
     via_stack_size: Float2 | None = None,
     with_drop: bool = True,
-    length_extension: float = 3.0,
+    length_extension: float | None = None,
 ) -> Component:
     """Returns a double bus ring with heater on top.
 
@@ -188,6 +188,8 @@ ring_single_heater = partial(ring_double_heater, with_drop=False)
 
 
 if __name__ == "__main__":
-    c = ring_double_heater(gap_top=0.4, length_y=2, length_extension=10)
+    c = ring_double_heater(
+        gap_top=0.4, length_y=2, length_extension=10, cross_section="strip"
+    )
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -7,14 +7,14 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 @gf.cell_with_module_name
 def ring_single(
     gap: float = 0.2,
-    radius: float = 10.0,
+    radius: float | None = None,
     length_x: float = 4.0,
     length_y: float = 0.6,
     bend: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
     coupler_ring: ComponentSpec = "coupler_ring",
     cross_section: CrossSectionSpec = "strip",
-    length_extension: float = 3.0,
+    length_extension: float | None = None,
 ) -> gf.Component:
     """Returns a single ring resonator with a directional coupler.
 
@@ -32,7 +32,7 @@ def ring_single(
 
     Args:
         gap: Gap between the ring and the straight waveguide in the coupler (μm).
-        radius: Radius of the ring bends (μm).
+        radius: Radius of the ring bends (μm). If None, it will use the radius from the cross section.
         length_x: Length of the horizontal straight section (μm).
         length_y: Length of the vertical straight sections (μm).
         bend: Component spec for the 90-degree bends. Default is "bend_euler".
@@ -126,14 +126,13 @@ if __name__ == "__main__":
     # c = ring_single(layer=(2, 0), cross_section_factory=gf.cross_section.pin, width=1)
     # c = ring_single(width=2, gap=1, layer=(2, 0), radius=7, length_y=1)
     c = ring_single(
-        radius=5,
         gap=0.111,
         bend="bend_circular",
         length_x=0,
         length_y=0,
-        length_extension=0,
+        # length_extension=0,
     )
-    n = c.get_netlist()
+    # n = c.get_netlist()
     # print(c.ports)
 
     # c = gf.routing.add_fiber_array(ring_single)

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import AnyComponentFactory, ComponentSpec, CrossSectionS
 
 @gf.cell_with_module_name
 def coupler_bend(
-    radius: float = 10.0,
+    radius: float | None = None,
     coupler_gap: float = 0.2,
     coupling_angle_coverage: float = 120.0,
     cross_section_inner: CrossSectionSpec = "strip",
@@ -52,6 +52,10 @@ def coupler_bend(
     width = xo.width / 2 + xi.width / 2
     spacing = gap + width
 
+    if radius is None:
+        radius = xi.radius or xo.radius
+        assert radius is not None, "cross_section must have a radius"
+
     bend90_inner_right = gf.get_component(
         bend,  # type: ignore[arg-type]
         radius=radius,
@@ -85,7 +89,7 @@ def coupler_bend(
 
 @gf.cell_with_module_name
 def coupler_ring_bend(
-    radius: float = 10.0,
+    radius: float | None = None,
     coupler_gap: float = 0.2,
     coupling_angle_coverage: float = 90.0,
     length_x: float = 0.0,
@@ -98,7 +102,7 @@ def coupler_ring_bend(
     r"""Two back-to-back coupler_bend.
 
     Args:
-        radius: um.
+        radius: um. Default is None, which uses the default radius of the cross_section.
         coupler_gap: um.
         angle_inner: of the inner bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
         angle_outer: of the outer bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
@@ -223,7 +227,7 @@ def ring_single_bend_coupler(
 if __name__ == "__main__":
     # c = coupler_bend()
     # n = c.get_netlist()
-    c = coupler_ring_bend()
+    c = coupler_ring_bend(cross_section_inner="rib", cross_section_outer="rib")
     # c = ring_single_bend_coupler()
     c.pprint_ports()
     c.show()

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -14,7 +14,7 @@ def ring_single_dut(
     gap: float = 0.2,
     length_x: float = 4,
     length_y: float = 0,
-    radius: float = 5.0,
+    radius: float | None = None,
     coupler: ComponentSpec = "coupler_ring",
     bend: ComponentSpec = "bend_euler",
     with_component: bool = True,
@@ -32,7 +32,7 @@ def ring_single_dut(
         gap: in um.
         length_x: in um.
         length_y: in um.
-        radius: in um.
+        radius: in um. Default is None, which uses the default radius of the cross_section.
         coupler: coupler function.
         bend: bend function.
         with_component: True adds component. False adds waveguide.

--- a/gdsfactory/generic_tech/__init__.py
+++ b/gdsfactory/generic_tech/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import typing
 from functools import cache, partial
 
+import kfactory as kf
+
 from gdsfactory.config import PATH
 from gdsfactory.generic_tech.layer_map import LAYER
 from gdsfactory.generic_tech.layer_stack import LAYER_STACK
@@ -63,6 +65,10 @@ def get_generic_pdk() -> Pdk:
         (LAYER.WGN, LAYER.WG): "taper_nc_sc",
         LAYER.M3: "taper_electrical",
     }
+    gf.kcl.layers = LAYER
+    gf.kcl.infos = kf.LayerInfos(
+        **{v.name: kf.kdb.LayerInfo(v.layer, v.datatype) for v in LAYER},  # type: ignore[attr-defined]
+    )
 
     return Pdk(
         name="generic",

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -514,7 +514,9 @@ class Pdk(BaseModel):
             return layer.layer
         else:
             if not hasattr(self.layers, layer):
-                raise ValueError(f"{layer!r} not in {self.layers}")
+                raise ValueError(
+                    f"{layer!r} not in PDK {self.name!r} {self.layers.__members__}"
+                )
             return cast(LayerEnum, getattr(self.layers, layer))
 
     def get_layer_name(self, layer: LayerSpec) -> str:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -513,10 +513,9 @@ class Pdk(BaseModel):
         elif isinstance(layer, kf.kdb.LayerInfo):
             return layer.layer
         else:
-            if not hasattr(self.layers, layer):
-                raise ValueError(
-                    f"{layer!r} not in PDK {self.name!r} {self.layers.__members__}"
-                )
+            if self.layers is None or not hasattr(self.layers, layer):
+                layer_members = self.layers.__members__ if self.layers else {}
+                raise ValueError(f"{layer!r} not in PDK {self.name!r} {layer_members}")
             return cast(LayerEnum, getattr(self.layers, layer))
 
     def get_layer_name(self, layer: LayerSpec) -> str:

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -77,6 +77,8 @@ class PortOrientationError(ValueError):
 
 def get_port_definitions(ports: Ports) -> str:
     """Returns port definition string."""
+    import gdsfactory as gf
+
     return "\n".join(
         [
             f"c.add_port(name='{port.name}', center={port.center}, "

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -75,11 +75,22 @@ class PortOrientationError(ValueError):
     pass
 
 
+def get_port_definitions(ports: Ports) -> str:
+    """Returns port definition string."""
+    return "\n".join(
+        [
+            f"c.add_port(name='{port.name}', center={port.center}, "
+            f"width={port.width}, orientation={port.orientation}, "
+            f"layer={gf.get_layer_tuple(port.layer)}, port_type='{port.port_type}')"
+            for port in ports
+        ]
+    )
+
+
 def pprint_ports(ports: Ports) -> None:
     """Prints ports in a rich table."""
     console = Console()
     table = Table(show_header=True, header_style="bold")
-
     keys = ["name", "width", "orientation", "layer", "center", "port_type"]
 
     for key in keys:

--- a/gdsfactory/routing/add_fiber_array.py
+++ b/gdsfactory/routing/add_fiber_array.py
@@ -22,6 +22,7 @@ def add_fiber_array(
     cross_section: CrossSectionSpec = "strip",
     start_straight_length: float = 0,
     end_straight_length: float = 0,
+    mirror_grating_coupler: bool = False,
     **kwargs: Any,
 ) -> Component:
     """Returns component with south routes and grating_couplers.
@@ -34,6 +35,7 @@ def add_fiber_array(
         gc_port_name: grating coupler input port name.
         select_ports: function to select ports.
         cross_section: cross_section function.
+        mirror_grating_coupler: if True, mirrors the grating coupler.
         kwargs: additional arguments.
 
     Keyword Args:
@@ -80,6 +82,8 @@ def add_fiber_array(
     else:
         gc = grating_coupler
     gc = gf.get_component(gc)
+    if mirror_grating_coupler:
+        gc = gf.functions.mirror(gc)
 
     gc_port_names = [port.name for port in gc.ports]
     if gc_port_name not in gc_port_names:

--- a/gdsfactory/routing/add_fiber_single.py
+++ b/gdsfactory/routing/add_fiber_single.py
@@ -27,6 +27,7 @@ def add_fiber_single(
     with_loopback: bool = True,
     loopback_spacing: float = 100.0,
     straight: ComponentSpec = "straight",
+    mirror_grating_coupler: bool = False,
     **kwargs: Any,
 ) -> Component:
     """Returns component with south routes and grating_couplers.
@@ -45,6 +46,7 @@ def add_fiber_single(
         with_loopback: adds loopback structures.
         loopback_spacing: spacing between loopback and test structure.
         straight: straight spec.
+        mirror_grating_coupler: if True, mirrors the grating coupler.
         kwargs: additional arguments.
 
     Keyword Args:
@@ -89,6 +91,10 @@ def add_fiber_single(
     else:
         gc = grating_coupler
     gc = gf.get_component(gc)
+
+    if mirror_grating_coupler:
+        gc = gf.functions.mirror(gc)
+
     if gc_port_name not in gc.ports:
         raise ValueError(f"gc_port_name={gc_port_name!r} not in {list(gc.ports)}")
 

--- a/notebooks/04_components_geometry.ipynb
+++ b/notebooks/04_components_geometry.ipynb
@@ -129,13 +129,79 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "## Offset"
+    "## Fix min space violations\n",
+    "\n",
+    "You can use `fix_spacing` to fix min space violations."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.components.coupler_ring(cross_section='rib')\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = c.copy()\n",
+    "c.fix_spacing(layer=(3,0), min_space=1)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Fix min width violations\n",
+    "\n",
+    "Some PDKs have minimum width rules, where a geometry is too narrow and needs to be widened. GDSFactory provides a function to fix this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.c.taper(width1=10, width2=1, length=5)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.c.taper(width1=10, width2=1, length=5).copy()\n",
+    "c.fix_width(layer=(1, 0), min_width=1)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "## Offset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "19",
    "metadata": {},
    "source": [
     "To avoid acute angles you can run over / under (dilation+erosion)."
@@ -181,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "21",
    "metadata": {},
    "source": [
     "You can also apply it to a component directly."
@@ -205,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +301,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Outline\n",
@@ -246,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "26",
    "metadata": {},
    "source": [
     "## Round corners"
@@ -272,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +394,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "30",
    "metadata": {},
    "source": [
     "## Union"
@@ -337,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "33",
    "metadata": {},
    "source": [
     "## Smooth\n",
@@ -390,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "35",
    "metadata": {},
    "source": [
     "As well as easily do boolean operations with regions."
@@ -412,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -428,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Importing GDS files"
@@ -436,7 +502,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "38",
    "metadata": {},
    "source": [
     "`gf.import_gds()` allows you to easily import external GDSII files.  It imports a single cell from the external GDS file and converts it into a gdsfactory component."
@@ -445,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Copying and extracting geometry"
@@ -466,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Import Images into GDS\n",
@@ -516,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +599,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "47",
    "metadata": {},
    "source": [
     "## Dummy Fill / Tiling\n",
@@ -558,7 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/_0_python.ipynb
+++ b/notebooks/_0_python.ipynb
@@ -483,78 +483,6 @@
     "\n",
     "hi()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "36",
-   "metadata": {},
-   "source": [
-    "For more Ipython tricks you can find many resources available online\n",
-    "\n",
-    "## gdsfactory downloads\n",
-    "\n",
-    "You can also use python plot the downloads for gdsfactory over the last year."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import datetime\n",
-    "\n",
-    "import plotly.graph_objects as go\n",
-    "import requests\n",
-    "\n",
-    "downloads0 = 0\n",
-    "\n",
-    "\n",
-    "def get_total_downloads(package_name):\n",
-    "    statistics = []\n",
-    "    end_date = datetime.date.today()\n",
-    "\n",
-    "    while True:\n",
-    "        url = f\"https://pypistats.org/api/packages/{package_name}/overall\"\n",
-    "        response = requests.get(url, params={\"last_day\": end_date})\n",
-    "        data = response.json()\n",
-    "\n",
-    "        if response.status_code != 200:\n",
-    "            return None\n",
-    "\n",
-    "        statistics.extend(\n",
-    "            [(entry[\"date\"], entry[\"downloads\"]) for entry in data[\"data\"]]\n",
-    "        )\n",
-    "        if \"next_day\" in data:\n",
-    "            end_date = data[\"next_day\"]\n",
-    "        else:\n",
-    "            break\n",
-    "    statistics.sort(key=lambda x: x[0])  # Sort by date\n",
-    "    dates, downloads = zip(*statistics)\n",
-    "    cumulative_downloads = [\n",
-    "        sum(downloads[: i + 1]) + downloads0 for i in range(len(downloads))\n",
-    "    ]\n",
-    "\n",
-    "    return dates, cumulative_downloads\n",
-    "\n",
-    "\n",
-    "# Replace 'gdsfactory' with the package you want to check\n",
-    "package_name = \"gdsfactory\"\n",
-    "dates, cumulative_downloads = get_total_downloads(package_name)\n",
-    "\n",
-    "if dates and cumulative_downloads:\n",
-    "    fig = go.Figure(data=go.Scatter(x=dates, y=cumulative_downloads))\n",
-    "    fig.update_layout(\n",
-    "        xaxis=dict(title=\"Date\", tickformat=\"%Y-%m-%d\", tickangle=45, showgrid=True),\n",
-    "        yaxis=dict(title=\"Total Downloads\", showgrid=True),\n",
-    "        title=f\"Total Downloads - {package_name}\",\n",
-    "    )\n",
-    "    fig.update_layout(autosize=False, width=800, height=600)\n",
-    "    fig.show()\n",
-    "else:\n",
-    "    print(f\"Failed to retrieve download statistics for package '{package_name}'.\")"
-   ]
   }
  ],
  "metadata": {
@@ -564,7 +492,7 @@
    "main_language": "python"
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/test-data-regression/test_netlists_coupler_ring_.yml
+++ b/test-data-regression/test_netlists_coupler_ring_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: coupler_ring_gdsfactory_8af83332
+name: coupler_ring_gdsfactory_9cdfdde6
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_coupler_symmetric_.yml
+++ b/test-data-regression/test_netlists_coupler_symmetric_.yml
@@ -41,7 +41,7 @@ instances:
       - 10
       - 1.633
       width: null
-name: coupler_symmetric_gdsfa_c947830c
+name: coupler_symmetric_gdsfa_7357aaee
 nets: []
 placements:
   bend_s_gdsfactorypcompo_77ca5fd8_0_367:

--- a/test-data-regression/test_netlists_die_with_pads_.yml
+++ b/test-data-regression/test_netlists_die_with_pads_.yml
@@ -1,5 +1,5 @@
 instances:
-  grating_coupler_array_g_caa057e5_5524199_0_A90:
+  grating_coupler_array_g_cdc53b92_5524199_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
@@ -7,6 +7,7 @@ instances:
       centered: true
       cross_section: strip
       grating_coupler: grating_coupler_te
+      mirror_grating_coupler: false
       n: 14
       pitch: 250
       port_name: o1
@@ -14,7 +15,7 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_caa057e5_m5524199_0_A270:
+  grating_coupler_array_g_cdc53b92_m5524199_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
@@ -22,6 +23,7 @@ instances:
       centered: true
       cross_section: strip
       grating_coupler: grating_coupler_te
+      mirror_grating_coupler: false
       n: 14
       pitch: 250
       port_name: o1
@@ -1473,12 +1475,12 @@ instances:
 name: die_with_pads_gdsfactor_9da714b1
 nets: []
 placements:
-  grating_coupler_array_g_caa057e5_5524199_0_A90:
+  grating_coupler_array_g_cdc53b92_5524199_0_A90:
     mirror: false
     rotation: 90
     x: 5524.199
     y: 0
-  grating_coupler_array_g_caa057e5_m5524199_0_A270:
+  grating_coupler_array_g_cdc53b92_m5524199_0_A270:
     mirror: false
     rotation: 270
     x: -5524.199
@@ -1861,30 +1863,30 @@ ports:
   e7: pad_gdsfactorypcomponen_457de54c_m2650000_m2250000,e2
   e8: pad_gdsfactorypcomponen_457de54c_m2350000_m2250000,e2
   e9: pad_gdsfactorypcomponen_457de54c_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_caa057e5_5524199_0_A90,o1
-  o10: grating_coupler_array_g_caa057e5_5524199_0_A90,o10
-  o11: grating_coupler_array_g_caa057e5_5524199_0_A90,o11
-  o12: grating_coupler_array_g_caa057e5_5524199_0_A90,o12
-  o13: grating_coupler_array_g_caa057e5_m5524199_0_A270,o1
-  o14: grating_coupler_array_g_caa057e5_m5524199_0_A270,o2
-  o15: grating_coupler_array_g_caa057e5_m5524199_0_A270,o3
-  o16: grating_coupler_array_g_caa057e5_m5524199_0_A270,o4
-  o17: grating_coupler_array_g_caa057e5_m5524199_0_A270,o5
-  o18: grating_coupler_array_g_caa057e5_m5524199_0_A270,o6
-  o19: grating_coupler_array_g_caa057e5_m5524199_0_A270,o7
-  o2: grating_coupler_array_g_caa057e5_5524199_0_A90,o2
-  o20: grating_coupler_array_g_caa057e5_m5524199_0_A270,o8
-  o21: grating_coupler_array_g_caa057e5_m5524199_0_A270,o9
-  o22: grating_coupler_array_g_caa057e5_m5524199_0_A270,o10
-  o23: grating_coupler_array_g_caa057e5_m5524199_0_A270,o11
-  o24: grating_coupler_array_g_caa057e5_m5524199_0_A270,o12
-  o3: grating_coupler_array_g_caa057e5_5524199_0_A90,o3
-  o4: grating_coupler_array_g_caa057e5_5524199_0_A90,o4
-  o5: grating_coupler_array_g_caa057e5_5524199_0_A90,o5
-  o6: grating_coupler_array_g_caa057e5_5524199_0_A90,o6
-  o7: grating_coupler_array_g_caa057e5_5524199_0_A90,o7
-  o8: grating_coupler_array_g_caa057e5_5524199_0_A90,o8
-  o9: grating_coupler_array_g_caa057e5_5524199_0_A90,o9
+  o1: grating_coupler_array_g_cdc53b92_5524199_0_A90,o1
+  o10: grating_coupler_array_g_cdc53b92_5524199_0_A90,o10
+  o11: grating_coupler_array_g_cdc53b92_5524199_0_A90,o11
+  o12: grating_coupler_array_g_cdc53b92_5524199_0_A90,o12
+  o13: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o1
+  o14: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o2
+  o15: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o3
+  o16: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o4
+  o17: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o5
+  o18: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o6
+  o19: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o7
+  o2: grating_coupler_array_g_cdc53b92_5524199_0_A90,o2
+  o20: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o8
+  o21: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o9
+  o22: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o10
+  o23: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o11
+  o24: grating_coupler_array_g_cdc53b92_m5524199_0_A270,o12
+  o3: grating_coupler_array_g_cdc53b92_5524199_0_A90,o3
+  o4: grating_coupler_array_g_cdc53b92_5524199_0_A90,o4
+  o5: grating_coupler_array_g_cdc53b92_5524199_0_A90,o5
+  o6: grating_coupler_array_g_cdc53b92_5524199_0_A90,o6
+  o7: grating_coupler_array_g_cdc53b92_5524199_0_A90,o7
+  o8: grating_coupler_array_g_cdc53b92_5524199_0_A90,o8
+  o9: grating_coupler_array_g_cdc53b92_5524199_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/test-data-regression/test_netlists_ring_double_.yml
+++ b/test-data-regression/test_netlists_ring_double_.yml
@@ -1,5 +1,5 @@
 instances:
-  coupler_ring_gdsfactory_0dce5cf1_0_0:
+  coupler_ring_gdsfactory_dd30faef_0_0:
     component: coupler_ring
     info: {}
     settings:
@@ -7,11 +7,11 @@ instances:
       cross_section: strip
       cross_section_bend: null
       gap: 0.2
-      length_extension: 3
+      length_extension: null
       length_x: 0.01
-      radius: 10
+      radius: null
       straight: straight
-  coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180:
+  coupler_ring_gdsfactory_dd30faef_m10_21410_A180:
     component: coupler_ring
     info: {}
     settings:
@@ -19,9 +19,9 @@ instances:
       cross_section: strip
       cross_section_bend: null
       gap: 0.2
-      length_extension: 3
+      length_extension: null
       length_x: 0.01
-      radius: 10
+      radius: null
       straight: straight
   straight_gdsfactorypcom_05377f40_10000_10710_A270:
     component: straight
@@ -51,23 +51,23 @@ instances:
       length: 0.01
       npoints: 2
       width: null
-name: ring_double_gdsfactoryp_0922feda
+name: ring_double_gdsfactoryp_fee0c62d
 nets:
-- p1: coupler_ring_gdsfactory_0dce5cf1_0_0,o2
+- p1: coupler_ring_gdsfactory_dd30faef_0_0,o2
   p2: straight_gdsfactorypcom_05377f40_m10010_10700_A90,o1
-- p1: coupler_ring_gdsfactory_0dce5cf1_0_0,o3
+- p1: coupler_ring_gdsfactory_dd30faef_0_0,o3
   p2: straight_gdsfactorypcom_05377f40_10000_10710_A270,o2
-- p1: coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180,o2
+- p1: coupler_ring_gdsfactory_dd30faef_m10_21410_A180,o2
   p2: straight_gdsfactorypcom_05377f40_10000_10710_A270,o1
-- p1: coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180,o3
+- p1: coupler_ring_gdsfactory_dd30faef_m10_21410_A180,o3
   p2: straight_gdsfactorypcom_05377f40_m10010_10700_A90,o2
 placements:
-  coupler_ring_gdsfactory_0dce5cf1_0_0:
+  coupler_ring_gdsfactory_dd30faef_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180:
+  coupler_ring_gdsfactory_dd30faef_m10_21410_A180:
     mirror: false
     rotation: 180
     x: -0.01
@@ -83,7 +83,7 @@ placements:
     x: -10.01
     y: 10.7
 ports:
-  o1: coupler_ring_gdsfactory_0dce5cf1_0_0,o1
-  o2: coupler_ring_gdsfactory_0dce5cf1_0_0,o4
-  o3: coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180,o4
-  o4: coupler_ring_gdsfactory_0dce5cf1_m10_21410_A180,o1
+  o1: coupler_ring_gdsfactory_dd30faef_0_0,o1
+  o2: coupler_ring_gdsfactory_dd30faef_0_0,o4
+  o3: coupler_ring_gdsfactory_dd30faef_m10_21410_A180,o4
+  o4: coupler_ring_gdsfactory_dd30faef_m10_21410_A180,o1

--- a/test-data-regression/test_netlists_ring_double_heater_.yml
+++ b/test-data-regression/test_netlists_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_gdsf_949b15cd
+name: ring_double_heater_gdsf_0378c340
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_netlists_ring_single_.yml
+++ b/test-data-regression/test_netlists_ring_single_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_gdsfactorypc_a86bc407_10000_11300_A90:
+  bend_euler_gdsfactorypc_387600b2_10000_11300_A90:
     component: bend_euler
     info:
       dy: 10
@@ -21,10 +21,10 @@ instances:
       layer: null
       npoints: null
       p: 0.5
-      radius: 10
+      radius: null
       width: null
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_m4000_21300_A180:
+  bend_euler_gdsfactorypc_387600b2_m4000_21300_A180:
     component: bend_euler
     info:
       dy: 10
@@ -46,10 +46,10 @@ instances:
       layer: null
       npoints: null
       p: 0.5
-      radius: 10
+      radius: null
       width: null
       with_arc_floorplan: true
-  coupler_ring_gdsfactory_7a1e2f00_0_0:
+  coupler_ring_gdsfactory_9cdfdde6_0_0:
     component: coupler_ring
     info: {}
     settings:
@@ -57,9 +57,9 @@ instances:
       cross_section: strip
       cross_section_bend: null
       gap: 0.2
-      length_extension: 3
+      length_extension: null
       length_x: 4
-      radius: 10
+      radius: null
       straight: straight
   straight_gdsfactorypcom_058e2168_10000_11300_A270:
     component: straight
@@ -103,32 +103,32 @@ instances:
       length: 4
       npoints: 2
       width: null
-name: ring_single_gdsfactoryp_d74ed1d8
+name: ring_single_gdsfactoryp_87a10a39
 nets:
-- p1: bend_euler_gdsfactorypc_a86bc407_10000_11300_A90,o1
+- p1: bend_euler_gdsfactorypc_387600b2_10000_11300_A90,o1
   p2: straight_gdsfactorypcom_058e2168_10000_11300_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_10000_11300_A90,o2
+- p1: bend_euler_gdsfactorypc_387600b2_10000_11300_A90,o2
   p2: straight_gdsfactorypcom_a6eac62c_0_21300_A180,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_m4000_21300_A180,o1
+- p1: bend_euler_gdsfactorypc_387600b2_m4000_21300_A180,o1
   p2: straight_gdsfactorypcom_a6eac62c_0_21300_A180,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_m4000_21300_A180,o2
+- p1: bend_euler_gdsfactorypc_387600b2_m4000_21300_A180,o2
   p2: straight_gdsfactorypcom_058e2168_m14000_10700_A90,o2
-- p1: coupler_ring_gdsfactory_7a1e2f00_0_0,o2
+- p1: coupler_ring_gdsfactory_9cdfdde6_0_0,o2
   p2: straight_gdsfactorypcom_058e2168_m14000_10700_A90,o1
-- p1: coupler_ring_gdsfactory_7a1e2f00_0_0,o3
+- p1: coupler_ring_gdsfactory_9cdfdde6_0_0,o3
   p2: straight_gdsfactorypcom_058e2168_10000_11300_A270,o2
 placements:
-  bend_euler_gdsfactorypc_a86bc407_10000_11300_A90:
+  bend_euler_gdsfactorypc_387600b2_10000_11300_A90:
     mirror: false
     rotation: 90
     x: 10
     y: 11.3
-  bend_euler_gdsfactorypc_a86bc407_m4000_21300_A180:
+  bend_euler_gdsfactorypc_387600b2_m4000_21300_A180:
     mirror: false
     rotation: 180
     x: -4
     y: 21.3
-  coupler_ring_gdsfactory_7a1e2f00_0_0:
+  coupler_ring_gdsfactory_9cdfdde6_0_0:
     mirror: false
     rotation: 0
     x: 0
@@ -149,5 +149,5 @@ placements:
     x: 0
     y: 21.3
 ports:
-  o1: coupler_ring_gdsfactory_7a1e2f00_0_0,o1
-  o2: coupler_ring_gdsfactory_7a1e2f00_0_0,o4
+  o1: coupler_ring_gdsfactory_9cdfdde6_0_0,o1
+  o2: coupler_ring_gdsfactory_9cdfdde6_0_0,o4

--- a/test-data-regression/test_netlists_ring_single_array_.yml
+++ b/test-data-regression/test_netlists_ring_single_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  ring_single_gdsfactoryp_36f99320_41000_0:
+  ring_single_gdsfactoryp_914c3c45_0_0:
     component: ring_single
     info: {}
     settings:
@@ -7,25 +7,25 @@ instances:
       coupler_ring: coupler_ring
       cross_section: strip
       gap: 0.2
-      length_extension: 3
-      length_x: 20
-      length_y: 0.6
-      radius: 10
-      straight: straight
-  ring_single_gdsfactoryp_7576c664_0_0:
-    component: ring_single
-    info: {}
-    settings:
-      bend: bend_euler
-      coupler_ring: coupler_ring
-      cross_section: strip
-      gap: 0.2
-      length_extension: 3
+      length_extension: null
       length_x: 10
       length_y: 0.6
       radius: 5
       straight: straight
-  straight_gdsfactorypcom_aa481ca5_3000_0:
+  ring_single_gdsfactoryp_c8ab51a3_56000_0:
+    component: ring_single
+    info: {}
+    settings:
+      bend: bend_euler
+      coupler_ring: coupler_ring
+      cross_section: strip
+      gap: 0.2
+      length_extension: null
+      length_x: 20
+      length_y: 0.6
+      radius: 10
+      straight: straight
+  straight_gdsfactorypcom_aa481ca5_8000_0:
     component: straight
     info:
       length: 15
@@ -41,26 +41,26 @@ instances:
       width: null
 name: ring_single_array_gdsfa_54fe30c4
 nets:
-- p1: ring_single_gdsfactoryp_36f99320_41000_0,o1
-  p2: straight_gdsfactorypcom_aa481ca5_3000_0,o2
-- p1: ring_single_gdsfactoryp_7576c664_0_0,o2
-  p2: straight_gdsfactorypcom_aa481ca5_3000_0,o1
+- p1: ring_single_gdsfactoryp_914c3c45_0_0,o2
+  p2: straight_gdsfactorypcom_aa481ca5_8000_0,o1
+- p1: ring_single_gdsfactoryp_c8ab51a3_56000_0,o1
+  p2: straight_gdsfactorypcom_aa481ca5_8000_0,o2
 placements:
-  ring_single_gdsfactoryp_36f99320_41000_0:
-    mirror: false
-    rotation: 0
-    x: 41
-    y: 0
-  ring_single_gdsfactoryp_7576c664_0_0:
+  ring_single_gdsfactoryp_914c3c45_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcom_aa481ca5_3000_0:
+  ring_single_gdsfactoryp_c8ab51a3_56000_0:
     mirror: false
     rotation: 0
-    x: 3
+    x: 56
+    y: 0
+  straight_gdsfactorypcom_aa481ca5_8000_0:
+    mirror: false
+    rotation: 0
+    x: 8
     y: 0
 ports:
-  o1: ring_single_gdsfactoryp_7576c664_0_0,o1
-  o2: ring_single_gdsfactoryp_36f99320_41000_0,o2
+  o1: ring_single_gdsfactoryp_914c3c45_0_0,o1
+  o2: ring_single_gdsfactoryp_c8ab51a3_56000_0,o2

--- a/test-data-regression/test_netlists_ring_single_dut_.yml
+++ b/test-data-regression/test_netlists_ring_single_dut_.yml
@@ -1,17 +1,17 @@
 instances:
-  bend_euler_gdsfactorypc_90a35c7e_5000_15700_A90:
+  bend_euler_gdsfactorypc_387600b2_10000_20700_A90:
     component: bend_euler
     info:
-      dy: 5
-      length: 8.318
-      min_bend_radius: 3.53
-      radius: 5
-      route_info_length: 8.318
-      route_info_min_bend_radius: 3.53
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 8.318
+      route_info_strip_length: 16.637
       route_info_type: strip
-      route_info_weight: 8.318
+      route_info_weight: 16.637
       width: 0.5
     settings:
       allow_min_radius_violation: false
@@ -21,22 +21,22 @@ instances:
       layer: null
       npoints: null
       p: 0.5
-      radius: 5
+      radius: null
       width: null
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_90a35c7e_m4000_20700_A180:
+  bend_euler_gdsfactorypc_387600b2_m4000_30700_A180:
     component: bend_euler
     info:
-      dy: 5
-      length: 8.318
-      min_bend_radius: 3.53
-      radius: 5
-      route_info_length: 8.318
-      route_info_min_bend_radius: 3.53
+      dy: 10
+      length: 16.637
+      min_bend_radius: 7.061
+      radius: 10
+      route_info_length: 16.637
+      route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_strip_length: 8.318
+      route_info_strip_length: 16.637
       route_info_type: strip
-      route_info_weight: 8.318
+      route_info_weight: 16.637
       width: 0.5
     settings:
       allow_min_radius_violation: false
@@ -46,10 +46,10 @@ instances:
       layer: null
       npoints: null
       p: 0.5
-      radius: 5
+      radius: null
       width: null
       with_arc_floorplan: true
-  coupler_ring_gdsfactory_e57d2f45_0_0:
+  coupler_ring_gdsfactory_9cdfdde6_0_0:
     component: coupler_ring
     info: {}
     settings:
@@ -59,9 +59,9 @@ instances:
       gap: 0.2
       length_extension: null
       length_x: 4
-      radius: 5
+      radius: null
       straight: straight
-  straight_gdsfactorypcom_a6eac62c_m4000_20700:
+  straight_gdsfactorypcom_a6eac62c_m4000_30700:
     component: straight
     info:
       length: 4
@@ -75,7 +75,7 @@ instances:
       length: 4
       npoints: 2
       width: null
-  straight_gdsfactorypcom_f2286423_5000_15700_A270:
+  straight_gdsfactorypcom_f2286423_10000_20700_A270:
     component: straight
     info:
       length: 10
@@ -89,7 +89,7 @@ instances:
       length: 10
       npoints: 2
       width: null
-  straight_gdsfactorypcom_f2286423_m9000_15700_A270:
+  straight_gdsfactorypcom_f2286423_m14000_20700_A270:
     component: straight
     info:
       length: 10
@@ -103,51 +103,51 @@ instances:
       length: 10
       npoints: 2
       width: null
-name: ring_single_dut_gdsfact_9fdbcb54
+name: ring_single_dut_gdsfact_3cf05ffd
 nets:
-- p1: bend_euler_gdsfactorypc_90a35c7e_5000_15700_A90,o1
-  p2: straight_gdsfactorypcom_f2286423_5000_15700_A270,o1
-- p1: bend_euler_gdsfactorypc_90a35c7e_5000_15700_A90,o2
-  p2: straight_gdsfactorypcom_a6eac62c_m4000_20700,o2
-- p1: bend_euler_gdsfactorypc_90a35c7e_m4000_20700_A180,o1
-  p2: straight_gdsfactorypcom_a6eac62c_m4000_20700,o1
-- p1: bend_euler_gdsfactorypc_90a35c7e_m4000_20700_A180,o2
-  p2: straight_gdsfactorypcom_f2286423_m9000_15700_A270,o1
-- p1: coupler_ring_gdsfactory_e57d2f45_0_0,o2
-  p2: straight_gdsfactorypcom_f2286423_m9000_15700_A270,o2
-- p1: coupler_ring_gdsfactory_e57d2f45_0_0,o3
-  p2: straight_gdsfactorypcom_f2286423_5000_15700_A270,o2
+- p1: bend_euler_gdsfactorypc_387600b2_10000_20700_A90,o1
+  p2: straight_gdsfactorypcom_f2286423_10000_20700_A270,o1
+- p1: bend_euler_gdsfactorypc_387600b2_10000_20700_A90,o2
+  p2: straight_gdsfactorypcom_a6eac62c_m4000_30700,o2
+- p1: bend_euler_gdsfactorypc_387600b2_m4000_30700_A180,o1
+  p2: straight_gdsfactorypcom_a6eac62c_m4000_30700,o1
+- p1: bend_euler_gdsfactorypc_387600b2_m4000_30700_A180,o2
+  p2: straight_gdsfactorypcom_f2286423_m14000_20700_A270,o1
+- p1: coupler_ring_gdsfactory_9cdfdde6_0_0,o2
+  p2: straight_gdsfactorypcom_f2286423_m14000_20700_A270,o2
+- p1: coupler_ring_gdsfactory_9cdfdde6_0_0,o3
+  p2: straight_gdsfactorypcom_f2286423_10000_20700_A270,o2
 placements:
-  bend_euler_gdsfactorypc_90a35c7e_5000_15700_A90:
+  bend_euler_gdsfactorypc_387600b2_10000_20700_A90:
     mirror: false
     rotation: 90
-    x: 5
-    y: 15.7
-  bend_euler_gdsfactorypc_90a35c7e_m4000_20700_A180:
+    x: 10
+    y: 20.7
+  bend_euler_gdsfactorypc_387600b2_m4000_30700_A180:
     mirror: false
     rotation: 180
     x: -4
-    y: 20.7
-  coupler_ring_gdsfactory_e57d2f45_0_0:
+    y: 30.7
+  coupler_ring_gdsfactory_9cdfdde6_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcom_a6eac62c_m4000_20700:
+  straight_gdsfactorypcom_a6eac62c_m4000_30700:
     mirror: false
     rotation: 0
     x: -4
+    y: 30.7
+  straight_gdsfactorypcom_f2286423_10000_20700_A270:
+    mirror: false
+    rotation: 270
+    x: 10
     y: 20.7
-  straight_gdsfactorypcom_f2286423_5000_15700_A270:
+  straight_gdsfactorypcom_f2286423_m14000_20700_A270:
     mirror: false
     rotation: 270
-    x: 5
-    y: 15.7
-  straight_gdsfactorypcom_f2286423_m9000_15700_A270:
-    mirror: false
-    rotation: 270
-    x: -9
-    y: 15.7
+    x: -14
+    y: 20.7
 ports:
-  o1: coupler_ring_gdsfactory_e57d2f45_0_0,o1
-  o2: coupler_ring_gdsfactory_e57d2f45_0_0,o4
+  o1: coupler_ring_gdsfactory_9cdfdde6_0_0,o1
+  o2: coupler_ring_gdsfactory_9cdfdde6_0_0,o4

--- a/test-data-regression/test_netlists_ring_single_heater_.yml
+++ b/test-data-regression/test_netlists_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: ring_double_heater_gdsf_de903155
+name: ring_double_heater_gdsf_55201c97
 nets: []
 placements: {}
 ports: {}

--- a/test-data-regression/test_settings_coupler_bend_.yml
+++ b/test-data-regression/test_settings_coupler_bend_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: coupler_bend_gdsfactory_147f47be
+name: coupler_bend_gdsfactory_33d3cd75
 settings:
   bend: bend_circular_all_angle
   bend_output: bend_euler
@@ -7,4 +7,3 @@ settings:
   coupling_angle_coverage: 120
   cross_section_inner: strip
   cross_section_outer: strip
-  radius: 10

--- a/test-data-regression/test_settings_coupler_ring_.yml
+++ b/test-data-regression/test_settings_coupler_ring_.yml
@@ -1,10 +1,8 @@
 info: {}
-name: coupler_ring_gdsfactory_8af83332
+name: coupler_ring_gdsfactory_9cdfdde6
 settings:
   bend: bend_euler
   cross_section: strip
   gap: 0.2
-  length_extension: 3
   length_x: 4
-  radius: 5
   straight: straight

--- a/test-data-regression/test_settings_coupler_ring_bend_.yml
+++ b/test-data-regression/test_settings_coupler_ring_bend_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: coupler_ring_bend_gdsfa_7e4f244b
+name: coupler_ring_bend_gdsfa_08bf6cd7
 settings:
   bend: bend_circular_all_angle
   bend_output: bend_euler
@@ -8,5 +8,4 @@ settings:
   cross_section_inner: strip
   cross_section_outer: strip
   length_x: 0
-  radius: 10
   straight: straight

--- a/test-data-regression/test_settings_coupler_symmetric_.yml
+++ b/test-data-regression/test_settings_coupler_symmetric_.yml
@@ -1,8 +1,9 @@
 info:
   length: 10.187
   min_bend_radius: 11.851
-name: coupler_symmetric_gdsfa_c947830c
+name: coupler_symmetric_gdsfa_7357aaee
 settings:
+  allow_min_radius_violation: false
   bend: bend_s
   cross_section: strip
   dx: 10

--- a/test-data-regression/test_settings_grating_coupler_array_.yml
+++ b/test-data-regression/test_settings_grating_coupler_array_.yml
@@ -1,10 +1,11 @@
 info: {}
-name: grating_coupler_array_g_ea39b0e7
+name: grating_coupler_array_g_1c646557
 settings:
   bend: bend_euler
   centered: true
   cross_section: strip
   grating_coupler: grating_coupler_elliptical
+  mirror_grating_coupler: false
   n: 6
   pitch: 127
   port_name: o1

--- a/test-data-regression/test_settings_ring_double_.yml
+++ b/test-data-regression/test_settings_ring_double_.yml
@@ -1,12 +1,10 @@
 info: {}
-name: ring_double_gdsfactoryp_0922feda
+name: ring_double_gdsfactoryp_fee0c62d
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
   cross_section: strip
   gap: 0.2
-  length_extension: 3
   length_x: 0.01
   length_y: 0.01
-  radius: 10
   straight: straight

--- a/test-data-regression/test_settings_ring_double_heater_.yml
+++ b/test-data-regression/test_settings_ring_double_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_gdsf_949b15cd
+name: ring_double_heater_gdsf_0378c340
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
@@ -7,10 +7,8 @@ settings:
   cross_section_heater: heater_metal
   cross_section_waveguide_heater: strip_heater_metal
   gap: 0.2
-  length_extension: 3
   length_x: 1
   length_y: 0.01
-  radius: 10
   straight: straight
   via_stack: via_stack_heater_mtop_mini
   via_stack_offset:

--- a/test-data-regression/test_settings_ring_single_.yml
+++ b/test-data-regression/test_settings_ring_single_.yml
@@ -1,12 +1,10 @@
 info: {}
-name: ring_single_gdsfactoryp_d74ed1d8
+name: ring_single_gdsfactoryp_87a10a39
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
   cross_section: strip
   gap: 0.2
-  length_extension: 3
   length_x: 4
   length_y: 0.6
-  radius: 10
   straight: straight

--- a/test-data-regression/test_settings_ring_single_dut_.yml
+++ b/test-data-regression/test_settings_ring_single_dut_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_single_dut_gdsfact_9fdbcb54
+name: ring_single_dut_gdsfact_3cf05ffd
 settings:
   bend: bend_euler
   component: straight
@@ -8,5 +8,4 @@ settings:
   length_x: 4
   length_y: 0
   port_name: o1
-  radius: 5
   with_component: true

--- a/test-data-regression/test_settings_ring_single_heater_.yml
+++ b/test-data-regression/test_settings_ring_single_heater_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: ring_double_heater_gdsf_de903155
+name: ring_double_heater_gdsf_55201c97
 settings:
   bend: bend_euler
   coupler_ring: coupler_ring
@@ -7,10 +7,8 @@ settings:
   cross_section_heater: heater_metal
   cross_section_waveguide_heater: strip_heater_metal
   gap: 0.2
-  length_extension: 3
   length_x: 1
   length_y: 0.01
-  radius: 10
   straight: straight
   via_stack: via_stack_heater_mtop_mini
   via_stack_offset:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -506,14 +506,6 @@ def test_container() -> None:
     assert len(result.insts) == 1
 
 
-def test_plot() -> None:
-    c = gf.Component()
-    c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))
-    c.plot()
-    c.to_graphviz()
-    c.to_dict(True)
-
-
 def test_offset() -> None:
     c = gf.Component()
     c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))
@@ -536,12 +528,6 @@ def test_over_under() -> None:
 
     assert len(c.shapes(get_layer((1, 0)))) == 1
     assert c.dbbox(get_layer((1, 0))) == kdb.Box(0, 0, 10, 5)
-
-
-def test_component_all_angle_plot() -> None:
-    c = gf.ComponentAllAngle()
-    c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))
-    c.plot()
 
 
 def test_component_to_3d() -> None:


### PR DESCRIPTION
- better error message when layer not found in PDK
- add `mirror_grating_coupler` flag to add_fiber_array and add_fiber_single and grating_coupler_array
- document Component.fix_space and  Component.fix_width
- better defaults for rings

## Summary

Enhance port utilities, extend fiber component functions with configurable mirroring, and improve PDK error reporting

New Features:
- Add get_port_definitions utility to generate port definition strings
- Support mirror_grating_coupler flag in add_fiber_single and add_fiber_array to optionally mirror grating couplers

Enhancements:
- Improve layer-not-found error message in PDK.get_layer to include PDK name and available layers