### PR TITLE
add pyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,15 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.11"
+    rev: "v0.14.8"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
       - id: ruff-format
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.407
+    hooks:
+      - id: pyright
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.15.0
     hooks:

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -56,7 +56,7 @@ def path_L(port1: typings.Port, port2: typings.Port) -> Path:
     )
     if delta_orientation not in (90, 270):
         raise ValueError("path_L(): ports must be orthogonal.")
-    e1, e2 = _get_rotated_basis(port1.orientation)
+    e1, _e2 = _get_rotated_basis(port1.orientation)
 
     # assemble waypoints
     pt1 = np.array(port1.center)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,24 @@ enabled = true
 live_mode = true
 strict = true
 
+[tool.pyright]
+exclude = ["gdsfactory/samples", "notebooks", "docs"]
+pythonVersion = "3.11"
+reportArgumentType = false
+reportAttributeAccessIssue = false
+reportCallIssue = false
+reportFunctionMemberAccess = false
+reportGeneralTypeIssues = false
+reportIndexIssue = false
+reportMissingImports = false
+reportMissingModuleSource = false
+reportOperatorIssue = false
+reportOptionalMemberAccess = false
+reportOverlappingOverload = false
+reportPossiblyUnboundVariable = false
+reportReturnType = false
+reportUnusedExpression = false
+
 [tool.pytest.ini_options]
 # addopts = --tb=no
 addopts = '--tb=short --ignore=gdsfactory/schematic_editor.py --ignore=gdsfactory/klayout_tech.py --ignore=gdsfactory/geometry/maskprep_flat.py --ignore=gdsfactory/fill_klayout.py --ignore=tests/test_samples.py'

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -33,5 +33,5 @@ def test_container_cell_conflict_raises_error() -> None:
         containers={"add_pads_top": gf.containers.add_pads_top},
     )
 
-    with pytest.raises(ValueError, match=".* overlapping cell names .*add_pads_top.*"):
+    with pytest.raises(ValueError, match=r".* overlapping cell names .*add_pads_top.*"):
         pdk.get_component("add_pads_top")


### PR DESCRIPTION
## Summary

Configure static type checking with Pyright and integrate it into the development workflow.

Bug Fixes:
- Adjust routing helper to avoid unused variable warnings and fix a PDK test regex to use a raw string literal.

Build:
- Add Pyright configuration to pyproject.toml with selective directory exclusions and relaxed diagnostics.

CI:
- Add a Pyright pre-commit hook alongside the existing Ruff hooks and update Ruff to a newer version.