### PR TITLE
Create ports on the pad itself that map to the array ports

### DIFF
--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -138,7 +138,10 @@ def pad_array(
     if size is not None:
         pad_kwargs["size"] = size
     pad_component = gf.get_component(
-        pad, port_orientations=None, port_orientation=port_orientation, **pad_kwargs
+        pad,
+        port_orientation=port_orientation,
+        port_orientations=(port_orientation,) if not centered_ports else None,
+        **pad_kwargs,
     )
 
     pad_size: Float2 = size or pad_component.info["size"]

--- a/tests/test-data-regression/test_netlists_pad_array0_.yml
+++ b/tests/test-data-regression/test_netlists_pad_array0_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_8da24944_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0:
     array:
       column_pitch: 150
       columns: 1
@@ -18,16 +18,20 @@ instances:
       layer: MTOP
       port_inclusion: 0
       port_orientation: 0
-      port_orientations: null
+      port_orientations:
+      - 0
       port_type: pad
       size:
       - 100
       - 100
 nets: []
 placements:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_8da24944_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<0.0>,e1
+  e21: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<0.1>,e1
+  e31: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<0.2>,e1

--- a/tests/test-data-regression/test_netlists_pad_array180_.yml
+++ b/tests/test-data-regression/test_netlists_pad_array180_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_14496117_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_943ed586_0_0:
     array:
       column_pitch: 150
       columns: 1
@@ -18,16 +18,20 @@ instances:
       layer: MTOP
       port_inclusion: 0
       port_orientation: 180
-      port_orientations: null
+      port_orientations:
+      - 180
       port_type: pad
       size:
       - 100
       - 100
 nets: []
 placements:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_14496117_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_943ed586_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_943ed586_0_0<0.0>,e1
+  e21: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_943ed586_0_0<0.1>,e1
+  e31: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_943ed586_0_0<0.2>,e1

--- a/tests/test-data-regression/test_netlists_pad_array270_.yml
+++ b/tests/test-data-regression/test_netlists_pad_array270_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_3a395e77_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -18,16 +18,23 @@ instances:
       layer: MTOP
       port_inclusion: 0
       port_orientation: 270
-      port_orientations: null
+      port_orientations:
+      - 270
       port_type: pad
       size:
       - 100
       - 100
 nets: []
 placements:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_3a395e77_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<0.0>,e1
+  e12: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<1.0>,e1
+  e13: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<2.0>,e1
+  e14: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<3.0>,e1
+  e15: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<4.0>,e1
+  e16: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_af5ddc87_0_0<5.0>,e1

--- a/tests/test-data-regression/test_netlists_pad_array90_.yml
+++ b/tests/test-data-regression/test_netlists_pad_array90_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_553ba667_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -18,16 +18,23 @@ instances:
       layer: MTOP
       port_inclusion: 0
       port_orientation: 90
-      port_orientations: null
+      port_orientations:
+      - 90
       port_type: pad
       size:
       - 100
       - 100
 nets: []
 placements:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_553ba667_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<0.0>,e1
+  e12: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<1.0>,e1
+  e13: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<2.0>,e1
+  e14: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<3.0>,e1
+  e15: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<4.0>,e1
+  e16: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_82713a36_0_0<5.0>,e1

--- a/tests/test-data-regression/test_netlists_pad_array_.yml
+++ b/tests/test-data-regression/test_netlists_pad_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_8da24944_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0:
     array:
       column_pitch: 150
       columns: 6
@@ -18,16 +18,23 @@ instances:
       layer: MTOP
       port_inclusion: 0
       port_orientation: 0
-      port_orientations: null
+      port_orientations:
+      - 0
       port_type: pad
       size:
       - 100
       - 100
 nets: []
 placements:
-  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_8da24944_0_0:
+  pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-ports: {}
+ports:
+  e11: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<0.0>,e1
+  e12: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<1.0>,e1
+  e13: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<2.0>,e1
+  e14: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<3.0>,e1
+  e15: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<4.0>,e1
+  e16: pad_gdsfactorypcomponentsppadsppad_S100_100_LMTOP_BLNon_2f7d9e34_0_0<5.0>,e1


### PR DESCRIPTION
## Summary

If you use `auto_rename_ports=True`, it's hard to keep track of which port came from which pad.
```
In [2]: gf.get_component("pad_array", auto_rename_ports=True).get_netlist()
Out[2]:
{'instances': {'pad': {'component': 'pad',
   'array': {'columns': 6, 'rows': 1, 'column_pitch': 150, 'row_pitch': 150},
   'settings': {'size': (100, 100),
    'layer': 'MTOP',
    'bbox_layers': None,
    'bbox_offsets': None,
    'port_inclusion': 0,
    'port_orientation': None,
    'port_orientations': (0,),
    'port_type': 'pad'},
   'info': {'size': (100, 100), 'xsize': 100, 'ysize': 100}}},
 'placements': {'pad': {'x': 0, 'y': 0, 'rotation': 0, 'mirror': False}},
 'ports': {'e1': 'pad<5.0>,e1',
  'e2': 'pad<4.0>,e1',
  'e3': 'pad<3.0>,e1',
  'e4': 'pad<2.0>,e1',
  'e5': 'pad<1.0>,e1',
  'e6': 'pad<0.0>,e1'},
 'nets': ()}
```

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Adjust pad array port configuration to better align pad instance ports with array ports and reduce unnecessary ports when not using centered ports.

Bug Fixes:
- Prevent creation of unwanted center pad ports in pad arrays when centered_ports is disabled to reduce netlist warnings.

Enhancements:
- Configure pad components in pad_array to use per-orientation edge ports or centered ports depending on the centered_ports option, improving port naming and traceability.

## Summary by Sourcery

Update pad_array to expose per-pad ports in the netlist while aligning port orientations with the pad orientation.

Enhancements:
- Create array-level pad ports that map directly to the underlying pad instance ports for easier netlist tracing.
- Set pad port_orientations explicitly based on pad_array orientation when ports are not centered.

Tests:
- Update pad_array netlist regression fixtures to reflect the new exposed ports and explicit port_orientations.