### PR TITLE
run schematic docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,6 @@ execute:
     - "*ray_optimiser*"
     - "*03_numerical_implantation*"
     - "*02_model_extraction*"
-    - "*10_schematic*"
     # - "*20_schematic_driven_layout*"
 # - "*001_meep_sparameters*"
 # - "*00_tidy3d.ipynb"


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Allow the schematic-related notebook to run as part of the documentation build by removing it from the execution exclusion patterns.