### PR TITLE
Fix bug #3609 incorrect angle_resolution parameter in ring

### DIFF
--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -38,19 +38,19 @@ def ring(
     if angle > 360 or angle < 0:
         raise ValueError(f"Error: angle is {angle}, but it must be in [0, 360].")
     
-    if distance_resolution != None:
-        if distance_resolution <= 0:
-            raise ValueError(f"Error: distance_resolution is {distance_resolution}, but it must be positive if given.")
-    elif angle_resolution <= 0:
+    if distance_resolution is not None and distance_resolution <= 0:
+        raise ValueError(f"Error: distance_resolution is {distance_resolution}, but it must be positive if given.")
+    
+    if distance_resolution is None and angle_resolution <= 0:
         raise ValueError(f"Error: angle_resolution is {angle_resolution}, but it must be positive.")
 
     D = gf.Component()
     inner_radius = radius - width / 2
     outer_radius = radius + width / 2
-    if distance_resolution != None:
+    if distance_resolution is not None:
         num_points = int(np.ceil(2 * pi * outer_radius * angle / 360 / distance_resolution))
     else:
-        num_points = int(np.ceil(360 / angle_resolution))
+        num_points = int(np.ceil(angle / angle_resolution))
     t = np.linspace(0, angle, num_points + 1) * pi / 180
     inner_points_x = inner_radius * cos(t)
     inner_points_y = inner_radius * sin(t)


### PR DESCRIPTION
This pull request fixes [bug #3609](https://github.com/gdsfactory/gdsfactory/issues/3609). The argument `angle_resolution` in `ring` was described as "number of points per degree" in the comments but actually it's number of degrees per point. I fixed the documentation here. I also took [tvt173](https://github.com/tvt173)'s suggestion and added an argument `distance_resolution` that allows the user to instead specify a max distance between points.

## Summary by Sourcery

Fix ring component resolution handling and parameter validation.

Bug Fixes:
- Correct the documentation for angle_resolution to reflect that it specifies maximum degrees per point instead of points per degree.

Enhancements:
- Add an optional distance_resolution parameter to control maximum spacing between ring points, taking precedence over angle_resolution when set.
- Validate ring parameters (radius vs width, nonnegative width, angle bounds, and positive resolution values) and compute the number of points based on either distance_resolution or angle_resolution.