### PR TITLE
Allow flex grid placements in gf.grid() and gf.grid_with_text()

### DIFF
--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -25,6 +25,7 @@ def grid(
     align_y: Literal["origin", "ymin", "ymax", "center"] = "center",
     rotation: int = 0,
     mirror: bool = False,
+    flex: bool = False,
 ) -> Component:
     """Returns Component with a 1D or 2D grid of components.
 
@@ -38,6 +39,7 @@ def grid(
         align_y: y alignment along (origin, ymin, ymax, center).
         rotation: for each component in degrees.
         mirror: horizontal mirror y axis (x, 1) (1, 0). most common mirror.
+        flex: use minimal row height and column width where possible.
 
     Returns:
         Component containing components grid.
@@ -59,7 +61,8 @@ def grid(
 
     """
     c = gf.Component()
-    instances = kf.grid(
+    grid_func = kf.flexgrid if flex else kf.grid
+    instances = grid_func(
         c,
         kcells=[gf.get_component(component) for component in components],
         shape=shape,
@@ -93,6 +96,7 @@ def grid_with_text(
     rotation: int = 0,
     mirror: bool = False,
     labels: Sequence[str] | None = None,
+    flex: bool = False,
 ) -> Component:
     """Returns Component with 1D or 2D grid of components with text labels.
 
@@ -112,6 +116,7 @@ def grid_with_text(
         rotation: for each component in degrees.
         mirror: horizontal mirror y axis (x, 1) (1, 0). most common mirror.
         labels: list of labels for each component.
+        flex: use minimal row height and column width where possible.
 
 
     .. plot::
@@ -145,7 +150,8 @@ def grid_with_text(
         )
 
     c = gf.Component()
-    instances = kf.grid(
+    grid_func = kf.flexgrid if flex else kf.grid
+    instances = grid_func(
         c,
         kcells=component_list,
         shape=shape,


### PR DESCRIPTION
## Summary

Add a `flex` parameter to `grid()` and `grid_with_text()` which switches between `kfactory.grid()` and `kfactory.flexgrid()` backend calls.

## Test Plan

Pytest passes.

Code snippet
```python
import gdsfactory as gf
rectangles = [gf.c.rectangle((1000, 100)), gf.c.rectangle((100, 1000)), gf.c.rectangle((100, 100)), gf.c.rectangle((100, 100))]
gf.grid(rectangles, shape=(2, 2), flex=False).plot()
gf.grid(rectangles, shape=(2, 2), flex=True).plot()
gf.grid_with_text(rectangles, shape=(2, 2), labels=['A', 'B', 'C', 'D'], flex=False).plot()
gf.grid_with_text(rectangles, shape=(2, 2), labels=['A', 'B', 'C', 'D'], flex=True).plot()
```
yields
<img width="800" height="600" alt="grid_flex_false" src="https://github.com/user-attachments/assets/c9c2f47e-8ad4-4996-84ea-ed8056293a5c" />
<img width="800" height="600" alt="grid_flex_true" src="https://github.com/user-attachments/assets/286bc328-951a-4c23-beb7-7363393a40e4" />
<img width="800" height="600" alt="grid_with_text_flex_false" src="https://github.com/user-attachments/assets/0377e6ed-a557-472d-8fb7-c0dbecf05496" />
<img width="800" height="600" alt="grid_with_text_flex_true" src="https://github.com/user-attachments/assets/695e72b2-3540-46b4-91f2-4f8b0289a445" />

## Summary by Sourcery

New Features:
- Introduce a flex option to grid() and grid_with_text() to select between fixed and flexible grid backends.