### PR TITLE
add tags arg to vcell

### DIFF
--- a/gdsfactory/_cell.py
+++ b/gdsfactory/_cell.py
@@ -191,6 +191,7 @@ def vcell(
     register_factory: bool = True,
     ports: PortsDefinition | None = None,
     lvs_equivalent_ports: list[list[str]] | None = None,
+    tags: list[str] | None = None,
 ) -> Callable[
     [ComponentAllAngleFunc[ComponentParams]], ComponentAllAngleFunc[ComponentParams]
 ]: ...
@@ -210,6 +211,7 @@ def vcell(
     check_ports: bool = True,
     ports: PortsDefinition | None = None,
     lvs_equivalent_ports: list[list[str]] | None = None,
+    tags: list[str] | None = None,
 ) -> (
     ComponentAllAngleFunc[ComponentParams]
     | Callable[
@@ -231,6 +233,7 @@ def vcell(
         check_ports=check_ports,
         ports=ports,
         lvs_equivalent_ports=lvs_equivalent_ports,
+        tags=tags,
     )
 
     if _func is not None:


### PR DESCRIPTION
## Summary

`@gf.cell(..., tags=[...])`

## Summary by Sourcery

New Features:
- Introduce an optional tags argument to vcell to allow attaching tag metadata to created cells.