### PR TITLE
Allow arbitrary kwargs in cell() decorator

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -56,6 +56,7 @@ def cell(
     tags: list[str] | None = None,
     with_module_name: bool = False,
     lvs_equivalent_ports: list[list[str]] | None = None,
+    **kwargs: Any,
 ) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]: ...
 
 
@@ -82,6 +83,7 @@ def cell(
     with_module_name: bool = False,
     lvs_equivalent_ports: list[list[str]] | None = None,
     ports: PortsDefinition | None = None,
+    **kwargs: Any,
 ) -> (
     ComponentFunc[ComponentParams]
     | Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]
@@ -97,6 +99,10 @@ def cell(
 
     if drop_params is None:
         drop_params = ["self", "cls"]
+    if kwargs:
+        if info is None:
+            info = {}
+        info.update(kwargs)
     if post_process is None:
         post_process = []
     c = _cell(  # type: ignore[call-overload,misc]


### PR DESCRIPTION
## Summary
- Accept `**kwargs` in `cell()` decorator and merge them into the component `info` dict
- Enables PDK libraries to attach static metadata (e.g. `symbol`, `models`) to cell decorators for AST-based extraction without executing Python

## Motivation
PDK libraries like [pepijn's IHP](https://github.com/pepijndevos/IHP/tree/metadata-annotations) need to annotate cells with metadata that can be statically extracted via tools like Ruff, without running Python. Passing these as top-level decorator kwargs (e.g. `@gf.cell(symbol="nmos", models=[...])`) makes them visible to AST parsers. This change forwards any unrecognized kwargs into the `info` dict so they're available at runtime via `c.info`.

Closes https://github.com/gdsfactory/gdsfactory/issues/4452

## Test plan
- [x] Verified `@gf.cell(symbol="nmos", models=[...])` no longer raises `TypeError`
- [x] Extra kwargs appear in `c.info` at runtime
- [x] Existing behavior unchanged when no extra kwargs are passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Support passing arbitrary keyword arguments to the cell() decorator that are forwarded into the component info dictionary.