### PR TITLE
Fix: deprecated docstring for base_pdks in Pdk class 

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -125,7 +125,7 @@ class Pdk(BaseModel):
         models: dict of models names to functions.
         symbols: dict of symbols names to functions.
         default_symbol_factory:
-        base_pdk: a pdk to copy from and extend.
+        base_pdks: list of pdks to copy from and extend.
         default_decorator: decorate all cells, if not otherwise defined on the cell.
         layers: maps name to gdslayer/datatype.
             For example dict(si=(1, 0), sin=(34, 0)).


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

A mistake was made in commit bc2e152f532963f5e7a7356fcce55c539e9ba7d5:

- https://github.com/gdsfactory/gdsfactory/commit/bc2e152f532963f5e7a7356fcce55c539e9ba7d5#diff-6e20162dd198cd70a338e095f619fa324ee92cc422d5189ebff8ee7cf0ef5ea6L197 removed `base_pdks` from the docstring of the class `Pdk`.

- https://github.com/gdsfactory/gdsfactory/commit/bc2e152f532963f5e7a7356fcce55c539e9ba7d5#diff-6e20162dd198cd70a338e095f619fa324ee92cc422d5189ebff8ee7cf0ef5ea6L231 removed `base_pdk` as a parameter of the class `Pdk`.

I believe that the error was to remove `base_pdks` instead of `base_pdk` from the docstring, which this PR fixes.

## Test Plan

<!-- How was it tested? -->

Since this is just a docstring fix, and the code is consistence with the use of `base_pdks`, no test is required.

## Summary by Sourcery

Documentation:
- Correct the Pdk class docstring to refer to base_pdks as a list of PDks to copy from and extend.