### PR TITLE
Passing width/offset functions to cross_section

### DIFF
--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -19,6 +19,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    NonNegativeFloat,
     PrivateAttr,
     field_serializer,
     model_validator,
@@ -72,12 +73,10 @@ class Section(BaseModel):
     """CrossSection to extrude a path with a waveguide.
 
     Parameters:
-        width: of the section (um) or parameterized function from 0 to 1. \
-                the width at t==0 is the width at the beginning of the Path. \
-                the width at t==1 is the width at the end.
-        offset: center offset (um) or function parameterized function from 0 to 1. \
-                the offset at t==0 is the offset at the beginning of the Path. \
-                the offset at t==1 is the offset at the end.
+        width: of the section (um). When `width_function` is set it takes \
+                precedence during extrusion, so `width` acts as a nominal value.
+        offset: center offset (um). When `offset_function` is set it takes \
+                precedence during extrusion, so `offset` acts as a nominal value.
         insets: distance (um) in x to inset section relative to end of the Path \
                 (i.e. (start inset, stop_inset)).
         layer: layer spec. If None does not draw the main section.
@@ -109,7 +108,7 @@ class Section(BaseModel):
             +offset
     """
 
-    width: float
+    width: NonNegativeFloat = 0
     offset: float = 0
     insets: tuple[float, float] | None = None
     layer: typings.LayerSpec
@@ -131,6 +130,12 @@ class Section(BaseModel):
             h = hashlib.md5(str(data).encode()).hexdigest()[:8]
             data["name"] = f"s_{h}"
         return data
