### PR TITLE
Use Literal for boolean operation type

### DIFF
--- a/gdsfactory/boolean.py
+++ b/gdsfactory/boolean.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import kfactory as kf
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 def boolean(
     A: ComponentOrReference,
     B: ComponentOrReference,
-    operation: str,
+    operation: Literal["or", "|", "not", "-", "^", "xor", "&", "and", "A-B"],
     layer: LayerSpec,
     layer1: LayerSpec | None = None,
     layer2: LayerSpec | None = None,


### PR DESCRIPTION
## Summary

Improve type safety for boolean operations by using `Literal` type annotation instead of generic `str`. Should also prompt better in IDEs/LSPs.

## Changes

- Import `Literal` from `typing`
- Replace `operation: str` parameter with `Literal["or", "|", "not", "-", "^", "xor", "&", "and", "A-B"]`

This provides better type checking and IDE autocompletion for the supported boolean operations.

## Summary by Sourcery

Enhancements:
- Restrict the `operation` parameter to a Literal of supported boolean operations for better type checking and IDE autocompletion.