### PR TITLE
Setting the DBU on PDK activation

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -143,6 +143,8 @@ class Pdk(BaseModel):
         routing_strategies: functions enabled to route.
         bend_points_distance: default points distance for bends in um.
         connectivity: defines connectivity between layers through vias.
+        dbu: database unit in um. If set, applied to kf.kcl on activate().
+            Default None leaves kfactory's default of 0.001 (1 nm/dbu).
 
     """
 
@@ -176,6 +178,7 @@ class Pdk(BaseModel):
     bend_points_distance: float = 20 * nm
     connectivity: Sequence[ConnectivitySpec] | None = None
     max_cellname_length: int = CONF.max_cellname_length
+    dbu: float | None = Field(default=None, gt=0)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -799,6 +802,15 @@ def get_constant(constant_name: Any) -> Any:
 
 def _set_active_pdk(pdk: Pdk) -> None:
     global _ACTIVE_PDK
+
+    if pdk.dbu is not None and pdk.dbu != kf.kcl.dbu:
+        if len(kf.kcl.kcells) > 0:
+            raise ValueError(
+                f"Cannot change DBU from {kf.kcl.dbu} to {pdk.dbu}: "
+                f"{len(kf.kcl.kcells)} cell(s) already exist on the KCLayout."
+                "Activate the PDK before building any cells."
+            )
+
     _ACTIVE_PDK = pdk
 
     if pdk.layers is not None:
@@ -809,6 +821,9 @@ def _set_active_pdk(pdk: Pdk) -> None:
     else:
         kf.kcl.infos = kf.LayerInfos()
         kf.kcl.layers = kf.kcl.layerenum_from_dict(layers=kf.kcl.infos)
+
+    if pdk.dbu is not None and pdk.dbu != kf.kcl.dbu:
+        kf.kcl.layout.dbu = pdk.dbu
 
 
 def get_routing_strategies() -> RoutingStrategies:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -143,8 +143,8 @@ class Pdk(BaseModel):
         routing_strategies: functions enabled to route.
         bend_points_distance: default points distance for bends in um.
         connectivity: defines connectivity between layers through vias.
-        dbu: database unit in um. If set, applied to kf.kcl on activate().
-            Default None leaves kfactory's default of 0.001 (1 nm/dbu).
+        dbu: database unit in um. Applied to kf.kcl on activate().
+           Default 0.001 (1 nm/dbu).
 
     """
 
@@ -178,7 +178,7 @@ class Pdk(BaseModel):
     bend_points_distance: float = 20 * nm
     connectivity: Sequence[ConnectivitySpec] | None = None
     max_cellname_length: int = CONF.max_cellname_length
-    dbu: float | None = Field(default=None, gt=0)
+    dbu: float = Field(default=1 * nm, gt=0)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -803,13 +803,12 @@ def get_constant(constant_name: Any) -> Any:
 def _set_active_pdk(pdk: Pdk) -> None:
     global _ACTIVE_PDK
 
-    if pdk.dbu is not None and pdk.dbu != kf.kcl.dbu:
-        if len(kf.kcl.kcells) > 0:
-            raise ValueError(
-                f"Cannot change DBU from {kf.kcl.dbu} to {pdk.dbu}: "
-                f"{len(kf.kcl.kcells)} cell(s) already exist on the KCLayout."
-                "Activate the PDK before building any cells."
-            )
+    if pdk.dbu != kf.kcl.dbu and len(kf.kcl.kcells) > 0:
+        raise ValueError(
+            f"Cannot change DBU from {kf.kcl.dbu} to {pdk.dbu}: "
+            f"{len(kf.kcl.kcells)} cell(s) already exist on the KCLayout."
+            "Activate the PDK before building any cells."
+        )
 
     _ACTIVE_PDK = pdk
 
