### PR TITLE
Fix: triangle4_thin should use triangle4, not triangle2

### DIFF
--- a/gdsfactory/components/shapes/triangles.py
+++ b/gdsfactory/components/shapes/triangles.py
@@ -140,4 +140,4 @@ def triangle4(**kwargs: Any) -> Component:
 
 triangle_thin = partial(triangle, xtop=0.2, x=2, y=5)
 triangle2_thin = partial(triangle2, xtop=0.2, x=2, y=5)
-triangle4_thin = partial(triangle2, xtop=0.2, x=2, y=5)
+triangle4_thin = partial(triangle4, xtop=0.2, x=2, y=5)


### PR DESCRIPTION
## Summary
- Fix `triangle4_thin` to use `triangle4` as its base function instead of `triangle2`

## Problem
In `gdsfactory/components/shapes/triangles.py`, line 143:
```python
triangle4_thin = partial(triangle2, xtop=0.2, x=2, y=5)  # wrong!
```
The name `triangle4_thin` clearly indicates it should be a thin variant of `triangle4`, but it was accidentally using `triangle2` as the base. This means:
- `triangle4_thin` produced only 2 triangles instead of 4
- `triangle2_thin` and `triangle4_thin` produced identical results

The pattern is consistent with the other thin variants:
- `triangle_thin = partial(triangle, ...)`
- `triangle2_thin = partial(triangle2, ...)`
- `triangle4_thin = partial(triangle4, ...)` ← should use `triangle4`

## Test plan
- [x] Verified `triangle4` exists and takes the same kwargs
- [ ] Visual comparison of `triangle4_thin` output (should now produce 4 thin triangles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix triangle4_thin to be based on triangle4 instead of triangle2, so it produces four thin triangles as intended.