### PR TITLE
fix: use per-end section widths and offsets in taper

### DIFF
--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -87,22 +87,20 @@ def taper(
         )
         c.add_polygon(p1, layer=layer)
 
-        s0_width = x.sections[0].width
-
-        for section in x.sections[1:]:
-            delta_width = section.width - s0_width
-            y1 = (width1 + delta_width) / 2
-            y2 = (width2 + delta_width) / 2
-            offset = section.offset
+        for s1, s2 in zip(x1.sections[1:], x2.sections[1:], strict=False):
+            y1 = s1.width / 2
+            y2 = s2.width / 2
+            offset1 = s1.offset
+            offset2 = s2.offset
             p1 = gf.kdb.DPolygon(
                 [
-                    gf.kdb.DPoint(0, offset + y1),
-                    gf.kdb.DPoint(length, offset + y2),
-                    gf.kdb.DPoint(length, offset - y2),
-                    gf.kdb.DPoint(0, offset - y1),
+                    gf.kdb.DPoint(0, offset1 + y1),
+                    gf.kdb.DPoint(length, offset2 + y2),
+                    gf.kdb.DPoint(length, offset2 - y2),
+                    gf.kdb.DPoint(0, offset1 - y1),
                 ]
             )
-            c.add_polygon(p1, layer=section.layer)
+            c.add_polygon(p1, layer=s1.layer)
 
     if with_bbox:
         x.add_bbox(c)

--- a/gdsfactory/components/tapers/taper.py
+++ b/gdsfactory/components/tapers/taper.py
@@ -351,3 +351,8 @@ taper_electrical = partial(
     port_names=("e1", "e2"),
     cross_section="metal_routing",
 )
+
+taper_with_trenches = partial(
+    taper,
+    cross_section="rib_with_trenches",
+)

--- a/tests/components/test_components.py
+++ b/tests/components/test_components.py
@@ -16,12 +16,14 @@ cells = get_cells([gf.components])
 
 pad_array_layer = partial(gf.c.pad_array, layer="M1")
 pad_array_size = partial(gf.c.pad_array, layer="M1", size=(100, 100))
+taper_with_trenches = partial(gf.c.taper, cross_section="rib_with_trenches")
 
 
 cells.update(
     {
         "pad_array_layer": pad_array_layer,
         "pad_array_size": pad_array_size,
+        "taper_with_trenches": taper_with_trenches,
     }
 )
 

--- a/tests/test-data-regression/test_settings_taper_with_trenches_.yml
+++ b/tests/test-data-regression/test_settings_taper_with_trenches_.yml
@@ -1,0 +1,17 @@
+info:
+  length: 10
+  width1: 0.5
+  width2: 0.5
+name: taper_gdsfactorypcomponentsptapersptaper_L10_W0p5_WNone_d39817d5
+settings:
+  cross_section: rib_with_trenches
+  length: 10
+  port_names:
+  - o1
+  - o2
+  port_types:
+  - optical
+  - optical
+  width1: 0.5
+  with_bbox: true
+  with_two_ports: true


### PR DESCRIPTION
## Summary
- The taper component used `delta_width` from the max-width cross section (`x`) for all sub-sections, applying the same offset at both ends
- For cross sections like `rib_with_trenches`, trench offsets depend on waveguide width (e.g., offset=1.25 at width=0.5 vs offset=2.0 at width=2.0), so using the max-width offset for both ends produced incorrect geometry at the narrower end
- Now uses `x1` and `x2` cross sections directly to get the correct section width and offset at each end of the taper

## Test plan
- [ ] Verify `sample_routing_auto_taper_trenches` renders correctly
- [ ] Check taper geometry for `rib_with_trenches` cross section at different width combinations
- [ ] Verify `slot` cross section tapers render correctly

## Summary by Sourcery

Bug Fixes:
- Fix taper generation for multi-section cross sections (e.g., rib_with_trenches, slot) by using the appropriate width and offset for each section at both ends of the taper.