### PR TITLE
fix is gf cell marker

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from functools import partial
+from functools import partial, wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, overload
 
 from cachetools import Cache
@@ -118,8 +118,18 @@ def cell(
         lvs_equivalent_ports=lvs_equivalent_ports,
         ports=ports,
     )
-    c.is_gf_cell = True
-    return c  # type: ignore[no-any-return]
+    if callable(c):
+
+        @wraps(c)
+        def decorator(func: Callable) -> Any:
+            comp = c(func)
+            comp.is_gf_cell = True  # type: ignore
+            return comp
+
+        return decorator
+    else:
+        c.is_gf_cell = True
+        return c
 
 
 class ComponentAllAngleFunc(Protocol[ComponentParams]):


### PR DESCRIPTION
I encountered a bug in GDSFactory where the is_gf_cell marker was not properly set for cells decorated with `@cell(...)`, i.e. when arguments are supplied to the cell decorator.

This PR fixes it.

## Summary by Sourcery

Bug Fixes:
- Ensure is_gf_cell attribute is applied for cells decorated via @cell(...) with arguments