### PR TITLE
Optionally pass start and end angle in Path constructor

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -104,8 +104,18 @@ class Path(UMGeometricObject):
         | Path
         | list[tuple[float, float]]
         | None = None,
+        start_angle: float | None = None,
+        end_angle: float | None = None,
     ) -> None:
-        """Creates an empty path."""
+        """Initializes a Path.
+
+        Args:
+            path: array-like[N][2], Path, or list of Paths.
+            start_angle: optional angle in degrees at the start of the path.
+                Overrides the angle inferred from the points.
+            end_angle: optional angle in degrees at the end of the path.
+                Overrides the angle inferred from the points.
+        """
         self.points: npt.NDArray[np.floating[Any]] = np.array(
             [[0, 0]], dtype=np.float64
         )
@@ -136,6 +146,10 @@ class Path(UMGeometricObject):
                     "Path() the `path` argument must be either blank, a path Object, "
                     "an array-like[N][2] list of points, or a list of these"
                 )
+        if start_angle is not None:
+            self.start_angle = mod(start_angle, 360)
+        if end_angle is not None:
+            self.end_angle = mod(end_angle, 360)
 
     def __repr__(self) -> str:
         """Returns path points."""


### PR DESCRIPTION
## Summary

I want to make it easy on me to pass the `start_angle` and `end_angle` manually.

Taken from pattern seen doing this in a custom helper.

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Allow explicit specification of start and end angles when constructing a Path instance.

New Features:
- Add optional start_angle and end_angle parameters to the Path constructor to override inferred angles.

Enhancements:
- Improve Path constructor docstring to describe new angle parameters and accepted path inputs.