### PR TITLE
fix edge coupler array

### DIFF
--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -93,7 +93,6 @@ def edge_coupler_array_with_loopback(
     radius: float | None = None,
     n: int = 8,
     pitch: float = 127.0,
-    extension_length: float = 0.0,
     x_reflection: bool = False,
     text: ComponentSpec | None = "text_rectangular",
     text_offset: Float2 = (0, 10),
@@ -107,7 +106,6 @@ def edge_coupler_array_with_loopback(
         radius: bend radius loopback (um).
         n: number of channels.
         pitch: Fiber pitch (um).
-        extension_length: in um.
         x_reflection: horizontal mirror.
         text: Optional text spec.
         text_offset: x, y.
@@ -126,20 +124,16 @@ def edge_coupler_array_with_loopback(
         text_offset=text_offset,
         text_rotation=text_rotation,
     )
-    # if extension_length > 0:
-    #     ec = gf.c.extend_ports(
-    #         component=ec,
-    #         port_names=("o1", "o2"),
-    #         length=extension_length,
-    #         extension=partial(
-    #             gf.c.straight, cross_section=cross_section, length=extension_length
-    #         ),
-    #     )
     ec_ref = c << ec
-    p1 = ec_ref.ports["o1"]
-    p2 = ec_ref.ports["o2"]
-    p3 = ec_ref.ports[f"o{n - 1}"]
-    p4 = ec_ref.ports[f"o{n}"]
+    if x_reflection:
+        ec_ref_ports = ec_ref.ports.filter(orientation=0)
+    else:
+        ec_ref_ports = ec_ref.ports.filter(orientation=180)
+
+    p1 = ec_ref_ports[0]
+    p2 = ec_ref_ports[1]
+    p3 = ec_ref_ports[-2]
+    p4 = ec_ref_ports[-1]
 
     gf.routing.route_single(
         c,
@@ -156,7 +150,7 @@ def edge_coupler_array_with_loopback(
         radius=radius,
     )
 
-    for i, port in enumerate(ec_ref.ports):
+    for i, port in enumerate(ec_ref_ports):
         if port not in [p1, p2, p3, p4]:
             c.add_port(str(i), port=port)
 
@@ -168,9 +162,8 @@ if __name__ == "__main__":
     # c = edge_coupler_array(x_reflection=True, port_orientation=0)
     # c = edge_coupler_array(x_reflection=False, port_orientation=180)
     c = edge_coupler_array_with_loopback(
-        n=8,
+        n=5,
         pitch=127.0,
-        extension_length=20.0,
         x_reflection=False,
         text="text_rectangular",
         text_offset=(0, 10),

--- a/tests/test-data-regression/test_netlists_die_frame_phix_dc_.yml
+++ b/tests/test-data-regression/test_netlists_die_frame_phix_dc_.yml
@@ -36,29 +36,12 @@ instances:
       size:
       - 11200
       - 5000
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500:
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500:
     component: edge_coupler_array_with_loopback
     info: {}
     settings:
       cross_section: strip
       edge_coupler: edge_coupler_silicon
-      extension_length: 0
-      n: 32
-      pitch: 127
-      radius: null
-      text: null
-      text_offset:
-      - 20
-      - 10
-      text_rotation: 0
-      x_reflection: true
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500:
-    component: edge_coupler_array_with_loopback
-    info: {}
-    settings:
-      cross_section: strip
-      edge_coupler: edge_coupler_silicon
-      extension_length: 0
       n: 32
       pitch: 127
       radius: null
@@ -68,6 +51,21 @@ instances:
       - 10
       text_rotation: 0
       x_reflection: false
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500:
+    component: edge_coupler_array_with_loopback
+    info: {}
+    settings:
+      cross_section: strip
+      edge_coupler: edge_coupler_silicon
+      n: 32
+      pitch: 127
+      radius: null
+      text: null
+      text_offset:
+      - 20
+      - 10
+      text_rotation: 0
+      x_reflection: true
   pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_0_2250000:
     component: pad
     info:
@@ -2954,15 +2952,15 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500:
-    mirror: false
-    rotation: 0
-    x: -5500
-    y: -1968.5
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500:
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500:
     mirror: false
     rotation: 0
     x: 5500
+    y: -1968.5
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500:
+    mirror: false
+    rotation: 0
+    x: -5500
     y: -1968.5
   pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_0_2250000:
     mirror: false
@@ -3693,62 +3691,62 @@ ports:
   e97: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m1200000_2250000,e4
   e98: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m1350000_2250000,e4
   e99: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m1500000_2250000,e4
-  o1: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o1
-  o10: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o10
-  o11: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o11
-  o12: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o12
-  o13: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o13
-  o14: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o14
-  o15: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o15
-  o16: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o16
-  o17: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o17
-  o18: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o18
-  o19: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o19
-  o2: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o2
-  o20: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o20
-  o21: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o21
-  o22: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o22
-  o23: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o23
-  o24: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o24
-  o25: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o25
-  o26: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o26
-  o27: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o27
-  o28: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o28
-  o29: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o1
-  o3: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o3
-  o30: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o2
-  o31: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o3
-  o32: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o4
-  o33: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o5
-  o34: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o6
-  o35: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o7
-  o36: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o8
-  o37: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o9
-  o38: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o10
-  o39: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o11
-  o4: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o4
-  o40: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o12
-  o41: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o13
-  o42: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o14
-  o43: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o15
-  o44: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o16
-  o45: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o17
-  o46: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o18
-  o47: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o19
-  o48: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o20
-  o49: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o21
-  o5: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o5
-  o50: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o22
-  o51: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o23
-  o52: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o24
-  o53: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o25
-  o54: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o26
-  o55: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o27
-  o56: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a4369520_m5500000_m1968500,o28
-  o6: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o6
-  o7: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o7
-  o8: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o8
-  o9: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5500000_m1968500,o9
+  o1: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o1
+  o10: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o10
+  o11: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o11
+  o12: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o12
+  o13: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o13
+  o14: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o14
+  o15: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o15
+  o16: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o16
+  o17: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o17
+  o18: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o18
+  o19: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o19
+  o2: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o2
+  o20: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o20
+  o21: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o21
+  o22: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o22
+  o23: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o23
+  o24: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o24
+  o25: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o25
+  o26: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o26
+  o27: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o27
+  o28: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o28
+  o29: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o1
+  o3: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o3
+  o30: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o2
+  o31: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o3
+  o32: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o4
+  o33: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o5
+  o34: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o6
+  o35: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o7
+  o36: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o8
+  o37: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o9
+  o38: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o10
+  o39: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o11
+  o4: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o4
+  o40: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o12
+  o41: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o13
+  o42: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o14
+  o43: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o15
+  o44: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o16
+  o45: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o17
+  o46: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o18
+  o47: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o19
+  o48: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o20
+  o49: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o21
+  o5: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o5
+  o50: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o22
+  o51: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o23
+  o52: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o24
+  o53: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o25
+  o54: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o26
+  o55: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o27
+  o56: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_a225519a_m5500000_m1968500,o28
+  o6: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o6
+  o7: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o7
+  o8: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o8
+  o9: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5500000_m1968500,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test-data-regression/test_netlists_die_frame_phix_rf_.yml
+++ b/tests/test-data-regression/test_netlists_die_frame_phix_rf_.yml
@@ -36,13 +36,12 @@ instances:
       size:
       - 10400
       - 5000
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500:
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500:
     component: edge_coupler_array_with_loopback
     info: {}
     settings:
       cross_section: strip
       edge_coupler: edge_coupler_silicon
-      extension_length: 0
       n: 32
       pitch: 127
       radius: null
@@ -2938,7 +2937,7 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500:
+  edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500:
     mirror: false
     rotation: 0
     x: 5100
@@ -3698,34 +3697,34 @@ ports:
   e97: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m700000_2250000,e4
   e98: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m850000_2250000,e4
   e99: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_457de54c_m1000000_2250000,e4
-  o1: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o1
-  o10: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o10
-  o11: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o11
-  o12: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o12
-  o13: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o13
-  o14: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o14
-  o15: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o15
-  o16: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o16
-  o17: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o17
-  o18: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o18
-  o19: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o19
-  o2: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o2
-  o20: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o20
-  o21: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o21
-  o22: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o22
-  o23: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o23
-  o24: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o24
-  o25: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o25
-  o26: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o26
-  o27: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o27
-  o28: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o28
-  o3: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o3
-  o4: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o4
-  o5: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o5
-  o6: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o6
-  o7: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o7
-  o8: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o8
-  o9: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_fcf8ee14_5100000_m1968500,o9
+  o1: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o1
+  o10: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o10
+  o11: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o11
+  o12: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o12
+  o13: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o13
+  o14: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o14
+  o15: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o15
+  o16: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o16
+  o17: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o17
+  o18: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o18
+  o19: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o19
+  o2: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o2
+  o20: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o20
+  o21: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o21
+  o22: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o22
+  o23: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o23
+  o24: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o24
+  o25: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o25
+  o26: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o26
+  o27: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o27
+  o28: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o28
+  o3: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o3
+  o4: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o4
+  o5: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o5
+  o6: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o6
+  o7: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o7
+  o8: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o8
+  o9: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_6386b7da_5100000_m1968500,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/tests/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -140,7 +140,7 @@ instances:
       length: 107
       npoints: 2
       width: null
-name: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_bacac422
+name: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_e95db816
 nets:
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_0_127000_A180,o1
   p2: edge_coupler_array_gdsfactorypcomponentspedge_couplersp_24e6908e_0_0,o2

--- a/tests/test-data-regression/test_settings_edge_coupler_array_with_loopback_.yml
+++ b/tests/test-data-regression/test_settings_edge_coupler_array_with_loopback_.yml
@@ -1,9 +1,8 @@
 info: {}
-name: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_bacac422
+name: edge_coupler_array_with_loopback_gdsfactorypcomponentsp_e95db816
 settings:
   cross_section: strip
   edge_coupler: edge_coupler_silicon
-  extension_length: 0
   n: 8
   pitch: 127
   text: text_rectangular


### PR DESCRIPTION
## Summary by Sourcery

Fix port mapping and reflection handling in edge_coupler_array_with_loopback, remove unused extension_length parameter, and update test fixtures accordingly

Bug Fixes:
- Correct port selection and coordinate mirroring when x_reflection is enabled in edge_coupler_array_with_loopback

Enhancements:
- Remove the deprecated extension_length parameter and cleanup related code in edge_coupler_array_with_loopback

Tests:
- Update regression test data for DC and RF netlists, settings, and netlists YAML to use new component IDs and reflect removal of extension_length