### PR TITLE
works with non-Manhattan

### DIFF
--- a/gdsfactory/samples/35_route_bundle_non_manhattan_steps.py
+++ b/gdsfactory/samples/35_route_bundle_non_manhattan_steps.py
@@ -1,0 +1,32 @@
+"""Sample route_bundle with non-Manhattan steps.
+
+Steps that combine dx and dy in a single step produce a diagonal
+(non-Manhattan) waypoint. The router automatically inserts corner
+points to convert these into Manhattan-compatible segments.
+"""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.gpdk import PDK
+
+PDK.activate()
+
+if __name__ == "__main__":
+    c = gf.Component()
+    c1 = c << gf.components.mmi2x2()
+    c2 = c << gf.components.mmi2x2()
+    c2.move((200, 240))
+
+    # A single step with both dx and dy creates a non-Manhattan waypoint.
+    # The router splits the diagonal into horizontal + vertical segments.
+    gf.routing.route_bundle(
+        c,
+        [c1.ports["o3"], c1.ports["o4"]],
+        [c2.ports["o2"], c2.ports["o1"]],
+        steps=[{"dx": 60, "dy": 100}],
+        separation=5.0,
+        cross_section="strip",
+        sort_ports=True,
+    )
+    c.show()

--- a/gdsfactory/samples/35_route_bundle_non_manhattan_waypoints.py
+++ b/gdsfactory/samples/35_route_bundle_non_manhattan_waypoints.py
@@ -1,0 +1,33 @@
+"""Sample route_bundle with non-Manhattan waypoints.
+
+Waypoints that are not axis-aligned (i.e. consecutive points differ
+in both x and y) are automatically converted to Manhattan paths by
+inserting corner points.  This lets you specify approximate route
+guides without worrying about strict axis alignment.
+"""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.gpdk import PDK
+
+PDK.activate()
+
+if __name__ == "__main__":
+    c = gf.Component()
+    c1 = c << gf.components.mmi2x2()
+    c2 = c << gf.components.mmi2x2()
+    c2.move((200, 240))
+
+    # These waypoints form a diagonal path.
+    # The router inserts corners so the actual route is Manhattan.
+    gf.routing.route_bundle(
+        c,
+        [c1.ports["o3"], c1.ports["o4"]],
+        [c2.ports["o2"], c2.ports["o1"]],
+        waypoints=[(60, 100), (150, 200)],
+        separation=5.0,
+        cross_section="strip",
+        sort_ports=True,
+    )
+    c.show()


### PR DESCRIPTION
Works even in these cases

<img width="743" height="531" alt="image" src="https://github.com/user-attachments/assets/9c64fdee-67ff-4eb2-8528-4bba3640039b" />


## Summary

Handle non-Manhattan waypoints in route_bundle by inserting Manhattan corner points and add sample scripts demonstrating the behavior.

New Features:
- Automatically convert non-Manhattan route_bundle waypoints into Manhattan-compatible paths by inserting intermediate corner points.
- Support non-Manhattan step definitions in route_bundle by splitting diagonal moves into horizontal and vertical segments.

Enhancements:
- Use the starting port orientation and recent routing direction to choose whether horizontal or vertical segments are created first when rectifying non-Manhattan segments.

Documentation:
- Add sample scripts demonstrating route_bundle usage with non-Manhattan waypoints and step definitions.