@@ -822,7 +821,7 @@ def _set_active_pdk(pdk: Pdk) -> None:
         kf.kcl.infos = kf.LayerInfos()
         kf.kcl.layers = kf.kcl.layerenum_from_dict(layers=kf.kcl.infos)
 
-    if pdk.dbu is not None and pdk.dbu != kf.kcl.dbu:
+    if pdk.dbu != kf.kcl.dbu:
         kf.kcl.layout.dbu = pdk.dbu
 
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 import pytest
 
 import gdsfactory as gf
@@ -95,3 +97,53 @@ def test_pdk_model_dump() -> None:
     pdk = _make_pdk()
     dumped = pdk.model_dump()
     assert dumped["name"] == "test"
+
+
+@pytest.fixture
+def restore_kcl_state() -> Iterator[None]:
+    from gdsfactory.gpdk import PDK
+
+    original_dbu = gf.kcl.dbu
+    gf.kcl.clear_kcells()
+    try:
+        yield
+    finally:
+        gf.kcl.clear_kcells()
+        gf.kcl.dbu = original_dbu
+        PDK.activate(force=True)
+
+
+def test_pdk_sets_dbu(restore_kcl_state: None) -> None:
+    pdk = gf.Pdk(
+        name="dbu_test",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+        dbu=0.0005,
+    )
+    pdk.activate(force=True)
+    assert gf.kcl.dbu == 0.0005
+
+
+def test_pdk_dbu_change_after_cells_raises(restore_kcl_state: None) -> None:
+    gf.components.straight()
+    assert len(gf.kcl.kcells) > 0
+
+    pdk = gf.Pdk(
+        name="dbu_blocked",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+        dbu=0.0005,
+    )
+    with pytest.raises(ValueError, match=r"cell\(s\) already exist"):
+        pdk.activate(force=True)
+
+
+def test_pdk_dbu_default_unchanged(restore_kcl_state: None) -> None:
+    original_dbu = gf.kcl.dbu
+    pdk = gf.Pdk(
+        name="dbu_unset",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    pdk.activate(force=True)
+    assert gf.kcl.dbu == original_dbu

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -136,14 +136,3 @@ def test_pdk_dbu_change_after_cells_raises(restore_kcl_state: None) -> None:
     )
     with pytest.raises(ValueError, match=r"cell\(s\) already exist"):
         pdk.activate(force=True)
-
-
-def test_pdk_dbu_default_unchanged(restore_kcl_state: None) -> None:
-    original_dbu = gf.kcl.dbu
-    pdk = gf.Pdk(
-        name="dbu_unset",
-        layers=LAYER,
-        cross_sections={"strip": gf.cross_section.strip},
-    )
-    pdk.activate(force=True)
-    assert gf.kcl.dbu == original_dbu

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -136,3 +136,17 @@ def test_pdk_dbu_change_after_cells_raises(restore_kcl_state: None) -> None:
     )
     with pytest.raises(ValueError, match=r"cell\(s\) already exist"):
         pdk.activate(force=True)
+
+def test_pdk_same_dbu_with_existing_cells_allowed(restore_kcl_state: None) -> None:
+    gf.components.straight()
+    assert len(gf.kcl.kcells) > 0
+
+    existing_dbu = gf.kcl.dbu
+
+    pdk = gf.Pdk(
+        name="dbu_same",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+        dbu=existing_dbu,
+    )
+    pdk.activate(force=True)


### PR DESCRIPTION
## Summary

Being able to define a DBU value attached to a PDK that sets it on activation with a guard.

## Test Plan

Unit tests.

## Summary by Sourcery

Allow PDKs to define and enforce the database unit (DBU) used on activation, with safeguards against changing it after cells exist.

New Features:
- Add a dbu configuration field to the PDK model that sets the KCLayout database unit on activation.

Bug Fixes:
- Prevent changing the global KCLayout DBU when cells already exist by raising a guarded error on PDK activation.

Tests:
- Add unit tests to verify that activating a PDK sets the DBU and that changing DBU after cells are created raises an error.