### PR TITLE
Feat: add new function to process .gds files with multiple top cells to read module

### DIFF
--- a/gdsfactory/read/__init__.py
+++ b/gdsfactory/read/__init__.py
@@ -3,7 +3,7 @@ from gdsfactory.read.from_np import from_image, from_np
 from gdsfactory.read.from_updk import from_updk
 from gdsfactory.read.from_yaml import from_yaml
 from gdsfactory.read.from_yaml_template import cell_from_yaml_template
-from gdsfactory.read.import_gds import import_gds
+from gdsfactory.read.import_gds import import_gds, import_gds_multiple_top_cells
 
 __all__ = [
     "cell_from_yaml_template",
@@ -14,4 +14,5 @@ __all__ = [
     "from_updk",
     "from_yaml",
     "import_gds",
+    "import_gds_multiple_top_cells",
 ]

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -46,7 +46,7 @@ def import_gds(
     if cellname is None:
         if len(temp_kcl.layout.top_cells()) > 1:
             raise ValueError(
-                "GDS file has multiple top cells. Use cellname to select a specific one, or use import_gds_multiple_top_cells to import all top cells.\n"
+                "GDS file has multiple top cells. Use cellname to select a specific one, or use gf.read.import_gds_multiple_top_cells instead.\n"
                 + f"Top cells: {[c.name for c in temp_kcl.layout.top_cells()]}"
             )
         cellname = temp_kcl.layout.top_cell().name


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

I had to import all the cells from a .gds file which had multiple top cells, but couldn't do it directly as the `import_gds` function only works on files with one top cell or by specifying the specific top cell to import.

Thus, I created a function called `import_gds_multiple_top_cells` which reads a GDS file and returns a dictionary of its top cells as Components.

## Test Plan

<!-- How was it tested? -->

I ran `make test-data` followed by `make test, and got the following result:

```bash
=================================================================================== short test summary info ===================================================================================
FAILED tests/components/test_components.py::test_gds[terminator] - EOFError: EOF when reading a line
============================================================ 1 failed, 1324 passed, 2 skipped, 4565 warnings in 191.58s (0:03:11) =============================================================
```

As it is currently is, this PR doesn't modify the default behaviour of `import_gds` as `accept_multiple_top_cells` is set to `False` by default, so I doubt that this error came from my contribution.


> [!NOTE]
> I've also successfully used this code locally to extract cells from .gds files.

## Summary by Sourcery

Add support for importing multiple top cells from a GDS file via a new helper while tightening validation for ambiguous imports.

New Features:
- Introduce import_gds_multiple_top_cells to load all or selected top cells from a GDS file and return them as a name-to-Component mapping.

Enhancements:
- Update import_gds to detect GDS files with multiple top cells when no cellname is provided and raise a descriptive error directing users to disambiguate or use the multi-top import helper.

## Summary by Sourcery

Add support for importing GDS files with multiple top cells while preserving existing single-top import behavior.

New Features:
- Introduce import_gds_multiple_top_cells to load one or more top cells from a GDS file and return them as a name-to-Component mapping.

Enhancements:
- Update import_gds to detect ambiguous multi-top GDS files when no cellname is provided and raise a descriptive error guiding users to disambiguate or use the multi-top import helper.