### PR TITLE
use rel imports

### DIFF
--- a/gdsfactory/components/containers/add_termination.py
+++ b/gdsfactory/components/containers/add_termination.py
@@ -6,8 +6,9 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper
 from gdsfactory.typings import ComponentSpec
+
+from ..tapers.taper import taper
 
 _terminator_function = partial(taper, width2=0.1)
 

--- a/gdsfactory/components/containers/splitter_tree.py
+++ b/gdsfactory/components/containers/splitter_tree.py
@@ -24,8 +24,9 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.mzis import mzi1x2_2x2
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Spacing
+
+from ..mzis import mzi1x2_2x2
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/couplers/coupler_adiabatic.py
+++ b/gdsfactory/components/couplers/coupler_adiabatic.py
@@ -4,8 +4,9 @@ __all__ = ["coupler_adiabatic"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import bezier
 from gdsfactory.typings import CrossSectionSpec
+
+from ..bends.bend_s import bezier
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -4,9 +4,10 @@ __all__ = ["coupler_ring"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.couplers.coupler import coupler_straight
-from gdsfactory.components.couplers.coupler90 import coupler90
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..couplers.coupler import coupler_straight
+from ..couplers.coupler90 import coupler90
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/filters/fiber.py
+++ b/gdsfactory/components/filters/fiber.py
@@ -4,8 +4,9 @@ __all__ = ["fiber"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.shapes.circle import circle
 from gdsfactory.typings import LayerSpec
+
+from ..shapes.circle import circle
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/filters/fiber_array.py
+++ b/gdsfactory/components/filters/fiber_array.py
@@ -4,8 +4,9 @@ __all__ = ["fiber_array"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.shapes.circle import circle
 from gdsfactory.typings import LayerSpec
+
+from ..shapes.circle import circle
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -6,8 +6,9 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import bend_s
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..bends.bend_s import bend_s
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/filters/polarization_splitter_rotator.py
+++ b/gdsfactory/components/filters/polarization_splitter_rotator.py
@@ -9,8 +9,9 @@ import numpy.typing as npt
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import bezier
 from gdsfactory.typings import CrossSectionSpec, Delta, Float2, Float3
+
+from ..bends.bend_s import bezier
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
@@ -12,12 +12,13 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.grating_couplers.functions import (
+from gdsfactory.functions import DEG2RAD
+from gdsfactory.typings import CrossSectionSpec, LayerSpec
+
+from ..grating_couplers.functions import (
     grating_taper_points,
     grating_tooth_points,
 )
-from gdsfactory.functions import DEG2RAD
-from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
@@ -11,12 +11,13 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.grating_couplers.functions import (
+from gdsfactory.functions import DEG2RAD
+from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
+
+from ..grating_couplers.functions import (
     grating_taper_points,
     grating_tooth_points,
 )
-from gdsfactory.functions import DEG2RAD
-from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
 _gaps = (0.1,) * 10
 _widths = (0.5,) * 10

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
@@ -10,10 +10,11 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.grating_couplers.grating_coupler_elliptical_arbitrary import (
+from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
+
+from ..grating_couplers.grating_coupler_elliptical_arbitrary import (
     grating_coupler_elliptical_arbitrary,
 )
-from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
 parameters = (
     -2.4298362615732447,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
@@ -12,9 +12,10 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.grating_couplers.functions import grating_tooth_points
 from gdsfactory.functions import DEG2RAD
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+
+from ..grating_couplers.functions import grating_tooth_points
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
@@ -6,8 +6,9 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper
 from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
+
+from ..tapers.taper import taper
 
 _gaps = (0.2,) * 10
 _widths = (0.5,) * 10

--- a/gdsfactory/components/mmis/mmi1x2.py
+++ b/gdsfactory/components/mmis/mmi1x2.py
@@ -4,9 +4,10 @@ __all__ = ["mmi1x2"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper as taper_function
-from gdsfactory.components.waveguides.straight import straight as straight_function
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..tapers.taper import taper as taper_function
+from ..waveguides.straight import straight as straight_function
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/mmis/mmi1x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi1x2_with_sbend.py
@@ -7,8 +7,9 @@ import numpy.typing as npt
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import bend_s
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
+
+from ..bends.bend_s import bend_s
 
 
 def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:

--- a/gdsfactory/components/mmis/mmi2x2.py
+++ b/gdsfactory/components/mmis/mmi2x2.py
@@ -4,9 +4,10 @@ __all__ = ["mmi2x2"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper as taper_function
-from gdsfactory.components.waveguides.straight import straight as straight_function
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..tapers.taper import taper as taper_function
+from ..waveguides.straight import straight as straight_function
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/mmis/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi2x2_with_sbend.py
@@ -5,8 +5,9 @@ import numpy.typing as npt
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import bend_s
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
+
+from ..bends.bend_s import bend_s
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -4,8 +4,9 @@ __all__ = ["mmi_90degree_hybrid"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper as taper_function
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..tapers.taper import taper as taper_function
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -4,8 +4,9 @@ __all__ = ["mmi_tapered"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.tapers.taper import taper as taper_function
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
+
+from ..tapers.taper import taper as taper_function
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/pcms/cutback_2x2.py
+++ b/gdsfactory/components/pcms/cutback_2x2.py
@@ -4,8 +4,9 @@ __all__ = ["cutback_2x2"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..containers.component_sequence import component_sequence
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/pcms/cutback_bend.py
+++ b/gdsfactory/components/pcms/cutback_bend.py
@@ -15,8 +15,9 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec
+
+from ..containers.component_sequence import component_sequence
 
 
 def _get_bend_size(bend90: Component) -> float:

--- a/gdsfactory/components/pcms/cutback_component.py
+++ b/gdsfactory/components/pcms/cutback_component.py
@@ -7,8 +7,9 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..containers.component_sequence import component_sequence
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/pcms/cutback_splitter.py
+++ b/gdsfactory/components/pcms/cutback_splitter.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..containers.component_sequence import component_sequence
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/pcms/version_stamp.py
+++ b/gdsfactory/components/pcms/version_stamp.py
@@ -7,8 +7,9 @@ import platform
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.texts.text import text
 from gdsfactory.typings import LayerSpec
+
+from ..texts.text import text
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/rings/ring_double_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_double_bend_coupler.py
@@ -4,8 +4,9 @@ __all__ = ["ring_double_bend_coupler"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_circular import bend_circular_all_angle
 from gdsfactory.typings import ComponentAllAngleFactory, CrossSectionSpec
+
+from ..bends.bend_circular import bend_circular_all_angle
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -8,8 +8,6 @@ from typing import Any
 import numpy as np
 
 import gdsfactory as gf
-from gdsfactory.components.vias.via import via
-from gdsfactory.components.vias.via_stack import via_stack
 from gdsfactory.cross_section import Section, rib
 from gdsfactory.typings import (
     ComponentSpec,
@@ -17,6 +15,9 @@ from gdsfactory.typings import (
     CrossSectionSpec,
     LayerSpec,
 )
+
+from ..vias.via import via
+from ..vias.via_stack import via_stack
 
 cross_section_rib = partial(
     gf.cross_section.strip,

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_circular import bend_circular_all_angle
 from gdsfactory.typings import AnyComponentFactory, ComponentSpec, CrossSectionSpec
+
+from ..bends.bend_circular import bend_circular_all_angle
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/delay_snake.py
+++ b/gdsfactory/components/spirals/delay_snake.py
@@ -6,10 +6,11 @@ import warnings
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_euler import bend_euler180
-from gdsfactory.components.containers.component_sequence import component_sequence
-from gdsfactory.components.waveguides.straight import straight
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..bends.bend_euler import bend_euler180
+from ..containers.component_sequence import component_sequence
+from ..waveguides.straight import straight
 
 _diagram = r"""
                  | length0   |

--- a/gdsfactory/components/spirals/delay_snake2.py
+++ b/gdsfactory/components/spirals/delay_snake2.py
@@ -6,8 +6,9 @@ import warnings
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..containers.component_sequence import component_sequence
 
 diagram = """
        | length0 | length1 |

--- a/gdsfactory/components/spirals/delay_snake_sbend.py
+++ b/gdsfactory/components/spirals/delay_snake_sbend.py
@@ -4,8 +4,9 @@ __all__ = ["delay_snake_sbend"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.waveguides.straight import straight
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..waveguides.straight import straight
 
 diagram = r"""
 

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -11,9 +11,6 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_euler import bend_euler
-from gdsfactory.components.bends.bend_s import get_min_sbend_size
-from gdsfactory.components.waveguides.straight import straight
 from gdsfactory.routing.route_single import route_single
 from gdsfactory.typings import (
     ComponentSpec,
@@ -21,6 +18,10 @@ from gdsfactory.typings import (
     Floats,
     Port,
 )
+
+from ..bends.bend_euler import bend_euler
+from ..bends.bend_s import get_min_sbend_size
+from ..waveguides.straight import straight
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/superconductors/snspd.py
+++ b/gdsfactory/components/superconductors/snspd.py
@@ -6,8 +6,9 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.superconductors.optimal_hairpin import optimal_hairpin
 from gdsfactory.typings import LayerSpec, Port, Size
+
+from ..superconductors.optimal_hairpin import optimal_hairpin
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/tapers/taper_hecken.py
+++ b/gdsfactory/components/tapers/taper_hecken.py
@@ -12,13 +12,14 @@ from numpy import log
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.analog.microstrip import (
+from gdsfactory.typings import LayerSpec
+
+from ..analog.microstrip import (
     _G,
     _find_microstrip_wire_width,
     _microstrip_v_with_Lk,
     _microstrip_Z_with_Lk,
 )
-from gdsfactory.typings import LayerSpec
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/texts/text_rectangular.py
+++ b/gdsfactory/components/texts/text_rectangular.py
@@ -8,12 +8,13 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.copy_layers import copy_layers
-from gdsfactory.components.texts.text_rectangular_font import (
+from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
+
+from ..containers.copy_layers import copy_layers
+from ..texts.text_rectangular_font import (
     pixel_array,
     rectangular_font,
 )
-from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -9,11 +9,12 @@ from kfactory.conf import CheckInstances
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.bends.bend_s import (
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta, LayerSpec
+
+from ..bends.bend_s import (
     bezier,
     find_min_curv_bezier_control_points,
 )
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta, LayerSpec
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/waveguides/straight_heater_meander_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander_doped.py
@@ -9,10 +9,11 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
-from gdsfactory.components.vias.via import via
-from gdsfactory.components.vias.via_stack import via_stack
 from gdsfactory.cross_section import Section
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpecs, Port
+
+from ..vias.via import via
+from ..vias.via_stack import via_stack
 
 _via_stack = partial(
     via_stack,

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -12,8 +12,9 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.components.containers.component_sequence import component_sequence
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
+from ..containers.component_sequence import component_sequence
 
 
 @gf.cell_with_module_name


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch intra-package imports in components and subpackages from absolute gdsfactory.components.* paths to relative imports to improve package modularity and local reuse.