### PR TITLE
add sized flag for the fix_min_space

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -965,12 +965,15 @@ class Component(ComponentBase, kf.DKCell):
         self.kdb_cell.shapes(layer_index).insert(region)
         self.kcl.layout.end_changes()
 
-    def fix_spacing(self, layer: LayerSpec, min_space: float = 0.2) -> None:
+    def fix_spacing(
+        self, layer: LayerSpec, min_space: float = 0.2, sized: float = 0
+    ) -> None:
         """Fixes layer spacing in the Component.
 
         Args:
             layer: layer to fix spacing on.
             min_space: minimum space in um.
+            sized: size to use for the fix spacing operation. in um.
         """
         import gdsfactory as gf
         from gdsfactory.pdk import get_layer
@@ -980,6 +983,10 @@ class Component(ComponentBase, kf.DKCell):
         fix = fix_spacing_tiled(
             self.to_itype(), min_space=self.kcl.to_dbu(min_space), layer=layer_info
         )
+        if sized:
+            sized_dbu = self.kcl.to_dbu(sized)
+            fix = fix.sized(sized_dbu)
+
         self.shapes(layer).insert(fix)
 
     def fix_width(


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow specifying a sizing value when fixing spacing on a layer to control the size of the resulting geometry.