### PR TITLE
feat: add schematic metadata to generic PDK cells

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -127,8 +127,7 @@ def cell(
         drop_params = ["self", "cls"]
     if post_process is None:
         post_process = []
-    c = _cell(  # type: ignore[call-overload,misc]
-        _func,
+    cell_kwargs: dict[str, Any] = dict(
         output_type=Component,
         set_settings=set_settings,
         set_name=set_name,
@@ -150,6 +149,7 @@ def cell(
         ports=ports,
         schematic_function=schematic_function,
     )
+    c = _cell(_func, **cell_kwargs)  # type: ignore[call-overload,misc]
 
     if _func is not None:
         c.is_gf_cell = True
@@ -164,29 +164,7 @@ def cell(
             bn = clean_name(
                 func.__name__ if mod == "__main__" else f"{func.__name__}_{mod}"
             )
-            decorated = _cell(  # type: ignore[call-overload,misc]
-                func,
-                output_type=Component,
-                set_settings=set_settings,
-                set_name=set_name,
-                check_ports=check_ports,
-                check_instances=check_instances,
-                snap_ports=snap_ports,
-                add_port_layers=add_port_layers,
-                cache=cache,
-                basename=bn,
-                drop_params=drop_params,
-                register_factory=register_factory,
-                overwrite_existing=overwrite_existing,
-                layout_cache=layout_cache,
-                info=info,
-                post_process=post_process,
-                debug_names=debug_names,
-                tags=tags,
-                lvs_equivalent_ports=lvs_equivalent_ports,
-                ports=ports,
-                schematic_function=schematic_function,
-            )
+            decorated = _cell(func, **{**cell_kwargs, "basename": bn})  # type: ignore[call-overload,misc]
         else:
             decorated = c(func)
         decorated.is_gf_cell = True

--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -159,7 +159,36 @@ def cell(
     def wrapper(
         func: ComponentFunc[ComponentParams],
     ) -> ComponentFunc[ComponentParams]:
-        decorated = c(func)
+        if with_module_name and basename is None:
+            mod = func.__module__
+            bn = clean_name(
+                func.__name__ if mod == "__main__" else f"{func.__name__}_{mod}"
+            )
+            decorated = _cell(  # type: ignore[call-overload,misc]
+                func,
+                output_type=Component,
+                set_settings=set_settings,
+                set_name=set_name,
+                check_ports=check_ports,
+                check_instances=check_instances,
+                snap_ports=snap_ports,
+                add_port_layers=add_port_layers,
+                cache=cache,
+                basename=bn,
+                drop_params=drop_params,
+                register_factory=register_factory,
+                overwrite_existing=overwrite_existing,
+                layout_cache=layout_cache,
+                info=info,
+                post_process=post_process,
+                debug_names=debug_names,
+                tags=tags,
+                lvs_equivalent_ports=lvs_equivalent_ports,
+                ports=ports,
+                schematic_function=schematic_function,
+            )
+        else:
+            decorated = c(func)
         decorated.is_gf_cell = True
         return cast(ComponentFunc[ComponentParams], decorated)
 

--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from functools import partial, wraps
+from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, cast, overload
 
 import kfactory as kf
@@ -149,7 +149,7 @@ def cell(
         ports=ports,
         schematic_function=schematic_function,
     )
-    c = _cell(_func, **cell_kwargs)  # type: ignore[call-overload,misc]
+    c: Any = _cell(_func, **cell_kwargs)  # type: ignore[arg-type]
 
     if _func is not None:
         c.is_gf_cell = True
@@ -164,7 +164,7 @@ def cell(
             bn = clean_name(
                 func.__name__ if mod == "__main__" else f"{func.__name__}_{mod}"
             )
-            decorated = _cell(func, **{**cell_kwargs, "basename": bn})  # type: ignore[call-overload,misc]
+            decorated: Any = _cell(func, **{**cell_kwargs, "basename": bn})
         else:
             decorated = c(func)
         decorated.is_gf_cell = True
@@ -255,14 +255,70 @@ def vcell(
     return wrapper
 
 
-def override_defaults(
-    func: Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]],
+@overload
+def cell_with_module_name(
+    _func: ComponentFunc[ComponentParams], /
+) -> ComponentFunc[ComponentParams]: ...
+
+
+@overload
+def cell_with_module_name(
+    *,
+    set_settings: bool = True,
+    set_name: bool = True,
+    check_ports: bool = True,
+    check_instances: CheckInstances | None = None,
+    snap_ports: bool = True,
+    add_port_layers: bool = True,
+    cache: Cache[int, Any] | dict[int, Any] | None = None,
+    basename: str | None = None,
+    drop_params: list[str] | None = None,
+    register_factory: bool = True,
+    overwrite_existing: bool | None = None,
+    layout_cache: bool | None = None,
+    info: dict[str, MetaData] | None = None,
+    post_process: Iterable[Callable[[Component], None]] | None = None,
+    debug_names: bool | None = None,
+    tags: list[str] | None = None,
+    lvs_equivalent_ports: list[list[str]] | None = None,
+    schematic_function: Callable[ComponentParams, Schematic],
+) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]: ...
+
+
+@overload
+def cell_with_module_name(
+    *,
+    set_settings: bool = True,
+    set_name: bool = True,
+    check_ports: bool = True,
+    check_instances: CheckInstances | None = None,
+    snap_ports: bool = True,
+    add_port_layers: bool = True,
+    cache: Cache[int, Any] | dict[int, Any] | None = None,
+    basename: str | None = None,
+    drop_params: list[str] | None = None,
+    register_factory: bool = True,
+    overwrite_existing: bool | None = None,
+    layout_cache: bool | None = None,
+    info: dict[str, MetaData] | None = None,
+    post_process: Iterable[Callable[[Component], None]] | None = None,
+    debug_names: bool | None = None,
+    tags: list[str] | None = None,
+    lvs_equivalent_ports: list[list[str]] | None = None,
+    schematic_function: None = None,
+) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]: ...
+
+
+def cell_with_module_name(
+    _func: ComponentFunc[ComponentParams] | None = None,
+    /,
     **kwargs: Any,
-) -> Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]:
-    return partial(func, **kwargs)
-
-
-cell_with_module_name = override_defaults(cell, with_module_name=True)
+) -> (
+    ComponentFunc[ComponentParams]
+    | Callable[[ComponentFunc[ComponentParams]], ComponentFunc[ComponentParams]]
+):
+    """Decorator like ``cell`` but with ``with_module_name=True`` by default."""
+    return cell(_func, with_module_name=True, **kwargs)  # type: ignore[call-overload,no-any-return]
 
 
 @overload

--- a/gdsfactory/components/_schematic.py
+++ b/gdsfactory/components/_schematic.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any, Literal, cast
+
 from kfactory.schematic import DSchematic
 
 # Port pattern: 2-port horizontal (straight, bend, taper, etc.)
@@ -79,16 +82,15 @@ _PHOTODIODE = [
 ]
 
 
-
 def _make_schematic(
     symbol: str,
     tags: list[str],
-    ports: list[dict],
+    ports: list[dict[str, str]],
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = tags
+    s.info["tags"] = tags  # type: ignore[assignment]
     s.info["symbol"] = symbol
-    s.info["ports"] = ports
+    s.info["ports"] = ports  # type: ignore[assignment]
 
     side_to_xy = {
         "left": (-1, 0, 180),
@@ -114,9 +116,9 @@ def _make_schematic(
         # Center multiple ports on the same side
         offset = (idx - (total - 1) / 2) * spacing
         if side in ("left", "right"):
-            x, y = bx, by + offset
+            x, y = float(bx), by + offset
         else:
-            x, y = bx + offset, by
+            x, y = bx + offset, float(by)
 
         xs = "metal1_routing" if port["type"] == "electric" else "strip"
         s.create_port(
@@ -124,7 +126,7 @@ def _make_schematic(
             cross_section=xs,
             x=x,
             y=y,
-            orientation=orientation,
+            orientation=cast(Literal[0, 90, 180, 270], orientation),
         )
 
     return s
@@ -133,11 +135,11 @@ def _make_schematic(
 def schematic(
     symbol: str,
     tags: list[str],
-    ports: list[dict],
-):
+    ports: list[dict[str, str]],
+) -> Callable[..., DSchematic]:
     """Returns a schematic function for use with @gf.cell(schematic_function=...)."""
 
-    def _schematic_fn(**kwargs) -> DSchematic:
+    def _schematic_fn(**kwargs: Any) -> DSchematic:
         return _make_schematic(symbol, tags, ports)
 
     return _schematic_fn
@@ -163,22 +165,38 @@ spiral_schematic = schematic("spiral", ["spiral"], _LEFT_RIGHT)
 grating_coupler_schematic = schematic("grating-coupler", ["grating-coupler"], _GRATING)
 photodiode_schematic = schematic("photodiode", ["photodiode"], _PHOTODIODE)
 modulator_schematic = schematic("modulator", ["modulator"], _MODULATOR)
-inductor_schematic = schematic("inductor", ["inductor"], [
-    {"name": "P1", "side": "left", "type": "electric"},
-    {"name": "P2", "side": "right", "type": "electric"},
-])
-capacitor_schematic = schematic("capacitor", ["capacitor"], [
-    {"name": "o1", "side": "left", "type": "electric"},
-    {"name": "o2", "side": "right", "type": "electric"},
-])
-wire_schematic = schematic("straight", ["wire"], [
-    {"name": "e1", "side": "left", "type": "electric"},
-    {"name": "e2", "side": "right", "type": "electric"},
-])
-pad_schematic = schematic("pad", ["pad"], [
-    {"name": "e1", "side": "left", "type": "electric"},
-    {"name": "e2", "side": "top", "type": "electric"},
-    {"name": "e3", "side": "right", "type": "electric"},
-    {"name": "e4", "side": "bottom", "type": "electric"},
-])
+inductor_schematic = schematic(
+    "inductor",
+    ["inductor"],
+    [
+        {"name": "P1", "side": "left", "type": "electric"},
+        {"name": "P2", "side": "right", "type": "electric"},
+    ],
+)
+capacitor_schematic = schematic(
+    "capacitor",
+    ["capacitor"],
+    [
+        {"name": "o1", "side": "left", "type": "electric"},
+        {"name": "o2", "side": "right", "type": "electric"},
+    ],
+)
+wire_schematic = schematic(
+    "straight",
+    ["wire"],
+    [
+        {"name": "e1", "side": "left", "type": "electric"},
+        {"name": "e2", "side": "right", "type": "electric"},
+    ],
+)
+pad_schematic = schematic(
+    "pad",
+    ["pad"],
+    [
+        {"name": "e1", "side": "left", "type": "electric"},
+        {"name": "e2", "side": "top", "type": "electric"},
+        {"name": "e3", "side": "right", "type": "electric"},
+        {"name": "e4", "side": "bottom", "type": "electric"},
+    ],
+)
 ckt_schematic = schematic("ckt", [], _LEFT_RIGHT)

--- a/gdsfactory/components/_schematic.py
+++ b/gdsfactory/components/_schematic.py
@@ -97,19 +97,25 @@ def _make_schematic(
         "bottom": (0, -1, 270),
     }
 
+    # Pre-count ports per side for centering
+    side_counts: dict[str, int] = {}
+    for port in ports:
+        side_counts[port["side"]] = side_counts.get(port["side"], 0) + 1
+
     seen_sides: dict[str, int] = {}
+    spacing = 0.5
     for port in ports:
         side = port["side"]
         idx = seen_sides.get(side, 0)
         seen_sides[side] = idx + 1
+        total = side_counts[side]
         bx, by, orientation = side_to_xy[side]
 
-        # Offset multiple ports on the same side
+        # Center multiple ports on the same side
+        offset = (idx - (total - 1) / 2) * spacing
         if side in ("left", "right"):
-            offset = idx * 0.5 - (seen_sides.get(side, 1) - 1) * 0.25
             x, y = bx, by + offset
         else:
-            offset = idx * 0.5 - (seen_sides.get(side, 1) - 1) * 0.25
             x, y = bx + offset, by
 
         xs = "metal1_routing" if port["type"] == "electric" else "strip"

--- a/gdsfactory/components/_schematic.py
+++ b/gdsfactory/components/_schematic.py
@@ -1,0 +1,178 @@
+"""Reusable schematic function factories for common photonic port patterns."""
+
+from __future__ import annotations
+
+from kfactory.schematic import DSchematic
+
+# Port pattern: 2-port horizontal (straight, bend, taper, etc.)
+# o1 ────── o2
+_LEFT_RIGHT = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+]
+
+# Port pattern: 2-port bend (90-degree turn)
+# o1 ──┐
+#      o2
+_LEFT_BOTTOM = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "bottom", "type": "photonic"},
+]
+
+# Port pattern: 1x2 splitter
+#        ── o2
+# o1 ──┤
+#        ── o3
+_1X2 = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+    {"name": "o3", "side": "right", "type": "photonic"},
+]
+
+# Port pattern: 2x2 coupler
+# o2 ──┐  ┌── o3
+#      ├──┤
+# o1 ──┘  └── o4
+_2X2 = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "left", "type": "photonic"},
+    {"name": "o3", "side": "right", "type": "photonic"},
+    {"name": "o4", "side": "right", "type": "photonic"},
+]
+
+# Port pattern: ring coupler (bus below, ring above)
+_COUPLER_RING = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "top", "type": "photonic"},
+    {"name": "o3", "side": "top", "type": "photonic"},
+    {"name": "o4", "side": "right", "type": "photonic"},
+]
+
+# Port pattern: 4-port crossing
+_CROSSING = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "bottom", "type": "photonic"},
+    {"name": "o3", "side": "right", "type": "photonic"},
+    {"name": "o4", "side": "top", "type": "photonic"},
+]
+
+# Port pattern: 1-port terminator
+_TERMINATOR = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+]
+
+# Port pattern: grating coupler (waveguide left, fiber top)
+_GRATING = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "top", "type": "photonic"},
+]
+
+# Port pattern: 2-port with electrical contacts (modulators, heaters)
+_MODULATOR = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+]
+
+# Port pattern: photodiode (optical in, electrical out)
+_PHOTODIODE = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+]
+
+
+
+def _make_schematic(
+    symbol: str,
+    tags: list[str],
+    ports: list[dict],
+) -> DSchematic:
+    s = DSchematic()
+    s.info["tags"] = tags
+    s.info["symbol"] = symbol
+    s.info["ports"] = ports
+
+    side_to_xy = {
+        "left": (-1, 0, 180),
+        "right": (1, 0, 0),
+        "top": (0, 1, 90),
+        "bottom": (0, -1, 270),
+    }
+
+    seen_sides: dict[str, int] = {}
+    for port in ports:
+        side = port["side"]
+        idx = seen_sides.get(side, 0)
+        seen_sides[side] = idx + 1
+        bx, by, orientation = side_to_xy[side]
+
+        # Offset multiple ports on the same side
+        if side in ("left", "right"):
+            offset = idx * 0.5 - (seen_sides.get(side, 1) - 1) * 0.25
+            x, y = bx, by + offset
+        else:
+            offset = idx * 0.5 - (seen_sides.get(side, 1) - 1) * 0.25
+            x, y = bx + offset, by
+
+        xs = "metal1_routing" if port["type"] == "electric" else "strip"
+        s.create_port(
+            name=port["name"],
+            cross_section=xs,
+            x=x,
+            y=y,
+            orientation=orientation,
+        )
+
+    return s
+
+
+def schematic(
+    symbol: str,
+    tags: list[str],
+    ports: list[dict],
+):
+    """Returns a schematic function for use with @gf.cell(schematic_function=...)."""
+
+    def _schematic_fn(**kwargs) -> DSchematic:
+        return _make_schematic(symbol, tags, ports)
+
+    return _schematic_fn
+
+
+# Pre-built schematic functions for common patterns
+straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
+bend_schematic = schematic("bend", ["bend"], _LEFT_BOTTOM)
+sbend_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
+taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)
+transition_schematic = schematic("transition", ["taper", "transition"], _LEFT_RIGHT)
+terminator_schematic = schematic("terminator", ["terminator"], _TERMINATOR)
+crossing_schematic = schematic("crossing", ["crossing"], _CROSSING)
+coupler_schematic = schematic("coupler", ["coupler"], _2X2)
+coupler_ring_schematic = schematic("coupler-ring", ["coupler", "ring"], _COUPLER_RING)
+mmi_1x2_schematic = schematic("mmi-1x2", ["mmi", "1x2"], _1X2)
+mmi_2x2_schematic = schematic("mmi-2x2", ["mmi", "2x2"], _2X2)
+mzi_1x2_schematic = schematic("mzi-1x2", ["mzi", "1x2"], _LEFT_RIGHT)
+mzi_2x2_schematic = schematic("mzi-2x2", ["mzi", "2x2"], _LEFT_RIGHT)
+ring_single_schematic = schematic("ring-single", ["ring", "single"], _LEFT_RIGHT)
+ring_double_schematic = schematic("ring-double", ["ring", "double"], _2X2)
+spiral_schematic = schematic("spiral", ["spiral"], _LEFT_RIGHT)
+grating_coupler_schematic = schematic("grating-coupler", ["grating-coupler"], _GRATING)
+photodiode_schematic = schematic("photodiode", ["photodiode"], _PHOTODIODE)
+modulator_schematic = schematic("modulator", ["modulator"], _MODULATOR)
+inductor_schematic = schematic("inductor", ["inductor"], [
+    {"name": "P1", "side": "left", "type": "electric"},
+    {"name": "P2", "side": "right", "type": "electric"},
+])
+capacitor_schematic = schematic("capacitor", ["capacitor"], [
+    {"name": "o1", "side": "left", "type": "electric"},
+    {"name": "o2", "side": "right", "type": "electric"},
+])
+wire_schematic = schematic("straight", ["wire"], [
+    {"name": "e1", "side": "left", "type": "electric"},
+    {"name": "e2", "side": "right", "type": "electric"},
+])
+pad_schematic = schematic("pad", ["pad"], [
+    {"name": "e1", "side": "left", "type": "electric"},
+    {"name": "e2", "side": "top", "type": "electric"},
+    {"name": "e3", "side": "right", "type": "electric"},
+    {"name": "e4", "side": "bottom", "type": "electric"},
+])
+ckt_schematic = schematic("ckt", [], _LEFT_RIGHT)

