### PR TITLE
fix schematic docs

### DIFF
--- a/docs/notebooks/10_schematic.ipynb
+++ b/docs/notebooks/10_schematic.ipynb
@@ -64,7 +64,7 @@
     "    return s\n",
     "\n",
     "c = my_schematic()\n",
-    "c"
+    "c.plot()"
    ]
   },
   {
@@ -102,7 +102,7 @@
     "    return s\n",
     "\n",
     "c = my_schematic()\n",
-    "c"
+    "c.plot()"
    ]
   },
   {
@@ -133,7 +133,7 @@
     "    return s\n",
     "\n",
     "c = ring_array()\n",
-    "c"
+    "c.plot()"
    ]
   },
   {
@@ -214,16 +214,8 @@
     "    return s\n",
     "\n",
     "c = lidar(n=2**4)\n",
-    "c"
+    "c.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -247,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Update schematic tutorial notebook to explicitly plot schematics in examples and clean up metadata.

Documentation:
- Adjust schematic notebook examples to call the plotting method instead of relying on implicit display of schematic objects.
- Remove an unused empty notebook cell and refresh kernel metadata in the schematic documentation notebook.