### PR TITLE
Allow setting name for add_ref_off_grid

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -476,16 +476,22 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         return get_netlist(self, **kwargs)  # type: ignore[arg-type]
 
-    def add_ref_off_grid(self, component: kf.ProtoTKCell[Any]) -> VInstance:
+    def add_ref_off_grid(
+        self, component: kf.ProtoTKCell[Any], name: str | None = None
+    ) -> VInstance:
         """Adds a component instance reference to a Component without snapping to grid.
 
         Args:
             component: The referenced component.
+            name: Name of the reference.
         """
         if self.locked:
             raise LockedError(self)
 
-        return self.create_vinst(component)
+        ref = self.create_vinst(component)
+        if name:
+            ref.name = name
+        return ref
 
 
 Route: TypeAlias = (


### PR DESCRIPTION
add_ref(...) also takes a name keyword. Adding this for consistency and ease of use.

## Summary by Sourcery

New Features:
- Add optional name parameter to add_ref_off_grid to set the instance reference name when creating off-grid references.