### PR TITLE
Fix LayerViews.from_lyp() for custom hatch patterns

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -1169,10 +1169,9 @@ class LayerViews(BaseModel):
                 properties_element, layer_pattern=layer_pattern
             )
             if lv:
-                if re.match(r"C\d+", lv.hatch_pattern):
-                    lv.hatch_pattern = list(dither_patterns.keys())[
-                        int(lv.hatch_pattern[1:])
-                    ]
+                hp = lv.hatch_pattern
+                if isinstance(hp, str) and re.match(r"C\d+", hp):
+                    lv.hatch_pattern = list(dither_patterns.keys())[int(hp[1:])]
                 layer_views[lv.name] = lv
 
         return LayerViews(


### PR DESCRIPTION
Using `LayerViews.from_lyp()` on `*.lyp` files with custom hatch patterns, currently results in `'C0'`, `'C1'` etc. being parsed for the hatch pattern name.
However, in the `LayerView` data structure custom hatch patterns are specified by name not by order.
Therefore, 'C0' etc. is not a valid name and
```python
LayerViews.from_lyp(lyp_file).to_lyp(other_lyp_file)
```
will raise
```
UserWarning: Dither pattern 'C0' does not correspond to any KLayout built-in or custom pattern! Using 'I3' instead.
```
With this fix, the commands above work as expected.

## Summary by Sourcery

Bug Fixes:
- Fix parsing of custom hatch patterns so that codes like 'C0' map to actual pattern names instead of being treated as invalid names