### PR TITLE
add allow_layer_missmatch in route_bundle, add wire_corner45_straight

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -363,7 +363,7 @@ from gdsfactory.components.waveguides import (
     wire,
     wire_corner,
     wire_corner45,
-    wire_corner45_single_layer,
+    wire_corner45_straight,
     wire_corner_sections,
     wire_straight,
 )
@@ -693,7 +693,7 @@ __all__ = [
     "wire",
     "wire_corner",
     "wire_corner45",
-    "wire_corner45_single_layer",
+    "wire_corner45_straight",
     "wire_corner_sections",
     "wire_straight",
 ]

--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -363,6 +363,7 @@ from gdsfactory.components.waveguides import (
     wire,
     wire_corner,
     wire_corner45,
+    wire_corner45_single_layer,
     wire_corner_sections,
     wire_straight,
 )
@@ -692,6 +693,7 @@ __all__ = [
     "wire",
     "wire_corner",
     "wire_corner45",
+    "wire_corner45_single_layer",
     "wire_corner_sections",
     "wire_straight",
 ]

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -95,6 +95,9 @@ def _bend_euler(
     x = gf.get_cross_section(cross_section)
     radius = radius or x.radius
 
+    if radius is None:
+        raise ValueError("radius must be specified")
+
     if layer and width:
         x = gf.get_cross_section(
             cross_section, layer=layer or x.layer, width=width or x.width
@@ -119,7 +122,7 @@ def _bend_euler(
         np.round(abs(float(path.points[0][0] - path.points[-1][0])), 3)
     )
     c.info["min_bend_radius"] = min_bend_radius
-    c.info["radius"] = float(radius)
+    c.info["radius"] = radius
     c.info["width"] = width or x.width
 
     if not allow_min_radius_violation:

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -95,9 +95,6 @@ def _bend_euler(
     x = gf.get_cross_section(cross_section)
     radius = radius or x.radius
 
-    if radius is None:
-        return gf.c.wire_corner(cross_section=x)
-
     if layer and width:
         x = gf.get_cross_section(
             cross_section, layer=layer or x.layer, width=width or x.width
@@ -246,6 +243,7 @@ def bend_euler(
         p=p,
         with_arc_floorplan=with_arc_floorplan,
         npoints=npoints,
+        angular_step=angular_step,
         layer=layer,
         width=width,
         cross_section=cross_section,

--- a/gdsfactory/components/waveguides/__init__.py
+++ b/gdsfactory/components/waveguides/__init__.py
@@ -39,7 +39,7 @@ from gdsfactory.components.waveguides.straight_pin_slot import (
 from gdsfactory.components.waveguides.wire import (
     wire_corner,
     wire_corner45,
-    wire_corner45_single_layer,
+    wire_corner45_straight,
     wire_corner_sections,
 )
 
@@ -67,7 +67,7 @@ __all__ = [
     "straight_pn_slot",
     "wire_corner",
     "wire_corner45",
-    "wire_corner45_single_layer",
+    "wire_corner45_straight",
     "wire_corner_sections",
     "wire_straight",
 ]

--- a/gdsfactory/components/waveguides/__init__.py
+++ b/gdsfactory/components/waveguides/__init__.py
@@ -39,6 +39,7 @@ from gdsfactory.components.waveguides.straight_pin_slot import (
 from gdsfactory.components.waveguides.wire import (
     wire_corner,
     wire_corner45,
+    wire_corner45_single_layer,
     wire_corner_sections,
 )
 
@@ -66,6 +67,7 @@ __all__ = [
     "straight_pn_slot",
     "wire_corner",
     "wire_corner45",
+    "wire_corner45_single_layer",
     "wire_corner_sections",
     "wire_straight",
 ]

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -235,8 +235,3 @@ def wire_corner_sections(
     c.info["dy"] = ymax - xmin
     x.add_bbox(c)
     return c
-
-
-if __name__ == "__main__":
-    c = wire_corner45_single_layer()
-    c.show()

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -69,18 +69,19 @@ def wire_corner(
 
 @gf.cell
 def wire_corner45_straight(
-    radius: float = 10,
     width: float | None = 5.0,
+    radius: float | None = None,
     cross_section: CrossSectionSpec = "metal_routing",
 ) -> gf.Component:
     """Returns 45 degrees wire straight ends.
 
     Args:
-        radius: of the corner.
         width: of the wire.
+        radius: of the corner. Defaults to width.
         cross_section: metal_routing.
     """
     c = gf.Component()
+    radius = radius or width
 
     p = gf.Path(
         [

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -68,12 +68,12 @@ def wire_corner(
 
 
 @gf.cell
-def wire_corner45(
+def wire_corner45_straight(
     radius: float = 10,
     width: float | None = 5.0,
     cross_section: CrossSectionSpec = "metal_routing",
 ) -> gf.Component:
-    """Returns 45 degrees electrical corner wire.
+    """Returns 45 degrees wire straight ends.
 
     Args:
         radius: of the corner.
@@ -97,7 +97,7 @@ def wire_corner45(
 
 
 @gf.cell_with_module_name
-def wire_corner45_single_layer(
+def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
     width: float | None = None,

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -83,6 +83,9 @@ def wire_corner45_straight(
     c = gf.Component()
     radius = radius or width
 
+    if radius is None:
+        raise ValueError("Either radius or width must be specified")
+
     p = gf.Path(
         [
             (0.0, 0.0),

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 import gdsfactory as gf
@@ -65,8 +67,37 @@ def wire_corner(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell
 def wire_corner45(
+    radius: float = 10,
+    width: float | None = 5.0,
+    cross_section: CrossSectionSpec = "metal_routing",
+) -> gf.Component:
+    """Returns 45 degrees electrical corner wire.
+
+    Args:
+        radius: of the corner.
+        width: of the wire.
+        cross_section: metal_routing.
+    """
+    c = gf.Component()
+
+    p = gf.Path(
+        [
+            (0.0, 0.0),
+            (radius / 2.0, 0.0),
+            (radius, radius / 2.0),
+            (radius, radius),
+        ]
+    )
+
+    xs = gf.get_cross_section(cross_section, width=width)
+    c = p.extrude(cross_section=xs)
+    return c
+
+
+@gf.cell_with_module_name
+def wire_corner45_single_layer(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
     width: float | None = None,
@@ -142,6 +173,7 @@ def wire_corner45(
 def wire_corner_sections(
     cross_section: CrossSectionSpec = "metal_routing",
     port_type: str = "electrical",
+    **kwargs: Any,
 ) -> Component:
     """Returns 90 degrees electrical corner wire, where all cross_section sections properly represented.
 
@@ -150,6 +182,7 @@ def wire_corner_sections(
     Args:
         cross_section: spec.
         port_type: "electrical" or "optical".
+        kwargs: cross_section settings, ignored (such as radius, width, layer).
     """
     x = gf.get_cross_section(cross_section)
 
@@ -202,3 +235,8 @@ def wire_corner_sections(
     c.info["dy"] = ymax - xmin
     x.add_bbox(c)
     return c
+
+
+if __name__ == "__main__":
+    c = wire_corner45_single_layer()
+    c.show()

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -1116,6 +1116,69 @@ def metal3(
 
 
 @xsection
+def gs(
+    width_metal: float = 10,
+    layer: typings.LayerSpec = "M3",
+    gap: float = 2,
+    layer_port: typings.LayerSpec = "M3_ABSTRACT",
+    radius: float | None = None,
+    **kwargs: Any,
+) -> CrossSection:
+    """Return Ground-Signal-Ground cross_section.
+
+    Args:
+        width_metal: in um.
+        layer: metal layer.
+        gap: between metal lines in um.
+        layer_port: port layer.
+        radius: bend radius. Optional, defaults to 2*width+gap.
+        kwargs: cross_section settings. (ignored)
+    """
+    width = width_metal
+    sections = [
+        Section(
+            width=gap,
+            layer=layer_port,
+            offset=0,
+            port_names=port_names_electrical,
+            port_types=port_types_electrical,
+        ),
+        Section(width=width, layer=layer, offset=+gap / 2 + width / 2),
+        Section(width=width, layer=layer, offset=-gap / 2 - width / 2),
+    ]
+    return CrossSection(sections=tuple(sections), radius=radius or 2 * width + gap)
+
+
+def gsg(
+    width: float = 10,
+    layer: typings.LayerSpec = "M3",
+    gap: float = 2,
+    radius: float | None = None,
+) -> CrossSection:
+    """Return Ground-Signal-Ground cross_section.
+
+    Args:
+        width_metal: in um.
+        layer: metal layer.
+        gap: between metal lines in um.
+        layer_port: port layer.
+        radius: bend radius. Optional, defaults to 3*width+2*gap.
+    """
+    sections = [
+        Section(
+            width=gap,
+            layer=layer,
+            offset=0,
+            port_names=port_names_electrical,
+            port_types=port_types_electrical,
+        ),
+        Section(width=width, layer=layer, offset=-gap - width / 2),
+        Section(width=width, layer=layer, offset=+gap + width / 2),
+    ]
+    return CrossSection(sections=tuple(sections), radius=radius or 3 * width + 2 * gap)
+
+
+@xsection
 def metal_routing(
     width: float = 10,
     layer: typings.LayerSpec = "M3",

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -572,6 +572,7 @@ def cross_section(
            │                                                            │
            └────────────────────────────────────────────────────────────┘
     """
+    radius = radius or width
     section_list: list[Section] = list(sections or [])
     cladding_simplify_not_none: list[float | None] | None = None
     cladding_offsets_not_none: list[float] | None = None
@@ -1188,6 +1189,7 @@ def metal_routing(
     **kwargs: Any,
 ) -> CrossSection:
     """Return Metal Strip cross_section."""
+
     return cross_section(
         width=width,
         layer=layer,

--- a/gdsfactory/generic_tech/layer_map.py
+++ b/gdsfactory/generic_tech/layer_map.py
@@ -41,6 +41,8 @@ class LAYER(gf.LayerEnum):
     M1: Layer = (41, 0)
     M2: Layer = (45, 0)
     M3: Layer = (49, 0)
+    M3_ABSTRACT: Layer = (49, 1)
+
     MTOP: Layer = (49, 0)
     VIAC: Layer = (40, 0)
     VIA1: Layer = (44, 0)

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -107,7 +107,9 @@ def route_bundle(
     collision_check_layers: LayerSpecs | None = None,
     on_collision: Literal["error", "show_error"] | None = None,
     bboxes: Sequence[kf.kdb.DBox] | None = None,
-    allow_width_mismatch: bool = False,
+    allow_width_mismatch: bool | None = None,
+    allow_layer_mismatch: bool | None = None,
+    allow_type_mismatch: bool | None = None,
     radius: float | None = None,
     route_width: float | None = None,
     straight: ComponentSpec = "straight",
@@ -145,6 +147,8 @@ def route_bundle(
         on_collision: action to take on collision. Defaults to None (ignore).
         bboxes: list of bounding boxes to avoid collisions.
         allow_width_mismatch: allow different port widths.
+        allow_layer_mismatch: allow different port layers to connect.
+        allow_type_mismatch: allow different port types to connect.
         radius: bend radius. If None, defaults to cross_section.radius.
         route_width: width of the route. If None, defaults to cross_section.width.
         straight: function for the straight. Defaults to straight.
@@ -367,6 +371,8 @@ def route_bundle(
             else None,
             on_collision=on_collision,
             allow_width_mismatch=allow_width_mismatch,
+            allow_layer_mismatch=allow_layer_mismatch,
+            allow_type_mismatch=allow_type_mismatch,
             bboxes=list(bboxes or []),
             route_width=width,
             sort_ports=sort_ports,

--- a/gdsfactory/samples/33_route_bundle_electrical.py
+++ b/gdsfactory/samples/33_route_bundle_electrical.py
@@ -38,5 +38,5 @@ if __name__ == "__main__":
         # router=router,
     )
 
-    lyrdb = c.connectivity_check()
+    lyrdb = c.connectivity_check(port_types=["electrical", "optical"])
     c.show(lyrdb=lyrdb)

--- a/gdsfactory/samples/35_route_gs.py
+++ b/gdsfactory/samples/35_route_gs.py
@@ -1,0 +1,35 @@
+"""Sample GS routing."""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+
+if __name__ == "__main__":
+    p = gf.path.straight()
+
+    s0 = gf.Section(
+        width=2,
+        offset=0,
+        layer=(2, 0),
+        port_names=("g1", "g2"),
+        port_types=("electrical", "electrical"),
+    )
+    s1 = gf.Section(width=2, offset=4, layer=(2, 0))
+    x = gf.CrossSection(sections=(s0, s1), radius=8)
+    c = gf.path.extrude(p, cross_section=x)
+    pad = c
+
+    c2 = gf.Component()
+    pad1 = c2 << pad
+    pad2 = c2 << pad
+    pad2.move((100, 100))
+
+    gf.routing.route_bundle(
+        c2,
+        [pad1.ports["g2"]],
+        [pad2.ports["g1"]],
+        cross_section=x,
+        raise_on_error=True,
+        port_type="electrical",
+    )
+    c2.show()

--- a/gdsfactory/samples/35_route_gs_optical.py
+++ b/gdsfactory/samples/35_route_gs_optical.py
@@ -1,0 +1,36 @@
+"""Sample GS routing."""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+
+if __name__ == "__main__":
+    p = gf.path.straight()
+    port_type = "optical"
+
+    s0 = gf.Section(
+        width=2,
+        offset=0,
+        layer=(2, 0),
+        port_names=("g1", "g2"),
+        port_types=(port_type, port_type),
+    )
+    s1 = gf.Section(width=2, offset=4, layer=(2, 0))
+    x = gf.CrossSection(sections=(s0, s1), radius=8)
+    c = gf.path.extrude(p, cross_section=x)
+    pad = c
+
+    c2 = gf.Component()
+    pad1 = c2 << pad
+    pad2 = c2 << pad
+    pad2.move((100, 100))
+
+    gf.routing.route_bundle(
+        c2,
+        [pad1.ports["g2"]],
+        [pad2.ports["g1"]],
+        cross_section=x,
+        raise_on_error=True,
+        port_type=port_type,
+    )
+    c2.show()

--- a/gdsfactory/samples/36_route_gsg.py
+++ b/gdsfactory/samples/36_route_gsg.py
@@ -1,0 +1,41 @@
+"""Sample GS routing."""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+
+if __name__ == "__main__":
+    p = gf.path.straight()
+
+    g = gf.Section(
+        width=2,
+        offset=0,
+        layer=(2, 0),
+        port_names=("e1", "e2"),
+        port_types=("electrical", "electrical"),
+    )
+    s0 = gf.Section(width=2, offset=-4, layer=(2, 0))
+    s1 = gf.Section(width=2, offset=4, layer=(2, 0))
+
+    x = gf.CrossSection(sections=(s0, s1, g), radius=8)
+    c = gf.path.extrude(p, cross_section=x)
+    pad = c
+
+    c2 = gf.Component()
+    pad1 = c2 << pad
+    pad2 = c2 << pad
+    pad2.move((100, 100))
+
+    gf.routing.route_bundle(
+        c2,
+        [pad1.ports["e2"]],
+        [pad2.ports["e1"]],
+        cross_section=x,
+        port_type="electrical",
+        raise_on_error=True,
+        # bend='bend_circular',
+        # bend='wire_corner'
+        bend="wire_corner45",
+        # bend='wire_corner_sections'
+    )
+    c2.show()

--- a/gdsfactory/samples/route_bundle_yaml.py
+++ b/gdsfactory/samples/route_bundle_yaml.py
@@ -1,3 +1,6 @@
+import gdsfactory as gf
+
+yaml_str = """
 instances:
   t:
     component: pad_array
@@ -10,20 +13,24 @@ instances:
       port_orientation: 90
       columns: 3
 
-
 placements:
   t:
     x: 200
     y: 400
 routes:
-  electrical:
+  route1:
     settings:
       bend: wire_corner
       start_straight_length: 150
       end_straight_length: 150
       cross_section: metal_routing
       allow_width_mismatch: True
-
+      sort_ports: True
     links:
       t,e11: b,e11
       t,e13: b,e13
+"""
+
+if __name__ == "__main__":
+    c = gf.read.from_yaml(yaml_str)
+    c.show()

--- a/notebooks/03_Path_CrossSection.ipynb
+++ b/notebooks/03_Path_CrossSection.ipynb
@@ -225,7 +225,7 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "If you add more ports to a section it also exposes its ports."
+    "If you add more ports to a CrossSection it also exposes its ports."
    ]
   },
   {
@@ -297,13 +297,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Don't do this for GS routing. See solution below.\n",
     "c2 = gf.Component()\n",
     "pad1 = c2 << pad\n",
     "pad2 = c2 << pad\n",
     "pad2.move((100, 100))\n",
     "\n",
     "gf.routing.route_bundle(c2, [pad1.ports[\"g2\"]], [pad2.ports[\"g1\"]], cross_section=x, sort_ports=True, bend='bend_euler')\n",
-    "c2.plot()\n"
+    "c2.plot()"
    ]
   },
   {
@@ -354,6 +355,58 @@
    "id": "26",
    "metadata": {},
    "source": [
+    "For GS routing the recommended solution is adding a dummy / abstract layer in the middle, where we add the ports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = gf.path.straight()\n",
+    "\n",
+    "# Add GS routing sections\n",
+    "# 99, 0 is an abstract layer that can be used to add ports to the path\n",
+    "s0 = gf.Section(width=2, offset=0, layer=(99, 0), port_names=(\"e1\", \"e2\"))\n",
+    "s1 = gf.Section(width=2, offset=-4, layer=(2, 0))\n",
+    "s2 = gf.Section(width=2, offset=+4, layer=(2, 0))\n",
+    "x = gf.CrossSection(sections=(s0, s1, s2), radius=8)\n",
+    "c = gf.path.extrude(p, cross_section=x)\n",
+    "pad = c\n",
+    "c_copy = c.copy()\n",
+    "c_copy.draw_ports()\n",
+    "c_copy.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2 = gf.Component()\n",
+    "pad1 = c2 << c\n",
+    "pad2 = c2 << c\n",
+    "pad2.move((100, 100))\n",
+    "gf.routing.route_bundle(c2,\n",
+    "    [pad1.ports[\"e2\"]],\n",
+    "    [pad2.ports[\"e1\"]],\n",
+    "    cross_section=x,\n",
+    "    port_type='optical',\n",
+    "    bend='bend_euler',\n",
+    "    raise_on_error=True,\n",
+    ")\n",
+    "c2.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
     "### Option 3: CrossSection with ComponentAlongPath\n",
     "\n",
     "You can also place components along a path, which is useful for wiring vias."
@@ -362,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "source": [
     "## Path\n",
@@ -428,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "35",
    "metadata": {},
    "source": [
     "**Example 2:** Create an \"S-turn\" just by making a list of `[left_turn,\n",
@@ -492,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +560,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "source": [
     "**Example 3:** Repeat the S-turn 3 times by nesting our S-turn list in another\n",
@@ -517,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +588,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "source": [
     "Note you can also use the Path() constructor to immediately construct your Path:"
@@ -544,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +607,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Waypoint smooth paths\n",
@@ -565,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Waypoint sharp paths\n",
@@ -607,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +670,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "46",
    "metadata": {},
    "source": [
     "**Example 2:** Using the \"turn and move\" method, where you manipulate the end angle of the Path so that when you append points to it, they're in the correct direction.  *Note: It is crucial that the number of points per straight section is set to 2 (`gf.path.straight(length, num_pts = 2)`) otherwise the extrusion algorithm will show defects.*"
@@ -626,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "48",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -660,7 +713,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "49",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -681,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "51",
    "metadata": {},
    "source": [
     "You can create Paths from any array of points -- just be sure that they form\n",
@@ -726,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +790,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "53",
    "metadata": {},
    "source": [
     "## Simplifying / reducing point usage\n",
@@ -760,7 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,7 +824,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "55",
    "metadata": {},
    "source": [
     "Let's say we need fewer points.  We can increase the simplify tolerance by\n",
@@ -782,7 +835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,7 +845,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "57",
    "metadata": {},
    "source": [
     "Taken to absurdity, what happens if we set `simplify = 0.3`?  Once again, the\n",
@@ -803,7 +856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "59",
    "metadata": {},
    "source": [
     "## Curvature calculation\n",
@@ -833,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +917,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "61",
    "metadata": {},
    "source": [
     "Arc paths are equivalent to `bend_circular` and euler paths are equivalent to `bend_euler`"
@@ -873,7 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -911,7 +964,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "65",
    "metadata": {},
    "source": [
     "You can compare two 90 degrees euler bend with 180 euler bend.\n",
@@ -922,7 +975,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,7 +997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +1009,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "68",
    "metadata": {},
    "source": [
     "## Transitioning between cross-sections\n",
@@ -976,7 +1029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,7 +1065,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "70",
    "metadata": {},
    "source": [
     "Now let's create the transitional CrossSection by calling `transition()` with\n",
@@ -1024,7 +1077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1041,7 +1094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "72",
    "metadata": {},
    "source": [
     "Now that we have all of our components, let's `connect()` everything and see\n",
@@ -1051,7 +1104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1069,7 +1122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "74",
    "metadata": {},
    "source": [
     "Note that since `transition()` outputs a `Transition`, we can make the transition follow an arbitrary path:"
@@ -1078,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "75",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1101,7 +1154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "76",
    "metadata": {},
    "source": [
     "You can also extrude an arbitrary Transition:"
@@ -1110,7 +1163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1126,7 +1179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "78",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1145,7 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "79",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1178,7 +1231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "80",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1189,7 +1242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "81",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1222,7 +1275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "82",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1238,7 +1291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1257,7 +1310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1269,7 +1322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1287,7 +1340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,7 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,7 +1371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1331,7 +1384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1346,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1362,7 +1415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1374,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1390,7 +1443,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "93",
    "metadata": {},
    "source": [
     "## Creating new cross_sections\n",
@@ -1407,7 +1460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1417,7 +1470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1469,7 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1480,7 +1533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1490,7 +1543,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "99",
    "metadata": {},
    "source": [
     "finally, you can also pass most components Dict that define the cross-section"
@@ -1499,7 +1552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1538,7 +1591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1557,7 +1610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1574,7 +1627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1584,7 +1637,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "101",
+   "id": "104",
    "metadata": {},
    "source": [
     "The port location, width and orientation remains the same for a sheared component. However, an additional property, `shear_angle` is set to the value of the shear angle. In general, shear ports can be safely connected together."
@@ -1592,7 +1645,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "105",
    "metadata": {},
    "source": [
     "## bbox_layers vs cladding_layers\n",
@@ -1606,7 +1659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1618,7 +1671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1629,7 +1682,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105",
+   "id": "108",
    "metadata": {},
    "source": [
     "## Insets\n",
@@ -1640,7 +1693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1670,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1699,7 +1752,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/03_Path_CrossSection.ipynb
+++ b/notebooks/03_Path_CrossSection.ipynb
@@ -216,13 +216,42 @@
     "x = gf.CrossSection(sections=(s0, s1, s2))\n",
     "\n",
     "c = gf.path.extrude(p, cross_section=x)\n",
+    "c.draw_ports()\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "If you add more ports to a section it also exposes its ports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = gf.path.straight()\n",
+    "\n",
+    "# Add a few \"sections\" to the cross-section\n",
+    "s0 = gf.Section(width=1, offset=0, layer=(1, 0), port_names=(\"in\", \"out\"))\n",
+    "s1 = gf.Section(width=2, offset=2, layer=(2, 0), port_names=(\"e1\", \"e2\"))\n",
+    "s2 = gf.Section(width=2, offset=-2, layer=(2, 0))\n",
+    "x = gf.CrossSection(sections=(s0, s1, s2))\n",
+    "\n",
+    "c = gf.path.extrude(p, cross_section=x)\n",
+    "c.draw_ports()\n",
     "c.plot()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +264,94 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "⚠️ Warning! for GS routing. You need to add a centered port for routing to work correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = gf.path.straight()\n",
+    "\n",
+    "# Add GS routing sections\n",
+    "s0 = gf.Section(width=2, offset=0, layer=(2, 0), port_names=(\"g1\", \"g2\"))\n",
+    "s1 = gf.Section(width=2, offset=4, layer=(2, 0))\n",
+    "x = gf.CrossSection(sections=(s0, s1), radius=8)\n",
+    "c = gf.path.extrude(p, cross_section=x)\n",
+    "pad = c\n",
+    "c_copy = c.copy()\n",
+    "c_copy.draw_ports()\n",
+    "c_copy.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2 = gf.Component()\n",
+    "pad1 = c2 << pad\n",
+    "pad2 = c2 << pad\n",
+    "pad2.move((100, 100))\n",
+    "\n",
+    "gf.routing.route_bundle(c2, [pad1.ports[\"g2\"]], [pad2.ports[\"g1\"]], cross_section=x, sort_ports=True, bend='bend_euler')\n",
+    "c2.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23",
+   "metadata": {},
+   "source": [
+    "For GSG routing it works well because the port is at the center."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = gf.path.straight()\n",
+    "\n",
+    "# Add a few \"sections\" to the cross-section\n",
+    "g = gf.Section(width=2, offset=0, layer=(2, 0), port_names=(\"e1\", \"e2\"), port_types=('electrical', 'electrical'))\n",
+    "s0 = gf.Section(width=2, offset=-4, layer=(2, 0))\n",
+    "s1 = gf.Section(width=2, offset=4, layer=(2, 0))\n",
+    "x = gf.CrossSection(sections=(g, s0, s1), radius=8)\n",
+    "c = gf.path.extrude(p, cross_section=x)\n",
+    "c_copy = c.copy()\n",
+    "c_copy.draw_ports()\n",
+    "c_copy.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2 = gf.Component()\n",
+    "pad1 = c2 << c\n",
+    "pad2 = c2 << c\n",
+    "pad2.move((100, 100))\n",
+    "gf.routing.route_bundle(c2, [pad1.ports[\"e2\"]], [pad2.ports[\"e1\"]], cross_section=x, port_type='electrical')\n",
+    "c2.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Option 3: CrossSection with ComponentAlongPath\n",
@@ -246,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Path\n",
@@ -312,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +482,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "32",
    "metadata": {},
    "source": [
     "**Example 2:** Create an \"S-turn\" just by making a list of `[left_turn,\n",
@@ -376,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "34",
    "metadata": {},
    "source": [
     "**Example 3:** Repeat the S-turn 3 times by nesting our S-turn list in another\n",
@@ -401,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "36",
    "metadata": {},
    "source": [
     "Note you can also use the Path() constructor to immediately construct your Path:"
@@ -428,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Waypoint smooth paths\n",
@@ -449,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Waypoint sharp paths\n",
@@ -491,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +617,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "43",
    "metadata": {},
    "source": [
     "**Example 2:** Using the \"turn and move\" method, where you manipulate the end angle of the Path so that when you append points to it, they're in the correct direction.  *Note: It is crucial that the number of points per straight section is set to 2 (`gf.path.straight(length, num_pts = 2)`) otherwise the extrusion algorithm will show defects.*"
@@ -510,7 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "45",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -544,7 +660,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "46",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -565,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "48",
    "metadata": {},
    "source": [
     "You can create Paths from any array of points -- just be sure that they form\n",
@@ -610,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "50",
    "metadata": {},
    "source": [
     "## Simplifying / reducing point usage\n",
@@ -644,7 +760,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +771,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "52",
    "metadata": {},
    "source": [
     "Let's say we need fewer points.  We can increase the simplify tolerance by\n",
@@ -666,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +792,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "54",
    "metadata": {},
    "source": [
     "Taken to absurdity, what happens if we set `simplify = 0.3`?  Once again, the\n",
@@ -687,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Curvature calculation\n",
@@ -717,7 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "58",
    "metadata": {},
    "source": [
     "Arc paths are equivalent to `bend_circular` and euler paths are equivalent to `bend_euler`"
@@ -757,7 +873,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -795,7 +911,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "62",
    "metadata": {},
    "source": [
     "You can compare two 90 degrees euler bend with 180 euler bend.\n",
@@ -806,7 +922,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +944,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "65",
    "metadata": {},
    "source": [
     "## Transitioning between cross-sections\n",
@@ -860,7 +976,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -896,7 +1012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "67",
    "metadata": {},
    "source": [
     "Now let's create the transitional CrossSection by calling `transition()` with\n",
@@ -908,7 +1024,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +1041,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "69",
    "metadata": {},
    "source": [
     "Now that we have all of our components, let's `connect()` everything and see\n",
@@ -935,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,7 +1069,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "71",
    "metadata": {},
    "source": [
     "Note that since `transition()` outputs a `Transition`, we can make the transition follow an arbitrary path:"
@@ -962,7 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "72",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -985,7 +1101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "73",
    "metadata": {},
    "source": [
     "You can also extrude an arbitrary Transition:"
@@ -994,7 +1110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1010,7 +1126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "75",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1029,7 +1145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "76",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1062,7 +1178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "77",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1073,7 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "78",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1106,7 +1222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "79",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1122,7 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1141,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,7 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1215,7 +1331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1230,7 +1346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1246,7 +1362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1258,7 +1374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1274,7 +1390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82",
+   "id": "90",
    "metadata": {},
    "source": [
     "## Creating new cross_sections\n",
@@ -1291,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,7 +1417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1342,7 +1458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1353,7 +1469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1364,7 +1480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1374,7 +1490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "96",
    "metadata": {},
    "source": [
     "finally, you can also pass most components Dict that define the cross-section"
@@ -1383,7 +1499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1422,7 +1538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1441,7 +1557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1468,7 +1584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "101",
    "metadata": {},
    "source": [
     "The port location, width and orientation remains the same for a sheared component. However, an additional property, `shear_angle` is set to the value of the shear angle. In general, shear ports can be safely connected together."
@@ -1476,7 +1592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "102",
    "metadata": {},
    "source": [
     "## bbox_layers vs cladding_layers\n",
@@ -1490,7 +1606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1502,7 +1618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97",
+   "id": "105",
    "metadata": {},
    "source": [
     "## Insets\n",
@@ -1524,7 +1640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1554,7 +1670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1583,7 +1699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1610,7 +1726,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/10_yaml_component.ipynb
+++ b/notebooks/10_yaml_component.ipynb
@@ -775,7 +775,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -789,7 +789,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/yaml_pics/pads.pic.yml
+++ b/notebooks/yaml_pics/pads.pic.yml
@@ -24,6 +24,7 @@ placements:
 routes:
   electrical:
     settings:
+      bend: wire_corner
       separation: 20
       cross_section: metal_routing
       allow_width_mismatch: True

--- a/notebooks/yaml_pics/pads_path_length_match.pic.yml
+++ b/notebooks/yaml_pics/pads_path_length_match.pic.yml
@@ -27,6 +27,7 @@ placements:
 routes:
     electrical:
         settings:
+            bend: wire_corner
             separation: 20
             width: 10
             path_length_match_loops: 2

--- a/notebooks/yaml_pics/pads_steps.pic.yml
+++ b/notebooks/yaml_pics/pads_steps.pic.yml
@@ -28,6 +28,7 @@ placements:
 routes:
   electrical:
     settings:
+      bend: wire_corner
       separation: 20
       cross_section: metal_routing
       allow_width_mismatch: True

--- a/notebooks/yaml_pics/routes_steps.pic.yml
+++ b/notebooks/yaml_pics/routes_steps.pic.yml
@@ -27,6 +27,7 @@ routes:
     routing_strategy: route_bundle
     settings:
       cross_section: metal_routing
+      bend: wire_corner
       steps:
         - dy: 100
           dx: -100

--- a/notebooks/yaml_pics/routes_waypoints.pic.yml
+++ b/notebooks/yaml_pics/routes_waypoints.pic.yml
@@ -18,6 +18,7 @@ routes:
   route1:
     routing_strategy: route_bundle
     settings:
+      bend: wire_corner
       cross_section: metal_routing
       waypoints:
         - [0, 300]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]>=1.14,<1.15",
+  "kfactory[ipy]>=1.14.2,<1.15",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -146,6 +146,7 @@ routes:
         settings:
             port_type: electrical
             separation: 20
+            bend: wire_corner
             cross_section:
                 cross_section: metal3
                 settings:

--- a/tests/routing/test_route_single_from_steps.py
+++ b/tests/routing/test_route_single_from_steps.py
@@ -56,6 +56,7 @@ def test_route_waypoints() -> None:
         p0,
         p1,
         cross_section="metal_routing",
+        bend="wire_corner",
         waypoints=[
             (p0x + o, p0y),
             (p0x + o, ytop),
@@ -89,6 +90,7 @@ def test_route_waypoints_numpy() -> None:
         c,
         p0,
         p1,
+        bend="wire_corner",
         cross_section="metal_routing",
         waypoints=[
             (p0x + o, p0y),

--- a/tests/test-data-regression/test_netlists_wire_corner45_straight_.yml
+++ b/tests/test-data-regression/test_netlists_wire_corner45_straight_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: wire_corner45_straight_R10_W5_CSmetal_routing
+name: wire_corner45_straight_W5_RNone_CSmetal_routing
 nets: []
 placements: {}
 ports: {}

--- a/tests/test-data-regression/test_netlists_wire_corner45_straight_.yml
+++ b/tests/test-data-regression/test_netlists_wire_corner45_straight_.yml
@@ -1,0 +1,5 @@
+instances: {}
+name: wire_corner45_straight_R10_W5_CSmetal_routing
+nets: []
+placements: {}
+ports: {}

--- a/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
+++ b/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
@@ -1,0 +1,7 @@
+info:
+  length: 17.071
+name: wire_corner45_straight_R10_W5_CSmetal_routing
+settings:
+  cross_section: metal_routing
+  radius: 10
+  width: 5

--- a/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
+++ b/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
@@ -1,7 +1,6 @@
 info:
-  length: 17.071
-name: wire_corner45_straight_R10_W5_CSmetal_routing
+  length: 8.536
+name: wire_corner45_straight_W5_RNone_CSmetal_routing
 settings:
   cross_section: metal_routing
-  radius: 10
   width: 5


### PR DESCRIPTION
## Summary by Sourcery

Introduce new flags for layer and type mismatches in route_bundle, update allow_width_mismatch to support a None default, and propagate these parameters through internal calls.

New Features:
- Add allow_layer_mismatch flag to route_bundle to permit connecting ports on different layers
- Add allow_type_mismatch flag to route_bundle to permit connecting ports with different types

Enhancements:
- Change allow_width_mismatch default to None to support tri-state behavior

Documentation:
- Update route_bundle docstring to describe the new allow_layer_mismatch and allow_type_mismatch parameters