### PR TITLE
Feat: add a get_layer_to_mesh_order() method to LayerStack

### DIFF
--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -476,6 +476,19 @@ class LayerStack(BaseModel):
 
         return d
 
+    def get_layer_to_mesh_order(
+        self,
+    ) -> dict[BroadLayer, int]:
+        """Returns layer tuple to mesh order."""
+        d: dict[BroadLayer, int] = defaultdict(int)
+        for level in self.layers.values():
+            if level.info is not None and "mesh_order" in level.info:
+                # cspdk LayerStack has the mesh_order in the info dict, override default mesh_order if specified there
+                d[level.layer] = level.info["mesh_order"]
+            else:
+                d[level.layer] = level.mesh_order
+        return d
+
     def to_dict(self) -> dict[str, dict[str, Any]]:
         return {level_name: dict(level) for level_name, level in self.layers.items()}
 

--- a/tests/technology/test_layerstack.py
+++ b/tests/technology/test_layerstack.py
@@ -2,7 +2,7 @@ import pytest
 
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER, LAYER_STACK
-from gdsfactory.technology import LayerLevel
+from gdsfactory.technology import LayerLevel, LayerStack
 from gdsfactory.technology.layer_stack import LogicalLayer
 
 nm = 1e-3
@@ -47,3 +47,32 @@ def test_layer_level() -> None:
         layer_ = gf.get_layer(level_layer.layer)
         assert isinstance(layer_, int)
         assert int(layer_) == 1, int(layer_)
+
+
+def test_get_layer_to_mesh_order() -> None:
+    ls = LayerStack(
+        layers=dict(
+            core=LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WG),
+                thickness=0.22,
+                zmin=0,
+                mesh_order=1,
+            ),
+            slab=LayerLevel(  # test that when the info dict contains mesh_order, it takes precedence over the top level mesh_order
+                layer=LogicalLayer(layer=LAYER.SLAB90),
+                thickness=0.09,
+                zmin=0,
+                info={"mesh_order": 2},
+            ),
+            metal=LayerLevel(  # test that if mesh_order is not set at the top level or in info, the default mesh_order is used (3)
+                layer=LogicalLayer(layer=LAYER.HEATER),
+                thickness=1.0,
+                zmin=1.0,
+            ),
+        )
+    )
+
+    result = ls.get_layer_to_mesh_order()
+    assert result[LogicalLayer(layer=LAYER.WG)] == 1
+    assert result[LogicalLayer(layer=LAYER.SLAB90)] == 2
+    assert result[LogicalLayer(layer=LAYER.HEATER)] == 3


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
I'm working on a function that would generate a mesh for femwell simulations from a cross_section.
As an intermediate step, I've added the `LayerStack.get_layer_to_mesh_order()` method to return a dictionary of the layers' mesh order, similar to `LayerStack.get_layer_to_get_layer_to_layername()` or `LayerStack.get_layer_to_zmin()`.

## Test Plan

<!-- How was it tested? -->

A new test was added to `tests/technology/test_layerstack.py`, checking that:
- For layers with the mesh order specified in the `layers.level.info['mesh_order']` (like in cspdk), it takes precedence over the top level `mesh_order`.
- For layers with the mesh order only specified in `layers.level.mesh_order`. the correct value is returned.
- In any other cases, the default mesh order is 3.

## Summary by Sourcery

Add a LayerStack API to retrieve mesh ordering per layer and cover it with tests.

New Features:
- Introduce LayerStack.get_layer_to_mesh_order() to map logical layers to their mesh order values.

Tests:
- Add unit test ensuring mesh_order precedence from info over top-level values and defaulting when unspecified.