### PR TITLE
Set the is_gf_cell and is_gf_vcell attributes correctly

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from functools import partial
-from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, overload
+from functools import partial, wraps
+from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, cast, overload
 
 import kfactory as kf
 from cachetools import Cache
@@ -121,8 +121,20 @@ def cell(
         lvs_equivalent_ports=lvs_equivalent_ports,
         ports=ports,
     )
-    c.is_gf_cell = True
-    return c  # type: ignore[no-any-return]
+
+    if _func is not None:
+        c.is_gf_cell = True
+        return cast(ComponentFunc[ComponentParams], c)
+
+    @wraps(c)
+    def wrapper(
+        func: ComponentFunc[ComponentParams],
+    ) -> ComponentFunc[ComponentParams]:
+        decorated = c(func)
+        decorated.is_gf_cell = True
+        return cast(ComponentFunc[ComponentParams], decorated)
+
+    return wrapper
 
 
 class ComponentAllAngleFunc(Protocol[ComponentParams]):
@@ -188,8 +200,20 @@ def vcell(
         check_ports=check_ports,
         ports=ports,
     )
-    vc.is_gf_vcell = True
-    return vc  # type: ignore[no-any-return]
+
+    if _func is not None:
+        vc.is_gf_vcell = True
+        return cast(ComponentAllAngleFunc[ComponentParams], vc)
+
+    @wraps(vc)
+    def wrapper(
+        func: ComponentAllAngleFunc[ComponentParams],
+    ) -> ComponentAllAngleFunc[ComponentParams]:
+        decorated = vc(func)
+        decorated.is_gf_vcell = True
+        return cast(ComponentAllAngleFunc[ComponentParams], decorated)
+
+    return wrapper
 
 
 def override_defaults(

--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -92,7 +92,7 @@ def cell(
     if with_module_name and _func is not None:
         mod = _func.__module__
         basename = basename or clean_name(
-            _func.__name__ if mod == "__main" else f"{_func.__name__}_{mod}"
+            _func.__name__ if mod == "__main__" else f"{_func.__name__}_{mod}"
         )
 
     if drop_params is None:

--- a/gdsfactory/get_factories.py
+++ b/gdsfactory/get_factories.py
@@ -9,7 +9,7 @@ from typing import Any
 import kfactory as kf
 
 from gdsfactory.component import Component, ComponentAllAngle
-from gdsfactory.typings import ComponentFactory
+from gdsfactory.typings import ComponentAllAngleFactory, ComponentFactory
 
 
 def get_cells(
@@ -17,7 +17,7 @@ def get_cells(
     ignore_non_decorated: bool = False,
     ignore_underscored: bool = True,
     ignore_partials: bool = False,
-) -> dict[str, ComponentFactory]:
+) -> dict[str, ComponentFactory | ComponentAllAngleFactory]:
     """Returns PCells (component functions) from a module or list of modules.
 
     Args:
@@ -27,7 +27,7 @@ def get_cells(
         ignore_partials: only include functions, not partials.
     """
     modules = modules if isinstance(modules, Iterable) else [modules]
-    cells: dict[str, ComponentFactory] = {}
+    cells: dict[str, ComponentFactory | ComponentAllAngleFactory] = {}
     for module in modules:
         cells.update(
             {
@@ -89,12 +89,12 @@ def is_cell(
             return False
 
         # Fast attribute check
-        is_cell_attr = getattr(func, "is_gf_cell", None)
-
-        if func in kf.kcl.virtual_factories.values():
+        if getattr(func, "is_gf_cell", None):
+            return True
+        if getattr(func, "is_gf_vcell", None):
             return True
 
-        if is_cell_attr:
+        if func in kf.kcl.virtual_factories.values():
             return True
 
         if not ignore_non_decorated:

--- a/gdsfactory/gpdk/__init__.py
+++ b/gdsfactory/gpdk/__init__.py
@@ -83,8 +83,8 @@ def get_generic_pdk() -> Pdk:
     return Pdk(
         name="generic",
         version=__version__,
-        cells={c: cells[c] for c in cells if c not in containers_dict},
-        containers=containers_dict,
+        cells={c: cells[c] for c in cells if c not in containers_dict},  # type: ignore
+        containers=containers_dict,  # type: ignore[arg-type]
         cross_sections=cross_sections,
         layers=LAYER,
         layer_stack=LAYER_STACK,

--- a/gdsfactory/samples/pdk/fab_c.py
+++ b/gdsfactory/samples/pdk/fab_c.py
@@ -229,7 +229,7 @@ layer_stack = get_layer_stack_fab_c()
 
 PDK = gf.Pdk(
     name="fab_c_demopdk",
-    cells=cells,
+    cells=cells,  # type: ignore[arg-type]
     cross_sections=cross_sections,
     layer_stack=layer_stack,
     layers=LAYER,

--- a/tests/test_get_factories.py
+++ b/tests/test_get_factories.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import gdsfactory as gf
 from gdsfactory.components.containers.add_trenches import add_trenches, add_trenches90
 from gdsfactory.get_factories import is_cell
 
@@ -13,3 +14,39 @@ def test_is_cell() -> None:
 
     assert not is_cell(random_function)
     assert not is_cell(partial(random_function, 1))
+
+
+def test_is_gf_cell() -> None:
+    @gf.cell
+    def with_no_paren() -> gf.Component:
+        return gf.Component()
+
+    @gf.cell()
+    def with_paren() -> gf.Component:
+        return gf.Component()
+
+    @gf.cell(basename="my_component")
+    def with_args() -> gf.Component:
+        return gf.Component()
+
+    assert getattr(with_no_paren, "is_gf_cell", None) is True
+    assert getattr(with_paren, "is_gf_cell", None) is True
+    assert getattr(with_args, "is_gf_cell", None) is True
+
+
+def test_is_gf_vcell() -> None:
+    @gf.vcell
+    def with_no_paren() -> gf.ComponentAllAngle:
+        return gf.ComponentAllAngle()
+
+    @gf.vcell()
+    def with_paren() -> gf.ComponentAllAngle:
+        return gf.ComponentAllAngle()
+
+    @gf.vcell(basename="my_component")
+    def with_args() -> gf.ComponentAllAngle:
+        return gf.ComponentAllAngle()
+
+    assert getattr(with_no_paren, "is_gf_vcell", None) is True
+    assert getattr(with_paren, "is_gf_vcell", None) is True
+    assert getattr(with_args, "is_gf_vcell", None) is True


### PR DESCRIPTION
## Summary

- Use `is_gf_vcell` to detect `vcell`
- Properly set the markers when using args in decorator
- Fix `__main__` typo

## Test Plan

See unit tests for second point

## Summary by Sourcery

Ensure gf.cell and gf.vcell decorators correctly mark factories and are detected as cells, while fixing minor type and module name issues.

Bug Fixes:
- Correctly set the is_gf_cell and is_gf_vcell attributes for functions decorated with gf.cell/gf.vcell, including when used with arguments or parentheses.
- Fix the __main__ module name check when deriving basenames in the cell decorator.
- Detect vcell-based factories via the is_gf_vcell marker and allow ComponentAllAngle factories to be returned by get_cells.

Enhancements:
- Relax get_cells and related typing to support both ComponentFactory and ComponentAllAngleFactory, adding type ignores where needed.

Tests:
- Add unit tests verifying that gf.cell and gf.vcell set their is_gf_cell and is_gf_vcell markers in all supported invocation forms.