### PR TITLE
remove route single deprecation warning

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -27,7 +27,6 @@ To generate a route:
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from typing import Literal, cast
 
@@ -73,9 +72,6 @@ def route_single(
 ) -> ManhattanRoute:
     """Returns a Manhattan Route between 2 ports.
 
-    .. deprecated::
-        Use :func:`~gdsfactory.routing.route_bundle.route_bundle` with single ports instead.
-
     The references are straights, bends and tapers.
 
     Args:
@@ -113,12 +109,6 @@ def route_single(
         c.plot()
 
     """
-    warnings.warn(
-        "route_single is less flexible and will be removed in GDSFactory10. "
-        "Please use route_bundle instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if cross_section is None and (layer is None or route_width is None):
         raise ValueError(
             f"Either {cross_section=} or {layer=} and route_width must be provided"


### PR DESCRIPTION
## Summary

Route bundle will be able to handle this in the future, but it will change the logic to use route_bundle internally instead as soon as it's merged into kfactory3.0

## Summary by Sourcery

Enhancements:
- Simplify route_single by dropping the deprecation warning in favor of continued direct use.