### PR TITLE
add flag to write GDS with no empty cells

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -387,10 +387,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         gdspath.parent.mkdir(parents=True, exist_ok=True)
 
         if save_options is None:
-            if no_empty_cells:
-                save_options = save_layout_options(no_empty_cells=True)
-            else:
-                save_options = save_layout_options()
+            save_options = save_layout_options(no_empty_cells=no_empty_cells)
 
         exclude_layers = exclude_layers or CONF.exclude_layers
 


### PR DESCRIPTION
## Summary

New Features:
- Introduce a no_empty_cells option to write_gds to optionally omit empty cells from generated GDS layouts.


## How to test it?

Create a cell with no polygons, then open Klayout and search

`cells * where cell.is_empty`

<img width="659" height="376" alt="image" src="https://github.com/user-attachments/assets/e176d711-ea0b-4aea-9208-6b897a195bd5" />
