### PR TITLE
Remove matthew from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @sebastian-goeldi @MatthewMckee4
+* @joamatab @sebastian-goeldi


### PR DESCRIPTION
## Summary

Since I'm leaving

## Summary by Sourcery

Chores:
- Adjust CODEOWNERS file to reflect current maintainers by removing an outdated code owner entry.