### PR TITLE
Using TypedDict instead of dataclass for Step

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -291,9 +291,8 @@ def route_bundle(
         x, y = ports1_[0].center
         for d in steps:
             if not STEP_DIRECTIVES.issuperset(d):
-                invalid_step_directives = list(set(d.keys()) - STEP_DIRECTIVES)
                 raise ValueError(
-                    f"Invalid step directives: {invalid_step_directives}."
+                    f"Invalid step directives: {list(d.keys() - STEP_DIRECTIVES)}."
                     f"Valid directives are {list(STEP_DIRECTIVES)}"
                 )
             x = d.get("x", x) + d.get("dx", 0)

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -12,7 +12,7 @@ route_bundle calls different function depending on the port orientation.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from functools import partial
 from typing import Literal
 from warnings import warn
@@ -32,6 +32,7 @@ from gdsfactory.typings import (
     LayerSpecs,
     LayerTransitions,
     Ports,
+    Step,
 )
 
 OpticalManhattanRoute = ManhattanRoute
@@ -112,7 +113,7 @@ def route_bundle(
     auto_taper: bool = True,
     auto_taper_taper: ComponentSpec | None = None,
     waypoints: Coordinates | Sequence[gf.kdb.DPoint] | None = None,
-    steps: Sequence[Mapping[str, int | float]] | None = None,
+    steps: Sequence[Step] | None = None,
     start_angles: float | list[float] | None = None,
     end_angles: float | list[float] | None = None,
     router: Literal["optical", "electrical"] | None = None,

--- a/gdsfactory/routing/route_fiber_array.py
+++ b/gdsfactory/routing/route_fiber_array.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import kfactory as kf
@@ -18,6 +18,7 @@ from gdsfactory.typings import (
     Coordinates,
     CrossSectionSpec,
     PortsFactory,
+    Step,
     Strs,
 )
 
@@ -56,7 +57,7 @@ def route_fiber_array(
     end_straight_length: float = 0,
     auto_taper: bool = True,
     waypoints: Coordinates | None = None,
-    steps: Sequence[Mapping[str, int | float]] | None = None,
+    steps: Sequence[Step] | None = None,
     bboxes: BoundingBoxes | None = None,
     avoid_component_bbox: bool = True,
     **kwargs: Any,

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -27,7 +27,7 @@ To generate a route:
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Literal, cast
 
 import kfactory as kf
@@ -45,6 +45,7 @@ from gdsfactory.typings import (
     LayerSpec,
     LayerTransitions,
     Port,
+    Step,
     WayPoints,
 )
 
@@ -60,7 +61,7 @@ def route_single(
     start_straight_length: float = 0.0,
     end_straight_length: float = 0.0,
     waypoints: WayPoints | None = None,
-    steps: Sequence[Mapping[Literal["x", "y", "dx", "dy"], int | float]] | None = None,
+    steps: Sequence[Step] | None = None,
     port_type: str | None = None,
     allow_width_mismatch: bool = False,
     radius: float | None = None,

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -155,20 +155,17 @@ def route_single(
         raise ValueError("Provide either steps or waypoints, not both")
 
     waypoints_list = [] if waypoints is None else list(waypoints)
-    if steps is None:
-        steps = []
 
     if steps:
         x, y = p1.center
         for d in steps:
             if not STEP_DIRECTIVES.issuperset(d):
-                invalid_step_directives = list(set[str](d.keys()) - STEP_DIRECTIVES)
                 raise ValueError(
-                    f"Invalid step directives: {invalid_step_directives}."
+                    f"Invalid step directives: {list(d.keys() - STEP_DIRECTIVES)}."
                     f"Valid directives are {list(STEP_DIRECTIVES)}"
                 )
-            x = float(d.get("x", x) + d.get("dx", 0.0))
-            y = float(d.get("y", y) + d.get("dy", 0.0))
+            x = d.get("x", x) + d.get("dx", 0)
+            y = d.get("y", y) + d.get("dy", 0)
             waypoints_list.append((x, y))
 
     if waypoints_list:

--- a/gdsfactory/typings.py
+++ b/gdsfactory/typings.py
@@ -21,11 +21,10 @@ Specs:
 
 from __future__ import annotations
 
-import dataclasses
 import pathlib
 from collections.abc import Callable, Generator, Sequence
 from functools import partial
-from typing import Any, Literal, ParamSpec, Protocol, TypeAlias, TypeVar
+from typing import Any, Literal, ParamSpec, Protocol, TypeAlias, TypedDict, TypeVar
 
 import kfactory as kf
 import klayout.db as kdb
@@ -53,8 +52,7 @@ STEP_DIRECTIVES_ALL_ANGLE = {
 }
 
 
-@dataclasses.dataclass
-class Step:
+class Step(TypedDict, total=False):
     """Manhattan Step.
 
     Parameters:
@@ -65,10 +63,10 @@ class Step:
 
     """
 
-    x: float | None = None
-    y: float | None = None
-    dx: Delta | None = None
-    dy: Delta | None = None
+    x: float
+    y: float
+    dx: Delta
+    dy: Delta
 
 
 Anchor: TypeAlias = Literal[


### PR DESCRIPTION
## Summary by Sourcery

Use a TypedDict for Step instead of a dataclass, adjust type hints in routing modules to Sequence[Step], and streamline step validation and coordinate calculation logic.

Enhancements:
- Replace the Step dataclass with a non-total TypedDict and adopt it as the steps parameter type in routing functions
- Update steps type hints across route_single, route_bundle, and route_fiber_array to use Sequence[Step]
- Simplify invalid directive validation by computing key differences directly in error messages
- Remove redundant steps initialization and float conversions during coordinate updates