### PR TITLE
Improvements to gf diff

### DIFF
--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -135,8 +135,12 @@ def diff(
     output: pathlib.Path | None = None,
     sliver_tolerance: int = 1,
 ) -> None:
-    """Show boolean difference between two layout files."""
-    gf.diff(
+    """Show boolean difference between two layout files.
+
+    Exits with code 0 when files are equivalent,
+    1 on real failures, and 2 when differences are found.
+    """
+    different = gf.diff(
         path1,
         path2,
         test_name=output.stem if output else "gf",
@@ -146,6 +150,8 @@ def diff(
         out_file=output,
         sliver_tolerance=sliver_tolerance,
     )
+    if different:
+        raise typer.Exit(code=2)
 
 
 @app.command()

--- a/gdsfactory/cli.py
+++ b/gdsfactory/cli.py
@@ -133,6 +133,7 @@ def diff(
     show: bool = False,
     stagger: bool = True,
     output: pathlib.Path | None = None,
+    sliver_tolerance: int = 1,
 ) -> None:
     """Show boolean difference between two layout files."""
     gf.diff(
@@ -143,6 +144,7 @@ def diff(
         show=show,
         stagger=stagger,
         out_file=output,
+        sliver_tolerance=sliver_tolerance,
     )
 
 

--- a/gdsfactory/difftest.py
+++ b/gdsfactory/difftest.py
@@ -521,7 +521,9 @@ def overwrite(ref_file: pathlib.Path, run_file: pathlib.Path) -> None:
 
 
 def read_top_cell(arg0: pathlib.Path) -> kf.DKCell:
-    kcl = KCLayout(name=str(arg0))
+    filename = get_name_short(clean_name(str(arg0)))
+
+    kcl = KCLayout(name=filename)
     kcl.read(arg0)
     kcell = kcl.dkcells[kcl.top_cell().name]
 


### PR DESCRIPTION
## Summary

- Fix when the arg is a path and the name isn't sanitized
- Make it easier to use in scripts by giving a status code when things are different
- Allow to control the sliver tolerance from CLI 

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Improve the `gf diff` CLI behavior and fix layout name sanitization when reading top cells from file paths.

New Features:
- Add CLI option to control sliver tolerance for `gf diff`.

Bug Fixes:
- Sanitize layout names derived from file paths when reading top cells to avoid invalid or inconsistent names.

Enhancements:
- Make `gf diff` return distinct exit codes for success, failure, and detected differences to better support scripting use cases.