### PR TITLE
better error message

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -26,7 +26,7 @@ from kfactory import (
     save_layout_options,
 )
 from kfactory.exceptions import LockedError
-from kfactory.kcell import AnyTKCell, BaseKCell, ProtoKCell
+from kfactory.kcell import BaseKCell, ProtoKCell
 from kfactory.port import ProtoPort
 from kfactory.utils.fill import fill_tiled
 from kfactory.utils.violations import (
@@ -561,7 +561,7 @@ class Component(ComponentBase, kf.DKCell):
             if flatten:
                 c.flatten()
 
-    def __lshift__(self, cell: AnyTKCell) -> kf.Instance:
+    def __lshift__(self, cell: kf.ProtoTKCell[Any]) -> ComponentReference:
         """Convenience function for adding instances/references to a Component.
 
         Args:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -26,7 +26,7 @@ from kfactory import (
     save_layout_options,
 )
 from kfactory.exceptions import LockedError
-from kfactory.kcell import BaseKCell, ProtoKCell
+from kfactory.kcell import AnyTKCell, BaseKCell, ProtoKCell
 from kfactory.port import ProtoPort
 from kfactory.utils.fill import fill_tiled
 from kfactory.utils.violations import (
@@ -561,6 +561,18 @@ class Component(ComponentBase, kf.DKCell):
             if flatten:
                 c.flatten()
 
+    def __lshift__(self, cell: AnyTKCell) -> kf.Instance:
+        """Convenience function for adding instances/references to a Component.
+
+        Args:
+            cell: The cell to be added as an instance
+        """
+        if isinstance(cell, ComponentAllAngle):
+            raise ValueError(
+                f"Use Component.add_ref_off_grid() for all angle {cell.name!r}"
+            )
+        return self.create_inst(cell)
+
     def add_ref(
         self,
         component: kf.ProtoTKCell[Any],
@@ -580,6 +592,12 @@ class Component(ComponentBase, kf.DKCell):
             column_pitch: column pitch.
             row_pitch: row pitch.
         """
+
+        if isinstance(component, ComponentAllAngle):
+            raise ValueError(
+                f"Use Component.add_ref_off_grid() for all angle {component.name!r}"
+            )
+
         if self.locked:
             raise LockedError(self)
 

--- a/gdsfactory/components/pcms/resistance_sheet.py
+++ b/gdsfactory/components/pcms/resistance_sheet.py
@@ -54,6 +54,8 @@ def resistance_sheet(
     )
 
     c.info["resistance"] = ohms_per_square * width * length if ohms_per_square else 0
+    c.info["length"] = length
+    c.info["width"] = width
     c.add_port(
         name="pad1",
         port=pad1.ports[pad_port_name],

--- a/tests/test-data-regression/test_settings_resistance_sheet_.yml
+++ b/tests/test-data-regression/test_settings_resistance_sheet_.yml
@@ -1,5 +1,7 @@
 info:
+  length: 50
   resistance: 0
+  width: 10
 name: resistance_sheet_gdsfactorypcomponentsppcmspresistance__cb73a501
 settings:
   layer_offsets:


### PR DESCRIPTION
- **better error message**
- **fix tests**

## Summary by Sourcery

Implement a new `<<` shortcut for adding component instances, improve error messaging for misused all-angle components, enrich resistance_sheet metadata with dimensions, and adjust tests to match the updated info fields.

New Features:
- Introduce the `<<` operator on Component to add instances via `create_inst`
- Record `length` and `width` properties in the `resistance_sheet` component’s info

Enhancements:
- Raise clear ValueError when attempting to reference a ComponentAllAngle via `<<` or `add_ref` instead of `add_ref_off_grid`

Tests:
- Update resistance_sheet regression test to include new `length` and `width` info fields