### PR TITLE
fix import_gds

### DIFF
--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -28,7 +28,7 @@ def import_gds(
     temp_kcl = KCLayout(name=str(gdspath))
     options = kf.utilities.load_layout_options()
     options.warn_level = 0
-    temp_kcl.read(gdspath, options=options)
+    temp_kcl.layout.read(gdspath, options=options)
     cellname = cellname or temp_kcl.layout.top_cell().name
     kcell = temp_kcl[cellname]
     if rename_duplicated_cells:


### PR DESCRIPTION
## Summary
 
Fix cell name truncation on `import_gds` as it was merge tested in kfactory and would truncate after the test. For now just bypass all those test as here they aren't necessary anyways.

Fixes https://github.com/gdsfactory/gdsfactory/issues/4107

## Summary by Sourcery

Fix cell name truncation in import_gds by invoking the layout-level read method and bypass unnecessary post-import tests

Bug Fixes:
- Prevent cell name truncation by calling temp_kcl.layout.read instead of temp_kcl.read in import_gds

Chores:
- Remove or bypass redundant import tests that are not needed in this context