### PR TITLE
better error message v2

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -468,9 +468,6 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if self.locked:
             raise LockedError(self)
 
-        if not isinstance(component, kf.ProtoTKCell):
-            raise ValueError(f"Expected a Component, got {type(component)}")
-
         return self.create_vinst(component)
 
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -575,7 +575,7 @@ class Component(ComponentBase, kf.DKCell):
                 f"Use Component.add_ref_off_grid() for all angle {cell.name!r}"
             )
 
-        elif not isinstance(cell, kf.ProtoTKCell):
+        if not isinstance(cell, kf.ProtoTKCell):
             raise ValueError(f"Expected a Component, got {type(cell)}")
         return self.create_inst(cell)
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -468,6 +468,9 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if self.locked:
             raise LockedError(self)
 
+        if not isinstance(component, kf.ProtoTKCell):
+            raise ValueError(f"Expected a Component, got {type(component)}")
+
         return self.create_vinst(component)
 
 
@@ -571,6 +574,9 @@ class Component(ComponentBase, kf.DKCell):
             raise ValueError(
                 f"Use Component.add_ref_off_grid() for all angle {cell.name!r}"
             )
+
+        elif not isinstance(cell, kf.ProtoTKCell):
+            raise ValueError(f"Expected a Component, got {type(cell)}")
         return self.create_inst(cell)
 
     def add_ref(
@@ -597,6 +603,8 @@ class Component(ComponentBase, kf.DKCell):
             raise ValueError(
                 f"Use Component.add_ref_off_grid() for all angle {component.name!r}"
             )
+        elif not isinstance(component, kf.ProtoTKCell):
+            raise ValueError(f"Expected a Component, got {type(component)}")
 
         if self.locked:
             raise LockedError(self)


### PR DESCRIPTION
- **better error message**
- **fix tests**
- **fix issue**
- **better_error_message, make sure add_ref receives a component**

## Summary by Sourcery

Enforce explicit type validation and improve error messaging for component reference methods

Enhancements:
- Add isinstance checks in add_ref_off_grid to verify inputs are kf.ProtoTKCell and raise ValueError if not
- Add type validation in __lshift__ to ensure only kf.ProtoTKCell instances are used and provide clear error messages
- Add type checking in add_ref to enforce valid component inputs and raise informative ValueError on mismatches