+
+    @model_validator(mode="after")
+    def _require_width_value_or_function(self) -> Self:
+        if self.width == 0 and self.width_function is None:
+            raise ValueError("Section requires `width > 0` or a `width_function`.")
+        return self
 
     @field_serializer("width_function")
     def serialize_width_function(

--- a/gdsfactory/cross_section.py
+++ b/gdsfactory/cross_section.py
@@ -535,8 +535,8 @@ def xsection(
 
 
 def cross_section(
-    width: float = 0.5,
-    offset: float = 0,
+    width: float | typings.WidthFunction = 0.5,
+    offset: float | typings.OffsetFunction = 0,
     layer: typings.LayerSpec = "WG",
     sections: Sections | None = None,
     port_names: typings.IOPorts = ("o1", "o2"),
@@ -554,8 +554,8 @@ def cross_section(
     """Return CrossSection.
 
     Args:
-        width: main Section width (um).
-        offset: main Section center offset (um).
+        width: main Section width (um) or parameterized function from 0 to 1.
+        offset: main Section center offset (um) or parameterized function from 0 to 1.
         layer: main section layer.
         sections: list of Sections(width, offset, layer, ports).
         port_names: for input and output ('o1', 'o2').
@@ -654,8 +654,10 @@ def cross_section(
             )
     s = [
         Section(
-            width=width,
-            offset=offset,
+            width=0 if callable(width) else width,
+            width_function=width if callable(width) else None,
+            offset=0 if callable(offset) else offset,
+            offset_function=offset if callable(offset) else None,
             layer=layer,
             port_names=port_names,
             port_types=port_types,
@@ -669,15 +671,26 @@ def cross_section(
         and cladding_simplify_not_none
         and cladding_centers_not_none
     ):
+
+        def _cladding_width_kwargs(offset: float) -> dict[str, Any]:
+            if callable(width):
+                return {"width_function": lambda t: width(t) + 2 * offset}
+            return {"width": width + 2 * offset}
+
         s += [
             Section(
-                width=width + 2 * offset,
-                layer=layer,
-                simplify=simplify,
-                offset=center,
+                **_cladding_width_kwargs(cladding_offset),
+                layer=cladding_layer,
+                simplify=cladding_simplify,
+                offset=cladding_center,
                 name=f"cladding_{i}",
             )
-            for i, (layer, offset, simplify, center) in enumerate(
+            for i, (
+                cladding_layer,
+                cladding_offset,
+                cladding_simplify,
+                cladding_center,
+            ) in enumerate(
                 zip(
                     cladding_layers,
                     cladding_offsets_not_none,

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -4,6 +4,8 @@ from functools import partial
 from typing import Any
 
 import jsondiff
+import numpy as np
+import numpy.typing as npt
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -176,6 +178,31 @@ def test_is_cross_section_invalid() -> None:
 def test_section_requires_width_value_or_function() -> None:
     with pytest.raises(ValidationError):
         gf.Section(layer=(1, 0))
+
+
+def test_cross_section_callable_width_offset() -> None:
+    def width_fn(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
+        return 0.5 + 0.5 * t
+
+    def offset_fn(t: float) -> float:
+        return 0.1 * t
+
+    cladding_offset = 2.0
+    xs = gf.cross_section.cross_section(
+        width=width_fn,
+        offset=offset_fn,
+        layer=(1, 0),
+        cladding_layers=((2, 0),),
+        cladding_offsets=(cladding_offset,),
+    )
+    core, cladding = xs.sections
+    assert core.width_function is width_fn
+    assert core.offset_function is offset_fn
+    assert cladding.width_function is not None
+    sampled = cladding.width_function(np.array([0.0, 1.0]))
+    np.testing.assert_allclose(
+        sampled, width_fn(np.array([0.0, 1.0])) + 2 * cladding_offset
+    )
 
 
 def test_is_cross_section_private() -> None:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -4,8 +4,10 @@ from functools import partial
 from typing import Any
 
 import jsondiff
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from pydantic import ValidationError
 
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER
@@ -169,6 +171,11 @@ def test_is_cross_section_invalid() -> None:
 
     assert not gf.cross_section.is_cross_section("not_xs", not_xs)
     assert not gf.cross_section.is_cross_section("len", len)
+
+
+def test_section_requires_width_value_or_function() -> None:
+    with pytest.raises(ValidationError):
+        gf.Section(layer=(1, 0))
 
 
 def test_is_cross_section_private() -> None:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 from pydantic import ValidationError
 
 import gdsfactory as gf
@@ -180,14 +181,36 @@ def test_section_requires_width_value_or_function() -> None:
         gf.Section(layer=(1, 0))
 
 
-def test_cross_section_callable_width_offset() -> None:
+@given(
+    t_points=arrays(
+        dtype=np.float64,
+        shape=st.integers(min_value=1, max_value=100),
+        elements=st.floats(
+            min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+        ),
+    ),
+    cladding_offset=st.floats(
+        min_value=0.1, max_value=10.0, allow_nan=False, allow_infinity=False
+    ),
+    w_base=st.floats(
+        min_value=0.1, max_value=5.0, allow_nan=False, allow_infinity=False
+    ),
+    w_slope=st.floats(
+        min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_cross_section_callable_width_offset(
+    t_points: npt.NDArray[np.float64],
+    cladding_offset: float,
+    w_base: float,
+    w_slope: float,
+) -> None:
     def width_fn(t: npt.NDArray[np.floating[Any]]) -> npt.NDArray[np.floating[Any]]:
-        return 0.5 + 0.5 * t
+        return w_base + w_slope * t
 
     def offset_fn(t: float) -> float:
         return 0.1 * t
 
-    cladding_offset = 2.0
     xs = gf.cross_section.cross_section(
         width=width_fn,
         offset=offset_fn,
@@ -196,12 +219,15 @@ def test_cross_section_callable_width_offset() -> None:
         cladding_offsets=(cladding_offset,),
     )
     core, cladding = xs.sections
+
     assert core.width_function is width_fn
     assert core.offset_function is offset_fn
     assert cladding.width_function is not None
-    sampled = cladding.width_function(np.array([0.0, 1.0]))
+    sampled = cladding.width_function(t_points)
     np.testing.assert_allclose(
-        sampled, width_fn(np.array([0.0, 1.0])) + 2 * cladding_offset
+        sampled,
+        width_fn(t_points) + 2 * cladding_offset,
+        err_msg="Sampled cladding width does not match expected mathematical output.",
     )
 
 


### PR DESCRIPTION
## Summary

Make it easy to either pass `width` or `width_function`. Same with the `offset`.

## Test Plan

Added tests.

## Summary by Sourcery

Allow cross_section and Section to accept width and offset as either numeric values or functions, and validate that a Section always has an effective width.

New Features:
- Support passing callable width and offset functions directly to cross_section, including propagation to cladding sections.

Enhancements:
- Make Section.width optional with validation ensuring either a positive width or a width_function is provided.
- Ensure width/offset functions take precedence over nominal values during extrusion for both core and cladding sections.

Documentation:
- Clarify Section and cross_section parameter docs to describe precedence of width/offset functions and support for callable width/offset.

Tests:
- Add validation test that Section requires either a positive width or a width_function.
- Add tests verifying cross_section correctly handles callable width and offset, including cladding width computation.