### PR TITLE
Inferring port type for the cross section in route functions

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -206,10 +206,10 @@ def route_bundle(
         raise ValueError(
             f"ports1={len(ports1_)} and ports2={len(ports2_)} must be equal"
         )
-    if route_width is None or route_width == 0:
-        xs = gf.get_cross_section(cross_section)
-    else:
+    if route_width:
         xs = gf.get_cross_section(cross_section, width=route_width)
+    else:
+        xs = gf.get_cross_section(cross_section)
     width = route_width or xs.width
 
     radius = radius or xs.radius

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from functools import partial
-from typing import Literal
+from typing import Literal, cast
 from warnings import warn
 
 import kfactory as kf
@@ -178,25 +178,29 @@ def route_bundle(
         c.plot()
 
     """
-    if layer and cross_section:
-        raise ValueError(
-            f"Cannot have both {layer=} and {cross_section=} provided. Choose one."
-        )
     if cross_section is None:
-        if layer is not None and route_width is not None:
-            cross_section = partial(
-                gf.cross_section.cross_section, layer=layer, width=route_width
-            )
-
-        else:
+        if layer is None or route_width is None:
             raise ValueError(
                 f"Either {cross_section=} or {layer=} and {route_width=} must be provided"
             )
+    elif layer is not None:
+        raise ValueError(
+            f"Cannot have both {layer=} and {cross_section=} provided. Choose one."
+        )
 
     c = component
     ports1_ = list(ports1)
     ports2_ = list(ports2)
     port_type = port_type or ports1_[0].port_type
+
+    if cross_section is None:
+        cross_section = partial(
+            gf.cross_section.cross_section,
+            layer=cast(LayerSpec, layer),
+            width=cast(float, route_width),
+            port_names=("e1", "e2") if port_type == "electrical" else ("o1", "o2"),
+            port_types=(port_type, port_type),
+        )
 
     if len(ports1_) != len(ports2_):
         raise ValueError(

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -105,29 +105,25 @@ def route_single(
         gf.routing.route_single(c, mmi1.ports["o2"], mmi2.ports["o1"], radius=5, cross_section="strip")
         c.plot()
     """
-    p1 = port1
-    p2 = port2
-    c = component
-
     if cross_section is None:
         if layer is None or route_width is None:
             raise ValueError(
                 f"Either {cross_section=} or {layer=} and route_width must be provided"
             )
 
-        elif radius:
-            cross_section = gf.cross_section.cross_section(
-                layer=layer,
-                width=route_width,
-                radius=radius,
-            )
-        else:
-            cross_section = gf.cross_section.cross_section(
-                layer=layer,
-                width=route_width,
-            )
-
+    c = component
+    p1 = port1
+    p2 = port2
     port_type = port_type or p1.port_type
+
+    if cross_section is None:
+        cross_section = gf.cross_section.cross_section(
+            layer=layer,
+            width=cast(float, route_width),
+            port_names=("e1", "e2") if port_type == "electrical" else ("o1", "o2"),
+            port_types=(port_type, port_type),
+        )
+
     if route_width:
         xs = gf.get_cross_section(cross_section, width=route_width)
     else:

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -118,7 +118,7 @@ def route_single(
 
     if cross_section is None:
         cross_section = gf.cross_section.cross_section(
-            layer=layer,
+            layer=cast(LayerSpec, layer),
             width=cast(float, route_width),
             port_names=("e1", "e2") if port_type == "electrical" else ("o1", "o2"),
             port_types=(port_type, port_type),
@@ -129,8 +129,9 @@ def route_single(
     else:
         xs = gf.get_cross_section(cross_section)
     width = route_width or xs.width
+
     radius = radius or xs.radius
-    bend90 = gf.get_component(bend, cross_section=xs, radius=radius)
+    bend90 = gf.get_component(bend, cross_section=xs, radius=radius, width=width)
     if auto_taper:
         p1 = add_auto_tapers(component, [p1], xs, layer_transitions)[0]
         p2 = add_auto_tapers(component, [p2], xs, layer_transitions)[0]

--- a/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_gdsfactorypc_24164978_0_889000_A180:
+  bend_euler_gdsfactorypc_1e74d3cf_0_889000_A180:
     component: bend_euler
     info:
       dy: 30
@@ -22,9 +22,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_24164978_m1000_127000_A180:
+  bend_euler_gdsfactorypc_1e74d3cf_m1000_127000_A180:
     component: bend_euler
     info:
       dy: 30
@@ -47,9 +47,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_24164978_m30000_792000_A270:
+  bend_euler_gdsfactorypc_1e74d3cf_m30000_792000_A270:
     component: bend_euler
     info:
       dy: 30
@@ -72,9 +72,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_24164978_m31000_30000_A270:
+  bend_euler_gdsfactorypc_1e74d3cf_m31000_30000_A270:
     component: bend_euler
     info:
       dy: 30
@@ -97,7 +97,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 30
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   extend_ports_gdsfactory_a22b19de_0_0:
     component: extend_ports
@@ -147,39 +147,39 @@ instances:
       width: null
 name: edge_coupler_array_with_76837e7b
 nets:
-- p1: bend_euler_gdsfactorypc_24164978_0_889000_A180,o1
+- p1: bend_euler_gdsfactorypc_1e74d3cf_0_889000_A180,o1
   p2: extend_ports_gdsfactory_a22b19de_0_0,o8
-- p1: bend_euler_gdsfactorypc_24164978_0_889000_A180,o2
+- p1: bend_euler_gdsfactorypc_1e74d3cf_0_889000_A180,o2
   p2: straight_gdsfactorypcom_602f5a09_m30000_792000_A90,o2
-- p1: bend_euler_gdsfactorypc_24164978_m1000_127000_A180,o1
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m1000_127000_A180,o1
   p2: extend_ports_gdsfactory_a22b19de_0_0,o2
-- p1: bend_euler_gdsfactorypc_24164978_m1000_127000_A180,o2
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m1000_127000_A180,o2
   p2: straight_gdsfactorypcom_602f5a09_m31000_30000_A90,o2
-- p1: bend_euler_gdsfactorypc_24164978_m30000_792000_A270,o1
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m30000_792000_A270,o1
   p2: straight_gdsfactorypcom_602f5a09_m30000_792000_A90,o1
-- p1: bend_euler_gdsfactorypc_24164978_m30000_792000_A270,o2
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m30000_792000_A270,o2
   p2: extend_ports_gdsfactory_a22b19de_0_0,o7
-- p1: bend_euler_gdsfactorypc_24164978_m31000_30000_A270,o1
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m31000_30000_A270,o1
   p2: straight_gdsfactorypcom_602f5a09_m31000_30000_A90,o1
-- p1: bend_euler_gdsfactorypc_24164978_m31000_30000_A270,o2
+- p1: bend_euler_gdsfactorypc_1e74d3cf_m31000_30000_A270,o2
   p2: extend_ports_gdsfactory_a22b19de_0_0,o1
 placements:
-  bend_euler_gdsfactorypc_24164978_0_889000_A180:
+  bend_euler_gdsfactorypc_1e74d3cf_0_889000_A180:
     mirror: false
     rotation: 180
     x: 0
     y: 889
-  bend_euler_gdsfactorypc_24164978_m1000_127000_A180:
+  bend_euler_gdsfactorypc_1e74d3cf_m1000_127000_A180:
     mirror: false
     rotation: 180
     x: -1
     y: 127
-  bend_euler_gdsfactorypc_24164978_m30000_792000_A270:
+  bend_euler_gdsfactorypc_1e74d3cf_m30000_792000_A270:
     mirror: false
     rotation: 270
     x: -30
     y: 792
-  bend_euler_gdsfactorypc_24164978_m31000_30000_A270:
+  bend_euler_gdsfactorypc_1e74d3cf_m31000_30000_A270:
     mirror: false
     rotation: 270
     x: -31

--- a/test-data-regression/test_netlists_grating_coupler_loss_.yml
+++ b/test-data-regression/test_netlists_grating_coupler_loss_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_gdsfactorypc_a86bc407_10000_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_10000_49529_A180:
     component: bend_euler
     info:
       dy: 10
@@ -22,9 +22,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_1596204_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_1596204_39529_A90:
     component: bend_euler
     info:
       dy: 10
@@ -47,9 +47,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_1642306_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_1642306_49529_A180:
     component: bend_euler
     info:
       dy: 10
@@ -72,9 +72,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_254000_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_254000_39529_A90:
     component: bend_euler
     info:
       dy: 10
@@ -97,9 +97,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_2648306_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_2648306_39529_A90:
     component: bend_euler
     info:
       dy: 10
@@ -122,9 +122,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_300102_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_300102_49529_A180:
     component: bend_euler
     info:
       dy: 10
@@ -147,9 +147,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_798102_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_798102_39529_A90:
     component: bend_euler
     info:
       dy: 10
@@ -172,9 +172,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_844204_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_844204_49529_A180:
     component: bend_euler
     info:
       dy: 10
@@ -197,7 +197,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   grating_coupler_ellipti_6c1e46af_0_0_A270:
     component: grating_coupler_elliptical_trenches
@@ -545,37 +545,37 @@ instances:
       width: null
 name: grating_coupler_loss_gd_e0b001ca
 nets:
-- p1: bend_euler_gdsfactorypc_a86bc407_10000_49529_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_10000_49529_A180,o1
   p2: straight_gdsfactorypcom_18b99f0e_10000_49529,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_10000_49529_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_10000_49529_A180,o2
   p2: straight_gdsfactorypcom_92237c63_0_m471_A90,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_1596204_39529_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_1596204_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_1596204_39529_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_1596204_39529_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_1596204_39529_A90,o2
   p2: straight_gdsfactorypcom_046a924a_844204_49529,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_1642306_49529_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_1642306_49529_A180,o1
   p2: straight_gdsfactorypcom_ef17e3a4_1642306_49529,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_1642306_49529_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_1642306_49529_A180,o2
   p2: straight_gdsfactorypcom_92237c63_1632306_m471_A90,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_254000_39529_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_254000_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_254000_39529_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_254000_39529_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_254000_39529_A90,o2
   p2: straight_gdsfactorypcom_18b99f0e_10000_49529,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_2648306_39529_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_2648306_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_2648306_39529_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_2648306_39529_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_2648306_39529_A90,o2
   p2: straight_gdsfactorypcom_ef17e3a4_1642306_49529,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_300102_49529_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_300102_49529_A180,o1
   p2: straight_gdsfactorypcom_f5f7f076_300102_49529,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_300102_49529_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_300102_49529_A180,o2
   p2: straight_gdsfactorypcom_92237c63_290102_m471_A90,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_798102_39529_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_798102_39529_A90,o1
   p2: straight_gdsfactorypcom_92237c63_798102_39529_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_798102_39529_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_798102_39529_A90,o2
   p2: straight_gdsfactorypcom_f5f7f076_300102_49529,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_844204_49529_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_844204_49529_A180,o1
   p2: straight_gdsfactorypcom_046a924a_844204_49529,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_844204_49529_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_844204_49529_A180,o2
   p2: straight_gdsfactorypcom_92237c63_834204_m471_A90,o2
 - p1: grating_coupler_ellipti_6c1e46af_0_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_0_m471_A90,o1
@@ -594,42 +594,42 @@ nets:
 - p1: grating_coupler_ellipti_6c1e46af_834204_0_A270,o1
   p2: straight_gdsfactorypcom_92237c63_834204_m471_A90,o1
 placements:
-  bend_euler_gdsfactorypc_a86bc407_10000_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_10000_49529_A180:
     mirror: false
     rotation: 180
     x: 10
     y: 49.529
-  bend_euler_gdsfactorypc_a86bc407_1596204_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_1596204_39529_A90:
     mirror: false
     rotation: 90
     x: 1596.204
     y: 39.529
-  bend_euler_gdsfactorypc_a86bc407_1642306_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_1642306_49529_A180:
     mirror: false
     rotation: 180
     x: 1642.306
     y: 49.529
-  bend_euler_gdsfactorypc_a86bc407_254000_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_254000_39529_A90:
     mirror: false
     rotation: 90
     x: 254
     y: 39.529
-  bend_euler_gdsfactorypc_a86bc407_2648306_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_2648306_39529_A90:
     mirror: false
     rotation: 90
     x: 2648.306
     y: 39.529
-  bend_euler_gdsfactorypc_a86bc407_300102_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_300102_49529_A180:
     mirror: false
     rotation: 180
     x: 300.102
     y: 49.529
-  bend_euler_gdsfactorypc_a86bc407_798102_39529_A90:
+  bend_euler_gdsfactorypc_335c8724_798102_39529_A90:
     mirror: false
     rotation: 90
     x: 798.102
     y: 39.529
-  bend_euler_gdsfactorypc_a86bc407_844204_49529_A180:
+  bend_euler_gdsfactorypc_335c8724_844204_49529_A180:
     mirror: false
     rotation: 180
     x: 844.204

--- a/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/test-data-regression/test_netlists_splitter_tree_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_gdsfactorypc_a86bc407_25500_10625_A270_M:
+  bend_euler_gdsfactorypc_335c8724_25500_10625_A270_M:
     component: bend_euler
     info:
       dy: 10
@@ -22,9 +22,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_25500_m10625_A90:
+  bend_euler_gdsfactorypc_335c8724_25500_m10625_A90:
     component: bend_euler
     info:
       dy: 10
@@ -47,9 +47,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_35500_25000_A180:
+  bend_euler_gdsfactorypc_335c8724_35500_25000_A180:
     component: bend_euler
     info:
       dy: 10
@@ -72,9 +72,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_35500_m25000_A180_M:
+  bend_euler_gdsfactorypc_335c8724_35500_m25000_A180_M:
     component: bend_euler
     info:
       dy: 10
@@ -97,7 +97,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   bend_s_gdsfactorypcompo_bd3e5121_105500_24375_M:
     component: bend_s
@@ -280,21 +280,21 @@ instances:
       width: null
 name: splitter_tree_gdsfactor_b6d59c93
 nets:
-- p1: bend_euler_gdsfactorypc_a86bc407_25500_10625_A270_M,o1
+- p1: bend_euler_gdsfactorypc_335c8724_25500_10625_A270_M,o1
   p2: straight_gdsfactorypcom_94881c7f_25500_10625_A90,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_25500_10625_A270_M,o2
+- p1: bend_euler_gdsfactorypc_335c8724_25500_10625_A270_M,o2
   p2: coupler_0_0,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_25500_m10625_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_25500_m10625_A90,o1
   p2: straight_gdsfactorypcom_94881c7f_25500_m10625_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_25500_m10625_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_25500_m10625_A90,o2
   p2: coupler_0_0,o3
-- p1: bend_euler_gdsfactorypc_a86bc407_35500_25000_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_35500_25000_A180,o1
   p2: straight_gdsfactorypcom_eefd19f7_35500_25000,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_35500_25000_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_35500_25000_A180,o2
   p2: straight_gdsfactorypcom_94881c7f_25500_10625_A90,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_35500_m25000_A180_M,o1
+- p1: bend_euler_gdsfactorypc_335c8724_35500_m25000_A180_M,o1
   p2: straight_gdsfactorypcom_eefd19f7_35500_m25000,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_35500_m25000_A180_M,o2
+- p1: bend_euler_gdsfactorypc_335c8724_35500_m25000_A180_M,o2
   p2: straight_gdsfactorypcom_94881c7f_25500_m10625_A270,o2
 - p1: bend_s_gdsfactorypcompo_bd3e5121_105500_24375_M,o1
   p2: coupler_1_1,o3
@@ -309,22 +309,22 @@ nets:
 - p1: coupler_1_1,o1
   p2: straight_gdsfactorypcom_eefd19f7_35500_25000,o2
 placements:
-  bend_euler_gdsfactorypc_a86bc407_25500_10625_A270_M:
+  bend_euler_gdsfactorypc_335c8724_25500_10625_A270_M:
     mirror: true
     rotation: 270
     x: 25.5
     y: 10.625
-  bend_euler_gdsfactorypc_a86bc407_25500_m10625_A90:
+  bend_euler_gdsfactorypc_335c8724_25500_m10625_A90:
     mirror: false
     rotation: 90
     x: 25.5
     y: -10.625
-  bend_euler_gdsfactorypc_a86bc407_35500_25000_A180:
+  bend_euler_gdsfactorypc_335c8724_35500_25000_A180:
     mirror: false
     rotation: 180
     x: 35.5
     y: 25
-  bend_euler_gdsfactorypc_a86bc407_35500_m25000_A180_M:
+  bend_euler_gdsfactorypc_335c8724_35500_m25000_A180_M:
     mirror: true
     rotation: 180
     x: 35.5

--- a/test-data-regression/test_netlists_switch_tree_.yml
+++ b/test-data-regression/test_netlists_switch_tree_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_gdsfactorypc_a86bc407_411000_10625_A270_M:
+  bend_euler_gdsfactorypc_335c8724_411000_10625_A270_M:
     component: bend_euler
     info:
       dy: 10
@@ -22,9 +22,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_411000_m10625_A90:
+  bend_euler_gdsfactorypc_335c8724_411000_m10625_A90:
     component: bend_euler
     info:
       dy: 10
@@ -47,9 +47,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_421000_50000_A180:
+  bend_euler_gdsfactorypc_335c8724_421000_50000_A180:
     component: bend_euler
     info:
       dy: 10
@@ -72,9 +72,9 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
-  bend_euler_gdsfactorypc_a86bc407_421000_m50000_A180_M:
+  bend_euler_gdsfactorypc_335c8724_421000_m50000_A180_M:
     component: bend_euler
     info:
       dy: 10
@@ -97,7 +97,7 @@ instances:
       npoints: null
       p: 0.5
       radius: 10
-      width: null
+      width: 0.5
       with_arc_floorplan: true
   bend_s_gdsfactorypcompo_23c8b359_901000_49375_M:
     component: bend_s
@@ -328,21 +328,21 @@ instances:
       width: null
 name: splitter_tree_gdsfactor_dfaf2fb9
 nets:
-- p1: bend_euler_gdsfactorypc_a86bc407_411000_10625_A270_M,o1
+- p1: bend_euler_gdsfactorypc_335c8724_411000_10625_A270_M,o1
   p2: straight_gdsfactorypcom_9857e1e1_411000_10625_A90,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_411000_10625_A270_M,o2
+- p1: bend_euler_gdsfactorypc_335c8724_411000_10625_A270_M,o2
   p2: coupler_0_0,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_411000_m10625_A90,o1
+- p1: bend_euler_gdsfactorypc_335c8724_411000_m10625_A90,o1
   p2: straight_gdsfactorypcom_9857e1e1_411000_m10625_A270,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_411000_m10625_A90,o2
+- p1: bend_euler_gdsfactorypc_335c8724_411000_m10625_A90,o2
   p2: coupler_0_0,o3
-- p1: bend_euler_gdsfactorypc_a86bc407_421000_50000_A180,o1
+- p1: bend_euler_gdsfactorypc_335c8724_421000_50000_A180,o1
   p2: straight_gdsfactorypcom_11566f47_421000_50000,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_421000_50000_A180,o2
+- p1: bend_euler_gdsfactorypc_335c8724_421000_50000_A180,o2
   p2: straight_gdsfactorypcom_9857e1e1_411000_10625_A90,o2
-- p1: bend_euler_gdsfactorypc_a86bc407_421000_m50000_A180_M,o1
+- p1: bend_euler_gdsfactorypc_335c8724_421000_m50000_A180_M,o1
   p2: straight_gdsfactorypcom_11566f47_421000_m50000,o1
-- p1: bend_euler_gdsfactorypc_a86bc407_421000_m50000_A180_M,o2
+- p1: bend_euler_gdsfactorypc_335c8724_421000_m50000_A180_M,o2
   p2: straight_gdsfactorypcom_9857e1e1_411000_m10625_A270,o2
 - p1: bend_s_gdsfactorypcompo_23c8b359_901000_49375_M,o1
   p2: coupler_1_1,o3
@@ -357,22 +357,22 @@ nets:
 - p1: coupler_1_1,o1
   p2: straight_gdsfactorypcom_11566f47_421000_50000,o2
 placements:
-  bend_euler_gdsfactorypc_a86bc407_411000_10625_A270_M:
+  bend_euler_gdsfactorypc_335c8724_411000_10625_A270_M:
     mirror: true
     rotation: 270
     x: 411
     y: 10.625
-  bend_euler_gdsfactorypc_a86bc407_411000_m10625_A90:
+  bend_euler_gdsfactorypc_335c8724_411000_m10625_A90:
     mirror: false
     rotation: 90
     x: 411
     y: -10.625
-  bend_euler_gdsfactorypc_a86bc407_421000_50000_A180:
+  bend_euler_gdsfactorypc_335c8724_421000_50000_A180:
     mirror: false
     rotation: 180
     x: 421
     y: 50
-  bend_euler_gdsfactorypc_a86bc407_421000_m50000_A180_M:
+  bend_euler_gdsfactorypc_335c8724_421000_m50000_A180_M:
     mirror: true
     rotation: 180
     x: 421


### PR DESCRIPTION
Relates to https://github.com/gdsfactory/gdsfactory/issues/4085

## Summary by Sourcery

Infer port types in route_single and route_bundle to automatically configure cross_section parameters, simplify cross_section construction and error handling, and ensure bends receive the correct width

Enhancements:
- Infer port_type from input ports and propagate it to cross_section port_names and port_types in routing functions
- Simplify cross_section creation logic and tighten error validation for layer, cross_section, and route_width parameters
- Pass the resolved width to the bend component in route_single to ensure consistent geometry

## Summary by Sourcery

Infer port types in routing functions to auto-configure cross_section parameters, streamline cross_section creation, ensure bends receive the correct width, and update regression fixtures accordingly

Enhancements:
- Infer port_type from input ports and auto-populate port_names and port_types in cross_section for route_single and route_bundle
- Simplify cross_section instantiation and tighten validation for layer, cross_section, and route_width parameters
- Pass the resolved width parameter to the bend component in route_single for consistent geometry

Tests:
- Update regression test fixtures to include default width values for bend components and reflect updated instance identifiers