### PR TITLE
Extend optional parameters for lyp_to_dataclass

### DIFF
--- a/gdsfactory/technology/layer_map.py
+++ b/gdsfactory/technology/layer_map.py
@@ -10,31 +10,37 @@ class LayerMap(gf.LayerEnum):
     layout = gf.constant(gf.kcl.layout)
 
 
-def lyp_to_dataclass(lyp_filepath: str | pathlib.Path, overwrite: bool = True) -> str:
+def lyp_to_dataclass(
+    lyp_filepath: str | pathlib.Path,
+    overwrite: bool = True,
+    sort_by_name: bool = True,  # sort_by_name=False means same order as in lyp file
+    map_name: str = "LayerMapFab",
+    filepathout: pathlib.Path | None = None,
+) -> str:
     """Returns python LayerMap script from a klayout layer properties file lyp."""
     filepathin = pathlib.Path(lyp_filepath)
-    filepathout = filepathin.with_suffix(".py")
+    filepathout = filepathout or filepathin.with_suffix(".py")
 
     if filepathout.exists() and not overwrite:
         raise FileExistsError(f"You can delete {filepathout}")
 
-    script = """
-from gdsfactory.typings import Layer
+    script = f"""from gdsfactory.typings import Layer
 from gdsfactory.technology.layer_map import LayerMap
 
 
-class LayerMapFab(LayerMap):
+class {map_name}(LayerMap):
 """
     lys = LayerViews.from_lyp(filepathin)
-    for layer_name, layer in sorted(lys.get_layer_views().items()):
+    maybe_sort = sorted if sort_by_name else lambda seq: seq
+    for layer_name, layer in maybe_sort(lys.get_layer_views().items()):
         if layer.layer is not None:
             script += (
                 f"    {layer_name}: Layer = ({layer.layer[0]}, {layer.layer[1]})\n"
             )
 
-    script += """
+    script += f"""
 
-LAYER = LayerMapFab
+LAYER = {map_name}
 """
 
     filepathout.write_text(script)

--- a/gdsfactory/technology/layer_map.py
+++ b/gdsfactory/technology/layer_map.py
@@ -15,14 +15,24 @@ def lyp_to_dataclass(
     overwrite: bool = True,
     sort_by_name: bool = True,  # sort_by_name=False means same order as in lyp file
     map_name: str = "LayerMapFab",
-    filepathout: pathlib.Path | None = None,
+    output_filepath: pathlib.Path | str | None = None,
 ) -> str:
     """Returns python LayerMap script from a klayout layer properties file lyp."""
     filepathin = pathlib.Path(lyp_filepath)
-    filepathout = filepathout or filepathin.with_suffix(".py")
+
+    if output_filepath is None:
+        filepathout = filepathin.with_suffix(".py")
+    else:
+        filepathout = pathlib.Path(output_filepath)
+    filepathout.parent.mkdir(parents=True, exist_ok=True)
 
     if filepathout.exists() and not overwrite:
         raise FileExistsError(f"You can delete {filepathout}")
+
+    if not map_name.isidentifier():
+        raise ValueError(
+            f"Argument 'map_name' must be a valid python identifier, but {map_name} is not."
+        )
 
     script = f"""from gdsfactory.typings import Layer
 from gdsfactory.technology.layer_map import LayerMap


### PR DESCRIPTION
This PR extends `gf.technology.lyp_to_dataclass()` by few optional parameters:
- optionally turn off sorting layers by name (new `sort_by_name` argument) and use original order in `*.lyp` file instead
- allow definition of LayerMap name in generated script (new `map_name` argument)
- allow specification of output filepath (new `filepathout` argument)

It should not change anything, when new parameters are not used.

## Summary by Sourcery

Extend lyp_to_dataclass to accept sort_by_name, map_name, and filepathout arguments without altering existing behavior when they are omitted.

New Features:
- Add optional parameters sort_by_name, map_name, and filepathout to lyp_to_dataclass

Enhancements:
- Allow toggling between sorted and original layer order via sort_by_name
- Permit customizing the generated LayerMap class name and LAYER variable via map_name
- Support specifying the output file path via filepathout, defaulting to the input file’s .py counterpart