### PR TITLE
Round half up on grid snapping

### DIFF
--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -88,7 +88,8 @@ def snap_to_grid(
     else:
         grid_um = nm / 1000
 
-    res = grid_um * np.round(np.asarray(x, dtype=np.float64) / grid_um)
+    # Round half up
+    res = grid_um * np.floor(np.asarray(x, dtype=np.float64) / grid_um + 0.5)
 
     if np.ndim(res) == 0:
         return float(res)

--- a/tests/test-data-regression/test_netlists_dbr_tapered_.yml
+++ b/tests/test-data-regression/test_netlists_dbr_tapered_.yml
@@ -1,5 +1,5 @@
 instances:
-  array_gdsfactorypcomponentspcontainersparray_component__bf81680f_m24437_m500:
+  array_gdsfactorypcomponentspcontainersparray_component__ef08f668_m24438_m500:
     component: array
     info: {}
     settings:
@@ -8,7 +8,7 @@ instances:
       centered: false
       column_pitch: 0.85
       columns: 58
-      component: rectangle_gdsfactorypcomponentspshapesprectangle_S0p424_a02634c4
+      component: rectangle_gdsfactorypcomponentspshapesprectangle_S0p426_6427083f
       post_process: null
       row_pitch: 150
       rows: 1
@@ -75,10 +75,10 @@ nets:
 - p1: straight_gdsfactorypcomponentspwaveguidespstraight_L10__2c3216f5_m5000_0,o2
   p2: taper_gdsfactorypcomponentsptapersptaper_L20_W0p4_W1_LN_66863c4a_5000_0,o1
 placements:
-  array_gdsfactorypcomponentspcontainersparray_component__bf81680f_m24437_m500:
+  array_gdsfactorypcomponentspcontainersparray_component__ef08f668_m24438_m500:
     mirror: false
     rotation: 0
-    x: -24.437
+    x: -24.438
     y: -0.5
   straight_gdsfactorypcomponentspwaveguidespstraight_L10__2c3216f5_m5000_0:
     mirror: false

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -38,8 +38,8 @@ def test_snap_to_grid_with_explicit_nm() -> None:
     assert gf.snap.snap_to_grid(0.0015, nm=1, grid_factor=2) == 0.002
     assert gf.snap.snap_to_grid(0.0015, nm=2, grid_factor=1) == 0.002
 
-    assert gf.snap.snap_to_grid(-0.0015, nm=1) == -0.002
-    assert gf.snap.snap_to_grid(-0.0015, nm=1, grid_factor=2) == -0.002
+    assert gf.snap.snap_to_grid(-0.0015, nm=1) == -0.001
+    assert gf.snap.snap_to_grid(-0.0015, nm=1, grid_factor=2) == -0.001
     assert gf.snap.snap_to_grid(-0.0015, nm=2, grid_factor=1) == -0.002
 
 
@@ -50,3 +50,13 @@ def test_snap_to_grid_sub_nm_dbu() -> None:
 
     assert gf.snap.snap_to_grid(0.00014, nm=0.1) == 0.0001
     assert gf.snap.snap_to_grid(0.00016, nm=0.1) == 0.0002
+
+
+def test_snap_to_grid_rounding() -> None:
+    assert gf.snap.snap_to_grid(0.00149, nm=1) == 0.001
+    assert gf.snap.snap_to_grid(0.0015, nm=1) == 0.002
+    assert gf.snap.snap_to_grid(0.00151, nm=1) == 0.002
+
+    assert gf.snap.snap_to_grid(-0.00149, nm=1) == -0.001
+    assert gf.snap.snap_to_grid(-0.0015, nm=1) == -0.001
+    assert gf.snap.snap_to_grid(-0.00151, nm=1) == -0.002


### PR DESCRIPTION
## Summary

Using Banker's rounding leads to unexpected results. This is safer. Also what the competition is doing, it seems like.

Stacked on top of https://github.com/gdsfactory/gdsfactory/pull/4347

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Switch snap-to-grid behavior to use half-up rounding based on the effective grid size, and update expectations accordingly.

Bug Fixes:
- Ensure snap_to_grid produces consistent, non-bankers-rounded results for positive and negative coordinates at grid boundaries.

Enhancements:
- Support explicit grid sizing in nanometers and sub-nanometer dbu snapping in snap_to_grid, decoupled from the default PDK dbu when provided.

Tests:
- Add unit tests covering explicit nm/grid_factor combinations, sub-nm dbu snapping, and precise half-up rounding behavior at boundary values.
- Update netlist regression data to reflect the new snapping behavior and resulting geometric placements.