### PR TITLE
fix: copy __pydantic_extra__ in Pdk.__init__

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -200,6 +200,7 @@ class Pdk(BaseModel):
             object.__setattr__(
                 self, "__pydantic_private__", {"_layer_views_cache": None}
             )
+        object.__setattr__(self, "__pydantic_extra__", constructed.__pydantic_extra__)
         self.model_post_init(None)
 
     def model_post_init(self, context: Any) -> None:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -200,7 +200,9 @@ class Pdk(BaseModel):
             object.__setattr__(
                 self, "__pydantic_private__", {"_layer_views_cache": None}
             )
-        object.__setattr__(self, "__pydantic_extra__", constructed.__pydantic_extra__)
+        object.__setattr__(
+            self, "__pydantic_extra__", getattr(constructed, "__pydantic_extra__", None)
+        )
         self.model_post_init(None)
 
     def model_post_init(self, context: Any) -> None:

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -35,3 +35,15 @@ def test_container_cell_conflict_raises_error() -> None:
 
     with pytest.raises(ValueError, match=r".* overlapping cell names .*add_pads_top.*"):
         pdk.get_component("add_pads_top")
+
+
+def test_pdk_copy() -> None:
+    """Regression test for #4485: copy.copy(pdk) must not raise AttributeError."""
+    import copy
+
+    pdk = gf.Pdk(
+        name="test",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    copy.copy(pdk)


### PR DESCRIPTION
Closes #4485.

## Summary
- Add the missing `object.__setattr__(self, "__pydantic_extra__", constructed.__pydantic_extra__)` in `Pdk.__init__` alongside the existing `__pydantic_private__` copy
- Add `test_pdk_copy` regression test covering `copy.copy(pdk)`

The custom `Pdk.__init__` introduced in 9.40.0 (#4465) builds a model via `model_construct` and copies `__dict__`, `__pydantic_fields_set__`, and `__pydantic_private__` onto `self` — but leaves `__pydantic_extra__` uninitialised. pydantic's `BaseModel.__copy__` accesses `self.__pydantic_extra__` directly, so any `copy.copy(pdk)` raises `AttributeError`. This breaks downstream consumers that snapshot the active PDK during hot reload.

## Test plan
- [x] `pytest tests/test_pdk.py::test_pdk_copy` passes with the fix
- [x] Same test fails on `main` without the fix (confirming it is a real regression test)
- [x] `pre-commit run --files gdsfactory/pdk.py tests/test_pdk.py` clean

## Summary by Sourcery

Ensure Pdk instances correctly copy all pydantic internal state and add a regression test to prevent AttributeError when copying a Pdk.

Bug Fixes:
- Copy the missing __pydantic_extra__ attribute in Pdk.__init__ so that copy.copy(pdk) no longer raises AttributeError.

Tests:
- Add a regression test verifying that copy.copy on a Pdk instance succeeds without errors.