### PR TITLE
preserve defaults

### DIFF
--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -147,6 +147,19 @@ class Config(Settings):
                 kwargs[key] = kfactory_dict[key]
         super().__init__(**kwargs)
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set attribute and sync to kfactory config if it's a shared setting."""
+        super().__setattr__(name, value)
+        # Sync to kfactory config if this is a shared attribute
+        if hasattr(kfactory_config, name):
+            setattr(kfactory_config, name, value)
+
+    def sync_to_kfactory(self) -> None:
+        """Explicitly sync all shared settings to kfactory config."""
+        for key in self.model_fields:
+            if hasattr(kfactory_config, key):
+                setattr(kfactory_config, key, getattr(self, key))
+
 
 CONF = Config()
 


### PR DESCRIPTION
- **better docs type hints**
- **add routing error traces**
- **fix docker and typing issues**
- **fix type annotations**
- **preserve_defaults**

## Summary by Sourcery

Consolidate and preserve default configuration values by migrating runtime assignments into the Config class definitions and removing redundant manual overrides

Enhancements:
- Embed default values directly in Config class attributes instead of assigning them on the instantiated CONF object
- Introduce new Config fields (connect_use_mirror, max_cellname_length, cell_layout_cache) with sensible defaults
- Use Pydantic Field(default_factory) for list-based settings (port_types and port_types_grating_couplers)
- Remove redundant manual default assignments following CONF instantiation