### PR TITLE
single_port_terminator

### DIFF
--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -50,6 +50,5 @@ def terminator_spiral(
     c = gf.Component()
     ref = c << spiral
     c.add_port("o1", port=ref["o2"])
-    c.add_port("o2", port=ref["o1"])
     c.flatten()
     return c


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Reduce port count of terminator_spiral from two to one by removing the 'o2' port.