### PR TITLE
Update route_single.py

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -156,7 +156,7 @@ def route_single(
         steps = []
 
     if steps:
-        x, y = port1.center
+        x, y = p1.center
         for d in steps:
             if not STEP_DIRECTIVES.issuperset(d):
                 invalid_step_directives = list(set[str](d.keys()) - STEP_DIRECTIVES)


### PR DESCRIPTION
I supposed relative steps should be calulated from the new taper's port, instead of the old port

## Summary by Sourcery

Bug Fixes:
- Use p1.center instead of port1.center when calculating relative steps.