### PR TITLE
ci: pin python-version on type_consistency setup-uv

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
       - run: make install
       - run: uv run mypy gdsfactory/
 


### PR DESCRIPTION
## Summary

The `type_consistency` job was the only step in `test_code.yml` without a `python-version` input on `astral-sh/setup-uv@v7`. Without a pin, uv picked a default Python (3.12 in practice) that didn't match the lockfile's resolution target, so `uv sync --all-extras --no-extra full` pulled **tifffile 2026.4.11** (released 2026-04-12, `requires_python >= 3.12`) instead of the locked **2026.3.3**.

tifffile 2026.4.11 uses Python 3.12's `type` statement, which mypy (configured for `python_version = "3.11"`) rejects:

```
.venv/lib/python3.12/site-packages/tifffile/tifffile.py:945: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

This started failing every PR filed after 2026-04-12, including #4486 and #fix-code-scanning-alerts, even though those PRs don't touch tifffile or mypy config.

Pinning `setup-uv` to 3.11 matches:

- `[tool.mypy].python_version = "3.11"`
- `[tool.pyright].pythonVersion = "3.11"`
- the `test_code_coverage` job (which already pins 3.11)

With Python 3.11, uv's resolver excludes tifffile 2026.4.11 and installs the locked 2026.3.3, resolving the CI failure at the root.

## Test plan
- [x] `pre-commit run --files .github/workflows/test_code.yml` clean
- [x] `type_consistency` job passes on this PR

## Summary by Sourcery

CI:
- Configure astral-sh/setup-uv in the type_consistency job to use Python 3.11 in the test_code workflow.