### PR TITLE
add via_stack tolerances

### DIFF
--- a/gdsfactory/components/vias/via_stack.py
+++ b/gdsfactory/components/vias/via_stack.py
@@ -176,7 +176,7 @@ def via_stack(
                     )
                 via = gf.get_component(via, size=(slot_via_width, h))
                 nb_vias_x = 1
-                nb_vias_y = max(0, (height - h - 2 * enclosure) / pitch_y + 1)
+                nb_vias_y = max(1, (height - 2 * enclosure - h) / pitch_y + 1)
                 # Use slot_via_width for via sizing, but keep width for positioning
                 w = slot_via_width
 
@@ -214,8 +214,9 @@ def via_stack(
             cw = (width - (nb_vias_x - 1) * pitch_x - w) / 2
             ch = (height - (nb_vias_y - 1) * pitch_y - h) / 2
 
-            # Verify that enclosure is respected
-            if cw < enclosure or ch < enclosure:
+            # Verify that enclosure is respected (with small tolerance for floating point precision)
+            tolerance = 1e-9
+            if cw < enclosure - tolerance or ch < enclosure - tolerance:
                 raise ValueError(
                     f"Enclosure violation: calculated margins (cw={cw:.3f}, ch={ch:.3f}) "
                     f"are less than required enclosure={enclosure}. "

--- a/gdsfactory/samples/route_astar.py
+++ b/gdsfactory/samples/route_astar.py
@@ -2,11 +2,11 @@ import gdsfactory as gf
 
 if __name__ == "__main__":
     c = gf.Component()
-    cross_section = "strip"
+    cross_section_name = "strip"
     port_prefix = "o"
     bend = gf.components.bend_euler
 
-    cross_section = gf.get_cross_section(cross_section, radius=5)
+    cross_section = gf.get_cross_section(cross_section_name, radius=5)
     w = gf.components.straight(cross_section=cross_section)
     left = c << w
     right = c << w


### PR DESCRIPTION
## Summary by Sourcery

Enforce at least one via row, add floating‐point tolerance to enclosure checks in via_stack, and improve variable naming in the route_astar sample.

Bug Fixes:
- Ensure nb_vias_y is at least 1 instead of allowing zero vias in via_stack

Enhancements:
- Add a small tolerance to the enclosure verification to avoid false violation errors due to floating point precision
- Rename cross_section variable to cross_section_name in route_astar sample to prevent naming conflicts