### PR TITLE
Pass down all vcell kwargs to kfactory

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -157,12 +157,12 @@ def vcell(
     *,
     set_settings: bool = True,
     set_name: bool = True,
-    check_ports: bool = True,
     add_port_layers: bool = True,
     cache: Cache[int, Any] | dict[int, Any] | None = None,
     basename: str | None = None,
     drop_params: tuple[str, ...] = ("self", "cls"),
     register_factory: bool = True,
+    check_ports: bool = True,
     ports: PortsDefinition | None = None,
 ) -> (
     ComponentAllAngleFunc[ComponentParams]
@@ -174,13 +174,15 @@ def vcell(
 
     vc = _vcell(  # type: ignore[call-overload]
         _func,
+        output_type=ComponentAllAngle,
         set_settings=set_settings,
         set_name=set_name,
-        check_ports=check_ports,
+        add_port_layers=add_port_layers,
+        cache=cache,
         basename=basename,
         drop_params=list(drop_params),
         register_factory=register_factory,
-        output_type=ComponentAllAngle,
+        check_ports=check_ports,
         ports=ports,
     )
     vc.is_gf_vcell = True


### PR DESCRIPTION
Not sure if this was done on purpose, but both keyword arguments are not being passed.

## Summary by Sourcery

Forward all keyword arguments from the vcell wrapper to the underlying kfactory _vcell function, including check_ports, add_port_layers, cache, and output_type.

Bug Fixes:
- Include missing kwargs (check_ports, add_port_layers, cache) when invoking _vcell
- Add output_type parameter to the initial _vcell call to maintain consistent behavior