### PR TITLE
expose xoffset_rf_pads

### DIFF
--- a/gdsfactory/components/dies/die_frame_with_pads.py
+++ b/gdsfactory/components/dies/die_frame_with_pads.py
@@ -146,6 +146,7 @@ def die_frame_phix(
     text_offset: Float2 = (20, 10),
     text: ComponentSpec | None = "text_rectangular",
     xoffset_dc_pads: float = -100,
+    xoffset_rf_pads: float = 50,
 ) -> Component:
     """A die_frame with grating couplers and pads.
 
@@ -175,6 +176,7 @@ def die_frame_phix(
         text_offset: offset for text.
         text: text component spec.
         xoffset_dc_pads: DC pads x-offset.
+        xoffset_rf_pads: RF pads x-offset.
     """
     if npads > 60:
         raise ValueError("npads should be <= 60. Reach out to PHIX for support.")
@@ -278,7 +280,7 @@ def die_frame_phix(
         for i in range(npads_rf):
             pad_ref = c << gf.get_component(pad_gsg)
             pad_ref.y = y0 - i * pad_pitch_gsg
-            pad_ref.xmin = fp.xmin + 50
+            pad_ref.xmin = fp.xmin + xoffset_rf_pads
             c.add_port(
                 name=f"e{i}",
                 port=pad_ref.ports["e2"],
@@ -414,6 +416,7 @@ def die_frame_phix_rf(
     text_offset: Float2 = (20, 10),
     text: ComponentSpec | None = None,
     xoffset_dc_pads: float = -500,
+    xoffset_rf_pads: float = 50,
 ) -> Component:
     return die_frame_phix(
         die_frame=die_frame,
@@ -441,6 +444,7 @@ def die_frame_phix_rf(
         text=text,
         xoffset_dc_pads=xoffset_dc_pads,
         fiber_coupler_xoffset=fiber_coupler_xoffset,
+        xoffset_rf_pads=xoffset_rf_pads,
     )
 
 

--- a/gdsfactory/components/shapes/rectangle.py
+++ b/gdsfactory/components/shapes/rectangle.py
@@ -88,6 +88,7 @@ def rectangles(
         raise ValueError(f"len(offsets) != len(layers) {len(offsets)} != {len(layers)}")
     for layer, offset in zip(layers, offsets, strict=False):
         current_size = size_np + 2 * offset
+        print(f"layer={layer} offset={offset} current_size={current_size}")
         ref = c << rectangle(
             size=(current_size[0], current_size[1]),
             layer=layer,

--- a/tests/test-data-regression/test_netlists_die_frame_phix_rf_.yml
+++ b/tests/test-data-regression/test_netlists_die_frame_phix_rf_.yml
@@ -2909,7 +2909,7 @@ instances:
       spacing: 5
       text_size: 3.5
       width: 2
-name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__a9352ede
+name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__ae3bbf00
 nets: []
 placements:
   circle_gdsfactorypcomponentspshapespcircle_R75_AR2p5_LM3_4555000_2250000:

--- a/tests/test-data-regression/test_settings_die_frame_phix_rf_.yml
+++ b/tests/test-data-regression/test_settings_die_frame_phix_rf_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__a9352ede
+name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__ae3bbf00
 settings:
   cross_section: strip
   die_frame: die_frame_rf
@@ -26,3 +26,4 @@ settings:
   with_left_fiber_coupler: false
   with_right_fiber_coupler: true
   xoffset_dc_pads: -500
+  xoffset_rf_pads: 50


### PR DESCRIPTION
## Summary by Sourcery

Expose a new xoffset_rf_pads parameter for RF pad positioning in die_frame_phix and die_frame_phix_rf, update corresponding regression tests, and add debug logging in the rectangle shape generator

New Features:
- Expose xoffset_rf_pads parameter in die_frame_phix and die_frame_phix_rf functions

Enhancements:
- Apply xoffset_rf_pads to RF pad placement instead of a hardcoded value

Tests:
- Include xoffset_rf_pads in regression test settings and netlists and update test names

Chores:
- Add debug print statement to rectangle shape creation