### PR TITLE
remove dbr_tapered from tests

### DIFF
--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -37,6 +37,7 @@ skip_test = {
     "text_freetype",
     "version_stamp",
     "die_frame_phix",
+    "dbr_tapered",
     "taper_hecken",
 }
 cells_to_test = set(cells.keys()) - skip_test


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Skip the dbr_tapered cell in the components test suite to avoid running its tests.