### PR TITLE
improve cdsem and wire_corner45_straight

### DIFF
--- a/gdsfactory/components/pcms/cdsem_bend180.py
+++ b/gdsfactory/components/pcms/cdsem_bend180.py
@@ -39,7 +39,11 @@ def cdsem_bend180(
         wg_length = 2 * r
 
     bend90 = gf.get_component(
-        bend90, cross_section=cross_section, radius=r, width=width
+        bend90,
+        cross_section=cross_section,
+        radius=r,
+        width=width,
+        allow_min_radius_violation=True,
     )
     wg = gf.get_component(
         straight, cross_section=cross_section, length=wg_length, width=width

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -83,7 +83,7 @@ def wire_corner45_straight(
     """
     c = gf.Component()
     xs = gf.get_cross_section(cross_section)
-    radius = radius or xs.radius
+    radius = radius or xs.radius or width
 
     if radius is None:
         raise ValueError("Either radius or width must be specified")


### PR DESCRIPTION
## Summary by Sourcery

Adjust bend and wire helper components to better handle small-radius configurations and missing radius parameters.

Bug Fixes:
- Ensure wire_corner45_straight can derive a valid bend radius from the wire width when neither an explicit nor cross-section radius is provided.

Enhancements:
- Allow cdsem_bend180 to instantiate bend90 components that intentionally violate minimum bend radius constraints for characterization layouts.