### PR TITLE
Fix for Unused import

### DIFF
--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -16,7 +16,6 @@ from natsort import natsorted
 import gdsfactory as gf
 import gdsfactory.schematic as scm
 from gdsfactory.component import Component
-from gdsfactory.name import get_instance_name_from_alias as legacy_namer  # noqa: F401
 from gdsfactory.serialization import DEFAULT_SERIALIZATION_MAX_DIGITS, clean_value_json
 
 Instance: TypeAlias = kf.DInstance | kf.VInstance | kf.Instance


### PR DESCRIPTION
Remove the unused import from `gdsfactory/get_netlist.py` line 19.  
This is the minimal and safest fix: it does not change runtime behavior (since the symbol is unused), and it also removes the unnecessary `# noqa: F401` suppression that was masking the issue.

Concretely:
- Edit the import block near lines 16–21.
- Delete `from gdsfactory.name import get_instance_name_from_alias as legacy_namer  # noqa: F401`.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Clean up the netlist module by deleting an unused import and its associated noqa suppression.