### PR TITLE
Copy the vinsts on ComponentAllAngle.dup

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1472,6 +1472,7 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):
         for layer, shapes in self.shapes().items():
             for shape in shapes:
                 c.shapes(layer).insert(shape)
+        c._base.vinsts = self.vinsts.dup()
 
         return c
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -277,7 +277,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         return _port
 
-    def copy(self) -> Self:
+    def copy(self) -> ComponentBase:
         """Copy the full cell."""
         return self.dup()
 
@@ -1459,7 +1459,7 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):
         VInstance(self).insert_into_flat(c, levels=0)
         c.plot(**kwargs)
 
-    def dup(self, new_name: str | None = None) -> Self:
+    def dup(self, new_name: str | None = None) -> ComponentAllAngle:
         """Copy the full cell."""
         c = self.__class__(
             kcl=self.kcl, name=new_name or self.name + "$1" if self.name else None


### PR DESCRIPTION
## Summary

This was missing and causing issues.

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Bug Fixes:
- Fix missing duplication of via instances when using ComponentAllAngle.dup, preventing inconsistencies between original and duplicated components.