### PR TITLE
Fix cross-section default naming (particularly for PDKs)

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -213,11 +213,9 @@ class Pdk(BaseModel):
             def xs_sc(width=TECH.width_sc, radius=TECH.radius_sc):
                 return gf.cross_section.cross_section(width=width, radius=radius)
         """
-        decorated_func = cross_section_xsection(func)
-
-        self.cross_sections[func.__name__] = decorated_func
-
-        return decorated_func
+        return cross_section_xsection(
+            func, self.cross_sections, self.cross_section_default_names
+        )
 
     def activate(self, force: bool = False) -> None:
         """Set current pdk to the active pdk (if not already active)."""
@@ -462,8 +460,11 @@ class Pdk(BaseModel):
             if cross_section not in self.cross_sections:
                 cross_sections = list(self.cross_sections.keys())
                 raise ValueError(f"{cross_section!r} not in {cross_sections}")
-            xs = self.cross_sections[cross_section]
-            return xs(**kwargs)
+            xs_func = self.cross_sections[cross_section]
+            xs = xs_func(**kwargs)
+            if xs.name in self.cross_section_default_names:
+                xs._name = self.cross_section_default_names[xs.name]
+            return xs
         elif isinstance(cross_section, dict):
             xs_name = cross_section.get("cross_section", None)
             if xs_name is None:


### PR DESCRIPTION
Currently, the names of cross-sections generated by `gf.get_cross_section()` are not always consistent.
Particularly, when using multiple PDKs, the same global default name mapping (`gf.cross_section._cross_section_default_names`) is used for getting default names while the PDK-specific `Pdk.cross_section_default_names` attribute is never used at all.

Detailed changes:
- make cross-sections container and default name mapping optional parameters in `@xsection` decorator
- simplify `Pdk.xsection()` to use `cross_sections` and `cross_section_default_names` attributes of `Pdk` as optional parameters of `xsection`
- in `Pdk.get_cross_section()` compare name of intermediate cross-section with `Pdk`'s default names and rename if necessary (e.g. for cross-sections defined before `Pdk` instantiation, partials etc.)

The following code sections illustrate the issues and changes:
- an (un-activated) PDK import causes changes in the default naming
- cross-sections not excplicitely constructed with `@xsection` decorator will not get default name conversion (e.g. `partial`s), even when default names are passed to `Pdk` constructor

_test_pdk_a/\_\_init\_\_.py_
```python
from functools import partial

import gdsfactory as gf
from gdsfactory.pdk import Pdk


def dummy_xs_a_before():
    return gf.cross_section.rib(width=0.7)


dummy_xs_a_partial = partial(gf.cross_section.rib_heater_doped, width=1.1)


PDK = Pdk(
    name="test_pdk_a",
    cross_sections={
        'dummy_xs_a_before_label': dummy_xs_a_before,
        'dummy_xs_a_partial_label': dummy_xs_a_partial,
    },
    cross_section_default_names={
        'xs_528e141d': 'dummy_xs_a_before_label',
        'xs_14d8000e': 'dummy_xs_a_partial_label',
    }
)


@PDK.xsection
def dummy_xs_a():
    return gf.cross_section.strip()

```

_test_pdk_b/\_\_init\_\_.py_
```python
import gdsfactory as gf
from gdsfactory.pdk import Pdk

PDK = Pdk(
    name="test_pdk_b",
)


@PDK.xsection
def dummy_xs_b():
    return gf.cross_section.strip()

```

_test_pdks.py_
```python
import gdsfactory as gf
from test_pdk_a import PDK as PDKa

PDKa.activate()

print(f'Before import: {gf.get_cross_section('dummy_xs_a').name=}')
from test_pdk_b import PDK as PDKb
print(f'After import : {gf.get_cross_section('dummy_xs_a').name=}')

print('\n=============== PDK content ===============')
print(f'{PDKa.cross_sections=}')
print(f'{PDKa.cross_section_default_names=}')
print(f'{PDKb.cross_sections=}')
print(f'{PDKb.cross_section_default_names=}')

print('\n=== some PDKa.get_cross_section queries ===')
print(f'{PDKa.get_cross_section('dummy_xs_a').name=}')
print(f'{PDKa.get_cross_section('dummy_xs_a_before_label').name=}')
print(f'{PDKa.get_cross_section('dummy_xs_a_partial_label').name=}')

print('\n=== some PDKb.get_cross_section queries ===')
print(f'{PDKb.get_cross_section('dummy_xs_b').name=}')

```

Running `test_pdks.py` results in
_current main_
```
Before import: gf.get_cross_section('dummy_xs_a').name='dummy_xs_a'
After import : gf.get_cross_section('dummy_xs_a').name='dummy_xs_b'

=============== PDK content ===============
PDKa.cross_sections={'dummy_xs_a_before_label': <function dummy_xs_a_before at 0x00000203BEE83BA0>, 'dummy_xs_a_partial_label': functools.partial(<function rib_heater_doped at 0x00000203BE9FAB60>, width=1.1), 'dummy_xs_a': <function dummy_xs_a at 0x00000203BEE839C0>}
PDKa.cross_section_default_names={'xs_528e141d': 'dummy_xs_a_before_label', 'xs_14d8000e': 'dummy_xs_a_partial_label'}
PDKb.cross_sections={'dummy_xs_b': <function dummy_xs_b at 0x00000203BEE83CE0>}
PDKb.cross_section_default_names={}

=== some PDKa.get_cross_section queries ===
PDKa.get_cross_section('dummy_xs_a').name='dummy_xs_b'
PDKa.get_cross_section('dummy_xs_a_before_label').name='xs_528e141d'
PDKa.get_cross_section('dummy_xs_a_partial_label').name='xs_14d8000e'

=== some PDKb.get_cross_section queries ===
PDKb.get_cross_section('dummy_xs_b').name='dummy_xs_b'
```

_after PR_
```
Before import: gf.get_cross_section('dummy_xs_a').name='dummy_xs_a'
After import : gf.get_cross_section('dummy_xs_a').name='dummy_xs_a'

=============== PDK content ===============
PDKa.cross_sections={'dummy_xs_a_before_label': <function dummy_xs_a_before at 0x0000024EEF5EFBA0>, 'dummy_xs_a_partial_label': functools.partial(<function rib_heater_doped at 0x0000024EEF16E5C0>, width=1.1), 'dummy_xs_a': <function dummy_xs_a at 0x0000024EEF5EF9C0>}
PDKa.cross_section_default_names={'xs_528e141d': 'dummy_xs_a_before_label', 'xs_14d8000e': 'dummy_xs_a_partial_label', 'strip': 'dummy_xs_a'}
PDKb.cross_sections={'dummy_xs_b': <function dummy_xs_b at 0x0000024EEF5EFCE0>}
PDKb.cross_section_default_names={'strip': 'dummy_xs_b'}

=== some PDKa.get_cross_section queries ===
PDKa.get_cross_section('dummy_xs_a').name='dummy_xs_a'
PDKa.get_cross_section('dummy_xs_a_before_label').name='dummy_xs_a_before_label'
PDKa.get_cross_section('dummy_xs_a_partial_label').name='dummy_xs_a_partial_label'

=== some PDKb.get_cross_section queries ===
PDKb.get_cross_section('dummy_xs_b').name='dummy_xs_b'
```

## Summary by Sourcery

Standardize cross-section naming across multiple PDKs by making the xsection decorator configurable with custom containers and default mappings, simplifying Pdk.xsection registration, and applying PDK-specific default names when retrieving cross-sections.

Enhancements:
- Make xsection decorator accept custom cross_sections container and default name mapping parameters
- Refactor Pdk.xsection to delegate registration to the configurable xsection decorator
- Apply PDK-specific cross_section_default_names mapping in Pdk.get_cross_section to enforce correct naming upon retrieval