### PR TITLE
Improve geometry docs and add delete cell sample

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.terminal.activateEnvironment": true,
-  "python.venvPath": "${workspaceFolder}",
-  "python.venvFolders": [
-    ".venv"
-  ],
-  "makefile.configureOnOpen": false
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvironment": true,
+    "python.venvPath": "${workspaceFolder}",
+    "python.venvFolders": [
+        ".venv"
+    ],
+    "makefile.configureOnOpen": false,
+    "python-envs.defaultEnvManager": "ms-python.python:venv",
+    "python-envs.defaultPackageManager": "ms-python.python:pip"
 }

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -17,16 +17,16 @@ parts:
         sections:
           - file: notebooks/00_geometry
           - file: notebooks/01_references
+          - file: notebooks/03_cells_autoname_and_cache
           - file: notebooks/03_Path_CrossSection
+          - file: notebooks/04_components_shapes
           - file: notebooks/04_components_geometry
+          - file: notebooks/04_components_hierarchy
           - file: notebooks/04_components_pack
           - file: notebooks/04_routing
           - file: notebooks/04_routing_electrical
           - file: notebooks/07_mask
           - file: notebooks/11_best_practices
-          - file: notebooks/03_cells_autoname_and_cache
-          - file: notebooks/04_components_hierarchy
-          - file: notebooks/04_components_shapes
           - file: notebooks/12_grid_snapping
       - file: schematic
         sections:

--- a/docs/notebooks/00_geometry.ipynb
+++ b/docs/notebooks/00_geometry.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Component\n",
+    "# Component basics\n",
     "\n",
     "A `Component` is like an empty canvas, in which you can add polygons, references to other Components and ports (to connect to other components)\n",
     "\n",

--- a/docs/notebooks/00_geometry.ipynb
+++ b/docs/notebooks/00_geometry.ipynb
@@ -49,7 +49,7 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "**Exercise** :\n",
+    "**Exercise:**\n",
     "\n",
     "Make a component similar to the one above that has a second polygon in layer (2, 0)"
    ]
@@ -105,7 +105,9 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "For operating boolean operations KLayout regions are very useful.\n",
+    "## Boolean with KLayout Regions\n",
+    "\n",
+    "For boolean operations, KLayout regions are very useful.\n",
     "\n",
     "Notice that many KLayout objects are in database units (DBU) which usually is 1nm, therefore we need to convert a DPolygon (in um) to DBU."
    ]
