### PR TITLE
add schematic_cell and Schematic from kfactory2.0

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -16,8 +16,9 @@ from kfactory import LayerEnum, show, Instance
 from kfactory.layout import kcl
 from kfactory import logger
 import klayout.db as kdb
+from kfactory import DSchematic as Schematic
 
-from gdsfactory._cell import cell, vcell, cell_with_module_name
+from gdsfactory._cell import cell, vcell, cell_with_module_name, schematic_cell
 from gdsfactory.path import Path
 from gdsfactory.component import (
     Component,
@@ -113,6 +114,7 @@ __all__ = (
     "Pdk",
     "Port",
     "Region",
+    "Schematic",
     "Section",
     "__version__",
     "add_padding",
@@ -161,6 +163,7 @@ __all__ = (
     "port",
     "read",
     "routing",
+    "schematic_cell",
     "show",
     "snap",
     "technology",

--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, overload
 
+import kfactory as kf
 from cachetools import Cache
 from kfactory import cell as _cell
 from kfactory import vcell as _vcell
@@ -197,3 +198,5 @@ def override_defaults(
 
 
 cell_with_module_name = override_defaults(cell, with_module_name=True)
+
+schematic_cell = kf.kcl.schematic_cell

--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -187,6 +187,9 @@ def route_bundle(
         gf.routing.route_bundle(component=c, ports1=ports1, ports2=ports2, cross_section='strip', separation=5)
         c.plot()
     """
+    component = gf.Component(base=component.base)
+    ports1 = [gf.Port(base=p1.base) for p1 in ports1]
+    ports2 = [gf.Port(base=p2.base) for p2 in ports2]
 
     if router:
         warnings.warn(


### PR DESCRIPTION
```python
from functools import partial

import gdsfactory as gf


@gf.schematic_cell(
    factories=gf.get_factories.get_cells("gdsfactory"),
    routing_strategies=gf.get_active_pdk().routing_strategies
    or {
        "route_bundle": partial(
            gf.routing.route_bundle, layer=gf.get_layer((1, 0)), route_width=1
        )
    },
)
def test_schematic(x: float = 108.5, y: float = 53.1) -> gf.kf.DSchematic:
    s = gf.Schematic()

    r1 = s.create_inst(name="r1", component="ring_single")
    r1.place(x=0, y=0)

    r2 = s.create_inst(name="r2", component="ring_single", settings={"radius": 32.2})
    r2.place(x=x, y=y)

    s.add_route(
        name="r1-r2",
        start_ports=[r1.ports["o2"]],
        end_ports=[r2.ports["o1"]],
        routing_strategy="route_bundle",
    )

    return s


test_schematic().show()
```
