### PR TITLE
Ability to output diff to a file

### DIFF
--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -6,9 +6,9 @@ from enum import Enum
 import typer
 from kfactory.cli.build import build
 
+import gdsfactory as gf
 from gdsfactory import show as _show
 from gdsfactory.config import print_version_plugins
-from gdsfactory.difftest import diff
 from gdsfactory.install import install_gdsdiff, install_klayout_package
 from gdsfactory.read.from_updk import from_updk
 from gdsfactory.watch import watch as _watch
@@ -122,7 +122,28 @@ def gds_diff(
     gdspath1: str, gdspath2: str, xor: bool = False, show: bool = False
 ) -> None:
     """Show boolean difference between two GDS files."""
-    diff(gdspath1, gdspath2, xor=xor, show=show)
+    gf.diff(gdspath1, gdspath2, xor=xor, show=show)
+
+
+@app.command()
+def diff(
+    path1: pathlib.Path,
+    path2: pathlib.Path,
+    xor: bool = False,
+    show: bool = False,
+    stagger: bool = True,
+    output: pathlib.Path | None = None,
+) -> None:
+    """Show boolean difference between two layout files."""
+    gf.diff(
+        path1,
+        path2,
+        test_name=output.stem if output else "gf",
+        xor=xor,
+        show=show,
+        stagger=stagger,
+        out_file=output,
+    )
 
 
 @app.command()

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -351,11 +351,13 @@ def diff(
         layer_label = kf.kcl.layout.layer(1, 0)
         c.shapes(layer_label).insert(kf.kdb.DText("old", old_ref.dtrans))
         c.shapes(layer_label).insert(kf.kdb.DText("new", new_ref.dtrans))
-        c.shapes(layer_label).insert(
-            kf.kdb.DText(
-                "xor", kf.kdb.DTrans(new_ref.xmin, old_ref.ymax - old_ref.ysize - dy)
+        if xor:
+            c.shapes(layer_label).insert(
+                kf.kdb.DText(
+                    "xor",
+                    kf.kdb.DTrans(new_ref.xmin, old_ref.ymax - old_ref.ysize - dy),
+                )
             )
-        )
 
         if xor:
             print("Running XOR on differences...")

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -217,6 +217,7 @@ def diff(
     ignore_label_differences: bool | None = None,
     show: bool = False,
     stagger: bool = True,
+    out_file: PathType | None = None,
 ) -> bool:
     """Returns True if files are different, prints differences and shows them in klayout.
 
@@ -230,6 +231,7 @@ def diff(
         ignore_label_differences: if True, ignores any label differences when run in XOR mode. If None (default) defers to the value set in CONF.difftest_ignore_label_differences
         show: shows diff in klayout.
         stagger: if True, staggers the old/new/xor views. If False, all three are overlaid.
+        out_file: if not None, saves the diff to the specified file.
     """
     ref_file, run_file = pathlib.Path(ref_file), pathlib.Path(run_file)
     if ref_file == run_file:
@@ -410,8 +412,12 @@ def diff(
             # if no additional xor verification, the two files are not equivalent
             equivalent = False
 
-        if show and not equivalent:
-            c.show()
+        if not equivalent:
+            if out_file is not None:
+                c.write(out_file)
+            if show:
+                c.show()
+
         return not equivalent
     return False
 


### PR DESCRIPTION
- Adds `out_file` as a parameter in `diff`
- Hides the "xor" label if xor wasn't enabled
- Adds a more neutral `diff` command as technically it can diff `oas` files too and not just `gds`

I didn't add a warning to migrate or anything for the last point, leaving to maintainers to decide.

## Summary by Sourcery

Allow saving diff results to a file, hide the XOR label when XOR mode is disabled, and replace the old GDS-only diff command with a generic layout diff CLI.

New Features:
- Add an `out_file` parameter to the diff API and CLI for exporting diff output to a file
- Introduce a new generic `diff` CLI command that works on any layout files, not just GDS

Bug Fixes:
- Omit the "xor" label in the visualization when XOR mode is turned off