### PR TITLE
dont_validate radius

### DIFF
--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -128,7 +128,7 @@ def _bend_euler(
     c.info["width"] = float(width or x.width)
 
     if not allow_min_radius_violation:
-        x.validate_radius(min_bend_radius)
+        x.validate_radius(radius)
 
     top = None if int(angle) in {180, -180, -90} else 0
     bottom = 0 if int(angle) in {-90} else None

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -228,7 +228,7 @@ class CrossSection(BaseModel):
     def validate_radius(
         self, radius: float, error_type: ErrorType | None = None
     ) -> None:
-        radius_min = self.radius_min
+        radius_min = self.radius_min or self.radius
 
         if radius_min and radius < radius_min:
             message = (


### PR DESCRIPTION
## Summary

Improve bend radius validation by using the requested bend radius and falling back to the cross-section radius when no explicit minimum is set.

Bug Fixes:
- Ensure bend Euler components validate against the actual bend radius instead of the global minimum bend radius.
- Avoid radius validation being skipped when no explicit minimum radius is defined by defaulting to the cross-section radius.

reverts https://github.com/gdsfactory/gdsfactory/pull/4421