### PR TITLE
Use pygit2 and depend on it explicitly

### DIFF
--- a/gdsfactory/install.py
+++ b/gdsfactory/install.py
@@ -8,19 +8,11 @@ import pathlib
 import shutil
 import sys
 
-from git import Repo
+from pygit2 import clone_repository
 
 from gdsfactory.config import PATH
 
 home = pathlib.Path.home()
-
-
-def clone_repository(repo_url: str, clone_dir: pathlib.Path) -> None:
-    try:
-        Repo.clone_from(repo_url, clone_dir)
-        print(f"Repository cloned to {clone_dir}")
-    except Exception as e:
-        print("Error cloning repository:", e)
 
 
 def remove_path_or_dir(dest: pathlib.Path) -> None:

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -170,9 +170,11 @@ class FileWatcher(FileSystemEventHandler):
 
         from gdsfactory.get_factories import get_cells_from_dict
 
-        dirpath = cwd
-        if (repo := discover_repository(cwd)) is not None:
-            dirpath = pathlib.Path(repo).parent
+        try:
+            repo = pygit2.Repository(cwd)
+            dirpath = repo.workdir or repo.path
+        except pygit2.GitError:
+            dirpath = cwd
 
         try:
             filepath = pathlib.Path(filepath)

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -166,7 +166,7 @@ class FileWatcher(FileSystemEventHandler):
             print(f"Ignored {what}: {src_path}")
 
     def get_component(self, filepath: PathType) -> Component | None:
-        from pygit2 import discover_repository
+        from pygit2 import pygit2
 
         from gdsfactory.get_factories import get_cells_from_dict
 

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -166,7 +166,7 @@ class FileWatcher(FileSystemEventHandler):
             print(f"Ignored {what}: {src_path}")
 
     def get_component(self, filepath: PathType) -> Component | None:
-        from pygit2 import pygit2
+        import pygit2
 
         from gdsfactory.get_factories import get_cells_from_dict
 

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -178,7 +178,7 @@ class FileWatcher(FileSystemEventHandler):
 
         try:
             filepath = pathlib.Path(filepath)
-            dirpath = dirpath / "build" / "gds"
+            dirpath = pathlib.Path(dirpath) / "build" / "gds"
             dirpath.mkdir(parents=True, exist_ok=True)
 
             if filepath.exists():

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -174,7 +174,7 @@ class FileWatcher(FileSystemEventHandler):
             repo = pygit2.Repository(cwd)
             dirpath_str = repo.workdir or repo.path
         except pygit2.GitError:
-            dirpath_str = cwd
+            dirpath_str = str(cwd)
 
         try:
             filepath = pathlib.Path(filepath)

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -166,21 +166,17 @@ class FileWatcher(FileSystemEventHandler):
             print(f"Ignored {what}: {src_path}")
 
     def get_component(self, filepath: PathType) -> Component | None:
-        import git
-        import git.repo as gr
+        from pygit2 import discover_repository
 
         from gdsfactory.get_factories import get_cells_from_dict
 
-        try:
-            repo = gr.Repo(".", search_parent_directories=True)
-            dirpath = repo.working_tree_dir
-        except git.InvalidGitRepositoryError:
-            dirpath = cwd
-        if dirpath is None:
-            dirpath = cwd
+        dirpath = cwd
+        if (repo := discover_repository(cwd)) is not None:
+            dirpath = pathlib.Path(repo).parent
+
         try:
             filepath = pathlib.Path(filepath)
-            dirpath = pathlib.Path(dirpath) / "build/gds"
+            dirpath = dirpath / "build" / "gds"
             dirpath.mkdir(parents=True, exist_ok=True)
 
             if filepath.exists():

--- a/gdsfactory/watch.py
+++ b/gdsfactory/watch.py
@@ -172,13 +172,13 @@ class FileWatcher(FileSystemEventHandler):
 
         try:
             repo = pygit2.Repository(cwd)
-            dirpath = repo.workdir or repo.path
+            dirpath_str = repo.workdir or repo.path
         except pygit2.GitError:
-            dirpath = cwd
+            dirpath_str = cwd
 
         try:
             filepath = pathlib.Path(filepath)
-            dirpath = pathlib.Path(dirpath) / "build" / "gds"
+            dirpath = pathlib.Path(dirpath_str) / "build" / "gds"
             dirpath.mkdir(parents=True, exist_ok=True)
 
             if filepath.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
   "attrs",
   "graphviz",
   "pyglet<3",
-  "typing-extensions"
+  "typing-extensions",
+  "pygit2"
 ]
 description = "python library to generate GDS layouts"
 keywords = ["eda", "photonics", "python"]


### PR DESCRIPTION
## Summary

kfactory switched the dependency to pygit2. gdsfactory implicitly depended on gitpython through kfactory.
This broke the CLI.

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Replace GitPython usage with pygit2 for repository discovery and cloning, and update the dependency list accordingly.

Enhancements:
- Refactor get_component in watch.py to use pygit2.discover_repository for repo detection instead of GitPython
- Remove custom GitPython-based clone_repository and switch to pygit2.clone_repository in install.py

Build:
- Add pygit2 to project dependencies in pyproject.toml