### PR TITLE
fix bend_s offset

### DIFF
--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -298,7 +298,8 @@ def bend_s_offset(
         npoints=npoints,
         angular_step=angular_step,
     )
-    path += gf.path.straight(length=middle_length)
+    if middle_length > 1e-6:
+        path += gf.path.straight(length=middle_length)
     path += gf.path.euler(
         radius=radius,
         angle=-angle,

--- a/gdsfactory/samples/sample_sbend.py
+++ b/gdsfactory/samples/sample_sbend.py
@@ -1,0 +1,16 @@
+import gdsfactory as gf
+from gdsfactory.components import bend_s_offset
+from gdsfactory.gpdk import PDK
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = gf.Component()
+
+    s_bend = c << bend_s_offset(
+        offset=127 / 2 - 3.2 / 2,
+        width=1.200,
+        with_euler=False,
+        radius=50,
+    )
+
+    c.show()


### PR DESCRIPTION
Root cause: In bend_s_offset(), a straight(length=0) path segment was always appended between the two euler bends, even when middle_length = 0. A zero-length straight creates two identical points [(0,0), (0,0)]. 

When Path.append() concatenates this (skipping the first point but keeping the second), it introduces a duplicate point in the path centerline. During extrusion, this duplicate creates a degenerate polygon vertex where the waveguide "doubles back" —  producing extra vertices ~1nm from the main body that fail DRC.

  Fix: Added a guard at line 301 of bend_s.py:
  if middle_length > 1e-6:
      path += gf.path.straight(length=middle_length)

This skips the straight segment entirely when it's effectively zero (< 1 picometer), eliminating the duplicate point. The threshold of 1e-6 um (1 pm) is well below any physical grid resolution (typically 1 nm = 1e-3 um).

Testing: All 8 existing bend_s-related tests pass, and the fix was verified across offsets from 5 to 100 um with both Euler (p=1) and circular arc (p=0) modes.


fixes #4400 

## Summary 

Guard bend_s_offset path construction against near-zero middle section and add a sample script demonstrating sbend usage.

New Features:
- Introduce a sample script illustrating how to instantiate and visualize an S-bend using bend_s_offset.

Bug Fixes:
- Prevent creation of an unnecessary straight segment in bend_s_offset when the computed middle length is effectively zero.