### PR TITLE
use kfactory xsection

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -219,6 +219,14 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
                 else getattr(port, "cross_section", port.info.get("cross_section"))
             )
 
+        # Check if cross_section is already a native KFactory type —
+        # preserve it to avoid lossy round-trip conversions
+        kf_xs: kf.SymmetricalCrossSection | None = None
+        if isinstance(cross_section, kf.DCrossSection):
+            kf_xs = cross_section.base
+        elif isinstance(cross_section, kf.SymmetricalCrossSection):
+            kf_xs = cross_section
+
         # Apply CrossSection overrides
         xs_name = None
         if cross_section:
@@ -228,6 +236,14 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
                 layer = xs.layer
             if width is None:
                 width = xs.width
+
+            # Convert GDSFactory CrossSection to KFactory cross_section if we
+            # don't already have one from a native KFactory source
+            if kf_xs is None:
+                try:
+                    kf_xs = xs.to_kf_cross_section(kcl=self.kcl).base
+                except Exception:
+                    kf_xs = None
 
         # Apply defaults if None
         if port_type is None:
@@ -264,13 +280,47 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         layer = get_layer(layer)
 
-        _port = DPorts(kcl=self.kcl, bases=self.ports.bases).create_port(
-            name=name,
-            width=width,
-            layer=layer,
-            port_type=port_type,
-            dcplx_trans=trans,
+        # Use the KFactory cross_section natively if available and its width
+        # and layer match the port's. In KFactory, port.width and port.layer
+        # derive from the cross_section, so we can only use a native
+        # cross_section when they agree.
+        layer_info = self.kcl.layout.get_info(layer)
+        width_dbu = self.kcl.to_dbu(width)
+        use_kf_xs = (
+            kf_xs is not None
+            and kf_xs.width == width_dbu
+            and kf_xs.main_layer == layer_info
         )
+        if use_kf_xs:
+            assert kf_xs is not None
+            try:
+                registered_xs = self.kcl.get_symmetrical_cross_section(kf_xs)
+            except (ValueError, KeyError):
+                registered_xs = None
+
+            if registered_xs is not None:
+                _port = DPorts(kcl=self.kcl, bases=self.ports.bases).create_port(
+                    name=name,
+                    cross_section=registered_xs,
+                    port_type=port_type,
+                    dcplx_trans=trans,
+                )
+            else:
+                _port = DPorts(kcl=self.kcl, bases=self.ports.bases).create_port(
+                    name=name,
+                    width=width,
+                    layer=layer,
+                    port_type=port_type,
+                    dcplx_trans=trans,
+                )
+        else:
+            _port = DPorts(kcl=self.kcl, bases=self.ports.bases).create_port(
+                name=name,
+                width=width,
+                layer=layer,
+                port_type=port_type,
+                dcplx_trans=trans,
+            )
 
         if xs_name:
             _port.info["cross_section"] = xs_name

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -408,6 +408,68 @@ class CrossSection(BaseModel):
 
         return xmin, xmax
 
+    def to_kf_cross_section(self, kcl: Any = None) -> DCrossSection:
+        """Convert this GDSFactory CrossSection to a KFactory DCrossSection.
+
+        Maps each GDSFactory Section(width, offset, layer, port_names, ...)
+        to KFactory section format with metadata.
+
+        Args:
+            kcl: KCLayout to use. If None, uses the default gdsfactory kcl.
+
+        Returns:
+            A KFactory DCrossSection.
+        """
+        from kfactory.enclosure import LayerEnclosure
+
+        from gdsfactory.pdk import get_layer_info
+
+        if kcl is None:
+            from gdsfactory import kcl
+
+        main_section = self.sections[0]
+        main_layer = get_layer_info(main_section.layer)
+        main_width_dbu = kcl.to_dbu(main_section.width)
+
+        kf_sections: list[tuple] = []
+        for section in self.sections[1:]:
+            if section.layer is None:
+                continue
+            layer_info = get_layer_info(section.layer)
+            d_min_um = section.offset - section.width / 2
+            d_max_um = section.offset + section.width / 2
+            d_min_dbu = kcl.to_dbu(d_min_um)
+            d_max_dbu = kcl.to_dbu(d_max_um)
+            kf_sections.append((layer_info, d_min_dbu, d_max_dbu))
+
+        enclosure = LayerEnclosure(
+            sections=kf_sections,
+            main_layer=main_layer,
+        )
+
+        # Build bbox_sections
+        bbox_secs: dict = {}
+        if self.bbox_layers and self.bbox_offsets:
+            for bl, bo in zip(self.bbox_layers, self.bbox_offsets, strict=False):
+                bbox_secs[get_layer_info(bl)] = kcl.to_dbu(bo)
+
+        allow_odd = main_width_dbu % 2 != 0
+
+        # Use auto-generated name (not self.name) to allow GDS round-trip.
+        # The auto-generated name is deterministic from enclosure+width,
+        # so it can be reconstructed when reading GDS files back.
+        # Note: radius/radius_min are routing metadata and not included
+        # here to avoid name conflicts with cross_sections created from
+        # raw width+layer (which have radius=None).
+        xs = SymmetricalCrossSection(
+            width=main_width_dbu,
+            enclosure=enclosure,
+            bbox_sections=bbox_secs,
+            allow_odd_width=allow_odd,
+        )
+
+        return DCrossSection(kcl=kcl, base=xs)
+
 
 CrossSection.model_rebuild()
 

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -527,5 +527,8 @@ def read_top_cell(arg0: pathlib.Path) -> kf.DKCell:
 
     if hasattr(kcl, "cross_sections"):
         for cross_section in kcl.cross_sections.cross_sections.values():
-            kf.kcl.get_symmetrical_cross_section(cross_section)
+            try:
+                kf.kcl.get_symmetrical_cross_section(cross_section)
+            except (ValueError, KeyError):
+                pass
     return kcell

--- a/gdsfactory/port.py
+++ b/gdsfactory/port.py
@@ -167,11 +167,12 @@ def port_array(
         xs = get_cross_section(cross_section)
         if width != xs.width:
             xs = get_cross_section(xs.copy(width=width))
+
+        # Convert to KFactory cross_section for native port support
         try:
-            sym_xs: kf.SymmetricalCrossSection | None = (
-                kcl.get_symmetrical_cross_section(xs.name)
-            )
-        except KeyError:
+            kf_xs = xs.to_kf_cross_section(kcl=kcl)
+            sym_xs: kf.SymmetricalCrossSection | None = kf_xs.base
+        except Exception:
             sym_xs = None
 
         kwargs.pop("cross_section", None)


### PR DESCRIPTION
## Summary by Sourcery

Integrate native KFactory cross_section support into port creation and cross-section handling, improving interoperability between gdsfactory and KFactory and making the system more robust to missing registrations.

New Features:
- Add conversion of gdsfactory CrossSection objects into KFactory DCrossSection/SymmetricalCrossSection for use in ports and layouts.

Bug Fixes:
- Handle missing or unregistered KFactory cross_sections gracefully in difftest and port creation to avoid errors when cross_sections are not registered.

Enhancements:
- Prefer native KFactory cross_sections when adding ports and port arrays when width and layer match, reducing lossy round-trip conversions between gdsfactory and KFactory representations.