### PR TITLE
add ports at via_stack correct location

### DIFF
--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -227,14 +227,14 @@ def straight_heater_meander(
             )
 
         if port_orientation1 is not None:
-            p1 = via_stack_west.ports.filter(orientation=port_orientation1)
+            p1 = list(via_stack_west.ports.filter(orientation=port_orientation1))
         else:
-            p1 = via_stack_west.ports
+            p1 = list(via_stack_west.ports)
 
         if port_orientation2 is not None:
-            p2 = via_stack_east.ports.filter(orientation=port_orientation2)
+            p2 = list(via_stack_east.ports.filter(orientation=port_orientation2))
         else:
-            p2 = via_stack_east.ports
+            p2 = list(via_stack_east.ports)
 
         if not p1:
             raise ValueError(


### PR DESCRIPTION
## Summary by Sourcery

Move port assignment logic to the end of straight_heater_meander, support None for port orientations, and add a CLI example under __main__.

Enhancements:
- Delay adding ports until after taper and via placement to ensure all features are applied first
- Allow port_orientation1 and port_orientation2 to be None to collect all ports when no specific orientation is given
- Add a __main__ block demonstrating example usage of straight_heater_meander with a None orientation