### PR TITLE
Use add_ref instead of create_inst in lshift

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -584,14 +584,7 @@ class Component(ComponentBase, kf.DKCell):
         Args:
             cell: The cell to be added as an instance
         """
-        if isinstance(cell, ComponentAllAngle):
-            raise ValueError(
-                f"Use Component.add_ref_off_grid() for all angle {cell.name!r}"
-            )
-
-        if not isinstance(cell, kf.ProtoTKCell):
-            raise ValueError(f"Expected a Component, got {type(cell)}")
-        return self.create_inst(cell)
+        return self.add_ref(cell)
 
     def add_ref(
         self,


### PR DESCRIPTION
## Summary

I'm surprised this repeats some of the checks of `add_ref`, but without the `locked` check.
Error message suggests `add_ref_off_grid` too.

Return type hint says `ComponentReference` when it's `DInstance`.

Not sure if this is something that was missed or done on purpose, but I do believe it should match `add_ref`

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Bug Fixes:
- Align the __lshift__ helper with add_ref so it benefits from the same validation and behavior when adding instances.