### PR TITLE
fix netlist performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.14.8"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
       - id: ruff-format
   - repo: https://github.com/RobertCraigie/pyright-python


### PR DESCRIPTION
## Summary

Converts O(2) port-matching algorithm to ~O(1).

## Test Plan

Tests pass

## Summary by Sourcery

Improve netlist extraction performance by using spatial bucketing for port matching and update linting hook configuration.

Enhancements:
- Replace quadratic port-matching loop in netlist extraction with spatially bucketed matching to reduce complexity for large circuits.

Build:
- Update pre-commit configuration to use the renamed Ruff lint hook id.