### PR TITLE
fix transformation of flattened vinst

### DIFF
--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -464,7 +464,7 @@ def _insert_netlist(
                 inst = inst.to_dtype()
             array = None
             virtual = True
-            transform = inst.dcplx_trans * inst.cell.vtrans
+            transform = inst.dcplx_trans * inst.cell.vtrans  # type: ignore[union-attr]
             _all_ports.update({f"{inst_name},{p.name}": p for p in inst.ports})
         elif _is_array_inst(inst):
             if hasattr(inst, "to_dtype"):  # always True - just making mypy happy


### PR DESCRIPTION
## Summary

Fixes bug in placement of vinst

## Test Plan

ran tests

## Summary by Sourcery

Adjust netlisting logic to correctly place virtual instances and improve hierarchical cell naming based on default vs non-default settings.

Bug Fixes:
- Fix transformation applied to flattened virtual instances to account for the cell’s virtual transform and correct placement.
- Avoid unnecessary counted renaming when a hierarchical cell uses default settings and its base name is unused.

Enhancements:
- Refine hierarchical cell naming to reuse the component name when settings are default and only apply counted names for non-default parameterizations or name collisions.
- Introduce a helper to detect whether a cell’s settings differ from its factory defaults using the active PDK’s cell factories and their signatures.
- Register the sample circuit as a reusable gdsfactory cell and update the example code to round-trip its netlist via YAML and display the reconstructed component.