### PR TITLE
Enable schematic function

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -57,7 +57,7 @@ def cell(
     tags: list[str] | None = None,
     with_module_name: bool = False,
     lvs_equivalent_ports: list[list[str]] | None = None,
-    schematic_function: None = None,
+    schematic_function: Callable[ComponentParams, Schematic],
 ) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]: ...
 
 
@@ -82,7 +82,7 @@ def cell(
     tags: list[str] | None = None,
     with_module_name: bool = False,
     lvs_equivalent_ports: list[list[str]] | None = None,
-    schematic_function: Callable[ComponentParams, Schematic],
+    schematic_function: None = None,
 ) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]: ...
 
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -28,5 +28,30 @@ def test_partial() -> None:
     assert b1.base is b2.base
 
 
+def test_schematic_cell() -> None:
+    def my_straight_schematic(width: float = 1.1, length: float = 3.5) -> gf.Schematic:
+        s = gf.Schematic()
+        s.info["c"] = 5
+        s.create_port("o1", "strip", x=0, y=0, orientation=180)
+        s.create_port("o2", "strip", x=length, y=0, orientation=0)
+        return s
+
+    @gf.cell(schematic_function=my_straight_schematic)
+    def my_straight(width: float, length: float) -> gf.Component:
+        return gf.Path(path=[(0, 0), (length, 0)]).extrude(
+            cross_section="strip", width=1.1
+        )
+
+    assert gf.kcl.layout.cell("my_straight_W1p1_L5") is None
+    factory = gf.kcl.factories["my_straight"]
+    schematic = factory.get_schematic(width=1.1, length=5)
+    assert schematic == my_straight_schematic(width=1.1, length=5)
+    assert gf.kcl.layout.cell("my_straight_W1p1_L5") is None
+    c = my_straight(1.1, 5)
+    # bug in kfactory
+    # assert schematic == c.schematic
+    assert c.cell_index() == gf.kcl.layout.cell("my_straight_W1p1_L5").cell_index()
+
+
 if __name__ == "__main__":
     test_partial()


### PR DESCRIPTION
## Summary

Exposes `@cell(schematic_function=...)` to gdsfactory

## Test Plan

test_cell.py::test_schematic_cell

## Summary by Sourcery

Expose support for attaching a schematic generation function to layout cells via the @cell decorator.

New Features:
- Allow specifying a schematic_function in the cell decorator to generate associated Schematic objects for component factories.

Tests:
- Add a test ensuring cells decorated with a schematic_function correctly produce schematics without creating layout instances prematurely.