@@ -493,7 +495,7 @@
    "id": "32",
    "metadata": {},
    "source": [
-    "Another simple example"
+    "## Labels example"
    ]
   },
   {
@@ -525,10 +527,9 @@
     "If you want to subtract one shape from another, merge two shapes, or\n",
     "perform an XOR on them, you can do that with the `boolean()` function.\n",
     "\n",
-    "\n",
-    "The ``operation`` argument should be {not, and, or, xor, 'A-B', 'B-A', 'A+B'}.\n",
+    "The `operation` argument should be {not, and, or, xor, 'A-B', 'B-A', 'A+B'}.\n",
     "Note that 'A+B' is equivalent to 'or', 'A-B' is equivalent to 'not', and\n",
-    "'B-A' is equivalent to 'not' with the operands switched"
+    "'B-A' is equivalent to 'not' with the operands switched."
    ]
   },
   {
@@ -625,13 +626,13 @@
    "id": "42",
    "metadata": {},
    "source": [
-    "## Write\n",
+    "## Write GDS / OASIS / STL\n",
     "\n",
     "You can write your Component to:\n",
     "\n",
     "- GDS file (Graphical Database System) or OASIS for chips.\n",
-    "- gerber for PCB.\n",
-    "- STL for 3d printing."
+    "- Gerber for PCB.\n",
+    "- STL for 3D printing."
    ]
   },
   {
@@ -730,6 +731,58 @@
     "scene = c.to_3d()\n",
     "scene.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52",
+   "metadata": {},
+   "source": [
+    "## Delete Cells\n",
+    "\n",
+    "You can remove cells from the layout to free memory or allow recreating a component.\n",
+    "\n",
+    "- `Component.delete()` — delete a single cell from the layout.\n",
+    "- `gf.kcl.delete_cell(cell)` — delete a cell via the layout object.\n",
+    "- `gf.clear_cache()` — clear all cells from the layout cache."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "ref1 = c << gf.components.text(\"1\")\n",
+    "ref2 = c << gf.components.text(\"2\")\n",
+    "ref2.xmin = ref1.xmax+1\n",
+    "\n",
+    "print(\"Cells before:\", len(list(gf.kcl.each_cell())))\n",
+    "c.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete a specific cell from the layout\n",
+    "gf.kcl.delete_cell(ref2.cell)\n",
+    "\n",
+    "print(\"Cells after:\", len(list(gf.kcl.each_cell())))\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -738,7 +791,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -752,7 +805,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/03_cells_autoname_and_cache.ipynb
+++ b/docs/notebooks/03_cells_autoname_and_cache.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Cell\n",
+    "# Cell decorator\n",
     "\n",
     "A `@cell` is a decorator for functions that return a Component. Make sure you add the `@cell` decorator to each function that returns a Component so you avoid having multiple components with the same name.\n",
     "\n",

--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Generic PDK\n",
+    "# Layers and layer stacks\n",
     "\n",
     "GDSFactory includes a generic Process Design Kit PDK, which is a library of components associated to a generic foundry process `gdsfactory.gpdk`.\n",
     "See components available in the [generic component library](https://gdsfactory.github.io/gdsfactory/components.html) that you can customize or adapt to create your own.\n",

--- a/docs/notebooks/04_components_geometry.ipynb
+++ b/docs/notebooks/04_components_geometry.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Geometry\n",
+    "# Geometry operations\n",
     "\n",
     "gdsfactory provides you with some geometric functions"
    ]

--- a/docs/notebooks/04_routing_electrical.ipynb
+++ b/docs/notebooks/04_routing_electrical.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Routing to IO\n",
+    "# Routing to pads and fiber arrays\n",
     "\n",
     "## Routing electrical\n",
     "For routing low speed DC electrical ports you can use sharp corners instead of smooth bends.\n",

--- a/docs/notebooks/07_mask.ipynb
+++ b/docs/notebooks/07_mask.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Die assembly\n",
+    "# Die and mask assembly\n",
     "\n",
     "With gdsfactory you can easily go from a simple component, to a component with many components inside.\n",
     "\n",

--- a/docs/notebooks/10_schematic.ipynb
+++ b/docs/notebooks/10_schematic.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Schematic\n",
+    "# Schematic driven layout\n",
     "\n",
     "A schematic is a graph representation of your circuit.\n",
     "\n",

--- a/docs/notebooks/12_config.ipynb
+++ b/docs/notebooks/12_config.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# CONFIG \n",
+    "# Configuration\n",
     "\n",
     "You have 2 ways of configuring gdsfactory:\n",
     "\n",

--- a/gdsfactory/samples/08_delete_cell.py
+++ b/gdsfactory/samples/08_delete_cell.py
@@ -1,0 +1,21 @@
+"""Delete a cell from the layout."""
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    gf.gpdk.PDK.activate()
+
+    c = gf.Component()
+    ref1 = c << gf.components.text("1")
+    ref2 = c << gf.components.text("2")
+
+    print("Cells before:", len(list(gf.kcl.each_cell())))
+
+    # Delete a specific cell from the layout
+    gf.kcl.delete_cell(ref2.cell)
+
+    print("Cells after:", len(list(gf.kcl.each_cell())))
+    c.show()
+
+    # Or clear the entire cache (all cells)
+    # gf.clear_cache()


### PR DESCRIPTION
## Summary
- Expanded `00_geometry.ipynb` notebook with improved documentation
- Added `08_delete_cell.py` sample script demonstrating cell deletion

## Test plan
- [x] Verify notebook renders correctly in docs

## Summary

Improve geometry tutorial notebook documentation and add examples for deleting cells from a layout.

New Features:
- Add a new sample script demonstrating how to delete cells from the layout and clear the cell cache.

Documentation:
- Clarify and expand geometry notebook sections, including boolean operations, label examples, and export formats, and add a new subsection on deleting cells from the layout.