### PR TITLE
optionally add interface instances in gf.get_netlist() to (e.g. to model mode mismatch)

### DIFF
--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -101,8 +101,11 @@ def _bend_circular(
         n_bend_90=abs(angle / 90.0),
         min_bend_radius=radius,
     )
-    for prt in c.ports:
-        prt.info["radius"] = radius
+    for prt in c.ports:  # positive radius for outward left turning
+        if all(prt.center == p.points[0]):
+            prt.info["radius"] = -radius if angle > 0 else radius
+        elif all(prt.center == p.points[-1]):
+            prt.info["radius"] = radius if angle > 0 else -radius
     return c
 
 

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -364,36 +364,14 @@ def get_netlist(
                 elif dst in top_ports_list:
                     top_ports[dst] = src
                 else:
-                    src_xs = name2port[src].cross_section
-                    src_xs_name = name2port[src].info.get("cross_section")
-                    src_r = name2port[src].info.get("radius")
-                    dst_xs = name2port[dst].cross_section
-                    dst_xs_name = name2port[dst].info.get("cross_section")
-                    dst_r = name2port[dst].info.get("radius")
-                    mismatch = src_xs.width != dst_xs.width or src_r != dst_r
-                    if add_interface_on_mismatch and mismatch:
-                        # inject interface instance and reconnect ports
-                        intf_inst_name = f"interface__{src.replace(',', '_')}__{dst.replace(',', '_')}"
-                        if intf_inst_name in instances:
-                            raise ValueError(
-                                f"'{intf_inst_name}' already present in instances."
-                            )
-                        settings = {
-                            "width1": src_xs.width,
-                            "width2": dst_xs.width,
-                            "radius1": src_r,
-                            "radius2": dst_r,
-                            "cross_section1": src_xs_name,
-                            "cross_section2": dst_xs_name,
-                        }
-                        instances[intf_inst_name] = {
-                            "component": "interface",
-                            "settings": settings,
-                        }
-                        src1, dst1 = sorted([src, f"{intf_inst_name},o1"])
-                        src2, dst2 = sorted([dst, f"{intf_inst_name},o2"])
-                        nets.extend(
-                            [{"p1": src1, "p2": dst1}, {"p1": src2, "p2": dst2}]
+                    if add_interface_on_mismatch:
+                        insert_interface_if_needed(
+                            src=src,
+                            dst=dst,
+                            instances=instances,
+                            placements=placements,
+                            nets=nets,
+                            name2port=name2port,
                         )
                     else:
                         src_dest = sorted([src, dst])
@@ -414,6 +392,54 @@ def get_netlist(
     if warnings:
         netlist["warnings"] = warnings
     return clean_value_json(netlist)  # type: ignore[no-any-return]
+
+
+def insert_interface_if_needed(
+    src: str,
+    dst: str,
+    instances: dict[str, dict[str, Any]],
+    placements: dict[str, dict[str, Any]],
+    nets: list[dict[str, Any]],
+    name2port: dict[str, typings.Port],
+) -> None:
+    # check cross sections for equality
+    src_xs_name = name2port[src].info.get("cross_section")
+    dst_xs_name = name2port[dst].info.get("cross_section")
+    xs_mismatch = src_xs_name != dst_xs_name
+
+    # check port radii for (signed) equality
+    src_r = name2port[src].info.get("radius")
+    dst_r = name2port[dst].info.get("radius")
+    # mirroring an instance turns left bends into right bends and vice versa
+    if placements[src.split(",")[0]]["mirror"] and src_r is not None:
+        src_r = -src_r
+    if placements[dst.split(",")[0]]["mirror"] and dst_r is not None:
+        dst_r = -dst_r
+    # Considering signal from src to dst, src_r stays outward oriented
+    # and dst_r must be turned from outward to inward orientation (inverted).
+    dst_r = dst_r if dst_r is None else -dst_r
+    r_mismatch = src_r != dst_r
+
+    if xs_mismatch or r_mismatch:  # inject interface instance and reconnect ports
+        intf_name = f"interface__{src.replace(',', '_')}__{dst.replace(',', '_')}"
+        if intf_name in instances:
+            raise ValueError(f"'{intf_name}' already present in instances.")
+        settings = {
+            "width1": name2port[src].cross_section.width,
+            "width2": name2port[dst].cross_section.width,
+            "radius1": src_r,
+            "radius2": dst_r,
+            "cross_section1": src_xs_name,
+            "cross_section2": dst_xs_name,
+        }
+        instances[intf_name] = {"component": "interface", "settings": settings}
+        src1, dst1 = sorted([src, f"{intf_name},o1"])
+        src2, dst2 = sorted([dst, f"{intf_name},o2"])
+        nets.extend([{"p1": src1, "p2": dst1}, {"p1": src2, "p2": dst2}])
+    else:  # just do normal connection for matched ports
+        src_dest = sorted([src, dst])
+        net = {"p1": src_dest[0], "p2": src_dest[1]}
+        nets.append(net)
 
 
 def extract_connections(


### PR DESCRIPTION
Similar extensions have been proposed in #1067 to allow simulation of mode mismatch at component boundaries, but have not been finished.
With this PR, whenever port properties do not match (and `add_interface_on_mismatch` is set), extra dummy `'interface'` instances and their connections are added to the netlist,
Relevant parameters of the interface on both sides are transported in the `'settings'` `dict` along with the `'interface'` instance.
The radius will be extracted from the `info` attribute of the port. Therefore, in `gf.components.bend_circular()` the radius was added to the port `info`.

## Summary by Sourcery

Enable modeling of mode or geometry mismatches by adding an 'add_interface_on_mismatch' flag to get_netlist, injecting interface instances for mismatched ports, and enriching port metadata with radius information.

New Features:
- Optionally insert dummy 'interface' instances with appropriate connections when port cross-section widths or radii mismatch during netlist generation

Enhancements:
- Include port cross-section names and radii in the interface settings dictionary for mismatch modeling
- Add radius metadata to ports of circular bend components for use in netlist generation