### PR TITLE
fixes issue with negative ``delta_length`` and small ``length_y``

### DIFF
--- a/gdsfactory/components/mzis/mzi.py
+++ b/gdsfactory/components/mzis/mzi.py
@@ -151,6 +151,15 @@ def mzi(
 
     # Use sign of ``delta_length`` to determine which arm to lengthen
     short_arm_length = length_y - delta_gap_ports / 2
+    if short_arm_length < 0:
+        raise ValueError(
+            "Computed short_arm_length is negative, which would result in a negative "
+            "straight section length. This usually happens when `length_y` is too "
+            "small relative to the splitter/combiner port gaps. "
+            f"Got length_y={length_y}, gap_ports_combiner={gap_ports_combiner}, "
+            f"gap_ports_splitter={gap_ports_splitter}, delta_gap_ports={delta_gap_ports}, "
+            f"short_arm_length={short_arm_length}."
+        )
     long_arm_length = abs(delta_length) / 2 + short_arm_length
 
     # Keep to the previous convention of the bottom arm being longer


### PR DESCRIPTION
yielding a ``ValueError`` due to negative straight lengths

## Summary

Solves Issue #4377.

## Test Plan

Minimum working example succeeds without throwing a ``ValueError`` (see Issue #4377 for details).
```python
import gdsfactory as gf

# Activate PDK
gf.gpdk.PDK.activate()

mzi = gf.c.mzi(  # <--- This no longer raises a ``ValueError``
    cross_section="strip",
    length_y=0,
    delta_length=-100,
)

mzi.plot()
mzi.show()
```

## Summary by Sourcery

Handle negative delta_length and small length_y in MZI component to avoid invalid straight segment lengths.

Bug Fixes:
- Prevent ValueError in MZI generation when delta_length is negative and/or length_y is small by ensuring both arms have non-negative straight lengths.

Enhancements:
- Generalize MZI arm length calculation to derive top and bottom arm lengths from port gaps and the sign of delta_length while preserving the convention that the bottom arm is longer for positive deltas.