### PR TITLE
fix recursive netlist naming

### DIFF
--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -151,11 +151,9 @@ class CountedNetlistNamer:
         if not _has_instances(cell):
             # Leaf cell: use component_namer (typically function_name)
             name = base
-        elif not _has_non_default_settings(cell):
-            # Hierarchical cell with default settings: use component name as-is
-            name = base
         else:
-            # Hierarchical cell with non-default settings: use counted naming
+            # Hierarchical cell: use counted naming to avoid collisions
+            # between different parameterizations of the same component
             name = self._get_unique_name(base)
 
         self._cell_names[cell.name] = name


### PR DESCRIPTION
## Summary

In extreme cases there could be naming collisions in the keys of the recursive get_netlist. This has been resolved.

## Summary by Sourcery

Bug Fixes:
- Fix rare naming collisions in recursively generated netlists by no longer reusing base names for hierarchical cells with default settings.