### PR TITLE
route_single not fail on error by default

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -67,7 +67,7 @@ def route_single(
     radius: float | None = None,
     route_width: float | None = None,
     auto_taper: bool = True,
-    on_error: Literal["error"] | None = "error",
+    on_error: Literal["error"] | None = None,
     layer_transitions: LayerTransitions | None = None,
 ) -> ManhattanRoute:
     """Returns a Manhattan Route between 2 ports.


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update route_single to default its on_error parameter to None instead of raising errors by default.