### PR TITLE
Remove convert_tuples_to_lists in favor of yaml.safe_dump

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -25,7 +25,6 @@ from gdsfactory import typings
 from gdsfactory.component import Component, ComponentReference, container
 from gdsfactory.config import CONF
 from gdsfactory.port import select_ports
-from gdsfactory.serialization import convert_tuples_to_lists
 from gdsfactory.typings import InstanceOrVInstance
 
 nm = 1e-3
@@ -471,7 +470,7 @@ def add_settings_label(
     )
     settings_dict = dict(info)
     settings_string = (
-        yaml.dump(convert_tuples_to_lists(settings_dict))
+        yaml.safe_dump(settings_dict)
         if with_yaml_format
         else f"settings={json.dumps(settings_dict)}"
     )

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -38,7 +38,7 @@ from pydantic import Field
 from trimesh.scene.scene import Scene
 
 from gdsfactory.config import CONF, GDSDIR_TEMP
-from gdsfactory.serialization import clean_value_json, convert_tuples_to_lists
+from gdsfactory.serialization import clean_value_json
 from gdsfactory.utils import to_kdb_dpoints
 
 if TYPE_CHECKING:
@@ -418,12 +418,11 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             netlist: netlist to write.
             filepath: Optional file path to write to.
         """
-        netlist_converted = convert_tuples_to_lists(netlist)
-        yaml_string = yaml.dump(netlist_converted)
+        yaml_string = yaml.safe_dump(netlist)
         if filepath:
             filepath = pathlib.Path(filepath)
             filepath.write_text(yaml_string)
-        return str(yaml_string)
+        return yaml_string
 
     def to_dict(self, with_ports: bool = False) -> dict[str, Any]:
         """Returns a dictionary representation of the Component."""

--- a/gdsfactory/labels/add_label_yaml.py
+++ b/gdsfactory/labels/add_label_yaml.py
@@ -11,7 +11,6 @@ import yaml
 import gdsfactory as gf
 from gdsfactory.read.from_yaml import valid_anchor_point_keywords
 from gdsfactory.routing.add_fiber_array import add_fiber_array
-from gdsfactory.serialization import convert_tuples_to_lists
 from gdsfactory.typings import LayerSpec
 
 
@@ -75,7 +74,7 @@ def add_label_yaml(
         xelec=[int(electrical_ports[0].x - xc)] if electrical_ports else [],
         yelec=[int(electrical_ports[0].y - yc)] if electrical_ports else [],
     )
-    text = yaml.dump(convert_tuples_to_lists(d)) if with_yaml_format else json.dumps(d)
+    text = yaml.safe_dump(d) if with_yaml_format else json.dumps(d)
     component.add_label(
         text=text,
         layer=layer,

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -21,7 +21,7 @@ from gdsfactory.cross_section import CrossSection, Section
 from gdsfactory.cross_section import xsection as cross_section_xsection
 from gdsfactory.generic_tech import get_generic_pdk
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
-from gdsfactory.serialization import clean_value_json, convert_tuples_to_lists
+from gdsfactory.serialization import clean_value_json
 from gdsfactory.symbols import floorplan_with_block_letters
 from gdsfactory.technology import LayerStack, LayerViews, klayout_tech
 from gdsfactory.typings import (
@@ -606,7 +606,7 @@ class Pdk(BaseModel):
         header = dict(description=self.name)
 
         d = {"blocks": blocks, "xsections": xsections_widths, "header": header}
-        return yaml.dump(convert_tuples_to_lists(d))
+        return yaml.safe_dump(d)
 
     def get_cross_section_name(self, cross_section: CrossSection) -> str:
         xs_name = next(

--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from gdsfactory.serialization import clean_value_name, convert_tuples_to_lists
+from gdsfactory.serialization import clean_value_name
 
 if TYPE_CHECKING:
     from gdsfactory.typings import LayerSpec, PathType
@@ -240,8 +240,7 @@ def {block_name}({parameters_string})->gf.Component:
             if layer_pin_label:
                 d = port
                 d["name"] = port_name
-                d = convert_tuples_to_lists(d)
-                text = yaml.dump(d)
+                text = yaml.safe_dump(d)
                 script += f"    c.add_label(text={text!r}, position=({xya[0]}, {xya[1]}), layer=layer_pin_label)\n"
         if layer_text:
             script += "    text = c << text_function(text=name)\n"

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import PATH
-from gdsfactory.serialization import convert_tuples_to_lists
 from gdsfactory.typings import Anchor, Delta, Port, Ports
 from gdsfactory.utils import is_component_spec
 
@@ -434,12 +433,11 @@ class Schematic(BaseModel):
             netlist: netlist to write.
             filepath: Optional file path to write to.
         """
-        netlist_converted = convert_tuples_to_lists(netlist)
-        yaml_string = yaml.dump(netlist_converted)
+        yaml_string = yaml.safe_dump(netlist)
         if filepath:
             filepath = pathlib.Path(filepath)
             filepath.write_text(yaml_string)
-        return str(yaml_string)
+        return yaml_string
 
 
 def plot_graphviz(

--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -22,16 +22,6 @@ DEFAULT_SERIALIZATION_MAX_DIGITS = 3
 """By default, the maximum number of digits retained when serializing float-like arrays"""
 
 
-def convert_tuples_to_lists(
-    data: dict[str, Any] | list[Any] | tuple[Any, ...] | Any,
-) -> dict[str, Any] | list[Any] | Any:
-    if isinstance(data, dict):
-        return {key: convert_tuples_to_lists(value) for key, value in data.items()}
-    elif isinstance(data, list | tuple):
-        return [convert_tuples_to_lists(item) for item in data]
-    return data
-
-
 def get_string(value: Any) -> str:
     try:
         s = orjson.dumps(

--- a/notebooks/10_schematic.ipynb
+++ b/notebooks/10_schematic.ipynb
@@ -284,11 +284,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gdsfactory.serialization import convert_tuples_to_lists\n",
-    "\n",
     "conf = s.netlist.model_dump(exclude_none=True)\n",
-    "conf = convert_tuples_to_lists(conf)\n",
-    "yaml_component = yaml.dump(conf)\n",
+    "yaml_component = yaml.safe_dump(conf)\n",
     "print(yaml_component)"
    ]
   },

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,15 +12,7 @@ from gdsfactory.serialization import (
     clean_value_name,
     clean_value_partial,
     complex_encoder,
-    convert_tuples_to_lists,
 )
-
-
-def test_convert_tuples_to_lists() -> None:
-    assert convert_tuples_to_lists({"a": (1, 2)}) == {"a": [1, 2]}
-    assert convert_tuples_to_lists([1, (2, 3)]) == [1, [2, 3]]
-    assert convert_tuples_to_lists((1, 2)) == [1, 2]
-    assert convert_tuples_to_lists(([1, 2], 3)) == [[1, 2], 3]
 
 
 def test_clean_dict() -> None:


### PR DESCRIPTION
## Summary by Sourcery

Eliminate the legacy tuple-to-list conversion step in serialization and standardize on yaml.safe_dump for all YAML outputs

Enhancements:
- Remove convert_tuples_to_lists utility, its imports, and associated tests
- Replace yaml.dump calls on converted data with yaml.safe_dump directly on original data structures across serialization, component writing, UPDK reading, schematic, and labeling modules