### PR TITLE
Show layer info in autotaper error

### DIFF
--- a/gdsfactory/routing/auto_taper.py
+++ b/gdsfactory/routing/auto_taper.py
@@ -111,7 +111,7 @@ def add_auto_tapers(
             p1, p0 = taper_ports
         else:
             width = p.width
-            layer = p.layer
+            layer = gf.get_layer_info(p.layer)
             raise ValueError(
                 f"Taper component ports do not match the port's layer and width!\nTaper name: {taper_component.name}\nPorts: {taper_ports}\nCross-section: {layer=}, {width=}"
             )


### PR DESCRIPTION
## Summary

Getting something like `layer=47` isn't useful for quick debugging.

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Enhancements:
- Include full layer information in auto taper mismatch errors to make debugging easier