### PR TITLE
simpler layer info check

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -712,14 +712,7 @@ def get_layer_tuple(layer: LayerSpec) -> tuple[int, int]:
 def get_layer_info(layer: LayerSpec) -> kf.kdb.LayerInfo:
     """Returns layer info from a layer spec."""
     layer_index = get_layer(layer)
-    if isinstance(layer_index, LayerEnum):
-        return kf.kcl.get_info(layer_index.value)  # type: ignore[no-any-return]
-    elif isinstance(layer_index, int):
-        return kf.kcl.get_info(layer_index)  # type: ignore[no-any-return]
-    else:
-        raise ValueError(
-            f"Invalid layer spec {layer!r} for PDK {get_active_pdk().name!r}"
-        )
+    return kf.kcl.get_info(layer_index)  # type: ignore[no-any-return]
 
 
 def get_layer_views() -> LayerViews:


### PR DESCRIPTION
## Summary by Sourcery

Simplify get_layer_info by removing redundant type checks and directly returning kf.kcl.get_info

Enhancements:
- Remove LayerEnum and int instance checks in get_layer_info
- Eliminate ValueError branch for invalid layer specs in get_layer_info