### PR TITLE
Fix: bend_euler_s duplicate connect undoes mirror

### DIFF
--- a/gdsfactory/components/bends/bend_euler.py
+++ b/gdsfactory/components/bends/bend_euler.py
@@ -203,7 +203,6 @@ def bend_euler_s(
     b1 = c.add_ref(b)
     b2 = c.add_ref(b)
     b2.connect(port1, b1[port2], mirror=True)
-    b2.connect(port1, b1[port2])
     c.add_port(port1, port=b1[port1])
     c.add_port(port2, port=b2[port2])
     c.info["length"] = 2 * b.info["length"]


### PR DESCRIPTION
## Summary
- Remove duplicate `b2.connect(port1, b1[port2])` call in `bend_euler_s` that was overriding the `mirror=True` from the previous line

## Problem
In `gdsfactory/components/bends/bend_euler.py`, the `bend_euler_s` function had two consecutive connect calls:
```python
b2.connect(port1, b1[port2], mirror=True)  # line 205
b2.connect(port1, b1[port2])                # line 206 - overwrites the mirror!
```
The second `connect()` call (without `mirror=True`) undoes the mirror from the first call. This means the S-bend component was not actually creating an S-shaped bend — it was placing two bends in the same direction.

## Fix
Remove the second duplicate `connect()` call so the `mirror=True` takes effect and creates a proper S-bend.

## Test plan
- [x] Verified only one `connect()` call remains with `mirror=True`
- [ ] Visual inspection of `bend_euler_s` component to confirm S-shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Remove a duplicate connect call that overrode the mirror=True parameter, ensuring the S-bend geometry is correctly mirrored.