### PR TITLE
Fix: add_ports_from_markers_center uses stale port_name variable

### DIFF
--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -341,7 +341,7 @@ def add_ports_from_markers_center(
                 "You can pass a port_name_prefix to add it with a different name."
             )
 
-        component.add_port(name=port_name, port=port)
+        component.add_port(name=_port_name_or_none, port=port)
     if auto_rename_ports:
         component.auto_rename_ports()
     return component


### PR DESCRIPTION
## Summary
- Fix `add_ports_from_markers_center` to use the correct `_port_name_or_none` variable instead of the stale `port_name` from the previous loop

## Problem
In `gdsfactory/add_ports.py`, the function `add_ports_from_markers_center` has two loops:

1. **First loop** (line 183): iterates over port markers and creates `port_name` for each, then creates `Port(name=port_name, ...)` objects
2. After sorting ports clockwise (line 333), **second loop** (line 335): adds each port to the component

The bug is on line 344:
```python
component.add_port(name=port_name, port=port)  # port_name is stale!
```

`port_name` still holds the value from the **last iteration of the first loop**, not the current port's name. After `sort_ports_clockwise()` reorders the ports, the name/port mismatch can cause incorrect port naming.

The variable `_port_name_or_none` was already correctly set to `port.name` on line 336, so the fix is to use it.

## Test plan
- [x] Verified `_port_name_or_none` is set to `port.name` on the line above
- [x] Verified the logic matches the pattern in `add_ports_from_boxes` (line 590) which correctly uses `_port_name_or_none`
- [ ] Test with a component that has markers to verify correct port naming after sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect port naming caused by using a stale port_name variable instead of the current port's name when adding sorted marker ports.