### PR TITLE
Fixing the slot cross-section

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,15 +57,35 @@ Classes and functions for construction and manipulation of geometric objects.
    Section
    cross_section
    strip
+   strip_no_ports
+   slot
+   rib
+   rib_bbox
+   rib2
+   rib_with_trenches
+   nitride
+   strip_rib_tip
+   strip_nitride_tip
+   l_with_trenches
+   metal1
+   metal2
+   metal3
+   metal_routing
+   gs
+   gsg
    heater_metal
+   npp
    pin
    pn
    pn_with_trenches
+   pn_with_trenches_asymmetric
+   l_wg_doped_with_trenches
    strip_heater_metal_undercut
    strip_heater_metal
    strip_heater_doped
    rib_heater_doped
    rib_heater_doped_via_stack
+   pn_ge_detector_si_contacts
    CrossSectionFactory
    CrossSectionSpec
 

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -914,9 +914,11 @@ def strip_nitride_tip(
 @xsection
 def slot(
     width: float = 0.5,
-    layer: typings.LayerSpec = "WG",
+    layer: typings.LayerSpec = "WG_ABSTRACT",
     slot_width: float = 0.04,
+    rail_layer: typings.LayerSpec = "WG",
     sections: Sections | None = None,
+    **kwargs: Any,
 ) -> CrossSection:
     """Return CrossSection Slot (with an etched region in the center).
 
@@ -926,7 +928,9 @@ def slot(
                 the width at t==1 is the width at the end.
         layer: main section layer.
         slot_width: in um.
+        rail_layer: rail layer.
         sections: list of Sections(width, offset, layer, ports).
+        kwargs: other cross section parameters.
 
     .. plot::
         :include-source:
@@ -938,6 +942,9 @@ def slot(
         c = p.extrude(xs)
         c.plot()
     """
+    if slot_width >= width:
+        raise ValueError(f"{width=} must be greater than {slot_width=}")
+
     rail_width = (width - slot_width) / 2
     rail_offset = (rail_width + slot_width) / 2
 
@@ -945,18 +952,25 @@ def slot(
     section_list.extend(
         [
             Section(
-                width=rail_width, offset=rail_offset, layer=layer, name="left_rail"
+                width=rail_width,
+                offset=+rail_offset,
+                layer=rail_layer,
+                name="left_rail",
             ),
             Section(
-                width=rail_width, offset=-rail_offset, layer=layer, name="right rail"
+                width=rail_width,
+                offset=-rail_offset,
+                layer=rail_layer,
+                name="right_rail",
             ),
         ]
     )
 
     return strip(
         width=width,
-        layer="WG_ABSTRACT",
-        sections=sections,
+        layer=layer,
+        sections=section_list,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
## Summary

- No sections were being passed (`sections` instead of `section_list`)
- Core layer was hardcoded
- Missing width check allowing for negative widths
- Sections didn't follow same naming convention

Also added a bunch of missing entries from the documentation (the new entries in the `.rst` were generated by an LLM).

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Update the slot waveguide cross-section definition to use configurable layers and validated geometry, and align its API and documentation with the rest of the cross-section utilities.

New Features:
- Allow configuring a separate rail layer for the slot cross-section and forward additional cross-section parameters via keyword arguments.

Bug Fixes:
- Ensure sections are correctly passed into the slot cross-section instead of being ignored.
- Validate that the slot width is smaller than the overall width to prevent invalid or negative rail widths.
- Align section naming for the slot cross-section rails to a consistent convention.

Enhancements:
- Change the default core layer for the slot cross-section to the abstract waveguide layer to better match core cross-section behavior.

Documentation:
- Add missing slot cross-section entries to the API documentation.