### PR TITLE
fix wire_corner45_straight radius

### DIFF
--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -21,7 +21,7 @@ def wire_corner(
     port_names: PortNames = port_names_electrical,
     port_types: PortTypes = port_types_electrical,
     width: float | None = None,
-    radius: None | float = None,
+    radius: float | None = None,
 ) -> Component:
     """Returns 45 degrees electrical corner wire.
 
@@ -36,6 +36,7 @@ def wire_corner(
         x = gf.get_cross_section(cross_section, width=width)
     else:
         x = gf.get_cross_section(cross_section)
+
     layer = x.layer
     assert layer is not None
     width = x.width
@@ -81,7 +82,8 @@ def wire_corner45_straight(
         cross_section: metal_routing.
     """
     c = gf.Component()
-    radius = radius or width
+    xs = gf.get_cross_section(cross_section)
+    radius = radius or xs.radius
 
     if radius is None:
         raise ValueError("Either radius or width must be specified")

--- a/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
+++ b/tests/test-data-regression/test_settings_wire_corner45_straight_.yml
@@ -1,5 +1,5 @@
 info:
-  length: 8.536
+  length: 17.071
 name: wire_corner45_straight_W5_RNone_CSmetal_routing
 settings:
   cross_section: metal_routing


### PR DESCRIPTION
## Summary by Sourcery

Correct the default radius logic for wire_corner45_straight and harmonize the radius parameter annotation in wire_corner.

Bug Fixes:
- Use the cross-section's radius fallback instead of the width for wire_corner45_straight when radius is not provided

Enhancements:
- Reorder the radius type annotation in wire_corner for consistency