### PR TITLE
fix taper delta_width for multi-section cross sections

### DIFF
--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -90,7 +90,7 @@ def taper(
         s0_width = x.sections[0].width
 
         for section in x.sections[1:]:
-            delta_width = abs(section.width - s0_width)
+            delta_width = section.width - s0_width
             y1 = (width1 + delta_width) / 2
             y2 = (width2 + delta_width) / 2
             offset = section.offset

--- a/gdsfactory/gpdk/__init__.py
+++ b/gdsfactory/gpdk/__init__.py
@@ -59,6 +59,7 @@ def get_generic_pdk() -> Pdk:
 
     layer_transitions = {
         LAYER.WG: "taper",
+        LAYER.WG_ABSTRACT: partial(gf.c.taper, cross_section="rib_with_trenches"),
         (LAYER.WG, LAYER.WGN): "taper_sc_nc",
         (LAYER.WGN, LAYER.WG): "taper_nc_sc",
         LAYER.M3: "taper_electrical",

--- a/gdsfactory/samples/sample_routing_auto_taper.py
+++ b/gdsfactory/samples/sample_routing_auto_taper.py
@@ -1,7 +1,5 @@
 """Slot sample."""
 
-from gpdk import PDK
-
 import gdsfactory as gf
 
 
@@ -44,6 +42,8 @@ def sample_routing_auto_taper_trenches() -> gf.Component:
 
 
 if __name__ == "__main__":
+    from gpdk import PDK
+
     PDK.activate()
 
     c = sample_routing_auto_taper_trenches()

--- a/gdsfactory/samples/sample_routing_auto_taper.py
+++ b/gdsfactory/samples/sample_routing_auto_taper.py
@@ -24,8 +24,27 @@ def sample_routing_auto_taper_slot() -> gf.Component:
     return c
 
 
+@gf.cell
+def sample_routing_auto_taper_trenches() -> gf.Component:
+    """Sample routing auto taper."""
+    c = gf.Component()
+    length = 1
+
+    c1 = c << gf.c.straight(length=length, cross_section="rib_with_trenches")
+    c2 = c << gf.c.straight(length=length, cross_section="rib_with_trenches", width=2)
+    c2.movex(50)
+    c2.movey(50)
+    gf.routing.route_bundle(
+        c,
+        c1.ports["o2"],
+        c2.ports["o1"],
+        cross_section="rib_with_trenches",
+    )
+    return c
+
+
 if __name__ == "__main__":
     PDK.activate()
 
-    c = sample_routing_auto_taper_slot()
+    c = sample_routing_auto_taper_trenches()
     c.show()

--- a/gdsfactory/samples/sample_routing_auto_taper.py
+++ b/gdsfactory/samples/sample_routing_auto_taper.py
@@ -1,0 +1,31 @@
+"""Slot sample."""
+
+from gpdk import PDK
+
+import gdsfactory as gf
+
+
+@gf.cell
+def sample_routing_auto_taper_slot() -> gf.Component:
+    """Sample routing auto taper."""
+    c = gf.Component()
+    length = 1
+
+    c1 = c << gf.c.straight(length=length, cross_section="slot")
+    c2 = c << gf.c.straight(length=length, cross_section="slot", width=2)
+    c2.movex(50)
+    c2.movey(50)
+    gf.routing.route_bundle(
+        c,
+        c1.ports["o2"],
+        c2.ports["o1"],
+        cross_section="slot",
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+
+    c = sample_routing_auto_taper_slot()
+    c.show()


### PR DESCRIPTION
## Summary
- Removed `abs()` from `delta_width` calculation in `taper.py` so that off-center sections (e.g. slot waveguides) taper correctly. Using `abs()` caused the sign of the offset to be lost, producing wrong geometry for sections that are narrower than the primary section.
- Added a sample script (`sample_routing_auto_taper.py`) demonstrating routing with auto-tapers for slot cross sections.

## Help needed
The auto-tapers don't seem to be working correctly for off-center sections in multi-section cross sections (e.g. slot waveguides). The `abs()` removal fixes the sign issue, but there may be additional problems with how offsets are computed during tapering. Would appreciate review and help verifying this works for all cross section types.

## Test plan
- [ ] Run `sample_routing_auto_taper.py` with gpdk and verify slot taper geometry
- [ ] Check existing taper tests still pass
- [ ] Visually inspect tapers for slot and other multi-section cross sections

## Summary by Sourcery

Fix auto-taper geometry for multi-section cross sections and add a sample demonstrating slot waveguide routing with auto-tapers.

New Features:
- Add a sample script showcasing auto-taper routing for slot cross sections using gpdk.

Bug Fixes:
- Correct delta_width computation in taper generation so that off-center sections in multi-section cross sections maintain the correct sign and geometry.