### PR TITLE
remove zero length straights in rings

### DIFF
--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -85,24 +85,27 @@ def ring_double(
         bend=bend,
         length_extension=length_extension,
     )
-    straight_component = gf.get_component(
-        straight,
-        length=length_y,
-        cross_section=cross_section,
-    )
 
     c = Component()
     cb = c.add_ref(coupler_component_bot)
     ct = c.add_ref(coupler_component_top)
 
-    length_y = length_y or 0.001
+    if length_y > 0:
+        # Add vertical straights when length_y > 0
+        straight_component = gf.get_component(
+            straight,
+            length=length_y,
+            cross_section=cross_section,
+        )
+        sl = c << straight_component
+        sr = c << straight_component
 
-    sl = c << straight_component
-    sr = c << straight_component
-
-    sl.connect(port="o1", other=cb.ports["o2"])
-    sr.connect(port="o2", other=cb.ports["o3"])
-    ct.connect(port="o3", other=sl.ports["o2"])
+        sl.connect(port="o1", other=cb.ports["o2"])
+        sr.connect(port="o2", other=cb.ports["o3"])
+        ct.connect(port="o3", other=sl.ports["o2"])
+    else:
+        # When length_y=0, connect couplers directly
+        ct.connect(port="o3", other=cb.ports["o2"])
 
     c.add_port("o1", port=cb.ports["o1"])
     c.add_port("o2", port=cb.ports["o4"])

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -100,24 +100,33 @@ def ring_single(
     cb = c << coupler
 
     # Create waveguide components
-    sy = gf.get_component(straight, length=length_y, cross_section=cross_section)
     b = gf.get_component(bend, cross_section=cross_section, radius=radius)
     sx = gf.get_component(straight, length=length_x, cross_section=cross_section)
 
     # Place waveguide components
-    sl = c << sy  # Left vertical straight
-    sr = c << sy  # Right vertical straight
     st = c << sx  # Top horizontal straight
     bl = c << b  # Left bend
     br = c << b  # Right bend
 
-    # Connect all components
-    sl.connect(port="o1", other=cb.ports["o2"])
-    bl.connect(port="o2", other=sl.ports["o2"])
-    st.connect(port="o2", other=bl.ports["o1"])
-    br.connect(port="o2", other=st.ports["o1"])
-    sr.connect(port="o1", other=br.ports["o1"])
-    sr.connect(port="o2", other=cb.ports["o3"])
+    if length_y > 0:
+        # Add vertical straights when length_y > 0
+        sy = gf.get_component(straight, length=length_y, cross_section=cross_section)
+        sl = c << sy  # Left vertical straight
+        sr = c << sy  # Right vertical straight
+
+        # Connect all components with vertical straights
+        sl.connect(port="o1", other=cb.ports["o2"])
+        bl.connect(port="o2", other=sl.ports["o2"])
+        st.connect(port="o2", other=bl.ports["o1"])
+        br.connect(port="o2", other=st.ports["o1"])
+        sr.connect(port="o1", other=br.ports["o1"])
+        sr.connect(port="o2", other=cb.ports["o3"])
+    else:
+        # When length_y=0, connect bends directly to coupler
+        bl.connect(port="o2", other=cb.ports["o2"])
+        st.connect(port="o2", other=bl.ports["o1"])
+        br.connect(port="o2", other=st.ports["o1"])
+        br.connect(port="o1", other=cb.ports["o3"])
 
     # Add ports
     c.add_port("o2", port=cb.ports["o4"])


### PR DESCRIPTION
## Summary by Sourcery

Handle ring components without inserting zero-length straight segments when vertical length is zero.

Enhancements:
- Conditionally instantiate and place vertical straight segments in single-ring layouts only when the vertical length is positive.
- Connect bends directly to the coupler in single-ring layouts when the vertical segment length is zero to avoid degenerate straights.
- Conditionally instantiate and place vertical straight segments in double-ring layouts only when the vertical length is positive.
- Connect ring couplers directly in double-ring layouts when the vertical segment length is zero to avoid degenerate straights.