### PR TITLE
Fix division by zero error when using arcs at 0° angles.

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1571,7 +1571,11 @@ def arc(
         npoints = npoints or int(
             abs(angle) / 360 * radius / PDK.bend_points_distance / 2
         )
-        npoints = max(int(npoints), int(360 / abs(angle)) + 1)
+        # Fix for zero-angle division by zero
+        if abs(angle) < 1e-6:  # Essentially zero angle
+            npoints = max(int(npoints), 2)  # Minimum points for straight line
+        else:
+            npoints = max(int(npoints), int(360 / abs(angle)) + 1)
 
     t = np.linspace(
         start_angle * np.pi / 180, (angle + start_angle) * np.pi / 180, npoints


### PR DESCRIPTION
When routing between ports e.g. using Dubins paths I got a division by zero error in the path function due to angle=0 in
```python
npoints = max(int(npoints), int(360 / abs(angle)) + 1)
```

Fixed with a conditional:
```python
# Fix for zero-angle division by zero
if abs(angle) < 1e-6:
    npoints = max(int(npoints), 2)
else:
    npoints = max(int(npoints), int(360 / abs(angle)) + 1)
```

## Summary by Sourcery

Bug Fixes:
- Prevent division by zero when angle is zero by enforcing a minimum of two points for straight-line arcs