### PR TITLE
fix taper offsets

### DIFF
--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -91,12 +91,13 @@ def taper(
             delta_width = abs(section.width - s0_width)
             y1 = (width1 + delta_width) / 2
             y2 = (width2 + delta_width) / 2
+            offset = section.offset
             p1 = gf.kdb.DPolygon(
                 [
-                    gf.kdb.DPoint(0, y1),
-                    gf.kdb.DPoint(length, y2),
-                    gf.kdb.DPoint(length, -y2),
-                    gf.kdb.DPoint(0, -y1),
+                    gf.kdb.DPoint(0, offset + y1),
+                    gf.kdb.DPoint(length, offset + y2),
+                    gf.kdb.DPoint(length, offset - y2),
+                    gf.kdb.DPoint(0, offset - y1),
                 ]
             )
             c.add_polygon(p1, layer=section.layer)

--- a/gdsfactory/samples/sample_taper_offsets.py
+++ b/gdsfactory/samples/sample_taper_offsets.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import gdsfactory as gf
+from gdsfactory.cross_section import CrossSection, cross_section, xsection
+from gdsfactory.typings import LayerSpec
+
+
+@xsection
+def strip3(
+    width: float = 1.5,
+    layer: LayerSpec = (1, 0),
+    radius: float = 40.0,
+    radius_min: float = 30,
+    layer_sides: LayerSpec = (2, 0),
+    layer_cover: LayerSpec = (3, 0),
+    width_sides: float = 15,
+    width_cover: float = 40,
+    offset_sides: float = 65,
+    **kwargs: Any,
+) -> CrossSection:
+    sections = (
+        gf.Section(layer=layer_sides, width=width_sides, offset=offset_sides),
+        gf.Section(layer=layer_sides, width=width_sides, offset=-offset_sides),
+        gf.Section(layer=layer_cover, width=width_cover, offset=0),
+    )
+
+    return cross_section(
+        width=width,
+        layer=layer,
+        radius=radius,
+        radius_min=radius_min,
+        sections=sections,
+        **kwargs,
+    )
+
+
+if __name__ == "__main__":
+    gf.gpdk.PDK.activate()
+    c = gf.components.mmi(
+        inputs=2,
+        outputs=4,
+        width=1.5,
+        width_taper=2.45,
+        length_taper=30,
+        length_mmi=550,
+        width_mmi=13.9,
+        gap_output_tapers=1.1,
+        input_positions=[5.325, -1.775],
+        cross_section=strip3,
+    )
+    c.show()


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of cross-section offsets in taper polygons and add a sample demonstrating tapered structures with multiple offset sections.

New Features:
- Add a sample script showcasing an MMI component using a custom cross section with multiple offset sections for taper visualization.

Bug Fixes:
- Correct application of section offset when generating taper polygons so that polygons are positioned according to each section's offset.

fixes https://github.com/gdsfactory/gdsfactory/issues/4360

thanks @gdsnovice