### PR TITLE
Fix `get_netlist` to handle transitive connectivity

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -501,12 +501,6 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             get_netlist_recursive,
         )
 
-        warnings.warn(
-            "The netlist format returned by Component.get_netlist is deprecated and will be removed in 10.0.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         if component_namer is None:
             component_namer = function_namer
 

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -339,7 +339,7 @@ def get_netlist(
     instance_namer: InstanceNamer | None = None,
     component_namer: ComponentNamer = function_namer,
     port_matcher: PortMatcher | None = None,
-    use_deprecated_format: bool = True,  # currently unused, to be removed in GDSF-10.0
+    use_deprecated_format: bool = True,
 ) -> dict[str, Any]:
     """Extract netlist from a cell's port connectivity.
 
@@ -355,7 +355,12 @@ def get_netlist(
             Defaults to function_namer.
         port_matcher: Callable to determine if two ports are connected.
             Defaults to SmartPortMatcher().
-        use_deprecated_format: Whether to use the deprecated netlist format.
+        use_deprecated_format: If True (default), returns the deprecated format
+            where 'nets' is a list of two-port connections. If False, returns
+            the new format where 'connects' is the list and 'nets' is a dict
+            mapping net names to lists of all ports in each net (supporting
+            multi-port nets via transitive connectivity). Will default to False
+            in 10.0.0.
 
     Returns:
         A dictionary containing instances, placements, ports, and nets.
@@ -391,7 +396,7 @@ def get_netlist_recursive(
     component_namer: ComponentNamer = function_namer,
     netlist_namer: NetlistNamer | None = None,
     port_matcher: PortMatcher | None = None,
-    use_deprecated_format: bool = True,  # currently unused, to be removed in GDSF-10.0
+    use_deprecated_format: bool = True,
 ) -> dict[str, Any]:
     """Extract netlists recursively from a cell and all its subcells.
 
@@ -409,7 +414,12 @@ def get_netlist_recursive(
             Defaults to CountedNetlistNamer(component_namer).
         port_matcher: Callable to determine if two ports are connected.
             Defaults to SmartPortMatcher().
-        use_deprecated_format: Whether to use the deprecated netlist format.
+        use_deprecated_format: If True (default), returns the deprecated format
+            where 'nets' is a list of two-port connections. If False, returns
+            the new format where 'connects' is the list and 'nets' is a dict
+            mapping net names to lists of all ports in each net (supporting
+            multi-port nets via transitive connectivity). Will default to False
+            in 10.0.0.
 
     Returns:
         A dictionary mapping cell names to their netlists.
@@ -446,7 +456,7 @@ def _insert_netlist(
     netlist_namer: NetlistNamer,
     port_matcher: PortMatcher,
     recursive: bool,
-    use_deprecated_format: bool = True,  # currently unused, to be removed in GDSF-10.0
+    use_deprecated_format: bool = True,
 ) -> None:
     cell_name = netlist_namer(cell)
     if cell_name in recnet:

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -262,7 +262,15 @@ def to_yaml_graph_networkx(
             pos[node] = (placement.x, placement.y)
 
     for net in nets:
-        graph.add_edge(net.p1.split(",")[0], net.p2.split(",")[0])
+        if isinstance(net, TwoPortNet):
+            graph.add_edge(net.p1.split(",")[0], net.p2.split(",")[0])
+        else:
+            # MultiNet: connect all ports in the net
+            # instances_in_net = [p.split(",")[0] for p in net.ports]
+            # for i in range(len(instances_in_net) - 1):
+            #    graph.add_edge(instances_in_net[i], instances_in_net[i + 1])
+
+            raise NotImplementedError("MultiNet to graph not implemented yet.")
 
     return graph, labels, pos
 
@@ -418,8 +426,8 @@ class Schematic(BaseModel):
         n = component.to_yaml()
         self.netlist = Netlist.model_validate(n)
 
-    def add_net(self, net: Net) -> None:
-        """Add a net between two ports."""
+    def add_net(self, net: TwoPortNet) -> None:
+        """Add a two-port net."""
         self.nets.append(net)
         if net.name not in self.netlist.routes:
             assert net.name is not None


### PR DESCRIPTION
## Summary

- Fix `_extract_nets_from_connects` to properly merge transitively connected ports into a single net using BFS
- Add `MultiNet` class to support multi-port nets (3+ ports)
- Add deprecation warnings for the old netlist format (to be removed in 10.0.0)
- Add `use_deprecated_format` parameter to `get_netlist` and `get_netlist_recursive`

## Problem

The previous implementation created a separate net for each (p1, p2) connection pair without considering transitive connectivity essential for electronic schematic capture and SPICE simulation.

```python
# Old behavior (wrong):
# A→B and B→C created: {net1: [A,B], net2: [B,C]}

# New behavior (correct):
# A→B and B→C creates: {net1: [A,B,C]}
```

## Solution

Replaced the naive per-pair hashing with a graph-based approach:
1. Build an adjacency graph from connections
2. Use BFS to find connected components
3. Each connected component becomes one net with a deterministic name

## Test plan

- [x] Added 7 unit tests for `_extract_nets_from_connects` covering empty input, single connection, transitive chains, star topology, disjoint nets, deterministic naming, and extra dict keys
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Update netlist generation to support multi-port nets via transitive connectivity while keeping the legacy format available behind a deprecation flag.

Bug Fixes:
- Fix net extraction so transitively connected ports are merged into a single net instead of separate pairwise nets.

Enhancements:
- Introduce a new net extraction helper that derives nets from a list of connections with deterministic naming.
- Add a MultiNet model and a Net type alias to represent both two-port and multi-port nets in schematics.
- Extend netlist insertion and public get_netlist APIs with a use_deprecated_format switch and emit deprecation warnings for the old netlist format.
- Restrict schematic.add_net to two-port nets and stub out MultiNet-to-graph conversion with an explicit NotImplemented error.

Tests:
- Add unit tests covering _extract_nets_from_connects behavior for empty, simple, transitive, star, disjoint, deterministic naming, and extra-key scenarios.