### PR TITLE
Grid snapping for sub-nm DBU

### DIFF
--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -7,9 +7,10 @@ from collections.abc import Sequence
 from functools import partial
 from typing import Any, TypeAlias, TypeVar, cast, overload
 
-import kfactory as kf
 import numpy as np
 import numpy.typing as npt
+
+import gdsfactory as gf
 
 Value: TypeAlias = float | Sequence[float] | npt.NDArray[np.floating[Any]]
 
@@ -82,10 +83,14 @@ def snap_to_grid(
         nm: Optional grid size in nm. If None, it will use the default grid size from PDK multiplied by grid_factor.
         grid_factor: snap to grid_factor * grid_size.
     """
-    grid_size = kf.kcl.dbu
-    nm = nm or round(grid_size * 1000 * grid_factor)
-    res = nm * np.round(np.asarray(x, dtype=float) * 1e3 / nm) / 1e3
-    if isinstance(res, np.floating):
+    if nm is None:
+        grid_um = gf.kcl.dbu * grid_factor
+    else:
+        grid_um = nm / 1000
+
+    res = grid_um * np.round(np.asarray(x, dtype=np.float64) / grid_um)
+
+    if np.ndim(res) == 0:
         return float(res)
     return cast("_T | float", res)
 

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -31,3 +31,22 @@ def test_point_is_on_grid() -> None:
 def test_point_is_on_2x_grid() -> None:
     assert gf.snap.is_on_grid([0.555, 0], grid_factor=2) is False
     assert gf.snap.is_on_grid([0.556, 0], grid_factor=2) is True
+
+
+def test_snap_to_grid_with_explicit_nm() -> None:
+    assert gf.snap.snap_to_grid(0.0015, nm=1) == 0.002
+    assert gf.snap.snap_to_grid(0.0015, nm=1, grid_factor=2) == 0.002
+    assert gf.snap.snap_to_grid(0.0015, nm=2, grid_factor=1) == 0.002
+
+    assert gf.snap.snap_to_grid(-0.0015, nm=1) == -0.002
+    assert gf.snap.snap_to_grid(-0.0015, nm=1, grid_factor=2) == -0.002
+    assert gf.snap.snap_to_grid(-0.0015, nm=2, grid_factor=1) == -0.002
+
+
+def test_snap_to_grid_sub_nm_dbu() -> None:
+    assert gf.snap.snap_to_grid(0.00074, nm=0.5) == 0.0005
+    assert gf.snap.snap_to_grid(0.00076, nm=0.5) == 0.001
+    assert gf.snap.snap_to_grid(0.00126, nm=0.5) == 0.0015
+
+    assert gf.snap.snap_to_grid(0.00014, nm=0.1) == 0.0001
+    assert gf.snap.snap_to_grid(0.00016, nm=0.1) == 0.0002


### PR DESCRIPTION
## Summary

Closes https://github.com/gdsfactory/gdsfactory/issues/4236

- Using `dbu = 1e-4` led to rounding to 0

## Test Plan

Added some tests

## Summary by Sourcery

Adjust grid snapping behavior for geometric coordinates to use consistent half-away-from-zero rounding and support explicit nanometer grid sizes, updating tests and regression data accordingly.

Bug Fixes:
- Fix snapping for very small database units to avoid rounding values to zero.
- Correct rounding behavior at 0.5 grid steps to avoid banker's rounding artifacts in grid snapping.

Enhancements:
- Allow snap_to_grid to use either the default DBU-based grid or an explicit nanometer grid size with grid_factor.
- Ensure scalar and array inputs to snap_to_grid are handled consistently via unified float64 computation.

Tests:
- Add unit tests covering explicit nm-based snapping, sub-nanometer DBU snapping, and rounding edge cases for positive and negative values.
- Update DBR tapered netlist regression data to reflect the new snapping behavior in component placement and naming.

## Summary by Sourcery

Adjust grid snapping behavior to use a consistent physical grid size in microns and avoid precision issues with very small DBU values.

Bug Fixes:
- Fix snap_to_grid rounding errors when using very small DBU or sub-nanometer grid sizes by basing snapping on a computed grid size in microns instead of integer nanometer rounding.

Tests:
- Add unit tests covering snap_to_grid with explicit nanometer grid sizes and sub-nanometer DBU scenarios for both positive and negative coordinates.