### PR TITLE
Fix check_layer() validator in LayerLevel to avoid circular dependency

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -363,14 +363,11 @@ class LayerLevel(BaseModel):
 
     @field_validator("layer")
     @classmethod
-    def check_layer(
-        cls, layer: BroadLayer | int | str | tuple[int, int] | LayerEnum
-    ) -> LogicalLayer | DerivedLayer:
-        if isinstance(layer, int | str | tuple | LayerEnum):
-            layer = gf.get_layer(layer)
+    def check_layer(cls, layer: BroadLayer) -> LogicalLayer | DerivedLayer:
+        if isinstance(layer, LogicalLayer | DerivedLayer):
+            return layer
+        else:
             return LogicalLayer(layer=layer)
-
-        return layer
 
     @property
     def bounds(self) -> tuple[float, float]:


### PR DESCRIPTION
Currently the `check_layer()` validator in `LayerLevel` dependes on `get_active_pdk().get_layer()`, which assumes the PDK is already defined.
However, `LayerLevel` is typically used in PDK definition, so a circular dependency arises, when `CONF.pdk` is redefined.

The following example

_test_pdk/\_\_init\_\_.py_
```python
from gdsfactory.pdk import Pdk
from .tech import LAYER_STACK#, LAYER_VIEWS

PDK = Pdk(
    name="test_pdk",
    layer_stack=LAYER_STACK,
    # layer_views=LAYER_VIEWS,
)

```

_test_pdk/config.py_
```python
import pathlib as pl
from gdsfactory.config import CONF

CONF.pdk = 'test_pdk'


class Path:
    lyp_file = pl.Path(__file__).parent.absolute() / 'layers.lyp'


PATH = Path()

```

_test_pdk/tech.py_
```python
from gdsfactory.technology import LayerStack, LayerLevel, LayerViews
from .config import PATH


LAYER_STACK = LayerStack(layers=dict(
    substrate=LayerLevel(
        layer=(1, 0),
        thickness=600.0,
        zmin=-600.0,
        material='Si',
    ),
))

# LAYER_VIEWS = LayerViews.from_lyp(PATH.lyp_file)

```

_python_
```python
import test_pdk
```
raises an error: `AttributeError: partially initialized module 'test_pdk' has no attribute 'PDK' (most likely due to a circular import). Did you mean: 'Pdk'?`.

With the submitted fix the last command succeeds.