### PR TITLE
Add type tags to all cell decorated components

### DIFF
--- a/gdsfactory/components/analog/inductors.py
+++ b/gdsfactory/components/analog/inductors.py
@@ -27,7 +27,9 @@ def inductor_min_diameter(width: float, space: float, turns: int, grid: float) -
     return round(min_d / grid) * grid
 
 
-@gf.cell_with_module_name(schematic_function=inductor_schematic)
+@gf.cell_with_module_name(
+    schematic_function=inductor_schematic, tags={"type": "analog"}
+)
 def inductor(
     width: float = 2.0,
     space: float = 2.1,

--- a/gdsfactory/components/analog/inductors.py
+++ b/gdsfactory/components/analog/inductors.py
@@ -27,9 +27,7 @@ def inductor_min_diameter(width: float, space: float, turns: int, grid: float) -
     return round(min_d / grid) * grid
 
 
-@gf.cell_with_module_name(
-    schematic_function=inductor_schematic, tags={"type": "analog"}
-)
+@gf.cell_with_module_name(schematic_function=inductor_schematic, tags=["analog"])
 def inductor(
     width: float = 2.0,
     space: float = 2.1,

--- a/gdsfactory/components/analog/interdigital_capacitor.py
+++ b/gdsfactory/components/analog/interdigital_capacitor.py
@@ -12,7 +12,9 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import capacitor_schematic
 
 
-@gf.cell_with_module_name(schematic_function=capacitor_schematic)
+@gf.cell_with_module_name(
+    schematic_function=capacitor_schematic, tags={"type": "analog"}
+)
 def interdigital_capacitor(
     fingers: int = 4,
     finger_length: float | int = 20.0,

--- a/gdsfactory/components/analog/interdigital_capacitor.py
+++ b/gdsfactory/components/analog/interdigital_capacitor.py
@@ -12,9 +12,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import capacitor_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=capacitor_schematic, tags={"type": "analog"}
-)
+@gf.cell_with_module_name(schematic_function=capacitor_schematic, tags=["analog"])
 def interdigital_capacitor(
     fingers: int = 4,
     finger_length: float | int = 20.0,

--- a/gdsfactory/components/analog/interdigitated_electrodes.py
+++ b/gdsfactory/components/analog/interdigitated_electrodes.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "analog"})
+@gf.cell_with_module_name(tags=["analog"])
 def interdigitated_electrodes(
     n_fingers: int = 10,
     finger_width: float = 0.5,

--- a/gdsfactory/components/analog/interdigitated_electrodes.py
+++ b/gdsfactory/components/analog/interdigitated_electrodes.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "analog"})
 def interdigitated_electrodes(
     n_fingers: int = 10,
     finger_width: float = 0.5,

--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -113,7 +113,7 @@ def _bend_circular(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags=["bends"])
 def bend_circular(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -113,7 +113,7 @@ def _bend_circular(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic)
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
 def bend_circular(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_circular_heater.py
+++ b/gdsfactory/components/bends/bend_circular_heater.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec
 from .._schematic import bend_schematic
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic)
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
 def bend_circular_heater(
     radius: float | None = None,
     angle: float = 90,

--- a/gdsfactory/components/bends/bend_circular_heater.py
+++ b/gdsfactory/components/bends/bend_circular_heater.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec
 from .._schematic import bend_schematic
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags=["bends"])
 def bend_circular_heater(
     radius: float | None = None,
     angle: float = 90,

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -144,7 +144,7 @@ def _bend_euler(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic)
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
 def bend_euler_s(
     radius: float | None = None,
     p: float = 0.5,
@@ -210,7 +210,7 @@ def bend_euler_s(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic)
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
 def bend_euler(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -144,7 +144,7 @@ def _bend_euler(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags=["bends"])
 def bend_euler_s(
     radius: float | None = None,
     p: float = 0.5,
@@ -210,7 +210,7 @@ def bend_euler_s(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=bend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=bend_schematic, tags=["bends"])
 def bend_euler(
     radius: float | None = None,
     angle: float = 90.0,

--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -39,7 +39,7 @@ def bezier_curve(
     return np.column_stack([xs, ys])
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags=["bends"])
 def bezier(
     control_points: Coordinates = ((0.0, 0.0), (5.0, 0.0), (5.0, 1.8), (10.0, 1.8)),
     npoints: int = 201,
@@ -162,7 +162,7 @@ def find_min_curv_bezier_control_points(
     return tuple(points)
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags=["bends"])
 def bend_s(
     size: Size = (11.0, 1.8),
     npoints: int = 99,
@@ -248,7 +248,7 @@ def _get_euler_sbend_angle_middle_length_from_jog(
     return angle_deg, middle_length
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags=["bends"])
 def bend_s_offset(
     offset: float = 40.0,
     radius: float | None = 10.0,

--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -39,7 +39,7 @@ def bezier_curve(
     return np.column_stack([xs, ys])
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic)
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
 def bezier(
     control_points: Coordinates = ((0.0, 0.0), (5.0, 0.0), (5.0, 1.8), (10.0, 1.8)),
     npoints: int = 201,
@@ -162,7 +162,7 @@ def find_min_curv_bezier_control_points(
     return tuple(points)
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic)
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
 def bend_s(
     size: Size = (11.0, 1.8),
     npoints: int = 99,
@@ -248,7 +248,7 @@ def _get_euler_sbend_angle_middle_length_from_jog(
     return angle_deg, middle_length
 
 
-@gf.cell_with_module_name(schematic_function=sbend_schematic)
+@gf.cell_with_module_name(schematic_function=sbend_schematic, tags={"type": "bends"})
 def bend_s_offset(
     offset: float = 40.0,
     radius: float | None = 10.0,

--- a/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def add_fiber_array_optical_south_electrical_north(
     component: ComponentSpec = "straight_heater_metal",
     pad: ComponentSpec = "pad",

--- a/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
+++ b/gdsfactory/components/containers/add_fiber_array_optical_south_electrical_north.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def add_fiber_array_optical_south_electrical_north(
     component: ComponentSpec = "straight_heater_metal",
     pad: ComponentSpec = "pad",

--- a/gdsfactory/components/containers/add_termination.py
+++ b/gdsfactory/components/containers/add_termination.py
@@ -13,7 +13,7 @@ from ..tapers.taper import taper
 _terminator_function = partial(taper, width2=0.1)
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def add_termination(
     component: ComponentSpec = "straight",
     port_names: tuple[str, ...] | None = None,

--- a/gdsfactory/components/containers/add_termination.py
+++ b/gdsfactory/components/containers/add_termination.py
@@ -13,7 +13,7 @@ from ..tapers.taper import taper
 _terminator_function = partial(taper, width2=0.1)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def add_termination(
     component: ComponentSpec = "straight",
     port_names: tuple[str, ...] | None = None,

--- a/gdsfactory/components/containers/add_trenches.py
+++ b/gdsfactory/components/containers/add_trenches.py
@@ -8,7 +8,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def add_trenches(
     component: ComponentSpec = "coupler",
     layer_component: LayerSpec = "WG",

--- a/gdsfactory/components/containers/add_trenches.py
+++ b/gdsfactory/components/containers/add_trenches.py
@@ -8,7 +8,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def add_trenches(
     component: ComponentSpec = "coupler",
     layer_component: LayerSpec = "WG",

--- a/gdsfactory/components/containers/array_component.py
+++ b/gdsfactory/components/containers/array_component.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, PostProcesses, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def array(
     component: ComponentSpec = "pad",
     columns: int = 6,

--- a/gdsfactory/components/containers/array_component.py
+++ b/gdsfactory/components/containers/array_component.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, PostProcesses, Size
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def array(
     component: ComponentSpec = "pad",
     columns: int = 6,

--- a/gdsfactory/components/containers/array_hexagonal.py
+++ b/gdsfactory/components/containers/array_hexagonal.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def array_hexagonal(
     component: ComponentSpec = "circle",
     columns: int = 10,

--- a/gdsfactory/components/containers/array_hexagonal.py
+++ b/gdsfactory/components/containers/array_hexagonal.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def array_hexagonal(
     component: ComponentSpec = "circle",
     columns: int = 10,

--- a/gdsfactory/components/containers/array_polar.py
+++ b/gdsfactory/components/containers/array_polar.py
@@ -13,7 +13,7 @@ from gdsfactory.typings import ComponentSpec
 @gf.cell(
     with_module_name=True,
     check_instances=CheckInstances.IGNORE,
-    tags={"type": "containers"},
+    tags=["containers"],
 )
 def array_polar(
     component: ComponentSpec = "C",

--- a/gdsfactory/components/containers/array_polar.py
+++ b/gdsfactory/components/containers/array_polar.py
@@ -10,7 +10,11 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell(with_module_name=True, check_instances=CheckInstances.IGNORE)
+@gf.cell(
+    with_module_name=True,
+    check_instances=CheckInstances.IGNORE,
+    tags={"type": "containers"},
+)
 def array_polar(
     component: ComponentSpec = "C",
     n_items: int = 6,

--- a/gdsfactory/components/containers/copy_layers.py
+++ b/gdsfactory/components/containers/copy_layers.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpecs
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def copy_layers(
     factory: ComponentSpec = "cross",
     layers: LayerSpecs = ((1, 0), (2, 0)),

--- a/gdsfactory/components/containers/copy_layers.py
+++ b/gdsfactory/components/containers/copy_layers.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpecs
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def copy_layers(
     factory: ComponentSpec = "cross",
     layers: LayerSpecs = ((1, 0), (2, 0)),

--- a/gdsfactory/components/containers/extend_ports_list.py
+++ b/gdsfactory/components/containers/extend_ports_list.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Strs
 
 
-@gf.cell(set_name=False)
+@gf.cell(set_name=False, tags={"type": "containers"})
 def extend_ports_list(
     component_spec: ComponentSpec,
     extension: ComponentSpec,

--- a/gdsfactory/components/containers/extend_ports_list.py
+++ b/gdsfactory/components/containers/extend_ports_list.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Strs
 
 
-@gf.cell(set_name=False, tags={"type": "containers"})
+@gf.cell(set_name=False, tags=["containers"])
 def extend_ports_list(
     component_spec: ComponentSpec,
     extension: ComponentSpec,

--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -84,7 +84,7 @@ def move_polar_rad_copy(
     return np.array([pos[0] + dx, pos[1] + dy], dtype=float)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def extend_ports(
     component: ComponentSpec = "mmi1x2",
     port_names: PortNames | None = None,

--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -84,7 +84,7 @@ def move_polar_rad_copy(
     return np.array([pos[0] + dx, pos[1] + dy], dtype=float)
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def extend_ports(
     component: ComponentSpec = "mmi1x2",
     port_names: PortNames | None = None,

--- a/gdsfactory/components/containers/pack_doe.py
+++ b/gdsfactory/components/containers/pack_doe.py
@@ -54,7 +54,7 @@ def generate_doe(
     return component_list, settings_list
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def pack_doe(
     doe: ComponentSpec | None = None,
     settings: Mapping[str, Sequence[kf.typings.MetaData]] | None = None,
@@ -108,7 +108,7 @@ def pack_doe(
     return component
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def pack_doe_grid(
     doe: ComponentSpec | None = None,
     settings: Mapping[str, Sequence[kf.typings.MetaData]] | None = None,

--- a/gdsfactory/components/containers/pack_doe.py
+++ b/gdsfactory/components/containers/pack_doe.py
@@ -54,7 +54,7 @@ def generate_doe(
     return component_list, settings_list
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def pack_doe(
     doe: ComponentSpec | None = None,
     settings: Mapping[str, Sequence[kf.typings.MetaData]] | None = None,
@@ -108,7 +108,7 @@ def pack_doe(
     return component
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def pack_doe_grid(
     doe: ComponentSpec | None = None,
     settings: Mapping[str, Sequence[kf.typings.MetaData]] | None = None,

--- a/gdsfactory/components/containers/splitter_chain.py
+++ b/gdsfactory/components/containers/splitter_chain.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def splitter_chain(
     splitter: ComponentSpec = "mmi1x2",
     columns: int = 3,

--- a/gdsfactory/components/containers/splitter_chain.py
+++ b/gdsfactory/components/containers/splitter_chain.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def splitter_chain(
     splitter: ComponentSpec = "mmi1x2",
     columns: int = 3,

--- a/gdsfactory/components/containers/splitter_tree.py
+++ b/gdsfactory/components/containers/splitter_tree.py
@@ -29,7 +29,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Spacing
 from ..mzis import mzi1x2_2x2
 
 
-@gf.cell_with_module_name(tags={"type": "containers"})
+@gf.cell_with_module_name(tags=["containers"])
 def splitter_tree(
     coupler: ComponentSpec = "mmi1x2",
     noutputs: int = 4,

--- a/gdsfactory/components/containers/splitter_tree.py
+++ b/gdsfactory/components/containers/splitter_tree.py
@@ -29,7 +29,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Spacing
 from ..mzis import mzi1x2_2x2
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "containers"})
 def splitter_tree(
     coupler: ComponentSpec = "mmi1x2",
     noutputs: int = 4,

--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "couplers"})
 def coupler_symmetric(
     bend: ComponentSpec = "bend_s",
     gap: float = 0.234,
@@ -77,7 +77,9 @@ def coupler_symmetric(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_straight(
     length: float = 10.0,
     gap: float = 0.27,
@@ -117,7 +119,9 @@ def coupler_straight(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler(
     gap: float = 0.236,
     length: float = 20.0,

--- a/gdsfactory/components/couplers/coupler.py
+++ b/gdsfactory/components/couplers/coupler.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Delta
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(tags={"type": "couplers"})
+@gf.cell_with_module_name(tags=["couplers"])
 def coupler_symmetric(
     bend: ComponentSpec = "bend_s",
     gap: float = 0.234,
@@ -77,9 +77,7 @@ def coupler_symmetric(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_straight(
     length: float = 10.0,
     gap: float = 0.27,
@@ -119,9 +117,7 @@ def coupler_straight(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler(
     gap: float = 0.236,
     length: float = 20.0,

--- a/gdsfactory/components/couplers/coupler90.py
+++ b/gdsfactory/components/couplers/coupler90.py
@@ -11,9 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler90(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler90.py
+++ b/gdsfactory/components/couplers/coupler90.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler90(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler90bend.py
+++ b/gdsfactory/components/couplers/coupler90bend.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler90bend(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/couplers/coupler90bend.py
+++ b/gdsfactory/components/couplers/coupler90bend.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler90bend(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/couplers/coupler_adiabatic.py
+++ b/gdsfactory/components/couplers/coupler_adiabatic.py
@@ -10,7 +10,9 @@ from .._schematic import coupler_schematic
 from ..bends.bend_s import bezier
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_adiabatic(
     length1: float = 20.0,
     length2: float = 50.0,

--- a/gdsfactory/components/couplers/coupler_adiabatic.py
+++ b/gdsfactory/components/couplers/coupler_adiabatic.py
@@ -10,9 +10,7 @@ from .._schematic import coupler_schematic
 from ..bends.bend_s import bezier
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_adiabatic(
     length1: float = 20.0,
     length2: float = 50.0,

--- a/gdsfactory/components/couplers/coupler_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_asymmetric.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import CrossSectionSpec, Delta
 from .._schematic import mmi_1x2_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=mmi_1x2_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags=["couplers"])
 def coupler_asymmetric(
     gap: float = 0.234,
     dy: Delta = 2.5,

--- a/gdsfactory/components/couplers/coupler_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_asymmetric.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import CrossSectionSpec, Delta
 from .._schematic import mmi_1x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
+@gf.cell_with_module_name(
+    schematic_function=mmi_1x2_schematic, tags={"type": "couplers"}
+)
 def coupler_asymmetric(
     gap: float = 0.234,
     dy: Delta = 2.5,

--- a/gdsfactory/components/couplers/coupler_bent.py
+++ b/gdsfactory/components/couplers/coupler_bent.py
@@ -7,7 +7,7 @@ import gdsfactory as gf
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "couplers"})
 def coupler_bent_half(
     gap: float = 0.200,
     radius: float = 26,
@@ -82,7 +82,9 @@ def coupler_bent_half(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_bent(
     gap: float = 0.200,
     radius: float = 26,

--- a/gdsfactory/components/couplers/coupler_bent.py
+++ b/gdsfactory/components/couplers/coupler_bent.py
@@ -7,7 +7,7 @@ import gdsfactory as gf
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(tags={"type": "couplers"})
+@gf.cell_with_module_name(tags=["couplers"])
 def coupler_bent_half(
     gap: float = 0.200,
     radius: float = 26,
@@ -82,9 +82,7 @@ def coupler_bent_half(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_bent(
     gap: float = 0.200,
     radius: float = 26,

--- a/gdsfactory/components/couplers/coupler_broadband.py
+++ b/gdsfactory/components/couplers/coupler_broadband.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_broadband(
     w_sc: float = 0.5,  # width of waveguides in the symmetric coupler section
     gap_sc: float = 0.2,  # gap size between the waveguides in the symmetric coupler section

--- a/gdsfactory/components/couplers/coupler_broadband.py
+++ b/gdsfactory/components/couplers/coupler_broadband.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_broadband(
     w_sc: float = 0.5,  # width of waveguides in the symmetric coupler section
     gap_sc: float = 0.2,  # gap size between the waveguides in the symmetric coupler section

--- a/gdsfactory/components/couplers/coupler_full.py
+++ b/gdsfactory/components/couplers/coupler_full.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import CrossSectionSpec, Delta
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_full(
     coupling_length: float = 40.0,
     dx: Delta = 10.0,

--- a/gdsfactory/components/couplers/coupler_full.py
+++ b/gdsfactory/components/couplers/coupler_full.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import CrossSectionSpec, Delta
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_full(
     coupling_length: float = 40.0,
     dx: Delta = 10.0,

--- a/gdsfactory/components/couplers/coupler_pulley.py
+++ b/gdsfactory/components/couplers/coupler_pulley.py
@@ -29,7 +29,7 @@ def _cubic_bezier(
     return result
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "couplers"})
 def coupler_pulley(
     radius: float = 10.0,
     ring_width: float | None = None,

--- a/gdsfactory/components/couplers/coupler_pulley.py
+++ b/gdsfactory/components/couplers/coupler_pulley.py
@@ -29,7 +29,7 @@ def _cubic_bezier(
     return result
 
 
-@gf.cell_with_module_name(tags={"type": "couplers"})
+@gf.cell_with_module_name(tags=["couplers"])
 def coupler_pulley(
     radius: float = 10.0,
     ring_width: float | None = None,

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -11,9 +11,7 @@ from ..couplers.coupler import coupler_straight
 from ..couplers.coupler90 import coupler90
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_ring_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_ring_schematic, tags=["couplers"])
 def coupler_ring(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler_ring.py
+++ b/gdsfactory/components/couplers/coupler_ring.py
@@ -11,7 +11,9 @@ from ..couplers.coupler import coupler_straight
 from ..couplers.coupler90 import coupler90
 
 
-@gf.cell_with_module_name(schematic_function=coupler_ring_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_ring_schematic, tags={"type": "couplers"}
+)
 def coupler_ring(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/couplers/coupler_straight_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_straight_asymmetric.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_schematic, tags={"type": "couplers"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["couplers"])
 def coupler_straight_asymmetric(
     length: float = 10.0,
     gap: float = 0.27,

--- a/gdsfactory/components/couplers/coupler_straight_asymmetric.py
+++ b/gdsfactory/components/couplers/coupler_straight_asymmetric.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_schematic, tags={"type": "couplers"}
+)
 def coupler_straight_asymmetric(
     length: float = 10.0,
     gap: float = 0.27,

--- a/gdsfactory/components/detectors/detector_ge.py
+++ b/gdsfactory/components/detectors/detector_ge.py
@@ -11,9 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import photodiode_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=photodiode_schematic, tags={"type": "detectors"}
-)
+@gf.cell_with_module_name(schematic_function=photodiode_schematic, tags=["detectors"])
 def ge_detector_straight_si_contacts(
     length: float = 40.0,
     cross_section: CrossSectionSpec = "pn_ge_detector_si_contacts",

--- a/gdsfactory/components/detectors/detector_ge.py
+++ b/gdsfactory/components/detectors/detector_ge.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import photodiode_schematic
 
 
-@gf.cell_with_module_name(schematic_function=photodiode_schematic)
+@gf.cell_with_module_name(
+    schematic_function=photodiode_schematic, tags={"type": "detectors"}
+)
 def ge_detector_straight_si_contacts(
     length: float = 40.0,
     cross_section: CrossSectionSpec = "pn_ge_detector_si_contacts",

--- a/gdsfactory/components/dies/align.py
+++ b/gdsfactory/components/dies/align.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def align_wafer(
     width: float = 10.0,
     spacing: float = 10.0,
@@ -72,7 +72,7 @@ def align_wafer(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def add_frame(
     component: ComponentSpec = "rectangle",
     width: float = 10.0,

--- a/gdsfactory/components/dies/align.py
+++ b/gdsfactory/components/dies/align.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def align_wafer(
     width: float = 10.0,
     spacing: float = 10.0,
@@ -72,7 +72,7 @@ def align_wafer(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def add_frame(
     component: ComponentSpec = "rectangle",
     width: float = 10.0,

--- a/gdsfactory/components/dies/die.py
+++ b/gdsfactory/components/dies/die.py
@@ -10,7 +10,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, Float2, LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def die(
     size: Size = (10000.0, 10000.0),
     street_width: float = 100.0,

--- a/gdsfactory/components/dies/die.py
+++ b/gdsfactory/components/dies/die.py
@@ -10,7 +10,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, Float2, LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def die(
     size: Size = (10000.0, 10000.0),
     street_width: float = 100.0,

--- a/gdsfactory/components/dies/die_frame_with_pads.py
+++ b/gdsfactory/components/dies/die_frame_with_pads.py
@@ -12,7 +12,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2, LayerSpec, Size
 
 
-@gf.cell(tags={"type": "dies"})
+@gf.cell(tags=["dies"])
 def die_frame(
     size: Size = (11200.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
@@ -22,7 +22,7 @@ def die_frame(
     )
 
 
-@gf.cell(tags={"type": "dies"})
+@gf.cell(tags=["dies"])
 def die_frame_rf(
     size: Size = (10400.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
@@ -32,7 +32,7 @@ def die_frame_rf(
     )
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def die_frame_with_pads(
     die_frame: ComponentSpec = "die_frame",
     ngratings: int = 14,
@@ -383,7 +383,7 @@ def die_frame_phix(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def die_frame_phix_dc(
     die_frame: ComponentSpec = "die_frame",
     nfibers: int = 32,
@@ -446,7 +446,7 @@ def die_frame_phix_dc(
     )
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def die_frame_phix_rf(
     die_frame: ComponentSpec = "die_frame_rf",
     nfibers: int = 32,

--- a/gdsfactory/components/dies/die_frame_with_pads.py
+++ b/gdsfactory/components/dies/die_frame_with_pads.py
@@ -12,7 +12,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2, LayerSpec, Size
 
 
-@gf.cell
+@gf.cell(tags={"type": "dies"})
 def die_frame(
     size: Size = (11200.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
@@ -22,7 +22,7 @@ def die_frame(
     )
 
 
-@gf.cell
+@gf.cell(tags={"type": "dies"})
 def die_frame_rf(
     size: Size = (10400.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
@@ -32,7 +32,7 @@ def die_frame_rf(
     )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def die_frame_with_pads(
     die_frame: ComponentSpec = "die_frame",
     ngratings: int = 14,
@@ -383,7 +383,7 @@ def die_frame_phix(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def die_frame_phix_dc(
     die_frame: ComponentSpec = "die_frame",
     nfibers: int = 32,
@@ -446,7 +446,7 @@ def die_frame_phix_dc(
     )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def die_frame_phix_rf(
     die_frame: ComponentSpec = "die_frame_rf",
     nfibers: int = 32,

--- a/gdsfactory/components/dies/die_with_pads.py
+++ b/gdsfactory/components/dies/die_with_pads.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def die_with_pads(
     size: Size = (11470.0, 4900.0),
     ngratings: int = 14,

--- a/gdsfactory/components/dies/die_with_pads.py
+++ b/gdsfactory/components/dies/die_with_pads.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def die_with_pads(
     size: Size = (11470.0, 4900.0),
     ngratings: int = 14,

--- a/gdsfactory/components/dies/seal_ring.py
+++ b/gdsfactory/components/dies/seal_ring.py
@@ -7,7 +7,7 @@ from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import ComponentSpec, Float2
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def seal_ring(
     size: Float2 = (500, 500),
     seal: ComponentSpec = "via_stack",
@@ -78,7 +78,7 @@ def seal_ring(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def seal_ring_segmented(
     size: Float2 = (500, 500),
     length_segment: float = 10,

--- a/gdsfactory/components/dies/seal_ring.py
+++ b/gdsfactory/components/dies/seal_ring.py
@@ -7,7 +7,7 @@ from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import ComponentSpec, Float2
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def seal_ring(
     size: Float2 = (500, 500),
     seal: ComponentSpec = "via_stack",
@@ -78,7 +78,7 @@ def seal_ring(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def seal_ring_segmented(
     size: Float2 = (500, 500),
     length_segment: float = 10,

--- a/gdsfactory/components/dies/wafer.py
+++ b/gdsfactory/components/dies/wafer.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec
 _cols_200mm_wafer = (2, 6, 6, 8, 8, 6, 6, 2)
 
 
-@gf.cell_with_module_name(tags={"type": "dies"})
+@gf.cell_with_module_name(tags=["dies"])
 def wafer(
     reticle: ComponentSpec = "die",
     cols: tuple[int, ...] = _cols_200mm_wafer,

--- a/gdsfactory/components/dies/wafer.py
+++ b/gdsfactory/components/dies/wafer.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec
 _cols_200mm_wafer = (2, 6, 6, 8, 8, 6, 6, 2)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "dies"})
 def wafer(
     reticle: ComponentSpec = "die",
     cols: tuple[int, ...] = _cols_200mm_wafer,

--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -13,9 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=taper_schematic, tags={"type": "edge_couplers"}
-)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["edge_couplers"])
 def edge_coupler_silicon(
     length: float = 100,
     width1: float = 0.5,
@@ -48,7 +46,7 @@ def edge_coupler_silicon(
     )
 
 
-@gf.cell_with_module_name(tags={"type": "edge_couplers"})
+@gf.cell_with_module_name(tags=["edge_couplers"])
 def edge_coupler_array(
     edge_coupler: ComponentSpec = "edge_coupler_silicon",
     n: int = 5,
@@ -96,7 +94,7 @@ def edge_coupler_array(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "edge_couplers"})
+@gf.cell_with_module_name(tags=["edge_couplers"])
 def edge_coupler_array_with_loopback(
     edge_coupler: ComponentSpec = "edge_coupler_silicon",
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/edge_couplers/edge_coupler_array.py
+++ b/gdsfactory/components/edge_couplers/edge_coupler_array.py
@@ -13,7 +13,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Float2
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(
+    schematic_function=taper_schematic, tags={"type": "edge_couplers"}
+)
 def edge_coupler_silicon(
     length: float = 100,
     width1: float = 0.5,
@@ -46,7 +48,7 @@ def edge_coupler_silicon(
     )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "edge_couplers"})
 def edge_coupler_array(
     edge_coupler: ComponentSpec = "edge_coupler_silicon",
     n: int = 5,
@@ -94,7 +96,7 @@ def edge_coupler_array(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "edge_couplers"})
 def edge_coupler_array_with_loopback(
     edge_coupler: ComponentSpec = "edge_coupler_silicon",
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/filters/awg.py
+++ b/gdsfactory/components/filters/awg.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def free_propagation_region(
     width1: float = 2.0,
     width2: float = 20.0,
@@ -100,7 +100,7 @@ free_propagation_region_output = partial(
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def awg(
     arms: int = 10,
     outputs: int = 3,

--- a/gdsfactory/components/filters/awg.py
+++ b/gdsfactory/components/filters/awg.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def free_propagation_region(
     width1: float = 2.0,
     width2: float = 20.0,
@@ -100,7 +100,7 @@ free_propagation_region_output = partial(
 )
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def awg(
     arms: int = 10,
     outputs: int = 3,

--- a/gdsfactory/components/filters/dbr.py
+++ b/gdsfactory/components/filters/dbr.py
@@ -25,7 +25,7 @@ w1 = w0 - dw / 2
 w2 = w0 + dw / 2
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def dbr_cell(
     w1: float = w1,
     w2: float = w2,
@@ -71,7 +71,7 @@ def dbr_cell(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def dbr(
     w1: float = w1,
     w2: float = w2,

--- a/gdsfactory/components/filters/dbr.py
+++ b/gdsfactory/components/filters/dbr.py
@@ -25,7 +25,7 @@ w1 = w0 - dw / 2
 w2 = w0 + dw / 2
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def dbr_cell(
     w1: float = w1,
     w2: float = w2,
@@ -71,7 +71,7 @@ def dbr_cell(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def dbr(
     w1: float = w1,
     w2: float = w2,

--- a/gdsfactory/components/filters/dbr_tapered.py
+++ b/gdsfactory/components/filters/dbr_tapered.py
@@ -63,7 +63,7 @@ def _generate_fins(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def dbr_tapered(
     length: float = 10.0,
     period: float = 0.85,

--- a/gdsfactory/components/filters/dbr_tapered.py
+++ b/gdsfactory/components/filters/dbr_tapered.py
@@ -63,7 +63,7 @@ def _generate_fins(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def dbr_tapered(
     length: float = 10.0,
     period: float = 0.85,

--- a/gdsfactory/components/filters/fiber.py
+++ b/gdsfactory/components/filters/fiber.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from ..shapes.circle import circle
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def fiber(
     core_diameter: float = 10,
     cladding_diameter: float = 125,

--- a/gdsfactory/components/filters/fiber.py
+++ b/gdsfactory/components/filters/fiber.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from ..shapes.circle import circle
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def fiber(
     core_diameter: float = 10,
     cladding_diameter: float = 125,

--- a/gdsfactory/components/filters/fiber_array.py
+++ b/gdsfactory/components/filters/fiber_array.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from ..shapes.circle import circle
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def fiber_array(
     n: int = 8,
     pitch: float = 127.0,

--- a/gdsfactory/components/filters/fiber_array.py
+++ b/gdsfactory/components/filters/fiber_array.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from ..shapes.circle import circle
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def fiber_array(
     n: int = 8,
     pitch: float = 127.0,

--- a/gdsfactory/components/filters/loop_mirror.py
+++ b/gdsfactory/components/filters/loop_mirror.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def loop_mirror(
     component: ComponentSpec = "mmi1x2",
     bend90: ComponentSpec = "bend_euler",

--- a/gdsfactory/components/filters/loop_mirror.py
+++ b/gdsfactory/components/filters/loop_mirror.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def loop_mirror(
     component: ComponentSpec = "mmi1x2",
     bend90: ComponentSpec = "bend_euler",

--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -12,7 +12,7 @@ from .._schematic import ckt_schematic
 from ..bends.bend_s import bend_s
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic)
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "filters"})
 def mode_converter(
     gap: float = 0.3,
     length: float = 10,

--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -12,7 +12,7 @@ from .._schematic import ckt_schematic
 from ..bends.bend_s import bend_s
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "filters"})
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags=["filters"])
 def mode_converter(
     gap: float = 0.3,
     length: float = 10,

--- a/gdsfactory/components/filters/polarization_splitter_rotator.py
+++ b/gdsfactory/components/filters/polarization_splitter_rotator.py
@@ -14,7 +14,7 @@ from gdsfactory.typings import CrossSectionSpec, Delta, Float2, Float3
 from ..bends.bend_s import bezier
 
 
-@gf.cell_with_module_name(tags={"type": "filters"})
+@gf.cell_with_module_name(tags=["filters"])
 def polarization_splitter_rotator(
     width_taper_in: Float3 = (0.54, 0.69, 0.83),
     length_taper_in: Float2 | Float3 = (4.0, 44.0),

--- a/gdsfactory/components/filters/polarization_splitter_rotator.py
+++ b/gdsfactory/components/filters/polarization_splitter_rotator.py
@@ -14,7 +14,7 @@ from gdsfactory.typings import CrossSectionSpec, Delta, Float2, Float3
 from ..bends.bend_s import bezier
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "filters"})
 def polarization_splitter_rotator(
     width_taper_in: Float3 = (0.54, 0.69, 0.83),
     length_taper_in: Float2 | Float3 = (4.0, 44.0),

--- a/gdsfactory/components/filters/terminator.py
+++ b/gdsfactory/components/filters/terminator.py
@@ -11,9 +11,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpecs
 from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=terminator_schematic, tags={"type": "filters"}
-)
+@gf.cell_with_module_name(schematic_function=terminator_schematic, tags=["filters"])
 def terminator(
     length: float | None = 50,
     cross_section_input: CrossSectionSpec = strip,

--- a/gdsfactory/components/filters/terminator.py
+++ b/gdsfactory/components/filters/terminator.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpecs
 from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name(schematic_function=terminator_schematic)
+@gf.cell_with_module_name(
+    schematic_function=terminator_schematic, tags={"type": "filters"}
+)
 def terminator(
     length: float | None = 50,
     cross_section_input: CrossSectionSpec = strip,

--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name(schematic_function=terminator_schematic)
+@gf.cell_with_module_name(
+    schematic_function=terminator_schematic, tags={"type": "filters"}
+)
 def terminator_spiral(
     separation: float = 3.0,
     width_tip: float = 0.2,

--- a/gdsfactory/components/filters/terminator_spiral.py
+++ b/gdsfactory/components/filters/terminator_spiral.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import terminator_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=terminator_schematic, tags={"type": "filters"}
-)
+@gf.cell_with_module_name(schematic_function=terminator_schematic, tags=["filters"])
 def terminator_spiral(
     separation: float = 3.0,
     width_tip: float = 0.2,

--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -10,7 +10,7 @@ from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "grating_couplers"})
+@gf.cell_with_module_name(tags=["grating_couplers"])
 def grating_coupler_array(
     grating_coupler: ComponentSpec = "grating_coupler_elliptical",
     pitch: float = 127.0,

--- a/gdsfactory/components/grating_couplers/grating_coupler_array.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_array.py
@@ -10,7 +10,7 @@ from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "grating_couplers"})
 def grating_coupler_array(
     grating_coupler: ComponentSpec = "grating_coupler_elliptical",
     pitch: float = 127.0,

--- a/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
@@ -17,7 +17,9 @@ def _unit_cell() -> gf.Component:
     )
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_dual_pol(
     unit_cell: ComponentSpec = _unit_cell,
     period_x: float = 0.58,

--- a/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_dual_pol.py
@@ -18,7 +18,7 @@ def _unit_cell() -> gf.Component:
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_dual_pol(
     unit_cell: ComponentSpec = _unit_cell,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
@@ -23,7 +23,7 @@ from ..grating_couplers.functions import (
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_elliptical(
     polarization: str = "te",

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical.py
@@ -22,7 +22,9 @@ from ..grating_couplers.functions import (
 )
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_elliptical(
     polarization: str = "te",
     taper_length: float = 16.6,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
@@ -25,7 +25,7 @@ _widths = (0.5,) * 10
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_elliptical_arbitrary(
     gaps: Floats = _gaps,
@@ -181,7 +181,7 @@ def grating_coupler_elliptical_arbitrary(
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_elliptical_uniform(
     n_periods: int = 20,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
@@ -24,7 +24,9 @@ _gaps = (0.1,) * 10
 _widths = (0.5,) * 10
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_elliptical_arbitrary(
     gaps: Floats = _gaps,
     widths: Floats = _widths,
@@ -178,7 +180,9 @@ def grating_coupler_elliptical_arbitrary(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_elliptical_uniform(
     n_periods: int = 20,
     period: float = 0.75,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
@@ -71,7 +71,9 @@ parameters = (
 )
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_elliptical_lumerical(
     parameters: Floats = parameters,
     layer_slab: LayerSpec | None = "SLAB150",

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
@@ -72,7 +72,7 @@ parameters = (
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_elliptical_lumerical(
     parameters: Floats = parameters,

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
@@ -20,7 +20,7 @@ from ..grating_couplers.functions import grating_tooth_points
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_elliptical_trenches(
     polarization: str = "te",

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_trenches.py
@@ -19,7 +19,9 @@ from .._schematic import grating_coupler_schematic
 from ..grating_couplers.functions import grating_tooth_points
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_elliptical_trenches(
     polarization: str = "te",
     taper_length: float = 16.6,

--- a/gdsfactory/components/grating_couplers/grating_coupler_loss.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_loss.py
@@ -8,7 +8,7 @@ from gdsfactory.routing.route_bundle import route_bundle
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "grating_couplers"})
 def grating_coupler_loss(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = "grating_coupler_elliptical_trenches",

--- a/gdsfactory/components/grating_couplers/grating_coupler_loss.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_loss.py
@@ -8,7 +8,7 @@ from gdsfactory.routing.route_bundle import route_bundle
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "grating_couplers"})
+@gf.cell_with_module_name(tags=["grating_couplers"])
 def grating_coupler_loss(
     pitch: float = 127.0,
     grating_coupler: ComponentSpec = "grating_coupler_elliptical_trenches",

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 from .._schematic import grating_coupler_schematic
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_rectangular(
     n_periods: int = 20,
     period: float = 0.75,

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular.py
@@ -12,7 +12,7 @@ from .._schematic import grating_coupler_schematic
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_rectangular(
     n_periods: int = 20,

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
@@ -15,7 +15,9 @@ _gaps = (0.2,) * 10
 _widths = (0.5,) * 10
 
 
-@gf.cell_with_module_name(schematic_function=grating_coupler_schematic)
+@gf.cell_with_module_name(
+    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+)
 def grating_coupler_rectangular_arbitrary(
     gaps: Floats = _gaps,
     widths: Floats = _widths,

--- a/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_rectangular_arbitrary.py
@@ -16,7 +16,7 @@ _widths = (0.5,) * 10
 
 
 @gf.cell_with_module_name(
-    schematic_function=grating_coupler_schematic, tags={"type": "grating_couplers"}
+    schematic_function=grating_coupler_schematic, tags=["grating_couplers"]
 )
 def grating_coupler_rectangular_arbitrary(
     gaps: Floats = _gaps,

--- a/gdsfactory/components/grating_couplers/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_tree.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "grating_couplers"})
 def grating_coupler_tree(
     n: int = 4,
     straight_spacing: float = 4.0,

--- a/gdsfactory/components/grating_couplers/grating_coupler_tree.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_tree.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "grating_couplers"})
+@gf.cell_with_module_name(tags=["grating_couplers"])
 def grating_coupler_tree(
     n: int = 4,
     straight_spacing: float = 4.0,

--- a/gdsfactory/components/mems/anchored_flexure.py
+++ b/gdsfactory/components/mems/anchored_flexure.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def anchored_flexure(
     hinge_width: float = 0.3,
     hinge_length: float = 5.0,

--- a/gdsfactory/components/mems/anchored_flexure.py
+++ b/gdsfactory/components/mems/anchored_flexure.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def anchored_flexure(
     hinge_width: float = 0.3,
     hinge_length: float = 5.0,

--- a/gdsfactory/components/mems/bent_beam.py
+++ b/gdsfactory/components/mems/bent_beam.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def bent_beam(
     beam_width: float = 1.0,
     beam_length: float = 40.0,

--- a/gdsfactory/components/mems/bent_beam.py
+++ b/gdsfactory/components/mems/bent_beam.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def bent_beam(
     beam_width: float = 1.0,
     beam_length: float = 40.0,

--- a/gdsfactory/components/mems/bolometer.py
+++ b/gdsfactory/components/mems/bolometer.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def bolometer(
     absorber_width: float = 20.0,
     absorber_length: float = 20.0,

--- a/gdsfactory/components/mems/bolometer.py
+++ b/gdsfactory/components/mems/bolometer.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def bolometer(
     absorber_width: float = 20.0,
     absorber_length: float = 20.0,

--- a/gdsfactory/components/mems/cantilever.py
+++ b/gdsfactory/components/mems/cantilever.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def cantilever(
     beam_width: float = 2.0,
     beam_length: float = 20.0,

--- a/gdsfactory/components/mems/cantilever.py
+++ b/gdsfactory/components/mems/cantilever.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def cantilever(
     beam_width: float = 2.0,
     beam_length: float = 20.0,

--- a/gdsfactory/components/mems/comb_drive.py
+++ b/gdsfactory/components/mems/comb_drive.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def comb_drive(
     finger_width: float = 0.5,
     finger_length: float = 10.0,

--- a/gdsfactory/components/mems/comb_drive.py
+++ b/gdsfactory/components/mems/comb_drive.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def comb_drive(
     finger_width: float = 0.5,
     finger_length: float = 10.0,

--- a/gdsfactory/components/mems/doubly_clamped_beam.py
+++ b/gdsfactory/components/mems/doubly_clamped_beam.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def doubly_clamped_beam(
     beam_width: float = 1.0,
     beam_length: float = 30.0,

--- a/gdsfactory/components/mems/doubly_clamped_beam.py
+++ b/gdsfactory/components/mems/doubly_clamped_beam.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def doubly_clamped_beam(
     beam_width: float = 1.0,
     beam_length: float = 30.0,

--- a/gdsfactory/components/mems/folded_spring.py
+++ b/gdsfactory/components/mems/folded_spring.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def folded_spring(
     beam_width: float = 0.5,
     beam_length: float = 20.0,

--- a/gdsfactory/components/mems/folded_spring.py
+++ b/gdsfactory/components/mems/folded_spring.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def folded_spring(
     beam_width: float = 0.5,
     beam_length: float = 20.0,

--- a/gdsfactory/components/mems/gear.py
+++ b/gdsfactory/components/mems/gear.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "mems"})
+@gf.cell_with_module_name(tags=["mems"])
 def gear(
     n_teeth: int = 20,
     module_size: float = 2.0,

--- a/gdsfactory/components/mems/gear.py
+++ b/gdsfactory/components/mems/gear.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "mems"})
 def gear(
     n_teeth: int = 20,
     module_size: float = 2.0,

--- a/gdsfactory/components/microfluidics/arrow_junction.py
+++ b/gdsfactory/components/microfluidics/arrow_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "microfluidics"})
 def arrow_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/microfluidics/arrow_junction.py
+++ b/gdsfactory/components/microfluidics/arrow_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "microfluidics"})
+@gf.cell_with_module_name(tags=["microfluidics"])
 def arrow_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/microfluidics/h_junction.py
+++ b/gdsfactory/components/microfluidics/h_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "microfluidics"})
 def h_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/microfluidics/h_junction.py
+++ b/gdsfactory/components/microfluidics/h_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "microfluidics"})
+@gf.cell_with_module_name(tags=["microfluidics"])
 def h_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/microfluidics/meander_channel.py
+++ b/gdsfactory/components/microfluidics/meander_channel.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "microfluidics"})
 def meander_channel(
     channel_width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/microfluidics/meander_channel.py
+++ b/gdsfactory/components/microfluidics/meander_channel.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "microfluidics"})
+@gf.cell_with_module_name(tags=["microfluidics"])
 def meander_channel(
     channel_width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/microfluidics/t_junction.py
+++ b/gdsfactory/components/microfluidics/t_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "microfluidics"})
 def t_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/microfluidics/t_junction.py
+++ b/gdsfactory/components/microfluidics/t_junction.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "microfluidics"})
+@gf.cell_with_module_name(tags=["microfluidics"])
 def t_junction(
     main_width: float = 1.0,
     branch_width: float = 1.0,

--- a/gdsfactory/components/mmis/mmi.py
+++ b/gdsfactory/components/mmis/mmi.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags=["mmis"])
 def mmi(
     inputs: int = 1,
     outputs: int = 4,

--- a/gdsfactory/components/mmis/mmi.py
+++ b/gdsfactory/components/mmis/mmi.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic)
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mmis"})
 def mmi(
     inputs: int = 1,
     outputs: int = 4,

--- a/gdsfactory/components/mmis/mmi1x2.py
+++ b/gdsfactory/components/mmis/mmi1x2.py
@@ -11,7 +11,7 @@ from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags=["mmis"])
 def mmi1x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi1x2.py
+++ b/gdsfactory/components/mmis/mmi1x2.py
@@ -11,7 +11,7 @@ from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
 def mmi1x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi1x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi1x2_with_sbend.py
@@ -39,7 +39,7 @@ def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     return cast("npt.NDArray[np.float64]", f(xnew))
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags=["mmis"])
 def mmi1x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi1x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi1x2_with_sbend.py
@@ -39,7 +39,7 @@ def mmi_widths(t: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     return cast("npt.NDArray[np.float64]", f(xnew))
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
 def mmi1x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi2x2.py
+++ b/gdsfactory/components/mmis/mmi2x2.py
@@ -11,7 +11,7 @@ from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags={"type": "mmis"})
 def mmi2x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi2x2.py
+++ b/gdsfactory/components/mmis/mmi2x2.py
@@ -11,7 +11,7 @@ from ..tapers.taper import taper as taper_function
 from ..waveguides.straight import straight as straight_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags=["mmis"])
 def mmi2x2(
     width: float | None = None,
     width_taper: float = 1.0,

--- a/gdsfactory/components/mmis/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi2x2_with_sbend.py
@@ -11,7 +11,7 @@ from .._schematic import mmi_2x2_schematic
 from ..bends.bend_s import bend_s
 
 
-@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags={"type": "mmis"})
 def mmi2x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi2x2_with_sbend.py
+++ b/gdsfactory/components/mmis/mmi2x2_with_sbend.py
@@ -11,7 +11,7 @@ from .._schematic import mmi_2x2_schematic
 from ..bends.bend_s import bend_s
 
 
-@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=mmi_2x2_schematic, tags=["mmis"])
 def mmi2x2_with_sbend(
     with_sbend: bool = True,
     s_bend: ComponentFactory = bend_s,

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -10,7 +10,7 @@ from .._schematic import ckt_schematic
 from ..tapers.taper import taper as taper_function
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags=["mmis"])
 def mmi_90degree_hybrid(
     width: float = 0.5,
     width_taper: float = 1.7,

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -10,7 +10,7 @@ from .._schematic import ckt_schematic
 from ..tapers.taper import taper as taper_function
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic)
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mmis"})
 def mmi_90degree_hybrid(
     width: float = 0.5,
     width_taper: float = 1.7,

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -10,7 +10,7 @@ from .._schematic import mmi_1x2_schematic
 from ..tapers.taper import taper as taper_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags=["mmis"])
 def mmi_tapered(
     inputs: int = 1,
     outputs: int = 2,

--- a/gdsfactory/components/mmis/mmi_tapered.py
+++ b/gdsfactory/components/mmis/mmi_tapered.py
@@ -10,7 +10,7 @@ from .._schematic import mmi_1x2_schematic
 from ..tapers.taper import taper as taper_function
 
 
-@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic)
+@gf.cell_with_module_name(schematic_function=mmi_1x2_schematic, tags={"type": "mmis"})
 def mmi_tapered(
     inputs: int = 1,
     outputs: int = 2,

--- a/gdsfactory/components/mzis/mzi.py
+++ b/gdsfactory/components/mzis/mzi.py
@@ -22,7 +22,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
 def mzi(
     delta_length: float = 10.0,
     length_y: float = 2.0,

--- a/gdsfactory/components/mzis/mzi.py
+++ b/gdsfactory/components/mzis/mzi.py
@@ -22,7 +22,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags=["mzis"])
 def mzi(
     delta_length: float = 10.0,
     length_y: float = 2.0,

--- a/gdsfactory/components/mzis/mzi_lattice.py
+++ b/gdsfactory/components/mzis/mzi_lattice.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component, ComponentReference
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
 def mzi_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),
@@ -123,7 +123,7 @@ def mzi_lattice(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
 def mzi_lattice_mmi(
     coupler_widths: tuple[float | None, float | None] = (None, None),
     coupler_widths_tapers: tuple[float, ...] = (

--- a/gdsfactory/components/mzis/mzi_lattice.py
+++ b/gdsfactory/components/mzis/mzi_lattice.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component, ComponentReference
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags=["mzis"])
 def mzi_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),
@@ -123,7 +123,7 @@ def mzi_lattice(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags=["mzis"])
 def mzi_lattice_mmi(
     coupler_widths: tuple[float | None, float | None] = (None, None),
     coupler_widths_tapers: tuple[float, ...] = (

--- a/gdsfactory/components/mzis/mzi_pads_center.py
+++ b/gdsfactory/components/mzis/mzi_pads_center.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags=["mzis"])
 def mzi_pads_center(
     ps_top: ComponentSpec = "straight_heater_metal",
     ps_bot: ComponentSpec = "straight_heater_metal",

--- a/gdsfactory/components/mzis/mzi_pads_center.py
+++ b/gdsfactory/components/mzis/mzi_pads_center.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ckt_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ckt_schematic)
+@gf.cell_with_module_name(schematic_function=ckt_schematic, tags={"type": "mzis"})
 def mzi_pads_center(
     ps_top: ComponentSpec = "straight_heater_metal",
     ps_bot: ComponentSpec = "straight_heater_metal",

--- a/gdsfactory/components/mzis/mzit.py
+++ b/gdsfactory/components/mzis/mzit.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, Delta
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags=["mzis"])
 def mzit(
     w0: float = 0.5,
     w1: float = 0.45,
@@ -208,7 +208,7 @@ def mzit(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags=["mzis"])
 def mzit_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),

--- a/gdsfactory/components/mzis/mzit.py
+++ b/gdsfactory/components/mzis/mzit.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, Delta
 from .._schematic import mzi_2x2_schematic
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
 def mzit(
     w0: float = 0.5,
     w1: float = 0.45,
@@ -208,7 +208,7 @@ def mzit(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic)
+@gf.cell_with_module_name(schematic_function=mzi_2x2_schematic, tags={"type": "mzis"})
 def mzit_lattice(
     coupler_lengths: Sequence[float] = (10.0, 20.0),
     coupler_gaps: Sequence[float] = (0.2, 0.3),

--- a/gdsfactory/components/pads/bump_pad.py
+++ b/gdsfactory/components/pads/bump_pad.py
@@ -14,7 +14,7 @@ from ..vias import via_stack
 __all__ = ["bump_pad", "bump_pad_grid"]
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def bump_pad(
     size: float = 36.244,
     layer: LayerSpec = "MTOP",
@@ -104,7 +104,7 @@ def bump_pad(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def bump_pad_grid(
     columns: int = 6,
     rows: int = 6,

--- a/gdsfactory/components/pads/bump_pad.py
+++ b/gdsfactory/components/pads/bump_pad.py
@@ -14,7 +14,7 @@ from ..vias import via_stack
 __all__ = ["bump_pad", "bump_pad_grid"]
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def bump_pad(
     size: float = 36.244,
     layer: LayerSpec = "MTOP",
@@ -104,7 +104,7 @@ def bump_pad(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def bump_pad_grid(
     columns: int = 6,
     rows: int = 6,

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -29,7 +29,7 @@ from gdsfactory.typings import (
 from .._schematic import pad_schematic
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags=["pads"])
 def pad(
     size: Size | str = (100.0, 100.0),
     layer: LayerSpec = "MTOP",
@@ -105,7 +105,7 @@ pad_rectangular = partial(pad, size="pad_size")
 pad_small = partial(pad, size=(80, 80))
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags=["pads"])
 def pad_array(
     pad: ComponentSpec = "pad",
     columns: int = 6,

--- a/gdsfactory/components/pads/pad.py
+++ b/gdsfactory/components/pads/pad.py
@@ -29,7 +29,7 @@ from gdsfactory.typings import (
 from .._schematic import pad_schematic
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic)
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
 def pad(
     size: Size | str = (100.0, 100.0),
     layer: LayerSpec = "MTOP",
@@ -105,7 +105,7 @@ pad_rectangular = partial(pad, size="pad_size")
 pad_small = partial(pad, size=(80, 80))
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic)
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
 def pad_array(
     pad: ComponentSpec = "pad",
     columns: int = 6,

--- a/gdsfactory/components/pads/pad_gsg.py
+++ b/gdsfactory/components/pads/pad_gsg.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import ComponentSpec, Float2, LayerSpec
 from .._schematic import pad_schematic
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def pad_gsg_short(
     size: Float2 = (22, 7),
     layer_metal: LayerSpec = "MTOP",
@@ -66,12 +66,12 @@ def pad_gsg_short(
 pad_gsg_open = partial(pad_gsg_short, short=False)
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic)
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
 def pad_gsg(length: float = 100, cross_section: str = "gsg") -> gf.Component:
     return gf.c.straight(cross_section=cross_section, length=length)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def pad_gs(length: float = 100, cross_section: str = "gs") -> gf.Component:
     return gf.c.straight(cross_section=cross_section, length=length)
 

--- a/gdsfactory/components/pads/pad_gsg.py
+++ b/gdsfactory/components/pads/pad_gsg.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import ComponentSpec, Float2, LayerSpec
 from .._schematic import pad_schematic
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def pad_gsg_short(
     size: Float2 = (22, 7),
     layer_metal: LayerSpec = "MTOP",
@@ -66,12 +66,12 @@ def pad_gsg_short(
 pad_gsg_open = partial(pad_gsg_short, short=False)
 
 
-@gf.cell_with_module_name(schematic_function=pad_schematic, tags={"type": "pads"})
+@gf.cell_with_module_name(schematic_function=pad_schematic, tags=["pads"])
 def pad_gsg(length: float = 100, cross_section: str = "gsg") -> gf.Component:
     return gf.c.straight(cross_section=cross_section, length=length)
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def pad_gs(length: float = 100, cross_section: str = "gs") -> gf.Component:
     return gf.c.straight(cross_section=cross_section, length=length)
 

--- a/gdsfactory/components/pads/pads_shorted.py
+++ b/gdsfactory/components/pads/pads_shorted.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def pads_shorted(
     pad: ComponentSpec = "pad",
     columns: int = 8,

--- a/gdsfactory/components/pads/pads_shorted.py
+++ b/gdsfactory/components/pads/pads_shorted.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def pads_shorted(
     pad: ComponentSpec = "pad",
     columns: int = 8,

--- a/gdsfactory/components/pads/rectangle_with_slits.py
+++ b/gdsfactory/components/pads/rectangle_with_slits.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "pads"})
+@gf.cell_with_module_name(tags=["pads"])
 def rectangle_with_slits(
     size: Size = (100.0, 200.0),
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/pads/rectangle_with_slits.py
+++ b/gdsfactory/components/pads/rectangle_with_slits.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pads"})
 def rectangle_with_slits(
     size: Size = (100.0, 200.0),
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/pcms/alignment_mark_cross.py
+++ b/gdsfactory/components/pcms/alignment_mark_cross.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def alignment_mark_cross(
     arm_width: float = 2.0,
     arm_length: float = 20.0,

--- a/gdsfactory/components/pcms/alignment_mark_cross.py
+++ b/gdsfactory/components/pcms/alignment_mark_cross.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def alignment_mark_cross(
     arm_width: float = 2.0,
     arm_length: float = 20.0,

--- a/gdsfactory/components/pcms/cavity.py
+++ b/gdsfactory/components/pcms/cavity.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cavity(
     component: ComponentSpec = "dbr",
     coupler: ComponentSpec = "coupler",

--- a/gdsfactory/components/pcms/cavity.py
+++ b/gdsfactory/components/pcms/cavity.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cavity(
     component: ComponentSpec = "dbr",
     coupler: ComponentSpec = "coupler",

--- a/gdsfactory/components/pcms/cdsem_all.py
+++ b/gdsfactory/components/pcms/cdsem_all.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cdsem_all(
     widths: tuple[float, ...] = (0.4, 0.45, 0.5, 0.6, 0.8, 1.0),
     dense_lines_width: float | None = 0.3,

--- a/gdsfactory/components/pcms/cdsem_all.py
+++ b/gdsfactory/components/pcms/cdsem_all.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cdsem_all(
     widths: tuple[float, ...] = (0.4, 0.45, 0.5, 0.6, 0.8, 1.0),
     dense_lines_width: float | None = 0.3,

--- a/gdsfactory/components/pcms/cdsem_bend180.py
+++ b/gdsfactory/components/pcms/cdsem_bend180.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 LINE_LENGTH = 420.0
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cdsem_bend180(
     width: float = 0.5,
     radius: float = 10.0,

--- a/gdsfactory/components/pcms/cdsem_bend180.py
+++ b/gdsfactory/components/pcms/cdsem_bend180.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 LINE_LENGTH = 420.0
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cdsem_bend180(
     width: float = 0.5,
     radius: float = 10.0,

--- a/gdsfactory/components/pcms/cdsem_coupler.py
+++ b/gdsfactory/components/pcms/cdsem_coupler.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cdsem_coupler(
     length: float = 420.0,
     gaps: Sequence[float] = (0.15, 0.2, 0.25),

--- a/gdsfactory/components/pcms/cdsem_coupler.py
+++ b/gdsfactory/components/pcms/cdsem_coupler.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cdsem_coupler(
     length: float = 420.0,
     gaps: Sequence[float] = (0.15, 0.2, 0.25),

--- a/gdsfactory/components/pcms/cdsem_straight.py
+++ b/gdsfactory/components/pcms/cdsem_straight.py
@@ -13,7 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 LINE_LENGTH = 420.0
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cdsem_straight(
     widths: Sequence[float] = (0.4, 0.45, 0.5, 0.6, 0.8, 1.0),
     length: float = LINE_LENGTH,

--- a/gdsfactory/components/pcms/cdsem_straight.py
+++ b/gdsfactory/components/pcms/cdsem_straight.py
@@ -13,7 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 LINE_LENGTH = 420.0
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cdsem_straight(
     widths: Sequence[float] = (0.4, 0.45, 0.5, 0.6, 0.8, 1.0),
     length: float = LINE_LENGTH,

--- a/gdsfactory/components/pcms/cdsem_straight_density.py
+++ b/gdsfactory/components/pcms/cdsem_straight_density.py
@@ -12,7 +12,7 @@ widths = 10 * (0.3,)
 gaps = 10 * (0.3,)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cdsem_straight_density(
     widths: Floats = widths,
     gaps: Floats = gaps,

--- a/gdsfactory/components/pcms/cdsem_straight_density.py
+++ b/gdsfactory/components/pcms/cdsem_straight_density.py
@@ -12,7 +12,7 @@ widths = 10 * (0.3,)
 gaps = 10 * (0.3,)
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cdsem_straight_density(
     widths: Floats = widths,
     gaps: Floats = gaps,

--- a/gdsfactory/components/pcms/cutback_2x2.py
+++ b/gdsfactory/components/pcms/cutback_2x2.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def _bendu_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
@@ -51,7 +51,7 @@ def _bendu_double(
     return bendu
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def _straight_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
@@ -97,7 +97,7 @@ def _straight_double(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_2x2(
     component: ComponentSpec = "mmi2x2",
     cols: int = 4,

--- a/gdsfactory/components/pcms/cutback_2x2.py
+++ b/gdsfactory/components/pcms/cutback_2x2.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def _bendu_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
@@ -51,7 +51,7 @@ def _bendu_double(
     return bendu
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def _straight_double(
     component: Component,
     cross_section: CrossSectionSpec = "strip",
@@ -97,7 +97,7 @@ def _straight_double(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_2x2(
     component: ComponentSpec = "mmi2x2",
     cols: int = 4,

--- a/gdsfactory/components/pcms/cutback_bend.py
+++ b/gdsfactory/components/pcms/cutback_bend.py
@@ -28,7 +28,7 @@ def _get_bend_size(bend90: Component) -> float:
     return max(dx, dy)
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_bend(
     component: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -82,7 +82,7 @@ def cutback_bend(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_bend90(
     component: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -136,7 +136,7 @@ def cutback_bend90(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def staircase(
     component: ComponentSpec | Component = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -185,7 +185,7 @@ def staircase(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_bend180(
     component: ComponentSpec = "bend_euler180",
     straight: ComponentSpec = "straight",

--- a/gdsfactory/components/pcms/cutback_bend.py
+++ b/gdsfactory/components/pcms/cutback_bend.py
@@ -28,7 +28,7 @@ def _get_bend_size(bend90: Component) -> float:
     return max(dx, dy)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_bend(
     component: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -82,7 +82,7 @@ def cutback_bend(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_bend90(
     component: ComponentSpec = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -136,7 +136,7 @@ def cutback_bend90(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def staircase(
     component: ComponentSpec | Component = "bend_euler",
     straight: ComponentSpec = "straight",
@@ -185,7 +185,7 @@ def staircase(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_bend180(
     component: ComponentSpec = "bend_euler180",
     straight: ComponentSpec = "straight",

--- a/gdsfactory/components/pcms/cutback_component.py
+++ b/gdsfactory/components/pcms/cutback_component.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_component(
     component: ComponentSpec = "taper_0p5_to_3_l36",
     cols: int = 4,

--- a/gdsfactory/components/pcms/cutback_component.py
+++ b/gdsfactory/components/pcms/cutback_component.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_component(
     component: ComponentSpec = "taper_0p5_to_3_l36",
     cols: int = 4,

--- a/gdsfactory/components/pcms/cutback_splitter.py
+++ b/gdsfactory/components/pcms/cutback_splitter.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def cutback_splitter(
     component: ComponentSpec = "mmi1x2",
     cols: int = 4,

--- a/gdsfactory/components/pcms/cutback_splitter.py
+++ b/gdsfactory/components/pcms/cutback_splitter.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def cutback_splitter(
     component: ComponentSpec = "mmi1x2",
     cols: int = 4,

--- a/gdsfactory/components/pcms/greek_cross.py
+++ b/gdsfactory/components/pcms/greek_cross.py
@@ -7,7 +7,7 @@ from gdsfactory.cross_section import metal1
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpecs
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def greek_cross(
     length: float = 30,
     layers: LayerSpecs = ("WG", "N"),
@@ -88,7 +88,7 @@ def greek_cross(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def greek_cross_with_pads(
     pad: ComponentSpec = "pad",
     pad_pitch: float = 150.0,

--- a/gdsfactory/components/pcms/greek_cross.py
+++ b/gdsfactory/components/pcms/greek_cross.py
@@ -7,7 +7,7 @@ from gdsfactory.cross_section import metal1
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpecs
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def greek_cross(
     length: float = 30,
     layers: LayerSpecs = ("WG", "N"),
@@ -88,7 +88,7 @@ def greek_cross(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def greek_cross_with_pads(
     pad: ComponentSpec = "pad",
     pad_pitch: float = 150.0,

--- a/gdsfactory/components/pcms/litho_calipers.py
+++ b/gdsfactory/components/pcms/litho_calipers.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def litho_calipers(
     notch_size: Size = (2.0, 5.0),
     notch_spacing: float = 2.0,

--- a/gdsfactory/components/pcms/litho_calipers.py
+++ b/gdsfactory/components/pcms/litho_calipers.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def litho_calipers(
     notch_size: Size = (2.0, 5.0),
     notch_spacing: float = 2.0,

--- a/gdsfactory/components/pcms/litho_ruler.py
+++ b/gdsfactory/components/pcms/litho_ruler.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def litho_ruler(
     height: float = 2,
     width: float = 0.5,

--- a/gdsfactory/components/pcms/litho_ruler.py
+++ b/gdsfactory/components/pcms/litho_ruler.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def litho_ruler(
     height: float = 2,
     width: float = 0.5,

--- a/gdsfactory/components/pcms/litho_steps.py
+++ b/gdsfactory/components/pcms/litho_steps.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def litho_steps(
     line_widths: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0),
     line_spacing: float = 10.0,

--- a/gdsfactory/components/pcms/litho_steps.py
+++ b/gdsfactory/components/pcms/litho_steps.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def litho_steps(
     line_widths: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0),
     line_spacing: float = 10.0,

--- a/gdsfactory/components/pcms/resistance_meander.py
+++ b/gdsfactory/components/pcms/resistance_meander.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def resistance_meander(
     name: str = "net",
     pad_size: Size = (50.0, 50.0),

--- a/gdsfactory/components/pcms/resistance_meander.py
+++ b/gdsfactory/components/pcms/resistance_meander.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def resistance_meander(
     name: str = "net",
     pad_size: Size = (50.0, 50.0),

--- a/gdsfactory/components/pcms/resistance_sheet.py
+++ b/gdsfactory/components/pcms/resistance_sheet.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Floats, LayerSpecs, Size
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def resistance_sheet(
     width: float = 10.0,
     layers: LayerSpecs = ("HEATER",),

--- a/gdsfactory/components/pcms/resistance_sheet.py
+++ b/gdsfactory/components/pcms/resistance_sheet.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, Floats, LayerSpecs, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def resistance_sheet(
     width: float = 10.0,
     layers: LayerSpecs = ("HEATER",),

--- a/gdsfactory/components/pcms/resolution_test_pattern.py
+++ b/gdsfactory/components/pcms/resolution_test_pattern.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def resolution_test_pattern(
     radius: float = 50.0,
     n_spokes: int = 36,

--- a/gdsfactory/components/pcms/resolution_test_pattern.py
+++ b/gdsfactory/components/pcms/resolution_test_pattern.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def resolution_test_pattern(
     radius: float = 50.0,
     n_spokes: int = 36,

--- a/gdsfactory/components/pcms/ruler.py
+++ b/gdsfactory/components/pcms/ruler.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def ruler(
     height_long: float = 55,
     height_short: float = 5,

--- a/gdsfactory/components/pcms/ruler.py
+++ b/gdsfactory/components/pcms/ruler.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def ruler(
     height_long: float = 55,
     height_short: float = 5,

--- a/gdsfactory/components/pcms/vernier_scale.py
+++ b/gdsfactory/components/pcms/vernier_scale.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def vernier_scale(
     n_divisions: int = 10,
     pitch_main: float = 10.0,

--- a/gdsfactory/components/pcms/vernier_scale.py
+++ b/gdsfactory/components/pcms/vernier_scale.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def vernier_scale(
     n_divisions: int = 10,
     pitch_main: float = 10.0,

--- a/gdsfactory/components/pcms/verniers.py
+++ b/gdsfactory/components/pcms/verniers.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def verniers(
     widths: Floats = (0.1, 0.2, 0.3, 0.4, 0.5),
     gap: float = 0.1,

--- a/gdsfactory/components/pcms/verniers.py
+++ b/gdsfactory/components/pcms/verniers.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def verniers(
     widths: Floats = (0.1, 0.2, 0.3, 0.4, 0.5),
     gap: float = 0.1,

--- a/gdsfactory/components/pcms/version_stamp.py
+++ b/gdsfactory/components/pcms/version_stamp.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import LayerSpec
 from ..texts.text import text
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def pixel(size: int = 1, layer: LayerSpec = "WG") -> Component:
     c = gf.Component()
     a = size / 2
@@ -20,7 +20,7 @@ def pixel(size: int = 1, layer: LayerSpec = "WG") -> Component:
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def qrcode(data: str = "mask01", psize: int = 1, layer: LayerSpec = "WG") -> Component:
     """Returns QRCode.
 
@@ -45,7 +45,7 @@ def qrcode(data: str = "mask01", psize: int = 1, layer: LayerSpec = "WG") -> Com
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "pcms"})
+@gf.cell_with_module_name(tags=["pcms"])
 def version_stamp(
     labels: tuple[str, ...] = ("demo_label",),
     with_qr_code: bool = False,

--- a/gdsfactory/components/pcms/version_stamp.py
+++ b/gdsfactory/components/pcms/version_stamp.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import LayerSpec
 from ..texts.text import text
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def pixel(size: int = 1, layer: LayerSpec = "WG") -> Component:
     c = gf.Component()
     a = size / 2
@@ -20,7 +20,7 @@ def pixel(size: int = 1, layer: LayerSpec = "WG") -> Component:
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def qrcode(data: str = "mask01", psize: int = 1, layer: LayerSpec = "WG") -> Component:
     """Returns QRCode.
 
@@ -45,7 +45,7 @@ def qrcode(data: str = "mask01", psize: int = 1, layer: LayerSpec = "WG") -> Com
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "pcms"})
 def version_stamp(
     labels: tuple[str, ...] = ("demo_label",),
     with_qr_code: bool = False,

--- a/gdsfactory/components/quantum/coupler_capacitive.py
+++ b/gdsfactory/components/quantum/coupler_capacitive.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def coupler_capacitive(
     pad_width: float = 20.0,
     pad_height: float = 50.0,
@@ -107,7 +107,7 @@ def coupler_capacitive(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def coupler_interdigital(
     fingers: int = 6,
     finger_length: float = 30.0,
@@ -241,7 +241,7 @@ def coupler_interdigital(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def coupler_tunable(
     pad_width: float = 30.0,
     pad_height: float = 40.0,

--- a/gdsfactory/components/quantum/coupler_capacitive.py
+++ b/gdsfactory/components/quantum/coupler_capacitive.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def coupler_capacitive(
     pad_width: float = 20.0,
     pad_height: float = 50.0,
@@ -107,7 +107,7 @@ def coupler_capacitive(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def coupler_interdigital(
     fingers: int = 6,
     finger_length: float = 30.0,
@@ -241,7 +241,7 @@ def coupler_interdigital(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def coupler_tunable(
     pad_width: float = 30.0,
     pad_height: float = 40.0,

--- a/gdsfactory/components/quantum/flux_qubit.py
+++ b/gdsfactory/components/quantum/flux_qubit.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def flux_qubit(
     loop_width: float = 50.0,
     loop_height: float = 50.0,
@@ -218,7 +218,7 @@ def flux_qubit(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def flux_qubit_asymmetric(
     loop_width: float = 60.0,
     loop_height: float = 40.0,

--- a/gdsfactory/components/quantum/flux_qubit.py
+++ b/gdsfactory/components/quantum/flux_qubit.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def flux_qubit(
     loop_width: float = 50.0,
     loop_height: float = 50.0,
@@ -218,7 +218,7 @@ def flux_qubit(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def flux_qubit_asymmetric(
     loop_width: float = 60.0,
     loop_height: float = 40.0,

--- a/gdsfactory/components/quantum/resonator.py
+++ b/gdsfactory/components/quantum/resonator.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def resonator_cpw(
     length: float = 1000.0,
     width: float = 10.0,
@@ -156,7 +156,7 @@ def resonator_cpw(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def resonator_lumped(
     capacitor_fingers: int = 4,
     capacitor_finger_length: float = 20.0,
@@ -290,7 +290,7 @@ def resonator_lumped(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def resonator_quarter_wave(
     length: float = 2500.0,
     width: float = 10.0,

--- a/gdsfactory/components/quantum/resonator.py
+++ b/gdsfactory/components/quantum/resonator.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def resonator_cpw(
     length: float = 1000.0,
     width: float = 10.0,
@@ -156,7 +156,7 @@ def resonator_cpw(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def resonator_lumped(
     capacitor_fingers: int = 4,
     capacitor_finger_length: float = 20.0,
@@ -290,7 +290,7 @@ def resonator_lumped(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def resonator_quarter_wave(
     length: float = 2500.0,
     width: float = 10.0,

--- a/gdsfactory/components/quantum/transmon.py
+++ b/gdsfactory/components/quantum/transmon.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def transmon(
     pad_width: float = 200.0,
     pad_height: float = 100.0,
@@ -123,7 +123,7 @@ def transmon(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "quantum"})
+@gf.cell_with_module_name(tags=["quantum"])
 def transmon_circular(
     pad_radius: float = 100.0,
     pad_gap: float = 6.0,

--- a/gdsfactory/components/quantum/transmon.py
+++ b/gdsfactory/components/quantum/transmon.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def transmon(
     pad_width: float = 200.0,
     pad_height: float = 100.0,
@@ -123,7 +123,7 @@ def transmon(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "quantum"})
 def transmon_circular(
     pad_radius: float = 100.0,
     pad_gap: float = 6.0,

--- a/gdsfactory/components/rings/disk.py
+++ b/gdsfactory/components/rings/disk.py
@@ -93,9 +93,7 @@ def _generate_straights(
     return (c, straight_left, straight_right)
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def disk(
     radius: float = 10.0,
     gap: float = 0.2,
@@ -165,9 +163,7 @@ def disk(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def disk_heater(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/disk.py
+++ b/gdsfactory/components/rings/disk.py
@@ -93,7 +93,9 @@ def _generate_straights(
     return (c, straight_left, straight_right)
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def disk(
     radius: float = 10.0,
     gap: float = 0.2,
@@ -163,7 +165,9 @@ def disk(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def disk_heater(
     radius: float = 10.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -10,7 +10,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "rings"})
 def ring(
     radius: float = 10.0,
     width: float = 0.5,

--- a/gdsfactory/components/rings/ring.py
+++ b/gdsfactory/components/rings/ring.py
@@ -10,7 +10,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "rings"})
+@gf.cell_with_module_name(tags=["rings"])
 def ring(
     radius: float = 10.0,
     width: float = 0.5,

--- a/gdsfactory/components/rings/ring_crow.py
+++ b/gdsfactory/components/rings/ring_crow.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_crow(
     gaps: tuple[float, ...] = (0.2, 0.2, 0.2, 0.2),
     radius: tuple[float, ...] = (10.0, 10.0, 10.0),
@@ -122,7 +124,7 @@ def ring_crow(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "rings"})
 def ring_asymmetric(
     radius: float = 10.0,
     length_x: float = 2.0,

--- a/gdsfactory/components/rings/ring_crow.py
+++ b/gdsfactory/components/rings/ring_crow.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_crow(
     gaps: tuple[float, ...] = (0.2, 0.2, 0.2, 0.2),
     radius: tuple[float, ...] = (10.0, 10.0, 10.0),
@@ -124,7 +122,7 @@ def ring_crow(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "rings"})
+@gf.cell_with_module_name(tags=["rings"])
 def ring_asymmetric(
     radius: float = 10.0,
     length_x: float = 2.0,

--- a/gdsfactory/components/rings/ring_crow_couplers.py
+++ b/gdsfactory/components/rings/ring_crow_couplers.py
@@ -13,9 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_crow_couplers(
     radius: Sequence[float] = (10.0,) * 3,
     bends: Sequence[ComponentSpec] = ("bend_circular",) * 3,

--- a/gdsfactory/components/rings/ring_crow_couplers.py
+++ b/gdsfactory/components/rings/ring_crow_couplers.py
@@ -13,7 +13,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_crow_couplers(
     radius: Sequence[float] = (10.0,) * 3,
     bends: Sequence[ComponentSpec] = ("bend_circular",) * 3,

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -9,9 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_double(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_double.py
+++ b/gdsfactory/components/rings/ring_double.py
@@ -9,7 +9,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_double(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_double_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_double_bend_coupler.py
@@ -10,9 +10,7 @@ from .._schematic import ring_double_schematic
 from ..bends.bend_circular import bend_circular_all_angle
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_double_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_double_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_double_bend_coupler.py
@@ -10,7 +10,9 @@ from .._schematic import ring_double_schematic
 from ..bends.bend_circular import bend_circular_all_angle
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_double_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, 
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_heater.py
+++ b/gdsfactory/components/rings/ring_heater.py
@@ -11,9 +11,7 @@ from gdsfactory.typings import AngleInDegrees, ComponentSpec, CrossSectionSpec, 
 from .._schematic import ring_double_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_double_heater(
     gap: float = 0.2,
     gap_top: float | None = None,

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -52,9 +52,7 @@ _heater_vias = partial(
 )
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_double_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_double_schematic, tags=["rings"])
 def ring_double_pn(
     add_gap: float = 0.3,
     drop_gap: float = 0.3,
@@ -213,9 +211,7 @@ def ring_double_pn(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def ring_single_pn(
     gap: float = 0.3,
     radius: float = 5.0,

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -52,7 +52,9 @@ _heater_vias = partial(
 )
 
 
-@gf.cell_with_module_name(schematic_function=ring_double_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_double_schematic, tags={"type": "rings"}
+)
 def ring_double_pn(
     add_gap: float = 0.3,
     drop_gap: float = 0.3,
@@ -211,7 +213,9 @@ def ring_double_pn(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def ring_single_pn(
     gap: float = 0.3,
     radius: float = 5.0,

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -8,7 +8,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def ring_single(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/rings/ring_single.py
+++ b/gdsfactory/components/rings/ring_single.py
@@ -8,9 +8,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def ring_single(
     gap: float = 0.2,
     radius: float | None = None,

--- a/gdsfactory/components/rings/ring_single_array.py
+++ b/gdsfactory/components/rings/ring_single_array.py
@@ -14,7 +14,7 @@ _list_of_dicts: tuple[dict[str, Any], ...] = (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "rings"})
 def ring_single_array(
     ring: ComponentSpec = "ring_single",
     spacing: float = 15.0,

--- a/gdsfactory/components/rings/ring_single_array.py
+++ b/gdsfactory/components/rings/ring_single_array.py
@@ -14,7 +14,7 @@ _list_of_dicts: tuple[dict[str, Any], ...] = (
 )
 
 
-@gf.cell_with_module_name(tags={"type": "rings"})
+@gf.cell_with_module_name(tags=["rings"])
 def ring_single_array(
     ring: ComponentSpec = "ring_single",
     spacing: float = 15.0,

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -16,7 +16,7 @@ from .._schematic import (
 from ..bends.bend_circular import bend_circular_all_angle
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic, tags={"type": "rings"})
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags=["rings"])
 def coupler_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -95,9 +95,7 @@ def coupler_bend(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=coupler_ring_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=coupler_ring_schematic, tags=["rings"])
 def coupler_ring_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -159,9 +157,7 @@ def coupler_ring_bend(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def ring_single_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -16,7 +16,7 @@ from .._schematic import (
 from ..bends.bend_circular import bend_circular_all_angle
 
 
-@gf.cell_with_module_name(schematic_function=coupler_schematic)
+@gf.cell_with_module_name(schematic_function=coupler_schematic, tags={"type": "rings"})
 def coupler_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -95,7 +95,9 @@ def coupler_bend(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=coupler_ring_schematic)
+@gf.cell_with_module_name(
+    schematic_function=coupler_ring_schematic, tags={"type": "rings"}
+)
 def coupler_ring_bend(
     radius: float | None = None,
     coupler_gap: float = 0.2,
@@ -157,7 +159,9 @@ def coupler_ring_bend(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def ring_single_bend_coupler(
     radius: float = 5.0,
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -12,9 +12,7 @@ from gdsfactory.typings import ComponentSpec
 from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=ring_single_schematic, tags={"type": "rings"}
-)
+@gf.cell_with_module_name(schematic_function=ring_single_schematic, tags=["rings"])
 def ring_single_dut(
     component: ComponentSpec = "straight",
     gap: float = 0.2,

--- a/gdsfactory/components/rings/ring_single_dut.py
+++ b/gdsfactory/components/rings/ring_single_dut.py
@@ -12,7 +12,9 @@ from gdsfactory.typings import ComponentSpec
 from .._schematic import ring_single_schematic
 
 
-@gf.cell_with_module_name(schematic_function=ring_single_schematic)
+@gf.cell_with_module_name(
+    schematic_function=ring_single_schematic, tags={"type": "rings"}
+)
 def ring_single_dut(
     component: ComponentSpec = "straight",
     gap: float = 0.2,

--- a/gdsfactory/components/shapes/C.py
+++ b/gdsfactory/components/shapes/C.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def C(
     width: float = 1.0,
     size: Size = (10.0, 20.0),

--- a/gdsfactory/components/shapes/C.py
+++ b/gdsfactory/components/shapes/C.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def C(
     width: float = 1.0,
     size: Size = (10.0, 20.0),

--- a/gdsfactory/components/shapes/L.py
+++ b/gdsfactory/components/shapes/L.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def L(
     width: int | float = 1,
     size: tuple[int, int] = (10, 20),

--- a/gdsfactory/components/shapes/L.py
+++ b/gdsfactory/components/shapes/L.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def L(
     width: int | float = 1,
     size: tuple[int, int] = (10, 20),

--- a/gdsfactory/components/shapes/bbox.py
+++ b/gdsfactory/components/shapes/bbox.py
@@ -44,7 +44,7 @@ def bbox_to_points(
     ]
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def bbox(
     component: gf.Component | ComponentReference,
     layer: LayerSpec,

--- a/gdsfactory/components/shapes/bbox.py
+++ b/gdsfactory/components/shapes/bbox.py
@@ -44,7 +44,7 @@ def bbox_to_points(
     ]
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def bbox(
     component: gf.Component | ComponentReference,
     layer: LayerSpec,

--- a/gdsfactory/components/shapes/circle.py
+++ b/gdsfactory/components/shapes/circle.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def circle(
     radius: float = 10.0,
     angle_resolution: float = 2.5,

--- a/gdsfactory/components/shapes/circle.py
+++ b/gdsfactory/components/shapes/circle.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def circle(
     radius: float = 10.0,
     angle_resolution: float = 2.5,

--- a/gdsfactory/components/shapes/circle_wave.py
+++ b/gdsfactory/components/shapes/circle_wave.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def circle_wave(
     radius: float = 10.0,
     amplitude: float = 1.0,

--- a/gdsfactory/components/shapes/circle_wave.py
+++ b/gdsfactory/components/shapes/circle_wave.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def circle_wave(
     radius: float = 10.0,
     amplitude: float = 1.0,

--- a/gdsfactory/components/shapes/compass.py
+++ b/gdsfactory/components/shapes/compass.py
@@ -9,7 +9,7 @@ from gdsfactory.snap import snap_to_grid2x
 from gdsfactory.typings import Ints, LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def compass(
     size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/shapes/compass.py
+++ b/gdsfactory/components/shapes/compass.py
@@ -9,7 +9,7 @@ from gdsfactory.snap import snap_to_grid2x
 from gdsfactory.typings import Ints, LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def compass(
     size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/shapes/cross.py
+++ b/gdsfactory/components/shapes/cross.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def cross(
     length: float = 10.0,
     width: float = 3.0,

--- a/gdsfactory/components/shapes/cross.py
+++ b/gdsfactory/components/shapes/cross.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def cross(
     length: float = 10.0,
     width: float = 3.0,

--- a/gdsfactory/components/shapes/dash.py
+++ b/gdsfactory/components/shapes/dash.py
@@ -29,7 +29,7 @@ def _bezier3(
     return list(x), list(y)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def dash(
     width: float = 10.0,
     width_end: float = 1.0,

--- a/gdsfactory/components/shapes/dash.py
+++ b/gdsfactory/components/shapes/dash.py
@@ -29,7 +29,7 @@ def _bezier3(
     return list(x), list(y)
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def dash(
     width: float = 10.0,
     width_end: float = 1.0,

--- a/gdsfactory/components/shapes/ellipse.py
+++ b/gdsfactory/components/shapes/ellipse.py
@@ -10,7 +10,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def ellipse(
     radii: tuple[float, float] = (10.0, 5.0),
     angle_resolution: float = 2.5,

--- a/gdsfactory/components/shapes/ellipse.py
+++ b/gdsfactory/components/shapes/ellipse.py
@@ -10,7 +10,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def ellipse(
     radii: tuple[float, float] = (10.0, 5.0),
     angle_resolution: float = 2.5,

--- a/gdsfactory/components/shapes/fiducial_squares.py
+++ b/gdsfactory/components/shapes/fiducial_squares.py
@@ -8,7 +8,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpecs
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def fiducial_squares(
     layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 0.14
 ) -> gf.Component:

--- a/gdsfactory/components/shapes/fiducial_squares.py
+++ b/gdsfactory/components/shapes/fiducial_squares.py
@@ -8,7 +8,7 @@ import gdsfactory as gf
 from gdsfactory.typings import Float2, LayerSpecs
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def fiducial_squares(
     layers: LayerSpecs = ("WG",), size: Float2 = (5, 5), offset: float = 0.14
 ) -> gf.Component:

--- a/gdsfactory/components/shapes/fractal.py
+++ b/gdsfactory/components/shapes/fractal.py
@@ -93,7 +93,7 @@ def _vicsek_saltire(depth: int, size: float) -> list[list[tuple[float, float]]]:
     return polygons
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def fractal(
     fractal_type: Literal[
         "sierpinski_triangle",

--- a/gdsfactory/components/shapes/fractal.py
+++ b/gdsfactory/components/shapes/fractal.py
@@ -93,7 +93,7 @@ def _vicsek_saltire(depth: int, size: float) -> list[list[tuple[float, float]]]:
     return polygons
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def fractal(
     fractal_type: Literal[
         "sierpinski_triangle",

--- a/gdsfactory/components/shapes/nxn.py
+++ b/gdsfactory/components/shapes/nxn.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def nxn(
     west: int = 1,
     east: int = 4,

--- a/gdsfactory/components/shapes/nxn.py
+++ b/gdsfactory/components/shapes/nxn.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def nxn(
     west: int = 1,
     east: int = 4,

--- a/gdsfactory/components/shapes/pie_arc.py
+++ b/gdsfactory/components/shapes/pie_arc.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def pie_arc(
     radius: float = 10.0,
     radius_y: float | None = None,

--- a/gdsfactory/components/shapes/pie_arc.py
+++ b/gdsfactory/components/shapes/pie_arc.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def pie_arc(
     radius: float = 10.0,
     radius_y: float | None = None,

--- a/gdsfactory/components/shapes/rect_su_shape.py
+++ b/gdsfactory/components/shapes/rect_su_shape.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def rect_su_shape(
     L1: float = 10.0,
     L2: float = 10.0,

--- a/gdsfactory/components/shapes/rect_su_shape.py
+++ b/gdsfactory/components/shapes/rect_su_shape.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def rect_su_shape(
     L1: float = 10.0,
     L2: float = 10.0,

--- a/gdsfactory/components/shapes/rect_taper.py
+++ b/gdsfactory/components/shapes/rect_taper.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def rect_taper(
     rect_width: float = 1.0,
     rect_length: float = 10.0,

--- a/gdsfactory/components/shapes/rect_taper.py
+++ b/gdsfactory/components/shapes/rect_taper.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def rect_taper(
     rect_width: float = 1.0,
     rect_length: float = 10.0,

--- a/gdsfactory/components/shapes/rectangle.py
+++ b/gdsfactory/components/shapes/rectangle.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import Ints, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def rectangle(
     size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",
@@ -47,7 +47,7 @@ marker_te = partial(rectangle, size=(fiber_size, fiber_size), layer="TE", center
 marker_tm = partial(rectangle, size=(fiber_size, fiber_size), layer="TM", centered=True)
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def rectangles(
     size: Size = (4.0, 2.0),
     offsets: Sequence[float] | None = None,

--- a/gdsfactory/components/shapes/rectangle.py
+++ b/gdsfactory/components/shapes/rectangle.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import Ints, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def rectangle(
     size: Size = (4.0, 2.0),
     layer: LayerSpec = "WG",
@@ -47,7 +47,7 @@ marker_te = partial(rectangle, size=(fiber_size, fiber_size), layer="TE", center
 marker_tm = partial(rectangle, size=(fiber_size, fiber_size), layer="TM", centered=True)
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def rectangles(
     size: Size = (4.0, 2.0),
     offsets: Sequence[float] | None = None,

--- a/gdsfactory/components/shapes/regular_polygon.py
+++ b/gdsfactory/components/shapes/regular_polygon.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def regular_polygon(
     sides: int = 6,
     side_length: float = 10,

--- a/gdsfactory/components/shapes/regular_polygon.py
+++ b/gdsfactory/components/shapes/regular_polygon.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def regular_polygon(
     sides: int = 6,
     side_length: float = 10,

--- a/gdsfactory/components/shapes/rounded_rectangle.py
+++ b/gdsfactory/components/shapes/rounded_rectangle.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def rounded_rectangle(
     width: float = 20.0,
     height: float = 10.0,

--- a/gdsfactory/components/shapes/rounded_rectangle.py
+++ b/gdsfactory/components/shapes/rounded_rectangle.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def rounded_rectangle(
     width: float = 20.0,
     height: float = 10.0,

--- a/gdsfactory/components/shapes/star.py
+++ b/gdsfactory/components/shapes/star.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def star(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/star.py
+++ b/gdsfactory/components/shapes/star.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def star(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/torus.py
+++ b/gdsfactory/components/shapes/torus.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def torus(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/torus.py
+++ b/gdsfactory/components/shapes/torus.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def torus(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/torus_wave.py
+++ b/gdsfactory/components/shapes/torus_wave.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def torus_wave(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/torus_wave.py
+++ b/gdsfactory/components/shapes/torus_wave.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def torus_wave(
     inner_radius: float = 5.0,
     outer_radius: float = 10.0,

--- a/gdsfactory/components/shapes/triangles.py
+++ b/gdsfactory/components/shapes/triangles.py
@@ -17,7 +17,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def triangle(
     x: float = 10,
     xtop: float = 0,
@@ -53,7 +53,7 @@ def triangle(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def triangle2(spacing: float = 3, **kwargs: Any) -> Component:
     r"""Return 2 triangles (bot, top).
 
@@ -97,7 +97,7 @@ def triangle2(spacing: float = 3, **kwargs: Any) -> Component:
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "shapes"})
+@gf.cell_with_module_name(tags=["shapes"])
 def triangle4(**kwargs: Any) -> Component:
     r"""Return 4 triangles.
 

--- a/gdsfactory/components/shapes/triangles.py
+++ b/gdsfactory/components/shapes/triangles.py
@@ -17,7 +17,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def triangle(
     x: float = 10,
     xtop: float = 0,
@@ -53,7 +53,7 @@ def triangle(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def triangle2(spacing: float = 3, **kwargs: Any) -> Component:
     r"""Return 2 triangles (bot, top).
 
@@ -97,7 +97,7 @@ def triangle2(spacing: float = 3, **kwargs: Any) -> Component:
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "shapes"})
 def triangle4(**kwargs: Any) -> Component:
     r"""Return 4 triangles.
 

--- a/gdsfactory/components/spirals/delay_snake.py
+++ b/gdsfactory/components/spirals/delay_snake.py
@@ -28,7 +28,7 @@ _diagram = r"""
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def delay_snake(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake.py
+++ b/gdsfactory/components/spirals/delay_snake.py
@@ -28,7 +28,7 @@ _diagram = r"""
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def delay_snake(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake2.py
+++ b/gdsfactory/components/spirals/delay_snake2.py
@@ -24,7 +24,7 @@ diagram = """
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def delay_snake2(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake2.py
+++ b/gdsfactory/components/spirals/delay_snake2.py
@@ -24,7 +24,7 @@ diagram = """
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def delay_snake2(
     length: float = 1600.0,
     length0: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake_sbend.py
+++ b/gdsfactory/components/spirals/delay_snake_sbend.py
@@ -27,7 +27,7 @@ diagram = r"""
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def delay_snake_sbend(
     length: float = 100.0,
     length1: float = 0.0,

--- a/gdsfactory/components/spirals/delay_snake_sbend.py
+++ b/gdsfactory/components/spirals/delay_snake_sbend.py
@@ -27,7 +27,7 @@ diagram = r"""
 """
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def delay_snake_sbend(
     length: float = 100.0,
     length1: float = 0.0,

--- a/gdsfactory/components/spirals/spiral.py
+++ b/gdsfactory/components/spirals/spiral.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral(
     length: float = 100,
     bend: ComponentSpec = "bend_euler",

--- a/gdsfactory/components/spirals/spiral.py
+++ b/gdsfactory/components/spirals/spiral.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral(
     length: float = 100,
     bend: ComponentSpec = "bend_euler",

--- a/gdsfactory/components/spirals/spiral_archimedes.py
+++ b/gdsfactory/components/spirals/spiral_archimedes.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "spirals"})
+@gf.cell_with_module_name(tags=["spirals"])
 def spiral_archimedes(
     width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/spirals/spiral_archimedes.py
+++ b/gdsfactory/components/spirals/spiral_archimedes.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "spirals"})
 def spiral_archimedes(
     width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/spirals/spiral_double.py
+++ b/gdsfactory/components/spirals/spiral_double.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_double(
     min_bend_radius: float = 10.0,
     separation: float = 2.0,

--- a/gdsfactory/components/spirals/spiral_double.py
+++ b/gdsfactory/components/spirals/spiral_double.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_double(
     min_bend_radius: float = 10.0,
     separation: float = 2.0,

--- a/gdsfactory/components/spirals/spiral_fermat.py
+++ b/gdsfactory/components/spirals/spiral_fermat.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "spirals"})
+@gf.cell_with_module_name(tags=["spirals"])
 def spiral_fermat(
     width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/spirals/spiral_fermat.py
+++ b/gdsfactory/components/spirals/spiral_fermat.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "spirals"})
 def spiral_fermat(
     width: float = 1.0,
     n_turns: int = 5,

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -25,7 +25,7 @@ from ..bends.bend_s import get_min_sbend_size
 from ..waveguides.straight import straight
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_racetrack(
     min_radius: float | None = None,
     straight_length: float = 20.0,
@@ -106,7 +106,7 @@ def spiral_racetrack(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_racetrack_fixed_length(
     length: float = 1000,
     in_out_port_spacing: float = 150,
@@ -313,7 +313,7 @@ def _req_straight_len(
     return float(f(length))
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_racetrack_heater_metal(
     min_radius: float | None = None,
     straight_length: float = 30,
@@ -420,7 +420,7 @@ def spiral_racetrack_heater_metal(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_racetrack_heater_doped(
     min_radius: float | None = None,
     straight_length: float = 30,

--- a/gdsfactory/components/spirals/spiral_heater.py
+++ b/gdsfactory/components/spirals/spiral_heater.py
@@ -25,7 +25,7 @@ from ..bends.bend_s import get_min_sbend_size
 from ..waveguides.straight import straight
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_racetrack(
     min_radius: float | None = None,
     straight_length: float = 20.0,
@@ -106,7 +106,7 @@ def spiral_racetrack(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_racetrack_fixed_length(
     length: float = 1000,
     in_out_port_spacing: float = 150,
@@ -313,7 +313,7 @@ def _req_straight_len(
     return float(f(length))
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_racetrack_heater_metal(
     min_radius: float | None = None,
     straight_length: float = 30,
@@ -420,7 +420,7 @@ def spiral_racetrack_heater_metal(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_racetrack_heater_doped(
     min_radius: float | None = None,
     straight_length: float = 30,

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic)
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
 def spiral_inductor(
     width: float = 3.0,
     pitch: float = 3.0,

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from .._schematic import spiral_schematic
 
 
-@gf.cell_with_module_name(schematic_function=spiral_schematic, tags={"type": "spirals"})
+@gf.cell_with_module_name(schematic_function=spiral_schematic, tags=["spirals"])
 def spiral_inductor(
     width: float = 3.0,
     pitch: float = 3.0,

--- a/gdsfactory/components/spirals/spiral_logarithmic.py
+++ b/gdsfactory/components/spirals/spiral_logarithmic.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "spirals"})
 def spiral_logarithmic(
     width: float = 0.5,
     n_turns: int = 4,

--- a/gdsfactory/components/spirals/spiral_logarithmic.py
+++ b/gdsfactory/components/spirals/spiral_logarithmic.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "spirals"})
+@gf.cell_with_module_name(tags=["spirals"])
 def spiral_logarithmic(
     width: float = 0.5,
     n_turns: int = 4,

--- a/gdsfactory/components/spirals/spiral_rectangular.py
+++ b/gdsfactory/components/spirals/spiral_rectangular.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "spirals"})
 def spiral_rectangular(
     n_turns: int = 4,
     width: float = 1.0,

--- a/gdsfactory/components/spirals/spiral_rectangular.py
+++ b/gdsfactory/components/spirals/spiral_rectangular.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "spirals"})
+@gf.cell_with_module_name(tags=["spirals"])
 def spiral_rectangular(
     n_turns: int = 4,
     width: float = 1.0,

--- a/gdsfactory/components/superconductors/hline.py
+++ b/gdsfactory/components/superconductors/hline.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def hline(
     length: float = 10.0,
     width: float = 0.5,

--- a/gdsfactory/components/superconductors/hline.py
+++ b/gdsfactory/components/superconductors/hline.py
@@ -7,7 +7,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def hline(
     length: float = 10.0,
     width: float = 0.5,

--- a/gdsfactory/components/superconductors/optimal_90deg.py
+++ b/gdsfactory/components/superconductors/optimal_90deg.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def optimal_90deg(
     width: float = 100,
     num_pts: int = 15,

--- a/gdsfactory/components/superconductors/optimal_90deg.py
+++ b/gdsfactory/components/superconductors/optimal_90deg.py
@@ -11,7 +11,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def optimal_90deg(
     width: float = 100,
     num_pts: int = 15,

--- a/gdsfactory/components/superconductors/optimal_hairpin.py
+++ b/gdsfactory/components/superconductors/optimal_hairpin.py
@@ -10,7 +10,7 @@ from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def optimal_hairpin(
     width: float = 0.2,
     pitch: float = 0.6,

--- a/gdsfactory/components/superconductors/optimal_hairpin.py
+++ b/gdsfactory/components/superconductors/optimal_hairpin.py
@@ -10,7 +10,7 @@ from gdsfactory.snap import snap_to_grid
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def optimal_hairpin(
     width: float = 0.2,
     pitch: float = 0.6,

--- a/gdsfactory/components/superconductors/optimal_step.py
+++ b/gdsfactory/components/superconductors/optimal_step.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def optimal_step(
     start_width: float = 10,
     end_width: float = 22,

--- a/gdsfactory/components/superconductors/optimal_step.py
+++ b/gdsfactory/components/superconductors/optimal_step.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def optimal_step(
     start_width: float = 10,
     end_width: float = 22,

--- a/gdsfactory/components/superconductors/snspd.py
+++ b/gdsfactory/components/superconductors/snspd.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import LayerSpec, Port, Size
 from ..superconductors.optimal_hairpin import optimal_hairpin
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def snspd(
     wire_width: float = 0.2,
     wire_pitch: float = 0.6,

--- a/gdsfactory/components/superconductors/snspd.py
+++ b/gdsfactory/components/superconductors/snspd.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import LayerSpec, Port, Size
 from ..superconductors.optimal_hairpin import optimal_hairpin
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def snspd(
     wire_width: float = 0.2,
     wire_pitch: float = 0.6,

--- a/gdsfactory/components/superconductors/ytron.py
+++ b/gdsfactory/components/superconductors/ytron.py
@@ -15,7 +15,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "superconductors"})
+@gf.cell_with_module_name(tags=["superconductors"])
 def ytron_round(
     rho: float = 1,
     arm_lengths: tuple[float, float] = (500, 300),

--- a/gdsfactory/components/superconductors/ytron.py
+++ b/gdsfactory/components/superconductors/ytron.py
@@ -15,7 +15,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "superconductors"})
 def ytron_round(
     rho: float = 1,
     arm_lengths: tuple[float, float] = (500, 300),

--- a/gdsfactory/components/tapers/ramp.py
+++ b/gdsfactory/components/tapers/ramp.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def ramp(
     length: float = 10.0,
     width1: float = 5.0,

--- a/gdsfactory/components/tapers/ramp.py
+++ b/gdsfactory/components/tapers/ramp.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def ramp(
     length: float = 10.0,
     width1: float = 5.0,

--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -20,7 +20,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec
 from .._schematic import taper_schematic, transition_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper(
     length: float = 10.0,
     width1: float = 0.5,
@@ -132,7 +132,9 @@ def taper(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=transition_schematic)
+@gf.cell_with_module_name(
+    schematic_function=transition_schematic, tags={"type": "tapers"}
+)
 def taper_strip_to_ridge(
     length: float = 10.0,
     width1: float = 0.5,
@@ -217,7 +219,9 @@ def taper_strip_to_ridge(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=transition_schematic)
+@gf.cell_with_module_name(
+    schematic_function=transition_schematic, tags={"type": "tapers"}
+)
 def taper_strip_to_ridge_trenches(
     length: float = 10.0,
     width: float = 0.5,
@@ -268,7 +272,9 @@ def taper_strip_to_ridge_trenches(
 taper_strip_to_slab150 = partial(taper_strip_to_ridge, layer_slab="SLAB150")
 
 
-@gf.cell_with_module_name(schematic_function=transition_schematic)
+@gf.cell_with_module_name(
+    schematic_function=transition_schematic, tags={"type": "tapers"}
+)
 def taper_sc_nc(
     width1: float = 0.5,
     width2: float = 1,
@@ -304,7 +310,9 @@ def taper_sc_nc(
     )
 
 
-@gf.cell_with_module_name(schematic_function=transition_schematic)
+@gf.cell_with_module_name(
+    schematic_function=transition_schematic, tags={"type": "tapers"}
+)
 def taper_nc_sc(
     width1: float = 1,
     width2: float = 0.5,

--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -20,7 +20,7 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec
 from .._schematic import taper_schematic, transition_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper(
     length: float = 10.0,
     width1: float = 0.5,
@@ -132,9 +132,7 @@ def taper(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=transition_schematic, tags={"type": "tapers"}
-)
+@gf.cell_with_module_name(schematic_function=transition_schematic, tags=["tapers"])
 def taper_strip_to_ridge(
     length: float = 10.0,
     width1: float = 0.5,
@@ -219,9 +217,7 @@ def taper_strip_to_ridge(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=transition_schematic, tags={"type": "tapers"}
-)
+@gf.cell_with_module_name(schematic_function=transition_schematic, tags=["tapers"])
 def taper_strip_to_ridge_trenches(
     length: float = 10.0,
     width: float = 0.5,
@@ -272,9 +268,7 @@ def taper_strip_to_ridge_trenches(
 taper_strip_to_slab150 = partial(taper_strip_to_ridge, layer_slab="SLAB150")
 
 
-@gf.cell_with_module_name(
-    schematic_function=transition_schematic, tags={"type": "tapers"}
-)
+@gf.cell_with_module_name(schematic_function=transition_schematic, tags=["tapers"])
 def taper_sc_nc(
     width1: float = 0.5,
     width2: float = 1,
@@ -310,9 +304,7 @@ def taper_sc_nc(
     )
 
 
-@gf.cell_with_module_name(
-    schematic_function=transition_schematic, tags={"type": "tapers"}
-)
+@gf.cell_with_module_name(schematic_function=transition_schematic, tags=["tapers"])
 def taper_nc_sc(
     width1: float = 1,
     width2: float = 0.5,

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -47,7 +47,7 @@ def neff_TE1550SOI_220nm(w: float) -> float:
     return float(np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w).item())
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper_adiabatic(
     width1: float = 0.5,
     width2: float = 5.0,

--- a/gdsfactory/components/tapers/taper_adiabatic.py
+++ b/gdsfactory/components/tapers/taper_adiabatic.py
@@ -47,7 +47,7 @@ def neff_TE1550SOI_220nm(w: float) -> float:
     return float(np.poly1d(adiabatic_polyfit_TE1550SOI_220nm)(w).item())
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper_adiabatic(
     width1: float = 0.5,
     width2: float = 5.0,

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -16,7 +16,9 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import transition_schematic
 
 
-@gf.cell_with_module_name(schematic_function=transition_schematic)
+@gf.cell_with_module_name(
+    schematic_function=transition_schematic, tags={"type": "tapers"}
+)
 def taper_cross_section(
     cross_section1: CrossSectionSpec = "strip_rib_tip",
     cross_section2: CrossSectionSpec = "rib2",

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -16,9 +16,7 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import transition_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=transition_schematic, tags={"type": "tapers"}
-)
+@gf.cell_with_module_name(schematic_function=transition_schematic, tags=["tapers"])
 def taper_cross_section(
     cross_section1: CrossSectionSpec = "strip_rib_tip",
     cross_section2: CrossSectionSpec = "rib2",

--- a/gdsfactory/components/tapers/taper_from_csv.py
+++ b/gdsfactory/components/tapers/taper_from_csv.py
@@ -28,7 +28,7 @@ from .._schematic import taper_schematic
 data = pathlib.Path(__file__).parent / "csv_data"
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper_from_csv(
     filepath: Path = data / "taper_strip_0p5_3_36.csv",
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/tapers/taper_from_csv.py
+++ b/gdsfactory/components/tapers/taper_from_csv.py
@@ -28,7 +28,7 @@ from .._schematic import taper_schematic
 data = pathlib.Path(__file__).parent / "csv_data"
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper_from_csv(
     filepath: Path = data / "taper_strip_0p5_3_36.csv",
     cross_section: CrossSectionSpec = "strip",

--- a/gdsfactory/components/tapers/taper_hecken.py
+++ b/gdsfactory/components/tapers/taper_hecken.py
@@ -23,7 +23,7 @@ from ..analog.microstrip import (
 )
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper_hecken(
     length: float = 200,
     B: float = 4.0091,

--- a/gdsfactory/components/tapers/taper_hecken.py
+++ b/gdsfactory/components/tapers/taper_hecken.py
@@ -23,7 +23,7 @@ from ..analog.microstrip import (
 )
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper_hecken(
     length: float = 200,
     B: float = 4.0091,

--- a/gdsfactory/components/tapers/taper_meander.py
+++ b/gdsfactory/components/tapers/taper_meander.py
@@ -18,7 +18,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper_meander(
     x_taper: tuple[float, ...] | None = None,
     w_taper: tuple[float, ...] | None = None,
@@ -54,7 +54,7 @@ def taper_meander(
         """Interpolate width at a given x position."""
         return float(np.interp(x, x_taper_arr, w_taper_arr))
 
-    @gf.cell(tags={"type": "tapers"})
+    @gf.cell(tags=["tapers"])
     def taper_section(
         x_start: float, x_end: float, num_pts: int = 30, layer: LayerSpec = layer
     ) -> Component:
@@ -97,7 +97,7 @@ def taper_meander(
         )
         return c
 
-    @gf.cell(tags={"type": "tapers"})
+    @gf.cell(tags=["tapers"])
     def arc_tapered(
         radius: float = 10,
         width1: float = 1,

--- a/gdsfactory/components/tapers/taper_meander.py
+++ b/gdsfactory/components/tapers/taper_meander.py
@@ -18,7 +18,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper_meander(
     x_taper: tuple[float, ...] | None = None,
     w_taper: tuple[float, ...] | None = None,
@@ -54,7 +54,7 @@ def taper_meander(
         """Interpolate width at a given x position."""
         return float(np.interp(x, x_taper_arr, w_taper_arr))
 
-    @gf.cell
+    @gf.cell(tags={"type": "tapers"})
     def taper_section(
         x_start: float, x_end: float, num_pts: int = 30, layer: LayerSpec = layer
     ) -> Component:
@@ -97,7 +97,7 @@ def taper_meander(
         )
         return c
 
-    @gf.cell
+    @gf.cell(tags={"type": "tapers"})
     def arc_tapered(
         radius: float = 10,
         width1: float = 1,

--- a/gdsfactory/components/tapers/taper_parabolic.py
+++ b/gdsfactory/components/tapers/taper_parabolic.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags=["tapers"])
 def taper_parabolic(
     length: float = 20,
     width1: float = 0.5,

--- a/gdsfactory/components/tapers/taper_parabolic.py
+++ b/gdsfactory/components/tapers/taper_parabolic.py
@@ -11,7 +11,7 @@ from gdsfactory.typings import LayerSpec
 from .._schematic import taper_schematic
 
 
-@gf.cell_with_module_name(schematic_function=taper_schematic)
+@gf.cell_with_module_name(schematic_function=taper_schematic, tags={"type": "tapers"})
 def taper_parabolic(
     length: float = 20,
     width1: float = 0.5,

--- a/gdsfactory/components/texts/text.py
+++ b/gdsfactory/components/texts/text.py
@@ -11,7 +11,7 @@ from gdsfactory.constants import _glyph, _indent, _width
 from gdsfactory.typings import Coordinate, LayerSpec, LayerSpecs
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text(
     text: str = "abcd",
     size: float = 10.0,
@@ -70,7 +70,7 @@ def text(
     return t
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text_lines(
     text: tuple[str, ...] = ("Chip", "01"),
     size: float = 0.4,
@@ -92,7 +92,7 @@ def text_lines(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text_klayout(
     text: str = "a",
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/texts/text.py
+++ b/gdsfactory/components/texts/text.py
@@ -11,7 +11,7 @@ from gdsfactory.constants import _glyph, _indent, _width
 from gdsfactory.typings import Coordinate, LayerSpec, LayerSpecs
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text(
     text: str = "abcd",
     size: float = 10.0,
@@ -70,7 +70,7 @@ def text(
     return t
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text_lines(
     text: tuple[str, ...] = ("Chip", "01"),
     size: float = 0.4,
@@ -92,7 +92,7 @@ def text_lines(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text_klayout(
     text: str = "a",
     layer: LayerSpec = "WG",

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -14,7 +14,7 @@ from gdsfactory.constants import _glyph, _indent, _width
 from gdsfactory.typings import LayerSpec, LayerSpecs, PathType
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text_freetype(
     text: str = "a",
     size: int = 10,

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -14,7 +14,7 @@ from gdsfactory.constants import _glyph, _indent, _width
 from gdsfactory.typings import LayerSpec, LayerSpecs, PathType
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text_freetype(
     text: str = "a",
     size: int = 10,

--- a/gdsfactory/components/texts/text_rectangular.py
+++ b/gdsfactory/components/texts/text_rectangular.py
@@ -17,7 +17,7 @@ from ..texts.text_rectangular_font import (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text_rectangular(
     text: str = "abcd",
     size: float = 10.0,
@@ -89,7 +89,7 @@ def text_rectangular(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def text_rectangular_multi_layer(
     text: str = "abcd",
     layers: LayerSpecs = ("WG", "M1", "M2", "MTOP"),

--- a/gdsfactory/components/texts/text_rectangular.py
+++ b/gdsfactory/components/texts/text_rectangular.py
@@ -17,7 +17,7 @@ from ..texts.text_rectangular_font import (
 )
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text_rectangular(
     text: str = "abcd",
     size: float = 10.0,
@@ -89,7 +89,7 @@ def text_rectangular(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def text_rectangular_multi_layer(
     text: str = "abcd",
     layers: LayerSpecs = ("WG", "M1", "M2", "MTOP"),

--- a/gdsfactory/components/texts/text_rectangular_font.py
+++ b/gdsfactory/components/texts/text_rectangular_font.py
@@ -18,7 +18,7 @@ X   X
 """
 
 
-@gf.cell_with_module_name(tags={"type": "texts"})
+@gf.cell_with_module_name(tags=["texts"])
 def pixel_array(
     pixels: str = character_a,
     pixel_size: float = 10.0,

--- a/gdsfactory/components/texts/text_rectangular_font.py
+++ b/gdsfactory/components/texts/text_rectangular_font.py
@@ -18,7 +18,7 @@ X   X
 """
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "texts"})
 def pixel_array(
     pixels: str = character_a,
     pixel_size: float = 10.0,

--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via(
     size: Size = (0.7, 0.7),
     enclosure: float = 1.0,
@@ -83,7 +83,7 @@ def via(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_circular(
     radius: float = 0.35,
     enclosure: float = 1.0,

--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -13,7 +13,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import LayerSpec, Size
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via(
     size: Size = (0.7, 0.7),
     enclosure: float = 1.0,
@@ -83,7 +83,7 @@ def via(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_circular(
     radius: float = 0.35,
     enclosure: float = 1.0,

--- a/gdsfactory/components/vias/via_chain.py
+++ b/gdsfactory/components/vias/via_chain.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpecs
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_chain(
     num_vias: int = 100,
     cols: int = 10,

--- a/gdsfactory/components/vias/via_chain.py
+++ b/gdsfactory/components/vias/via_chain.py
@@ -9,7 +9,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpecs
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_chain(
     num_vias: int = 100,
     cols: int = 10,

--- a/gdsfactory/components/vias/via_corner.py
+++ b/gdsfactory/components/vias/via_corner.py
@@ -12,7 +12,7 @@ from gdsfactory.port import select_ports
 from gdsfactory.typings import ComponentSpec, MultiCrossSectionAngleSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_corner(
     cross_section: MultiCrossSectionAngleSpec = (
         (metal2, (0, 180)),

--- a/gdsfactory/components/vias/via_corner.py
+++ b/gdsfactory/components/vias/via_corner.py
@@ -12,7 +12,7 @@ from gdsfactory.port import select_ports
 from gdsfactory.typings import ComponentSpec, MultiCrossSectionAngleSpec
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_corner(
     cross_section: MultiCrossSectionAngleSpec = (
         (metal2, (0, 180)),

--- a/gdsfactory/components/vias/via_stack.py
+++ b/gdsfactory/components/vias/via_stack.py
@@ -30,7 +30,7 @@ from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, Floats, Ints, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_stack(
     size: Size = (11.0, 11.0),
     layers: LayerSpecs = ("M1", "M2", "MTOP"),
@@ -249,7 +249,7 @@ def via_stack(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_stack_corner45(
     width: float = 10,
     layers: Sequence[LayerSpec | None] = ("M1", "M2", "MTOP"),
@@ -391,7 +391,7 @@ def via_stack_corner45(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_stack_corner45_extended(
     corner: ComponentSpec = "via_stack_corner45",
     via_stack: ComponentSpec = "via_stack",

--- a/gdsfactory/components/vias/via_stack.py
+++ b/gdsfactory/components/vias/via_stack.py
@@ -30,7 +30,7 @@ from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, Floats, Ints, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_stack(
     size: Size = (11.0, 11.0),
     layers: LayerSpecs = ("M1", "M2", "MTOP"),
@@ -249,7 +249,7 @@ def via_stack(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_stack_corner45(
     width: float = 10,
     layers: Sequence[LayerSpec | None] = ("M1", "M2", "MTOP"),
@@ -391,7 +391,7 @@ def via_stack_corner45(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_stack_corner45_extended(
     corner: ComponentSpec = "via_stack_corner45",
     via_stack: ComponentSpec = "via_stack",

--- a/gdsfactory/components/vias/via_stack_with_offset.py
+++ b/gdsfactory/components/vias/via_stack_with_offset.py
@@ -17,7 +17,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name(tags={"type": "vias"})
+@gf.cell_with_module_name(tags=["vias"])
 def via_stack_with_offset(
     layers: LayerSpecs = ("PPP", "M1"),
     size: Size | None = (10, 10),

--- a/gdsfactory/components/vias/via_stack_with_offset.py
+++ b/gdsfactory/components/vias/via_stack_with_offset.py
@@ -17,7 +17,7 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs, Size
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "vias"})
 def via_stack_with_offset(
     layers: LayerSpecs = ("PPP", "M1"),
     size: Size | None = (10, 10),

--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -18,7 +18,7 @@ from ..bends.bend_s import (
 )
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def crossing_arm(
     r1: float = 3.0,
     r2: float = 1.1,
@@ -83,9 +83,7 @@ def crossing_arm(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=crossing_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=crossing_schematic, tags=["waveguides"])
 def crossing(
     arm: ComponentSpec = crossing_arm,
 ) -> gf.Component:
@@ -105,9 +103,7 @@ def crossing(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=crossing_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=crossing_schematic, tags=["waveguides"])
 def crossing_linear_taper(
     width1: float = 2.5,
     width2: float = 0.5,
@@ -132,9 +128,7 @@ def crossing_linear_taper(
     return crossing(arm=arm)
 
 
-@gf.cell_with_module_name(
-    schematic_function=crossing_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=crossing_schematic, tags=["waveguides"])
 def crossing_etched(
     width: float = 0.5,
     r1: float = 3.0,
@@ -212,7 +206,7 @@ def crossing_etched(
     check_instances=CheckInstances.IGNORE,
     with_module_name=True,
     schematic_function=crossing_schematic,
-    tags={"type": "waveguides"},
+    tags=["waveguides"],
 )
 def crossing45(
     crossing: ComponentSpec = crossing,

--- a/gdsfactory/components/waveguides/crossing_waveguide.py
+++ b/gdsfactory/components/waveguides/crossing_waveguide.py
@@ -18,7 +18,7 @@ from ..bends.bend_s import (
 )
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def crossing_arm(
     r1: float = 3.0,
     r2: float = 1.1,
@@ -83,7 +83,9 @@ def crossing_arm(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=crossing_schematic)
+@gf.cell_with_module_name(
+    schematic_function=crossing_schematic, tags={"type": "waveguides"}
+)
 def crossing(
     arm: ComponentSpec = crossing_arm,
 ) -> gf.Component:
@@ -103,7 +105,9 @@ def crossing(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=crossing_schematic)
+@gf.cell_with_module_name(
+    schematic_function=crossing_schematic, tags={"type": "waveguides"}
+)
 def crossing_linear_taper(
     width1: float = 2.5,
     width2: float = 0.5,
@@ -128,7 +132,9 @@ def crossing_linear_taper(
     return crossing(arm=arm)
 
 
-@gf.cell_with_module_name(schematic_function=crossing_schematic)
+@gf.cell_with_module_name(
+    schematic_function=crossing_schematic, tags={"type": "waveguides"}
+)
 def crossing_etched(
     width: float = 0.5,
     r1: float = 3.0,
@@ -206,6 +212,7 @@ def crossing_etched(
     check_instances=CheckInstances.IGNORE,
     with_module_name=True,
     schematic_function=crossing_schematic,
+    tags={"type": "waveguides"},
 )
 def crossing45(
     crossing: ComponentSpec = crossing,

--- a/gdsfactory/components/waveguides/straight.py
+++ b/gdsfactory/components/waveguides/straight.py
@@ -11,7 +11,9 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import straight_schematic, wire_schematic
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight(
     length: float = 10.0,
     npoints: int = 2,
@@ -79,7 +81,7 @@ def straight_all_angle(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def straight_array(
     n: int = 4,
     spacing: float = 4.0,
@@ -108,7 +110,9 @@ def straight_array(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=wire_schematic)
+@gf.cell_with_module_name(
+    schematic_function=wire_schematic, tags={"type": "waveguides"}
+)
 def wire_straight(
     length: float = 10.0,
     npoints: int = 2,

--- a/gdsfactory/components/waveguides/straight.py
+++ b/gdsfactory/components/waveguides/straight.py
@@ -11,9 +11,7 @@ from gdsfactory.typings import CrossSectionSpec
 from .._schematic import straight_schematic, wire_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight(
     length: float = 10.0,
     npoints: int = 2,
@@ -81,7 +79,7 @@ def straight_all_angle(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def straight_array(
     n: int = 4,
     spacing: float = 4.0,
@@ -110,9 +108,7 @@ def straight_array(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=wire_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=wire_schematic, tags=["waveguides"])
 def wire_straight(
     length: float = 10.0,
     npoints: int = 2,

--- a/gdsfactory/components/waveguides/straight_heater_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_doped.py
@@ -10,9 +10,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Size
 from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_doped_rib(
     length: float = 320.0,
     nsections: int = 3,
@@ -185,9 +183,7 @@ def straight_heater_doped_rib(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_doped_strip(
     length: float = 320.0,
     nsections: int = 3,

--- a/gdsfactory/components/waveguides/straight_heater_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_doped.py
@@ -10,7 +10,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Size
 from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_doped_rib(
     length: float = 320.0,
     nsections: int = 3,
@@ -183,7 +185,9 @@ def straight_heater_doped_rib(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_doped_strip(
     length: float = 320.0,
     nsections: int = 3,

--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -13,7 +13,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpe
 from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_meander(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_meander.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander.py
@@ -13,9 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Floats, LayerSpe
 from .._schematic import straight_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_meander(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_meander_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander_doped.py
@@ -39,7 +39,9 @@ _via_stack = partial(
 )
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_meander_doped(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_meander_doped.py
+++ b/gdsfactory/components/waveguides/straight_heater_meander_doped.py
@@ -39,9 +39,7 @@ _via_stack = partial(
 )
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_meander_doped(
     length: float = 300.0,
     spacing: float = 2.0,

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -18,7 +18,9 @@ from .._schematic import straight_schematic
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_metal_undercut(
     length: float = 320.0,
     length_undercut_spacing: float = 6.0,
@@ -169,7 +171,9 @@ def straight_heater_metal_undercut(
     return c
 
 
-@gf.cell_with_module_name(schematic_function=straight_schematic)
+@gf.cell_with_module_name(
+    schematic_function=straight_schematic, tags={"type": "waveguides"}
+)
 def straight_heater_metal_simple(
     length: float = 320.0,
     cross_section_heater: CrossSectionSpec = "heater_metal",

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -18,9 +18,7 @@ from .._schematic import straight_schematic
 from ..containers.component_sequence import component_sequence
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_metal_undercut(
     length: float = 320.0,
     length_undercut_spacing: float = 6.0,
@@ -171,9 +169,7 @@ def straight_heater_metal_undercut(
     return c
 
 
-@gf.cell_with_module_name(
-    schematic_function=straight_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=straight_schematic, tags=["waveguides"])
 def straight_heater_metal_simple(
     length: float = 320.0,
     cross_section_heater: CrossSectionSpec = "heater_metal",

--- a/gdsfactory/components/waveguides/straight_piecewise.py
+++ b/gdsfactory/components/waveguides/straight_piecewise.py
@@ -13,7 +13,7 @@ from gdsfactory.path import Path
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def straight_piecewise(
     x: Sequence[float] | Path,
     widths: Sequence[float],

--- a/gdsfactory/components/waveguides/straight_piecewise.py
+++ b/gdsfactory/components/waveguides/straight_piecewise.py
@@ -13,7 +13,7 @@ from gdsfactory.path import Path
 from gdsfactory.typings import LayerSpec
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def straight_piecewise(
     x: Sequence[float] | Path,
     widths: Sequence[float],

--- a/gdsfactory/components/waveguides/straight_pin.py
+++ b/gdsfactory/components/waveguides/straight_pin.py
@@ -14,7 +14,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name(schematic_function=modulator_schematic)
+@gf.cell_with_module_name(
+    schematic_function=modulator_schematic, tags={"type": "waveguides"}
+)
 def straight_pin(
     length: float = 500.0,
     cross_section: CrossSectionSpec = pin,

--- a/gdsfactory/components/waveguides/straight_pin.py
+++ b/gdsfactory/components/waveguides/straight_pin.py
@@ -14,9 +14,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=modulator_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=modulator_schematic, tags=["waveguides"])
 def straight_pin(
     length: float = 500.0,
     cross_section: CrossSectionSpec = pin,

--- a/gdsfactory/components/waveguides/straight_pin_slot.py
+++ b/gdsfactory/components/waveguides/straight_pin_slot.py
@@ -13,9 +13,7 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name(
-    schematic_function=modulator_schematic, tags={"type": "waveguides"}
-)
+@gf.cell_with_module_name(schematic_function=modulator_schematic, tags=["waveguides"])
 def straight_pin_slot(
     length: float = 500.0,
     cross_section: CrossSectionSpec = "pin",

--- a/gdsfactory/components/waveguides/straight_pin_slot.py
+++ b/gdsfactory/components/waveguides/straight_pin_slot.py
@@ -13,7 +13,9 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 from .._schematic import modulator_schematic
 
 
-@gf.cell_with_module_name(schematic_function=modulator_schematic)
+@gf.cell_with_module_name(
+    schematic_function=modulator_schematic, tags={"type": "waveguides"}
+)
 def straight_pin_slot(
     length: float = 500.0,
     cross_section: CrossSectionSpec = "pin",

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -22,7 +22,7 @@ from gdsfactory.cross_section import (
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, PortNames, PortTypes
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing",
     port_names: PortNames = port_names_electrical,
@@ -75,7 +75,7 @@ def wire_corner(
     return c
 
 
-@gf.cell
+@gf.cell(tags={"type": "waveguides"})
 def wire_corner45_straight(
     width: float | None = None,
     radius: float | None = None,
@@ -112,7 +112,7 @@ def wire_corner45_straight(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -185,7 +185,7 @@ def wire_corner45(
     return c
 
 
-@gf.cell_with_module_name
+@gf.cell_with_module_name(tags={"type": "waveguides"})
 def wire_corner_sections(
     cross_section: CrossSectionSpec = "metal_routing",
     port_type: str = "electrical",

--- a/gdsfactory/components/waveguides/wire.py
+++ b/gdsfactory/components/waveguides/wire.py
@@ -22,7 +22,7 @@ from gdsfactory.cross_section import (
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, PortNames, PortTypes
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing",
     port_names: PortNames = port_names_electrical,
@@ -75,7 +75,7 @@ def wire_corner(
     return c
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["waveguides"])
 def wire_corner45_straight(
     width: float | None = None,
     radius: float | None = None,
@@ -112,7 +112,7 @@ def wire_corner45_straight(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -185,7 +185,7 @@ def wire_corner45(
     return c
 
 
-@gf.cell_with_module_name(tags={"type": "waveguides"})
+@gf.cell_with_module_name(tags=["waveguides"])
 def wire_corner_sections(
     cross_section: CrossSectionSpec = "metal_routing",
     port_type: str = "electrical",


### PR DESCRIPTION
## Summary
- Adds `tags={"type": "<folder>"}` to every `@gf.cell` / `@gf.cell_with_module_name` decorator across all 24 component subdirectories (~230 cells)
- Tag value matches the folder name (e.g. `waveguides`, `rings`, `bends`, `couplers`, etc.)
- Enables filtering and categorization of components by type

## Test plan
- [x] All files pass `py_compile` syntax check
- [x] All pre-commit hooks pass (ruff check, ruff format, pyright, codespell)
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Annotate component cell decorators with tags indicating their component type (e.g. waveguides, rings, bends, couplers, pads, filters, containers, shapes, spirals, vias, pcms, quantum, mems, microfluidics, superconductors, analog, mmis, mzis, tapers, grating_couplers, dies, texts).