### PR TITLE
Fix rendering errors when `text_freetype` contains spaces

### DIFF
--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -88,8 +88,13 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
     font.load_char(letter, freetype.FT_LOAD_FLAGS["FT_LOAD_NO_BITMAP"])
     glyph = font.glyph
     outline = glyph.outline
-    points = np.array(outline.points, dtype=float) / font.size.ascender
-    tags = outline.tags
+    # Glyphs such as spaces can legitimately have no outline geometry while still
+    # carrying a valid advance width. Return an empty component in that case.
+    if not outline.contours:
+        component = Component()
+        component.name = block_name
+        font.gds_glyphs[letter] = (component, glyph.advance.x, font.size.ascender)
+        return font.gds_glyphs[letter]  # type: ignore[no-any-return]
 
     # Add polylines
     start, end = 0, -1


### PR DESCRIPTION
## Summary

Fixes incorrect handling of space characters in `gf.components.text_freetype()` function.

**Problem**: The `text_freetype` function was failing to render text containing spaces correctly. Glyphs without outline geometry  need to maintain their advance width in the character layout even though they have no visible geometry.
**Solution**: Enhanced `_get_glyph()` function in `font.py` to properly handle characters without outline contours by:
- Detecting glyphs with empty outline geometry
- Creating empty components with correct advance width metadata
- Preserving proper character spacing in rendered text

## Test Plan
```python
import gdsfactory as gf
gf.gpdk.PDK.activate()
```

**Test 1: Proportional font with basic spaced text**
```python
c1 = gf.components.text_freetype(text="Hello World", font="Arial", size=20)
c1.plot()
```

**Test 2: Monospace font with leading spaces**
```python
c2 = gf.components.text_freetype(text="  Leading spaces", font="Courier New", size=20)
c2.plot()
```

**Test 3: Serif font with trailing spaces**
```python
c3 = gf.components.text_freetype(text="Trailing spaces  ", font="Times New Roman", size=20)
c3.plot()
```

**Test 4: Monospace font with multiple consecutive spaces**
```python
c4 = gf.components.text_freetype(text="Word    Word", font="Courier New", size=20)
c4.plot()
```

**Test 5: Mixed spacing pattern (leading, middle, trailing)**
```python
c5 = gf.components.text_freetype(text="  Mix  It  Up  ", font="Arial", size=20)
c5.plot()
```

**Test 6: Large font size (robustness testing)**
```python
c6 = gf.components.text_freetype(text="Scaled  Text", font="Arial", size=40)
c6.plot()
```

**Test 7: Small font size (precision testing)**
```python
c7 = gf.components.text_freetype(text="Small  Size  Text", font="Times New Roman", size=10)
c7.plot()
```


<!-- How was it tested? -->

## Summary by Sourcery

Bug Fixes:
- Fix incorrect spacing and rendering when text strings passed to text_freetype contain space or other non-outline glyphs by returning empty components that still carry advance width metadata.