### PR TITLE
add exclude layers to write_gds and CONF

### DIFF
--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -112,6 +112,7 @@ class Config(Settings):
     layer_label: tuple[int, int]
     port_types: list[str]
     port_types_grating_couplers: list[str]
+    exclude_layers: list[tuple[int, int]] | list[str] | None
 
 
 CONF: Config = config  # type: ignore[assignment]

--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -139,6 +139,7 @@ CONF.port_types = [
     "edge_coupler",  # for edge couplers
 ]
 CONF.port_types_grating_couplers = ["vertical_te", "vertical_tm", "vertical_dual"]
+CONF.exclude_layers = None
 
 
 class Paths:


### PR DESCRIPTION
- **add exclude layers**
- **write exclude layers**

## Summary by Sourcery

Add support for excluding specified layers when exporting components to GDS by introducing an exclude_layers parameter to the write_gds function and configuration.

New Features:
- Add exclude_layers parameter to write_gds to allow users to specify layers to omit from the GDS file
- Introduce exclude_layers setting in Config to configure global layer exclusions
- Implement logic in write_gds to deselect excluded layers and build save_options accordingly