### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [Changelog](https://keepachangelog.com/en/1.0.0/)
-## [Unreleased](https://github.com/gdsfactory/gdsfactory/compare/v9.20.7...main)
+## [Unreleased](https://github.com/gdsfactory/gdsfactory/compare/v9.20.8...main)
 
 <!-- towncrier release notes start -->
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump the unreleased comparison link to v9.20.8 in the changelog