### PR TITLE
Allow to flatten on copy_layers

### DIFF
--- a/gdsfactory/components/containers/copy_layers.py
+++ b/gdsfactory/components/containers/copy_layers.py
@@ -20,7 +20,7 @@ def copy_layers(
         factory: component spec.
         layers: iterable of layers.
         flatten: flatten the result.
-        kwargs: keyword arguments.
+        kwargs: keyword arguments passed to the component.
     """
     c = Component()
 

--- a/gdsfactory/components/containers/copy_layers.py
+++ b/gdsfactory/components/containers/copy_layers.py
@@ -11,6 +11,7 @@ from gdsfactory.typings import ComponentSpec, LayerSpecs
 def copy_layers(
     factory: ComponentSpec = "cross",
     layers: LayerSpecs = ((1, 0), (2, 0)),
+    flatten: bool = False,
     **kwargs: Any,
 ) -> Component:
     """Returns a component with the geometry copied in different layers.
@@ -18,14 +19,19 @@ def copy_layers(
     Args:
         factory: component spec.
         layers: iterable of layers.
+        flatten: flatten the result.
         kwargs: keyword arguments.
     """
     c = Component()
-    for layer in layers:
-        ci = gf.get_component(factory, layer=layer, **kwargs)
-        _ = c << ci
 
-    c.copy_child_info(ci)
+    ci = None
+    for layer in layers:
+        c << (ci := gf.get_component(factory, layer=layer, **kwargs))
+    if ci is not None:
+        c.copy_child_info(ci)
+
+    if flatten:
+        c.flatten()
     return c
 
 

--- a/test-data-regression/test_netlists_copy_layers_.yml
+++ b/test-data-regression/test_netlists_copy_layers_.yml
@@ -19,7 +19,7 @@ instances:
       length: 10
       port_type: null
       width: 3
-name: copy_layers_gdsfactoryp_c7a2a834
+name: copy_layers_gdsfactoryp_eb05f809
 nets: []
 placements:
   cross_gdsfactorypcompon_2c767e3f_0_0:

--- a/test-data-regression/test_settings_copy_layers_.yml
+++ b/test-data-regression/test_settings_copy_layers_.yml
@@ -1,7 +1,8 @@
 info: {}
-name: copy_layers_gdsfactoryp_c7a2a834
+name: copy_layers_gdsfactoryp_eb05f809
 settings:
   factory: cross
+  flatten: false
   layers:
   - - 1
     - 0


### PR DESCRIPTION
The `ci = None` tweak is to deal with unbound variable.

## Summary by Sourcery

Allow flattening of the output component in copy_layers via a new flatten flag and streamline its implementation

New Features:
- Add flatten parameter to copy_layers to optionally flatten the resulting component

Enhancements:
- Refactor loop to use inline assignment for child components
- Guard copy_child_info call to only execute when a component is present