### PR TITLE
Avoid implicit point simplification on itype conversion in add_polygon

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -78,14 +78,9 @@ def ensure_tuple_of_tuples(points: Any) -> tuple[tuple[float, float], ...]:
 def points_to_polygon(
     points: _PolygonPoints,
 ) -> kdb.Polygon | kdb.DPolygon | kdb.DSimplePolygon | kdb.Region:
-    if isinstance(points, tuple | list | np.ndarray):
-        points = ensure_tuple_of_tuples(points)
-        polygon = kdb.DPolygon()
-        polygon.assign_hull(to_kdb_dpoints(points))
-    elif isinstance(
-        points, kdb.Polygon | kdb.DPolygon | kdb.DSimplePolygon | kdb.Region
-    ):
+    if isinstance(points, kdb.Polygon | kdb.DPolygon | kdb.DSimplePolygon | kdb.Region):
         return points
+    points = ensure_tuple_of_tuples(points)
     return kdb.DPolygon(to_kdb_dpoints(points))
 
 
@@ -1084,6 +1079,8 @@ class Component(ComponentBase, kf.DKCell):
         _layer = get_layer(layer)
 
         polygon = points_to_polygon(points)
+        if isinstance(polygon, kdb.DPolygon | kdb.DSimplePolygon):
+            polygon = polygon.to_itype(self.kcl.dbu)  # type: ignore[assignment]
 
         return self.kdb_cell.shapes(_layer).insert(polygon)
 


### PR DESCRIPTION
## Summary

During the `insert`, KLayout will simplify the points implicitly when going from `DPolygon` to `Polygon` which has been noticed and is not desirable. Making an explicit conversion beforehand solves the issue and yields the expected number of points in the polygon.

Removed some dead code in `points_to_polygon`.

For `vcell`, see https://github.com/gdsfactory/kfactory/pull/850

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Avoid implicit point simplification when inserting polygons by explicitly converting floating-point polygons to integer-type polygons before insertion and simplifying point-to-polygon conversion logic.

Bug Fixes:
- Preserve the expected number of polygon points during add_polygon by explicitly converting DPolygon/DSimplePolygon to integer type before insertion instead of relying on implicit conversion.

Enhancements:
- Simplify and consolidate points_to_polygon handling of input types by removing redundant dead code paths.

## Summary by Sourcery

Ensure polygons are explicitly converted to the correct integer type before insertion to avoid implicit point simplification and streamline polygon point handling.

Bug Fixes:
- Preserve the expected number of polygon points during add_polygon by explicitly converting DPolygon/DSimplePolygon to integer type before insertion instead of relying on implicit conversion.

Enhancements:
- Simplify points_to_polygon by returning pre-constructed polygon/region objects directly and using a unified path for converting raw point sequences into DPolygons.