### PR TITLE
 Configure kcl.layers on activation instead of hardcoding to generic PDK

### DIFF
--- a/gdsfactory/gpdk/__init__.py
+++ b/gdsfactory/gpdk/__init__.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import typing
 from functools import cache, partial
 
-import kfactory as kf
-
 from gdsfactory.config import PATH
 from gdsfactory.gpdk.layer_map import LAYER
 from gdsfactory.gpdk.layer_stack import LAYER_STACK
@@ -68,10 +66,6 @@ def get_generic_pdk() -> Pdk:
         (LAYER.WGN, LAYER.WG): "taper_nc_sc",
         LAYER.M3: "taper_electrical",
     }
-    gf.kcl.layers = LAYER
-    gf.kcl.infos = kf.LayerInfos(
-        **{v.name: kf.kdb.LayerInfo(v.layer, v.datatype) for v in LAYER},  # type: ignore[attr-defined]
-    )
     routing_strategies: dict[str, RoutingStrategy] = dict(
         route_bundle=partial(gf.routing.route_bundle, cross_section="strip"),
         route_bundle_all_angle=partial(

--- a/gdsfactory/gpdk/layer_map.py
+++ b/gdsfactory/gpdk/layer_map.py
@@ -68,6 +68,3 @@ class LAYER(gf.LayerEnum):
 
     SOURCE: Layer = (110, 0)
     MONITOR: Layer = (101, 0)
-
-
-gf.kcl.layers = LAYER

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -777,6 +777,15 @@ def _set_active_pdk(pdk: Pdk) -> None:
     global _ACTIVE_PDK
     _ACTIVE_PDK = pdk
 
+    if pdk.layers is not None:
+        kf.kcl.layers = pdk.layers
+        kf.kcl.infos = kf.LayerInfos(
+            **{v.name: kf.kdb.LayerInfo(v.layer, v.datatype) for v in pdk.layers},  # type: ignore[attr-defined]
+        )
+    else:
+        kf.kcl.infos = kf.LayerInfos()
+        kf.kcl.layers = kf.kcl.layerenum_from_dict(layers=kf.kcl.infos)
+
 
 def get_routing_strategies() -> RoutingStrategies:
     """Gets a dictionary of named routing functions available to the PDK, if defined, or gdsfactory defaults otherwise."""

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -493,22 +493,20 @@ class Pdk(BaseModel):
 
             return cross_section
         if isinstance(cross_section, kf.DCrossSection | kf.SymmetricalCrossSection):
-            from gdsfactory import kcl
-
             if isinstance(cross_section, kf.DCrossSection):
                 cross_section_ = cross_section.base
             else:
                 cross_section_ = cross_section
             section_ = Section(
                 name="_default",
-                width=kcl.to_um(cross_section_.width),
-                layer=kcl.layout.layer(cross_section_.main_layer),
+                width=kf.kcl.to_um(cross_section_.width),
+                layer=kf.kcl.layout.layer(cross_section_.main_layer),
                 port_names=("o1", "o2"),
             )
             xs_ = CrossSection(
                 sections=(section_,),
-                radius=kcl.to_um(cross_section_.radius),
-                radius_min=kcl.to_um(cross_section_.radius_min),
+                radius=kf.kcl.to_um(cross_section_.radius),
+                radius_min=kf.kcl.to_um(cross_section_.radius_min),
             )
             xs_._name = cross_section_.name
             return xs_


### PR DESCRIPTION
## Summary

Getting weird errors where port layers weren't matching when using a custom PDK.
Realized the `kcl` stuff is hardcoded for the generic PDK. I'm surprised nobody complained before. I guess it's "tribal" knowledge to set the `kcl` stuff in your own PDK?

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Configure KLayout (kcl) layer mappings from the active PDK instead of hardcoding them to the generic PDK, ensuring correct layer usage for custom PDKs.

Bug Fixes:
- Fix incorrect port and routing layer mappings when using custom PDKs by deriving kcl layers from the active PDK configuration.

Enhancements:
- Initialize kcl layer and info mappings whenever the active PDK is set, decoupling KLayout integration from the generic PDK defaults.