### PR TITLE
Fix for crossing45 port alignment and contour connectivity

### DIFF
--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -236,7 +236,7 @@ def crossing45(
     crossing = gf.get_component(crossing)
 
     c = Component()
-    x = c << crossing
+    x = c.create_vinst(crossing)
     x.rotate(45)
 
     p_e = x.ports["o3"].center
@@ -268,10 +268,10 @@ def crossing45(
     )
     assert abs(bend.info["end_angle"] - end_angle) < tol, bend.info["end_angle"]
 
-    b_tr = c << bend
-    b_tl = c << bend
-    b_bl = c << bend
-    b_br = c << bend
+    b_tr = c.create_vinst(bend)
+    b_tl = c.create_vinst(bend)
+    b_bl = c.create_vinst(bend)
+    b_br = c.create_vinst(bend)
 
     b_tr.connect("o2", x.ports["o3"], mirror=True)
     b_tl.connect("o2", x.ports["o1"], mirror=True)
@@ -299,5 +299,9 @@ __all__ = [
 ]
 
 if __name__ == "__main__":
-    c = crossing45()
+    c = gf.Component()
+    x = c << crossing45()
+    s = c << gf.c.straight(length=100)
+    x.connect("o1", s.ports["o1"])
+    c.flatten()
     c.show()


### PR DESCRIPTION
# Fix for `crossing45` port alignment and contour connectivity

## Description  
When using `gf.c.crossing45()` in a component, the generated structure currently exhibits two issues:  

1. The contour of the crossing is not fully connected, which leads to small gaps ("cracks") in the geometry.  
2. The ports of the `crossing45` are not perfectly aligned with the connected waveguides (e.g., `gf.c.straight()`), resulting in a visible mismatch.  

### Minimal example to reproduce  
```python
import gdsfactory as gf

c = gf.Component()
cross = c << gf.c.crossing45()
st = c << gf.c.straight()
cross.connect("o1", st.ports["o2"])
c.show()
```
## Proposed fix

I resolved this by using VCells as suggested in the documentation. 

## Additional information

The images above show the slit that results from connecting a straight to a crossing45 port.
<img width="789" height="395" alt="grafik" src="https://github.com/user-attachments/assets/812b2218-50e1-460b-9d14-b056447af081" />
<img width="945" height="640" alt="grafik" src="https://github.com/user-attachments/assets/ff7532e6-a135-41c8-9b4a-05fa4561453b" />

## Summary by Sourcery

Use VCells for crossings and bends in crossing45 to fix contour connectivity issues and port misalignment.

Enhancements:
- Replace direct component instantiation with create_vinst for the main crossing and all bends in crossing45
- Update the example script to use a Component, demonstrate connecting a crossing45 to a straight, and apply flatten