--- a/gdsfactory/components/analog/inductors.py
+++ b/gdsfactory/components/analog/inductors.py
@@ -7,6 +7,7 @@ __all__ = ["inductor"]
 import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.typings import LayerSpec, LayerSpecs
+from .._schematic import inductor_schematic
 
 
 def inductor_min_diameter(width: float, space: float, turns: int, grid: float) -> float:
@@ -25,7 +26,7 @@ def inductor_min_diameter(width: float, space: float, turns: int, grid: float) -
     return round(min_d / grid) * grid
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=inductor_schematic)
 def inductor(
     width: float = 2.0,
     space: float = 2.1,

--- a/gdsfactory/components/analog/inductors.py
+++ b/gdsfactory/components/analog/inductors.py
@@ -7,6 +7,7 @@ __all__ = ["inductor"]
 import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.typings import LayerSpec, LayerSpecs
+
 from .._schematic import inductor_schematic
 
 

--- a/gdsfactory/components/analog/interdigital_capacitor.py
+++ b/gdsfactory/components/analog/interdigital_capacitor.py
@@ -8,6 +8,7 @@ from math import ceil, floor
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+
 from .._schematic import capacitor_schematic
 
 

--- a/gdsfactory/components/analog/interdigital_capacitor.py
+++ b/gdsfactory/components/analog/interdigital_capacitor.py
@@ -8,9 +8,10 @@ from math import ceil, floor
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import capacitor_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=capacitor_schematic)
 def interdigital_capacitor(
     fingers: int = 4,
     finger_length: float | int = 20.0,

--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -11,9 +11,8 @@ from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.path import arc
 from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+
 from .._schematic import bend_schematic
-
-
 
 
 @overload

--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -11,6 +11,9 @@ from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.path import arc
 from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+from .._schematic import bend_schematic
+
+
 
 
 @overload
@@ -111,7 +114,7 @@ def _bend_circular(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=bend_schematic)
 def bend_circular(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_circular_heater.py
+++ b/gdsfactory/components/bends/bend_circular_heater.py
@@ -6,6 +6,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.path import arc
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+
 from .._schematic import bend_schematic
 
 

--- a/gdsfactory/components/bends/bend_circular_heater.py
+++ b/gdsfactory/components/bends/bend_circular_heater.py
@@ -6,9 +6,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.path import arc
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+from .._schematic import bend_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=bend_schematic)
 def bend_circular_heater(
     radius: float | None = None,
     angle: float = 90,

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -12,6 +12,9 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.path import euler
 from gdsfactory.typings import AnyComponent, CrossSectionSpec, LayerSpec
+from .._schematic import bend_schematic, sbend_schematic
+
+
 
 
 @overload
@@ -142,7 +145,7 @@ def _bend_euler(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=sbend_schematic)
 def bend_euler_s(
     radius: float | None = None,
     p: float = 0.5,
@@ -208,7 +211,7 @@ def bend_euler_s(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=bend_schematic)
 def bend_euler(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -12,9 +12,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.path import euler
 from gdsfactory.typings import AnyComponent, CrossSectionSpec, LayerSpec
+
 from .._schematic import bend_schematic, sbend_schematic
-
-
 
 
 @overload

--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -13,6 +13,9 @@ from gdsfactory.component import Component
 from gdsfactory.config import ErrorType
 from gdsfactory.functions import angles_deg, curvature, snap_angle
 from gdsfactory.typings import Coordinate, Coordinates, CrossSectionSpec, Size
+from .._schematic import sbend_schematic
+
+
 
 
 def bezier_curve(
@@ -37,7 +40,7 @@ def bezier_curve(
     return np.column_stack([xs, ys])
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=sbend_schematic)
 def bezier(
     control_points: Coordinates = ((0.0, 0.0), (5.0, 0.0), (5.0, 1.8), (10.0, 1.8)),
     npoints: int = 201,
@@ -160,7 +163,7 @@ def find_min_curv_bezier_control_points(
     return tuple(points)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=sbend_schematic)
 def bend_s(
     size: Size = (11.0, 1.8),
     npoints: int = 99,
@@ -246,7 +249,7 @@ def _get_euler_sbend_angle_middle_length_from_jog(
     return angle_deg, middle_length
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=sbend_schematic)
 def bend_s_offset(
     offset: float = 40.0,
     radius: float | None = 10.0,

--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -13,9 +13,8 @@ from gdsfactory.component import Component
 from gdsfactory.config import ErrorType
 from gdsfactory.functions import angles_deg, curvature, snap_angle
 from gdsfactory.typings import Coordinate, Coordinates, CrossSectionSpec, Size
+
 from .._schematic import sbend_schematic
-
-
 
 
 def bezier_curve(

--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -5,9 +5,8 @@ __all__ = ["coupler", "coupler_straight", "coupler_symmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta
+
 from .._schematic import coupler_schematic
-
-
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -5,6 +5,9 @@ __all__ = ["coupler", "coupler_straight", "coupler_symmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta
+from .._schematic import coupler_schematic
+
+
 
 
 @gf.cell_with_module_name
@@ -75,7 +78,7 @@ def coupler_symmetric(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_straight(
     length: float = 10.0,
     gap: float = 0.27,
@@ -115,7 +118,7 @@ def coupler_straight(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler(
     gap: float = 0.236,
     length: float = 20.0,

--- a/gdsfactory/components/couplers/coupler90.py
+++ b/gdsfactory/components/couplers/coupler90.py
@@ -7,9 +7,10 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler90(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler90.py
+++ b/gdsfactory/components/couplers/coupler90.py
@@ -7,6 +7,7 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/couplers/coupler90bend.py
+++ b/gdsfactory/components/couplers/coupler90bend.py
@@ -5,6 +5,7 @@ __all__ = ["coupler90bend"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/couplers/coupler90bend.py
+++ b/gdsfactory/components/couplers/coupler90bend.py
@@ -5,9 +5,10 @@ __all__ = ["coupler90bend"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler90bend(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/couplers/coupler_adiabatic.py
+++ b/gdsfactory/components/couplers/coupler_adiabatic.py
@@ -6,8 +6,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
 
-from ..bends.bend_s import bezier
 from .._schematic import coupler_schematic
+from ..bends.bend_s import bezier
 
 
 @gf.cell_with_module_name(schematic_function=coupler_schematic)

--- a/gdsfactory/components/couplers/coupler_adiabatic.py
+++ b/gdsfactory/components/couplers/coupler_adiabatic.py
@@ -7,9 +7,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
 
 from ..bends.bend_s import bezier
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_adiabatic(
     length1: float = 20.0,
     length2: float = 50.0,

--- a/gdsfactory/components/couplers/coupler_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_asymmetric.py
@@ -5,6 +5,7 @@ __all__ = ["coupler_asymmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Delta
+
 from .._schematic import mmi_1x2_schematic
 
 

--- a/gdsfactory/components/couplers/coupler_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_asymmetric.py
@@ -5,9 +5,10 @@ __all__ = ["coupler_asymmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Delta
+from .._schematic import mmi_1x2_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
 def coupler_asymmetric(
     gap: float = 0.234,
     dy: Delta = 2.5,

--- a/gdsfactory/components/couplers/coupler_bent.py
+++ b/gdsfactory/components/couplers/coupler_bent.py
@@ -3,6 +3,7 @@ __all__ = ["coupler_bent"]
 import numpy as np
 
 import gdsfactory as gf
+from .._schematic import coupler_schematic
 
 
 @gf.cell_with_module_name
@@ -80,7 +81,7 @@ def coupler_bent_half(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_bent(
     gap: float = 0.200,
     radius: float = 26,

--- a/gdsfactory/components/couplers/coupler_bent.py
+++ b/gdsfactory/components/couplers/coupler_bent.py
@@ -3,6 +3,7 @@ __all__ = ["coupler_bent"]
 import numpy as np
 
 import gdsfactory as gf
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/couplers/coupler_broadband.py
+++ b/gdsfactory/components/couplers/coupler_broadband.py
@@ -5,9 +5,10 @@ __all__ = ["coupler_broadband"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_broadband(
     w_sc: float = 0.5,  # width of waveguides in the symmetric coupler section
     gap_sc: float = 0.2,  # gap size between the waveguides in the symmetric coupler section

--- a/gdsfactory/components/couplers/coupler_broadband.py
+++ b/gdsfactory/components/couplers/coupler_broadband.py
@@ -5,6 +5,7 @@ __all__ = ["coupler_broadband"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/couplers/coupler_full.py
+++ b/gdsfactory/components/couplers/coupler_full.py
@@ -5,6 +5,7 @@ __all__ = ["coupler_full"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Delta
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/couplers/coupler_full.py
+++ b/gdsfactory/components/couplers/coupler_full.py
@@ -5,9 +5,10 @@ __all__ = ["coupler_full"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Delta
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_full(
     coupling_length: float = 40.0,
     dx: Delta = 10.0,

--- a/gdsfactory/components/couplers/coupler_pulley.py
+++ b/gdsfactory/components/couplers/coupler_pulley.py
@@ -9,6 +9,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+from .._schematic import coupler_schematic
 
 
 def _cubic_bezier(

--- a/gdsfactory/components/couplers/coupler_pulley.py
+++ b/gdsfactory/components/couplers/coupler_pulley.py
@@ -9,7 +9,6 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
-from .._schematic import coupler_schematic
 
 
 def _cubic_bezier(

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -6,11 +6,9 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+from .._schematic import coupler_ring_schematic
 from ..couplers.coupler import coupler_straight
 from ..couplers.coupler90 import coupler90
-from .._schematic import coupler_ring_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=coupler_ring_schematic)

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -8,9 +8,12 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..couplers.coupler import coupler_straight
 from ..couplers.coupler90 import coupler90
+from .._schematic import coupler_ring_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=coupler_ring_schematic)
 def coupler_ring(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler_straight_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_straight_asymmetric.py
@@ -5,9 +5,10 @@ __all__ = ["coupler_straight_asymmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_straight_asymmetric(
     length: float = 10.0,
     gap: float = 0.27,

--- a/gdsfactory/components/couplers/coupler_straight_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_straight_asymmetric.py
@@ -5,6 +5,7 @@ __all__ = ["coupler_straight_asymmetric"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import coupler_schematic
 
 

--- a/gdsfactory/components/detectors/detector_ge.py
+++ b/gdsfactory/components/detectors/detector_ge.py
@@ -7,6 +7,7 @@ __all__ = ["ge_detector_straight_si_contacts"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import photodiode_schematic
 
 

--- a/gdsfactory/components/detectors/detector_ge.py
+++ b/gdsfactory/components/detectors/detector_ge.py
@@ -7,9 +7,10 @@ __all__ = ["ge_detector_straight_si_contacts"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import photodiode_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=photodiode_schematic)
 def ge_detector_straight_si_contacts(
     length: float = 40.0,
     cross_section: CrossSectionSpec = "pn_ge_detector_si_contacts",

--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -9,9 +9,10 @@ __all__ = [
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
+from .._schematic import grating_coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def edge_coupler_silicon(
     length: float = 100,
     width1: float = 0.5,

--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -9,6 +9,7 @@ __all__ = [
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
+
 from .._schematic import taper_schematic
 
 

--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -9,10 +9,10 @@ __all__ = [
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
-from .._schematic import grating_coupler_schematic
+from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def edge_coupler_silicon(
     length: float = 100,
     width1: float = 0.5,

--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -8,8 +8,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from ..bends.bend_s import bend_s
 from .._schematic import ckt_schematic
+from ..bends.bend_s import bend_s
 
 
 @gf.cell_with_module_name(schematic_function=ckt_schematic)

--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -9,9 +9,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..bends.bend_s import bend_s
+from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ckt_schematic)
 def mode_converter(
     gap: float = 0.3,
     length: float = 10,

--- a/gdsfactory/components/filters/terminator.py
+++ b/gdsfactory/components/filters/terminator.py
@@ -7,9 +7,10 @@ from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
 from gdsfactory.cross_section import strip
 from gdsfactory.typings import CrossSectionSpec, LayerSpecs
+from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=terminator_schematic)
 def terminator(
     length: float | None = 50,
     cross_section_input: CrossSectionSpec = strip,

--- a/gdsfactory/components/filters/terminator.py
+++ b/gdsfactory/components/filters/terminator.py
@@ -7,6 +7,7 @@ from gdsfactory.add_padding import get_padding_points
 from gdsfactory.component import Component
 from gdsfactory.cross_section import strip
 from gdsfactory.typings import CrossSectionSpec, LayerSpecs
+
 from .._schematic import terminator_schematic
 
 

--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -5,6 +5,7 @@ __all__ = ["terminator_spiral"]
 import gdsfactory as gf
 from gdsfactory.path import extrude_transition, spiral_archimedean, transition
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import terminator_schematic
 
 

--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -5,9 +5,10 @@ __all__ = ["terminator_spiral"]
 import gdsfactory as gf
 from gdsfactory.path import extrude_transition, spiral_archimedean, transition
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=terminator_schematic)
 def terminator_spiral(
     separation: float = 3.0,
     width_tip: float = 0.2,

--- a/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+from .._schematic import grating_coupler_schematic
 
 
 def _unit_cell() -> gf.Component:
@@ -15,7 +16,7 @@ def _unit_cell() -> gf.Component:
     )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_dual_pol(
     unit_cell: ComponentSpec = _unit_cell,
     period_x: float = 0.58,

--- a/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+
 from .._schematic import grating_coupler_schematic
 
 

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
@@ -22,8 +22,6 @@ from ..grating_couplers.functions import (
 )
 
 
-
-
 @gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical(
     polarization: str = "te",

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
@@ -15,13 +15,16 @@ from gdsfactory.component import Component
 from gdsfactory.functions import DEG2RAD
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
+from .._schematic import grating_coupler_schematic
 from ..grating_couplers.functions import (
     grating_taper_points,
     grating_tooth_points,
 )
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical(
     polarization: str = "te",
     taper_length: float = 16.6,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
@@ -14,6 +14,7 @@ from gdsfactory.component import Component
 from gdsfactory.functions import DEG2RAD
 from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
+from .._schematic import grating_coupler_schematic
 from ..grating_couplers.functions import (
     grating_taper_points,
     grating_tooth_points,
@@ -23,7 +24,7 @@ _gaps = (0.1,) * 10
 _widths = (0.5,) * 10
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical_arbitrary(
     gaps: Floats = _gaps,
     widths: Floats = _widths,
@@ -177,7 +178,7 @@ def grating_coupler_elliptical_arbitrary(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical_uniform(
     n_periods: int = 20,
     period: float = 0.75,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
@@ -12,6 +12,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
+from .._schematic import grating_coupler_schematic
 from ..grating_couplers.grating_coupler_elliptical_arbitrary import (
     grating_coupler_elliptical_arbitrary,
 )
@@ -70,7 +71,7 @@ parameters = (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical_lumerical(
     parameters: Floats = parameters,
     layer_slab: LayerSpec | None = "SLAB150",

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
@@ -16,9 +16,10 @@ from gdsfactory.functions import DEG2RAD
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
 from ..grating_couplers.functions import grating_tooth_points
+from .._schematic import grating_coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_elliptical_trenches(
     polarization: str = "te",
     taper_length: float = 16.6,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
@@ -15,8 +15,8 @@ from gdsfactory.component import Component
 from gdsfactory.functions import DEG2RAD
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
-from ..grating_couplers.functions import grating_tooth_points
 from .._schematic import grating_coupler_schematic
+from ..grating_couplers.functions import grating_tooth_points
 
 
 @gf.cell_with_module_name(schematic_function=grating_coupler_schematic)

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
@@ -7,9 +7,10 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+from .._schematic import grating_coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_rectangular(
     n_periods: int = 20,
     period: float = 0.75,

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
+
 from .._schematic import grating_coupler_schematic
 
 

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
@@ -9,12 +9,13 @@ from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
 from ..tapers.taper import taper
+from .._schematic import grating_coupler_schematic
 
 _gaps = (0.2,) * 10
 _widths = (0.5,) * 10
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
 def grating_coupler_rectangular_arbitrary(
     gaps: Floats = _gaps,
     widths: Floats = _widths,

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
@@ -8,8 +8,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, Floats, LayerSpec
 
-from ..tapers.taper import taper
 from .._schematic import grating_coupler_schematic
+from ..tapers.taper import taper
 
 _gaps = (0.2,) * 10
 _widths = (0.5,) * 10

--- a/gdsfactory/components/mmis/mmi.py
+++ b/gdsfactory/components/mmis/mmi.py
@@ -5,9 +5,10 @@ __all__ = ["mmi"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ckt_schematic)
 def mmi(
     inputs: int = 1,
     outputs: int = 4,

--- a/gdsfactory/components/mmis/mmi.py
+++ b/gdsfactory/components/mmis/mmi.py
@@ -5,6 +5,7 @@ __all__ = ["mmi"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import ckt_schematic
 
 

--- a/gdsfactory/components/mmis/mmi1x2.py
+++ b/gdsfactory/components/mmis/mmi1x2.py
@@ -6,11 +6,9 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+from .._schematic import mmi_1x2_schematic
 from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
-from .._schematic import mmi_1x2_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)

--- a/gdsfactory/components/mmis/mmi1x2.py
+++ b/gdsfactory/components/mmis/mmi1x2.py
@@ -8,9 +8,12 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
+from .._schematic import mmi_1x2_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
 def mmi1x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi1x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi1x2_with_sbend.py
@@ -9,8 +9,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
-from ..bends.bend_s import bend_s
 from .._schematic import mmi_1x2_schematic
+from ..bends.bend_s import bend_s
 
 
 def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:

--- a/gdsfactory/components/mmis/mmi1x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi1x2_with_sbend.py
@@ -10,6 +10,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
 from ..bends.bend_s import bend_s
+from .._schematic import mmi_1x2_schematic
 
 
 def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
@@ -38,7 +39,7 @@ def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     return cast("npt.NDArray[np.float64]", f(xnew))
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
 def mmi1x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi2x2.py
+++ b/gdsfactory/components/mmis/mmi2x2.py
@@ -8,9 +8,12 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
+from .._schematic import mmi_2x2_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)
 def mmi2x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi2x2.py
+++ b/gdsfactory/components/mmis/mmi2x2.py
@@ -6,11 +6,9 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+from .._schematic import mmi_2x2_schematic
 from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
-from .._schematic import mmi_2x2_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)

--- a/gdsfactory/components/mmis/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi2x2_with_sbend.py
@@ -7,8 +7,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
-from ..bends.bend_s import bend_s
 from .._schematic import mmi_2x2_schematic
+from ..bends.bend_s import bend_s
 
 
 @gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)

--- a/gdsfactory/components/mmis/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi2x2_with_sbend.py
@@ -8,9 +8,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
 from ..bends.bend_s import bend_s
+from .._schematic import mmi_2x2_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)
 def mmi2x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -7,9 +7,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..tapers.taper import taper as taper_function
+from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ckt_schematic)
 def mmi_90degree_hybrid(
     width: float = 0.5,
     width_taper: float = 1.7,

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -6,8 +6,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from ..tapers.taper import taper as taper_function
 from .._schematic import ckt_schematic
+from ..tapers.taper import taper as taper_function
 
 
 @gf.cell_with_module_name(schematic_function=ckt_schematic)

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -6,8 +6,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
-from ..tapers.taper import taper as taper_function
 from .._schematic import mmi_1x2_schematic
+from ..tapers.taper import taper as taper_function
 
 
 @gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -7,9 +7,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentFactory, CrossSectionSpec
 
 from ..tapers.taper import taper as taper_function
+from .._schematic import mmi_1x2_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
 def mmi_tapered(
     inputs: int = 1,
     outputs: int = 2,

--- a/gdsfactory/components/mzis/mzi.py
+++ b/gdsfactory/components/mzis/mzi.py
@@ -18,9 +18,12 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
 def mzi(
     delta_length: float = 10.0,
     length_y: float = 2.0,

--- a/gdsfactory/components/mzis/mzi.py
+++ b/gdsfactory/components/mzis/mzi.py
@@ -18,9 +18,8 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import mzi_2x2_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)

--- a/gdsfactory/components/mzis/mzi_lattice.py
+++ b/gdsfactory/components/mzis/mzi_lattice.py
@@ -7,9 +7,10 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
+from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
 def mzi_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),
@@ -121,7 +122,7 @@ def mzi_lattice(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
 def mzi_lattice_mmi(
     coupler_widths: tuple[float | None, float | None] = (None, None),
     coupler_widths_tapers: tuple[float, ...] = (

--- a/gdsfactory/components/mzis/mzi_lattice.py
+++ b/gdsfactory/components/mzis/mzi_lattice.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
+
 from .._schematic import mzi_2x2_schematic
 
 

--- a/gdsfactory/components/mzis/mzi_pads_center.py
+++ b/gdsfactory/components/mzis/mzi_pads_center.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import ckt_schematic
 
 

--- a/gdsfactory/components/mzis/mzi_pads_center.py
+++ b/gdsfactory/components/mzis/mzi_pads_center.py
@@ -6,9 +6,10 @@ from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ckt_schematic)
 def mzi_pads_center(
     ps_top: ComponentSpec = "straight_heater_metal",
     ps_bot: ComponentSpec = "straight_heater_metal",

--- a/gdsfactory/components/mzis/mzit.py
+++ b/gdsfactory/components/mzis/mzit.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Delta
+
 from .._schematic import mzi_2x2_schematic
 
 

--- a/gdsfactory/components/mzis/mzit.py
+++ b/gdsfactory/components/mzis/mzit.py
@@ -7,9 +7,10 @@ from collections.abc import Sequence
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Delta
+from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
 def mzit(
     w0: float = 0.5,
     w1: float = 0.45,
@@ -206,7 +207,7 @@ def mzit(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
 def mzit_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -17,6 +17,7 @@ from typing import Any
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import valid_port_orientations
+from .._schematic import pad_schematic
 from gdsfactory.typings import (
     AngleInDegrees,
     ComponentSpec,
@@ -27,7 +28,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=pad_schematic)
 def pad(
     size: Size | str = (100.0, 100.0),
     layer: LayerSpec = "MTOP",
@@ -103,7 +104,7 @@ pad_rectangular = partial(pad, size="pad_size")
 pad_small = partial(pad, size=(80, 80))
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=pad_schematic)
 def pad_array(
     pad: ComponentSpec = "pad",
     columns: int = 6,

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -17,7 +17,6 @@ from typing import Any
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.config import valid_port_orientations
-from .._schematic import pad_schematic
 from gdsfactory.typings import (
     AngleInDegrees,
     ComponentSpec,
@@ -26,6 +25,8 @@ from gdsfactory.typings import (
     LayerSpec,
     Size,
 )
+
+from .._schematic import pad_schematic
 
 
 @gf.cell_with_module_name(schematic_function=pad_schematic)

--- a/gdsfactory/components/pads/pad_gsg.py
+++ b/gdsfactory/components/pads/pad_gsg.py
@@ -8,6 +8,7 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, Float2, LayerSpec
+
 from .._schematic import pad_schematic
 
 

--- a/gdsfactory/components/pads/pad_gsg.py
+++ b/gdsfactory/components/pads/pad_gsg.py
@@ -8,6 +8,7 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, Float2, LayerSpec
+from .._schematic import pad_schematic
 
 
 @gf.cell_with_module_name
@@ -64,7 +65,7 @@ def pad_gsg_short(
 pad_gsg_open = partial(pad_gsg_short, short=False)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=pad_schematic)
 def pad_gsg(length: float = 100, cross_section: str = "gsg") -> gf.Component:
     return gf.c.straight(cross_section=cross_section, length=length)
 

--- a/gdsfactory/components/rings/disk.py
+++ b/gdsfactory/components/rings/disk.py
@@ -8,13 +8,14 @@ import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.component import ComponentReference
 from gdsfactory.cross_section import CrossSection
-from .._schematic import ring_single_schematic
 from gdsfactory.typings import (
     AngleInDegrees,
     ComponentSpec,
     CrossSectionSpec,
     LayerSpec,
 )
+
+from .._schematic import ring_single_schematic
 
 
 def _compute_parameters(

--- a/gdsfactory/components/rings/disk.py
+++ b/gdsfactory/components/rings/disk.py
@@ -8,6 +8,7 @@ import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.component import ComponentReference
 from gdsfactory.cross_section import CrossSection
+from .._schematic import ring_single_schematic
 from gdsfactory.typings import (
     AngleInDegrees,
     ComponentSpec,
@@ -91,7 +92,7 @@ def _generate_straights(
     return (c, straight_left, straight_right)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def disk(
     radius: float = 10.0,
     gap: float = 0.2,
@@ -161,7 +162,7 @@ def disk(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def disk_heater(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -8,6 +8,7 @@ from numpy import cos, pi, sin
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import ring_single_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -8,7 +8,6 @@ from numpy import cos, pi, sin
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
-from .._schematic import ring_single_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/rings/ring_crow.py
+++ b/gdsfactory/components/rings/ring_crow.py
@@ -5,7 +5,8 @@ __all__ = ["ring_asymmetric", "ring_crow"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
-from .._schematic import ring_double_schematic, ring_single_schematic
+
+from .._schematic import ring_double_schematic
 
 
 @gf.cell_with_module_name(schematic_function=ring_double_schematic)

--- a/gdsfactory/components/rings/ring_crow.py
+++ b/gdsfactory/components/rings/ring_crow.py
@@ -5,9 +5,10 @@ __all__ = ["ring_asymmetric", "ring_crow"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ring_double_schematic, ring_single_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_crow(
     gaps: tuple[float, ...] = (0.2, 0.2, 0.2, 0.2),
     radius: tuple[float, ...] = (10.0, 10.0, 10.0),

--- a/gdsfactory/components/rings/ring_crow_couplers.py
+++ b/gdsfactory/components/rings/ring_crow_couplers.py
@@ -9,6 +9,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import ring_double_schematic
 
 

--- a/gdsfactory/components/rings/ring_crow_couplers.py
+++ b/gdsfactory/components/rings/ring_crow_couplers.py
@@ -9,9 +9,10 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_crow_couplers(
     radius: Sequence[float] = (10.0,) * 3,
     bends: Sequence[ComponentSpec] = ("bend_circular",) * 3,

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -5,9 +5,12 @@ __all__ = ["ring_double"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_double(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -5,9 +5,8 @@ __all__ = ["ring_double"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import ring_double_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=ring_double_schematic)

--- a/gdsfactory/components/rings/ring_double_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_double_bend_coupler.py
@@ -7,9 +7,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentAllAngleFactory, CrossSectionSpec
 
 from ..bends.bend_circular import bend_circular_all_angle
+from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_double_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_double_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_double_bend_coupler.py
@@ -6,8 +6,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentAllAngleFactory, CrossSectionSpec
 
-from ..bends.bend_circular import bend_circular_all_angle
 from .._schematic import ring_double_schematic
+from ..bends.bend_circular import bend_circular_all_angle
 
 
 @gf.cell_with_module_name(schematic_function=ring_double_schematic)

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -7,9 +7,10 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, Float2
+from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -7,6 +7,7 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, Float2
+
 from .._schematic import ring_double_schematic
 
 

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -16,9 +16,9 @@ from gdsfactory.typings import (
     LayerSpec,
 )
 
+from .._schematic import ring_double_schematic, ring_single_schematic
 from ..vias.via import via
 from ..vias.via_stack import via_stack
-from .._schematic import ring_double_schematic, ring_single_schematic
 
 cross_section_rib = partial(
     gf.cross_section.strip,

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -18,6 +18,7 @@ from gdsfactory.typings import (
 
 from ..vias.via import via
 from ..vias.via_stack import via_stack
+from .._schematic import ring_double_schematic, ring_single_schematic
 
 cross_section_rib = partial(
     gf.cross_section.strip,
@@ -51,7 +52,7 @@ _heater_vias = partial(
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_double_schematic)
 def ring_double_pn(
     add_gap: float = 0.3,
     drop_gap: float = 0.3,
@@ -210,7 +211,7 @@ def ring_double_pn(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def ring_single_pn(
     gap: float = 0.3,
     radius: float = 5.0,

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -4,9 +4,12 @@ __all__ = ["ring_single"]
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def ring_single(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -4,9 +4,8 @@ __all__ = ["ring_single"]
 
 import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import ring_single_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=ring_single_schematic)

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -9,9 +9,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import AnyComponentFactory, ComponentSpec, CrossSectionSpec
 
 from ..bends.bend_circular import bend_circular_all_angle
+from .._schematic import coupler_ring_schematic, coupler_schematic, ring_single_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_schematic)
 def coupler_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -90,7 +91,7 @@ def coupler_bend(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=coupler_ring_schematic)
 def coupler_ring_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -152,7 +153,7 @@ def coupler_ring_bend(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def ring_single_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -8,8 +8,12 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import AnyComponentFactory, ComponentSpec, CrossSectionSpec
 
+from .._schematic import (
+    coupler_ring_schematic,
+    coupler_schematic,
+    ring_single_schematic,
+)
 from ..bends.bend_circular import bend_circular_all_angle
-from .._schematic import coupler_ring_schematic, coupler_schematic, ring_single_schematic
 
 
 @gf.cell_with_module_name(schematic_function=coupler_schematic)

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -8,6 +8,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.snap import assert_on_2x_grid
 from gdsfactory.typings import ComponentSpec
+
 from .._schematic import ring_single_schematic
 
 

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -8,9 +8,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.snap import assert_on_2x_grid
 from gdsfactory.typings import ComponentSpec
+from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=ring_single_schematic)
 def ring_single_dut(
     component: ComponentSpec = "straight",
     gap: float = 0.2,

--- a/gdsfactory/components/spirals/delay_snake.py
+++ b/gdsfactory/components/spirals/delay_snake.py
@@ -11,6 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..bends.bend_euler import bend_euler180
 from ..containers.component_sequence import component_sequence
 from ..waveguides.straight import straight
+from .._schematic import spiral_schematic
 
 _diagram = r"""
                  | length0   |
@@ -27,7 +28,7 @@ _diagram = r"""
 """
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def delay_snake(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake.py
+++ b/gdsfactory/components/spirals/delay_snake.py
@@ -8,10 +8,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+from .._schematic import spiral_schematic
 from ..bends.bend_euler import bend_euler180
 from ..containers.component_sequence import component_sequence
 from ..waveguides.straight import straight
-from .._schematic import spiral_schematic
 
 _diagram = r"""
                  | length0   |

--- a/gdsfactory/components/spirals/delay_snake2.py
+++ b/gdsfactory/components/spirals/delay_snake2.py
@@ -9,6 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..containers.component_sequence import component_sequence
+from .._schematic import spiral_schematic
 
 diagram = """
        | length0 | length1 |
@@ -23,7 +24,7 @@ diagram = """
 """
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def delay_snake2(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake2.py
+++ b/gdsfactory/components/spirals/delay_snake2.py
@@ -8,8 +8,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from ..containers.component_sequence import component_sequence
 from .._schematic import spiral_schematic
+from ..containers.component_sequence import component_sequence
 
 diagram = """
        | length0 | length1 |

--- a/gdsfactory/components/spirals/delay_snake_sbend.py
+++ b/gdsfactory/components/spirals/delay_snake_sbend.py
@@ -7,6 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..waveguides.straight import straight
+from .._schematic import spiral_schematic
 
 diagram = r"""
 
@@ -26,7 +27,7 @@ diagram = r"""
 """
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def delay_snake_sbend(
     length: float = 100.0,
     length1: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake_sbend.py
+++ b/gdsfactory/components/spirals/delay_snake_sbend.py
@@ -6,8 +6,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from ..waveguides.straight import straight
 from .._schematic import spiral_schematic
+from ..waveguides.straight import straight
 
 diagram = r"""
 

--- a/gdsfactory/components/spirals/spiral.py
+++ b/gdsfactory/components/spirals/spiral.py
@@ -5,9 +5,12 @@ __all__ = ["spiral"]
 import gdsfactory as gf
 from gdsfactory.cross_section import CrossSectionSpec
 from gdsfactory.typings import ComponentSpec
+from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral(
     length: float = 100,
     bend: ComponentSpec = "bend_euler",

--- a/gdsfactory/components/spirals/spiral.py
+++ b/gdsfactory/components/spirals/spiral.py
@@ -5,9 +5,8 @@ __all__ = ["spiral"]
 import gdsfactory as gf
 from gdsfactory.cross_section import CrossSectionSpec
 from gdsfactory.typings import ComponentSpec
+
 from .._schematic import spiral_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=spiral_schematic)

--- a/gdsfactory/components/spirals/spiral_archimedes.py
+++ b/gdsfactory/components/spirals/spiral_archimedes.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_archimedes.py
+++ b/gdsfactory/components/spirals/spiral_archimedes.py
@@ -7,7 +7,6 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
-from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_double.py
+++ b/gdsfactory/components/spirals/spiral_double.py
@@ -5,6 +5,7 @@ __all__ = ["spiral_double"]
 import gdsfactory as gf
 from gdsfactory.path import spiral_archimedean
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import spiral_schematic
 
 

--- a/gdsfactory/components/spirals/spiral_double.py
+++ b/gdsfactory/components/spirals/spiral_double.py
@@ -5,9 +5,10 @@ __all__ = ["spiral_double"]
 import gdsfactory as gf
 from gdsfactory.path import spiral_archimedean
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_double(
     min_bend_radius: float = 10.0,
     separation: float = 2.0,

--- a/gdsfactory/components/spirals/spiral_fermat.py
+++ b/gdsfactory/components/spirals/spiral_fermat.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_fermat.py
+++ b/gdsfactory/components/spirals/spiral_fermat.py
@@ -7,7 +7,6 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
-from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -22,9 +22,10 @@ from gdsfactory.typings import (
 from ..bends.bend_euler import bend_euler
 from ..bends.bend_s import get_min_sbend_size
 from ..waveguides.straight import straight
+from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_racetrack(
     min_radius: float | None = None,
     straight_length: float = 20.0,
@@ -105,7 +106,7 @@ def spiral_racetrack(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_racetrack_fixed_length(
     length: float = 1000,
     in_out_port_spacing: float = 150,
@@ -312,7 +313,7 @@ def _req_straight_len(
     return float(f(length))
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_racetrack_heater_metal(
     min_radius: float | None = None,
     straight_length: float = 30,
@@ -419,7 +420,7 @@ def spiral_racetrack_heater_metal(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_racetrack_heater_doped(
     min_radius: float | None = None,
     straight_length: float = 30,

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -19,10 +19,10 @@ from gdsfactory.typings import (
     Port,
 )
 
+from .._schematic import spiral_schematic
 from ..bends.bend_euler import bend_euler
 from ..bends.bend_s import get_min_sbend_size
 from ..waveguides.straight import straight
-from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name(schematic_function=spiral_schematic)

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -4,6 +4,7 @@ __all__ = ["spiral_inductor"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+
 from .._schematic import spiral_schematic
 
 

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -4,9 +4,10 @@ __all__ = ["spiral_inductor"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=spiral_schematic)
 def spiral_inductor(
     width: float = 3.0,
     pitch: float = 3.0,

--- a/gdsfactory/components/spirals/spiral_logarithmic.py
+++ b/gdsfactory/components/spirals/spiral_logarithmic.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_logarithmic.py
+++ b/gdsfactory/components/spirals/spiral_logarithmic.py
@@ -7,7 +7,6 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
-from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_rectangular.py
+++ b/gdsfactory/components/spirals/spiral_rectangular.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/spirals/spiral_rectangular.py
+++ b/gdsfactory/components/spirals/spiral_rectangular.py
@@ -7,7 +7,6 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
-from .._schematic import spiral_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/tapers/ramp.py
+++ b/gdsfactory/components/tapers/ramp.py
@@ -5,6 +5,7 @@ __all__ = ["ramp"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+
 from .._schematic import taper_schematic
 
 

--- a/gdsfactory/components/tapers/ramp.py
+++ b/gdsfactory/components/tapers/ramp.py
@@ -5,9 +5,10 @@ __all__ = ["ramp"]
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def ramp(
     length: float = 10.0,
     width1: float = 5.0,

--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -16,9 +16,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.port import Port
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+
 from .._schematic import taper_schematic, transition_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=taper_schematic)

--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -16,9 +16,12 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.port import Port
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
+from .._schematic import taper_schematic, transition_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper(
     length: float = 10.0,
     width1: float = 0.5,
@@ -130,7 +133,7 @@ def taper(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=transition_schematic)
 def taper_strip_to_ridge(
     length: float = 10.0,
     width1: float = 0.5,
@@ -215,7 +218,7 @@ def taper_strip_to_ridge(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=transition_schematic)
 def taper_strip_to_ridge_trenches(
     length: float = 10.0,
     width: float = 0.5,
@@ -266,7 +269,7 @@ def taper_strip_to_ridge_trenches(
 taper_strip_to_slab150 = partial(taper_strip_to_ridge, layer_slab="SLAB150")
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=transition_schematic)
 def taper_sc_nc(
     width1: float = 0.5,
     width2: float = 1,
@@ -302,7 +305,7 @@ def taper_sc_nc(
     )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=transition_schematic)
 def taper_nc_sc(
     width1: float = 1,
     width2: float = 0.5,

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import gdsfactory as gf
 from gdsfactory.path import transition_adiabatic
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import taper_schematic
 
 

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import gdsfactory as gf
 from gdsfactory.path import transition_adiabatic
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import taper_schematic
 
 
 def neff_TE1550SOI_220nm(w: float) -> float:
@@ -45,7 +46,7 @@ def neff_TE1550SOI_220nm(w: float) -> float:
     return float(np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w).item())
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper_adiabatic(
     width1: float = 0.5,
     width2: float = 5.0,

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -12,9 +12,10 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import transition_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=transition_schematic)
 def taper_cross_section(
     cross_section1: CrossSectionSpec = "strip_rib_tip",
     cross_section2: CrossSectionSpec = "rib2",

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -12,6 +12,7 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import transition_schematic
 
 

--- a/gdsfactory/components/tapers/taper_from_csv.py
+++ b/gdsfactory/components/tapers/taper_from_csv.py
@@ -22,11 +22,12 @@ import numpy.typing as npt
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import taper_schematic
 
 data = pathlib.Path(__file__).parent / "csv_data"
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper_from_csv(
     filepath: Path = data / "taper_strip_0p5_3_36.csv",
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/tapers/taper_from_csv.py
+++ b/gdsfactory/components/tapers/taper_from_csv.py
@@ -22,6 +22,7 @@ import numpy.typing as npt
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import taper_schematic
 
 data = pathlib.Path(__file__).parent / "csv_data"

--- a/gdsfactory/components/tapers/taper_hecken.py
+++ b/gdsfactory/components/tapers/taper_hecken.py
@@ -14,6 +14,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
+from .._schematic import taper_schematic
 from ..analog.microstrip import (
     _G,
     _find_microstrip_wire_width,
@@ -22,7 +23,7 @@ from ..analog.microstrip import (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper_hecken(
     length: float = 200,
     B: float = 4.0091,

--- a/gdsfactory/components/tapers/taper_meander.py
+++ b/gdsfactory/components/tapers/taper_meander.py
@@ -14,6 +14,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+
 from .._schematic import taper_schematic
 
 

--- a/gdsfactory/components/tapers/taper_meander.py
+++ b/gdsfactory/components/tapers/taper_meander.py
@@ -14,9 +14,10 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
+from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper_meander(
     x_taper: tuple[float, ...] | None = None,
     w_taper: tuple[float, ...] | None = None,

--- a/gdsfactory/components/tapers/taper_parabolic.py
+++ b/gdsfactory/components/tapers/taper_parabolic.py
@@ -7,6 +7,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.path import transition_exponential
 from gdsfactory.typings import LayerSpec
+
 from .._schematic import taper_schematic
 
 

--- a/gdsfactory/components/tapers/taper_parabolic.py
+++ b/gdsfactory/components/tapers/taper_parabolic.py
@@ -7,9 +7,10 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.path import transition_exponential
 from gdsfactory.typings import LayerSpec
+from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=taper_schematic)
 def taper_parabolic(
     length: float = 20,
     width1: float = 0.5,

--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -11,10 +11,13 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta, LayerSpec
 
+from .._schematic import crossing_schematic
 from ..bends.bend_s import (
     bezier,
     find_min_curv_bezier_control_points,
 )
+
+
 
 
 @gf.cell_with_module_name
@@ -82,7 +85,7 @@ def crossing_arm(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=crossing_schematic)
 def crossing(
     arm: ComponentSpec = crossing_arm,
 ) -> gf.Component:
@@ -102,7 +105,7 @@ def crossing(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=crossing_schematic)
 def crossing_linear_taper(
     width1: float = 2.5,
     width2: float = 0.5,
@@ -127,7 +130,7 @@ def crossing_linear_taper(
     return crossing(arm=arm)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=crossing_schematic)
 def crossing_etched(
     width: float = 0.5,
     r1: float = 3.0,
@@ -201,7 +204,7 @@ def crossing_etched(
     return c
 
 
-@gf.cell(check_instances=CheckInstances.IGNORE, with_module_name=True)
+@gf.cell(check_instances=CheckInstances.IGNORE, with_module_name=True, schematic_function=crossing_schematic)
 def crossing45(
     crossing: ComponentSpec = crossing,
     port_spacing: float = 40.0,

--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -18,8 +18,6 @@ from ..bends.bend_s import (
 )
 
 
-
-
 @gf.cell_with_module_name
 def crossing_arm(
     r1: float = 3.0,
@@ -204,7 +202,11 @@ def crossing_etched(
     return c
 
 
-@gf.cell(check_instances=CheckInstances.IGNORE, with_module_name=True, schematic_function=crossing_schematic)
+@gf.cell(
+    check_instances=CheckInstances.IGNORE,
+    with_module_name=True,
+    schematic_function=crossing_schematic,
+)
 def crossing45(
     crossing: ComponentSpec = crossing,
     port_spacing: float = 40.0,

--- a/gdsfactory/components/waveguides/straight.py
+++ b/gdsfactory/components/waveguides/straight.py
@@ -7,9 +7,8 @@ __all__ = ["straight", "straight_all_angle", "straight_array", "wire_straight"]
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.typings import CrossSectionSpec
+
 from .._schematic import straight_schematic, wire_schematic
-
-
 
 
 @gf.cell_with_module_name(schematic_function=straight_schematic)

--- a/gdsfactory/components/waveguides/straight.py
+++ b/gdsfactory/components/waveguides/straight.py
@@ -7,9 +7,12 @@ __all__ = ["straight", "straight_all_angle", "straight_array", "wire_straight"]
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.typings import CrossSectionSpec
+from .._schematic import straight_schematic, wire_schematic
 
 
-@gf.cell_with_module_name
+
+
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight(
     length: float = 10.0,
     npoints: int = 2,
@@ -106,7 +109,7 @@ def straight_array(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=wire_schematic)
 def wire_straight(
     length: float = 10.0,
     npoints: int = 2,

--- a/gdsfactory/components/waveguides/straight_heater_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_doped.py
@@ -6,6 +6,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Size
+
 from .._schematic import straight_schematic
 
 

--- a/gdsfactory/components/waveguides/straight_heater_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_doped.py
@@ -6,9 +6,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Size
+from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_doped_rib(
     length: float = 320.0,
     nsections: int = 3,
@@ -181,7 +182,7 @@ def straight_heater_doped_rib(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_doped_strip(
     length: float = 320.0,
     nsections: int = 3,

--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -9,6 +9,7 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpec, Port
+
 from .._schematic import straight_schematic
 
 

--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -9,9 +9,10 @@ import numpy as np
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpec, Port
+from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_meander(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_meander_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander_doped.py
@@ -14,6 +14,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpe
 
 from ..vias.via import via
 from ..vias.via_stack import via_stack
+from .._schematic import straight_schematic
 
 _via_stack = partial(
     via_stack,
@@ -38,7 +39,7 @@ _via_stack = partial(
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_meander_doped(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_meander_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander_doped.py
@@ -12,9 +12,9 @@ from gdsfactory.component import Component, ComponentReference
 from gdsfactory.cross_section import Section
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpecs, Port
 
+from .._schematic import straight_schematic
 from ..vias.via import via
 from ..vias.via_stack import via_stack
-from .._schematic import straight_schematic
 
 _via_stack = partial(
     via_stack,

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -15,9 +15,10 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from ..containers.component_sequence import component_sequence
+from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_metal_undercut(
     length: float = 320.0,
     length_undercut_spacing: float = 6.0,
@@ -168,7 +169,7 @@ def straight_heater_metal_undercut(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=straight_schematic)
 def straight_heater_metal_simple(
     length: float = 320.0,
     cross_section_heater: CrossSectionSpec = "heater_metal",

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -14,8 +14,8 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from ..containers.component_sequence import component_sequence
 from .._schematic import straight_schematic
+from ..containers.component_sequence import component_sequence
 
 
 @gf.cell_with_module_name(schematic_function=straight_schematic)

--- a/gdsfactory/components/waveguides/straight_piecewise.py
+++ b/gdsfactory/components/waveguides/straight_piecewise.py
@@ -11,7 +11,6 @@ from gdsfactory.component import Component
 from gdsfactory.cross_section import Section
 from gdsfactory.path import Path
 from gdsfactory.typings import LayerSpec
-from .._schematic import straight_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/waveguides/straight_piecewise.py
+++ b/gdsfactory/components/waveguides/straight_piecewise.py
@@ -11,6 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.cross_section import Section
 from gdsfactory.path import Path
 from gdsfactory.typings import LayerSpec
+from .._schematic import straight_schematic
 
 
 @gf.cell_with_module_name

--- a/gdsfactory/components/waveguides/straight_pin.py
+++ b/gdsfactory/components/waveguides/straight_pin.py
@@ -10,6 +10,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.cross_section import pin
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import modulator_schematic
 
 

--- a/gdsfactory/components/waveguides/straight_pin.py
+++ b/gdsfactory/components/waveguides/straight_pin.py
@@ -10,9 +10,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.cross_section import pin
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=modulator_schematic)
 def straight_pin(
     length: float = 500.0,
     cross_section: CrossSectionSpec = pin,

--- a/gdsfactory/components/waveguides/straight_pin_slot.py
+++ b/gdsfactory/components/waveguides/straight_pin_slot.py
@@ -10,6 +10,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.cross_section import pn
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+
 from .._schematic import modulator_schematic
 
 

--- a/gdsfactory/components/waveguides/straight_pin_slot.py
+++ b/gdsfactory/components/waveguides/straight_pin_slot.py
@@ -10,9 +10,10 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.cross_section import pn
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(schematic_function=modulator_schematic)
 def straight_pin_slot(
     length: float = 500.0,
     cross_section: CrossSectionSpec = "pin",

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -550,7 +550,7 @@ class LayerStack(BaseModel):
             if level.derived_layer:
                 unetched_layers_dict[level.derived_layer.layer].append(layer_name)
                 if level.derived_layer.layer in unetched_layers:
-                    unetched_layers.remove(level.derived_layer.layer)
+                    unetched_layers.remove(level.derived_layer.layer)  # type: ignore[arg-type]
 
         # Define layers
         out += "\n".join(

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -549,8 +549,9 @@ class LayerStack(BaseModel):
             level = layers[layer_name]
             if level.derived_layer:
                 unetched_layers_dict[level.derived_layer.layer].append(layer_name)
-                if level.derived_layer.layer in unetched_layers:
-                    unetched_layers.remove(level.derived_layer.layer)  # type: ignore[arg-type]
+                derived = level.derived_layer.layer
+                if isinstance(derived, str) and derived in unetched_layers:
+                    unetched_layers.remove(derived)
 
         # Define layers
         out += "\n".join(

--- a/tests/test-data-regression/test_settings_array_polar_.yml
+++ b/tests/test-data-regression/test_settings_array_polar_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: array_polar_CC_NI6_R50_SA0_EA360_RITrue_APTrue
+name: array_polar_gdsfactorypcomponentspcontainersparray_pola_983b73dc
 settings:
   add_ports: true
   component: C

--- a/tests/test-data-regression/test_settings_crossing45_.yml
+++ b/tests/test-data-regression/test_settings_crossing45_.yml
@@ -1,7 +1,7 @@
 info:
   bezier_length: 42.085
   min_bend_radius: 44.312
-name: crossing45_Ccrossing_PS40_DNone_A0p08_N101_CSstrip_CSBstrip
+name: crossing45_gdsfactorypcomponentspwaveguidespcrossing_wa_631c2603
 settings:
   alpha: 0.08
   cross_section: strip


### PR DESCRIPTION
## Summary

- Add schematic metadata (symbol, tags, ports) to 99 of 265 generic PDK cell factories, enabling the gfp+ server to generate `models.nyanlib` entries for use by the Mosaic schematic editor.
- New shared `_schematic.py` module with reusable schematic function factories for common photonic port patterns.
- Fix `cell` decorator to correctly apply `with_module_name` when used with keyword arguments like `schematic_function=`.

### Symbol coverage (99 factories across 22 types)

| Symbol | # | Examples |
|---|---|---|
| `spiral` | 10 | spiral, delay_snake, spiral_racetrack_heater_metal |
| `coupler` | 9 | coupler, coupler90, coupler_full |
| `straight` | 8 | straight, straight_heater_metal_simple |
| `grating-coupler` | 7 | grating_coupler_elliptical, edge_coupler_silicon |
| `taper` | 7 | taper, taper_adiabatic, taper_parabolic |
| `ring-single` | 6 | ring_single, disk, ring_single_pn |
| `ring-double` | 6 | ring_double, ring_crow, ring_double_heater |
| `mzi-2x2` | 5 | mzi, mzi_lattice, mzit |
| `sbend` | 4 | bend_s, bezier, bend_euler_s |
| `mmi-1x2` | 4 | mmi1x2, mmi_tapered, coupler_asymmetric |
| `bend` | 3 | bend_euler, bend_circular |
| `crossing` | 4 | crossing, crossing45, crossing_etched |
| `ckt` | 3 | mmi (NxM), mmi_90degree_hybrid, mode_converter |
| Others | 23 | pad, modulator, terminator, photodiode, inductor, capacitor, transition, mmi-2x2, coupler-ring |

## Test plan

- [x] All 322 `test_settings` tests pass
- [x] All 99 annotated cells generate correctly with proper port counts
- [x] Schematic info accessible via `kfactory.kcl.factories[name].get_schematic().info`
- [ ] Verify nyanlib generation in gfp+ server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add shared schematic metadata utilities and annotate numerous generic PDK cell factories so their photonic and electrical ports, symbols, and tags are available for schematic generation, while fixing the cell decorator to handle module-name decoration when used with schematic functions.

New Features:
- Introduce a reusable _schematic module that defines common schematic metadata patterns and factory functions for standard photonic components such as straights, bends, tapers, rings, couplers, gratings, spirals, pads, inductors, capacitors, modulators, and photodiodes.
- Attach schematic_function metadata to many existing component factories (e.g., waveguides, bends, couplers, rings, MMIs, MZIs, gratings, spirals, pads, terminators, inductors, capacitors, detectors) to expose consistent schematic symbols and ports.
- Expose schematic information for components through the existing cell factory mechanism by wiring schematic functions into cell_with_module_name and cell decorators.

Bug Fixes:
- Correct the cell decorator so with_module_name is applied properly when schematic_function or other keyword arguments are provided, fixing factory naming for such cells.
- Update regression expectations for components whose generated names change due to the corrected with_module_name handling.

Enhancements:
- Standardize schematic port layouts and tagging for key photonic building blocks to support downstream schematic editors and library generation.