### PR TITLE
fix: boolean subtraction for rectangle_with_slits

### DIFF
--- a/gdsfactory/components/pads/rectangle_with_slits.py
+++ b/gdsfactory/components/pads/rectangle_with_slits.py
@@ -13,7 +13,7 @@ from gdsfactory.typings import LayerSpec, Size
 def rectangle_with_slits(
     size: Size = (100.0, 200.0),
     layer: LayerSpec = "WG",
-    layer_slit: LayerSpec = "SLAB150",
+    layer_slit: LayerSpec | None = None,
     centered: bool = False,
     port_type: str | None = None,
     slit_size: Size = (1.0, 1.0),
@@ -61,19 +61,46 @@ def rectangle_with_slits(
     c = Component()
     layer = gf.get_layer(layer)
 
-    r = c << gf.c.rectangle(
+    rectangle = gf.c.rectangle(
         size=size, layer=layer, port_type=port_type, centered=centered
     )
+    r = c << rectangle
     c.add_ports(r.ports)
-    slit = gf.c.rectangle(size=slit_size, port_type=None, layer=layer_slit or layer)
-    columns = np.floor((size[0] - 2 * slit_enclosure) / slit_column_pitch)
-    rows = np.floor((size[1] - 2 * slit_enclosure) / slit_row_pitch)
-    slits = c << gf.c.array(
-        slit,
-        columns=columns,
-        rows=rows,
-        column_pitch=slit_column_pitch,
-        row_pitch=slit_row_pitch,
-    )
-    slits.center = r.center
+    columns = int(np.floor((size[0] - 2 * slit_enclosure) / slit_column_pitch))
+    rows = int(np.floor((size[1] - 2 * slit_enclosure) / slit_row_pitch))
+
+    if layer_slit is None:
+        layer2 = (layer[0], layer[1] + 1)
+        slit = gf.c.rectangle(size=slit_size, port_type=None, layer=layer2)
+        slits = gf.c.array(
+            slit,
+            columns=columns,
+            rows=rows,
+            column_pitch=slit_column_pitch,
+            row_pitch=slit_row_pitch,
+            centered=centered,
+        )
+        slits_ref = c << slits
+        slits_ref.center = r.center
+        c = gf.boolean(
+            rectangle,
+            slits_ref,
+            operation="not",
+            layer1=layer,
+            layer2=layer2,
+            layer=layer,
+        )
+        c.add_ports(rectangle.ports)
+
+    else:
+        slit = gf.c.rectangle(size=slit_size, port_type=None, layer=layer_slit)
+        slits = c << gf.c.array(
+            slit,
+            columns=columns,
+            rows=rows,
+            column_pitch=slit_column_pitch,
+            row_pitch=slit_row_pitch,
+            centered=centered,
+        )
+        slits.center = r.center
     return c

--- a/gdsfactory/components/pads/rectangle_with_slits.py
+++ b/gdsfactory/components/pads/rectangle_with_slits.py
@@ -59,7 +59,7 @@ def rectangle_with_slits(
                         size[0]
     """
     c = Component()
-    layer = gf.get_layer(layer)
+    layer_tuple = gf.get_layer_tuple(layer)
 
     rectangle = gf.c.rectangle(
         size=size, layer=layer, port_type=port_type, centered=centered
@@ -70,7 +70,7 @@ def rectangle_with_slits(
     rows = int(np.floor((size[1] - 2 * slit_enclosure) / slit_row_pitch))
 
     if layer_slit is None:
-        layer2 = (layer[0], layer[1] + 1)
+        layer2 = (layer_tuple[0], layer_tuple[1] + 1)
         slit = gf.c.rectangle(size=slit_size, port_type=None, layer=layer2)
         slits = gf.c.array(
             slit,
@@ -94,7 +94,7 @@ def rectangle_with_slits(
 
     else:
         slit = gf.c.rectangle(size=slit_size, port_type=None, layer=layer_slit)
-        slits = c << gf.c.array(
+        slits_ref = c << gf.c.array(
             slit,
             columns=columns,
             rows=rows,
@@ -102,5 +102,5 @@ def rectangle_with_slits(
             row_pitch=slit_row_pitch,
             centered=centered,
         )
-        slits.center = r.center
+        slits_ref.center = r.center
     return c

--- a/tests/test-data-regression/test_netlists_rectangle_with_slits_.yml
+++ b/tests/test-data-regression/test_netlists_rectangle_with_slits_.yml
@@ -1,43 +1,4 @@
-instances:
-  array_gdsfactorypcomponentspcontainersparray_component__83c06869_19500_19500:
-    component: array
-    info: {}
-    settings:
-      add_ports: true
-      auto_rename_ports: false
-      centered: false
-      column_pitch: 20
-      columns: 4
-      component: rectangle_gdsfactorypcomponentspshapesprectangle_S1_1_L_87bf09b9
-      post_process: null
-      row_pitch: 20
-      rows: 9
-      size: null
-  rectangle_gdsfactorypcomponentspshapesprectangle_S100_2_1f6c5d69_0_0:
-    component: rectangle
-    info: {}
-    settings:
-      centered: false
-      layer: WG
-      port_orientations:
-      - 180
-      - 90
-      - 0
-      - -90
-      port_type: null
-      size:
-      - 100
-      - 200
+instances: {}
 nets: []
-placements:
-  array_gdsfactorypcomponentspcontainersparray_component__83c06869_19500_19500:
-    mirror: false
-    rotation: 0
-    x: 19.5
-    y: 19.5
-  rectangle_gdsfactorypcomponentspshapesprectangle_S100_2_1f6c5d69_0_0:
-    mirror: false
-    rotation: 0
-    x: 0
-    y: 0
+placements: {}
 ports: {}

--- a/tests/test-data-regression/test_settings_rectangle_with_slits_.yml
+++ b/tests/test-data-regression/test_settings_rectangle_with_slits_.yml
@@ -1,9 +1,8 @@
 info: {}
-name: rectangle_with_slits_gdsfactorypcomponentsppadsprectang_442d6bfc
+name: rectangle_with_slits_gdsfactorypcomponentsppadsprectang_f03dfc73
 settings:
   centered: false
   layer: WG
-  layer_slit: SLAB150
   size:
   - 100
   - 200

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -137,6 +137,7 @@ def test_pdk_dbu_change_after_cells_raises(restore_kcl_state: None) -> None:
     with pytest.raises(ValueError, match=r"cell\(s\) already exist"):
         pdk.activate(force=True)
 
+
 def test_pdk_same_dbu_with_existing_cells_allowed(restore_kcl_state: None) -> None:
     gf.components.straight()
     assert len(gf.kcl.kcells) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1182,7 +1182,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.40.2"
+version = "9.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -1285,7 +1285,7 @@ requires-dist = [
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = ">=0.15.1,<1.1" },
     { name = "jupyterlab", marker = "extra == 'dev'" },
     { name = "jupytext", marker = "extra == 'docs'" },
-    { name = "kfactory", extras = ["ipy"], specifier = ">=2.4.4,<2.5" },
+    { name = "kfactory", extras = ["ipy"], specifier = "~=2.5.0" },
     { name = "kweb", marker = "extra == 'cad'", specifier = ">=1.1.9,<2.1" },
     { name = "loguru", specifier = "<1" },
     { name = "mapbox-earcut" },
@@ -2249,7 +2249,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "2.4.5"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -2270,9 +2270,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/84/ad1aa246d7896e2599891331b67d373a69c200eff5f59235d850b2de238c/kfactory-2.4.5.tar.gz", hash = "sha256:a923a49edc649d3cab401618b24fca696d4576686535e1feb6859c60e0040c36", size = 13523536, upload-time = "2026-02-27T20:56:26.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/12/1b4daa76e1d0d60f8d6f9b6eccf89096b53277c6c33582a395da78ae3e09/kfactory-2.5.0.tar.gz", hash = "sha256:796b4a0a08025f6810d9b4c81d355bb9b60b279ea6e0e10f4fab3445271c484b", size = 13525447, upload-time = "2026-04-29T00:32:45.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/d0/15adeaca31fbc9a807c3bb427d43022d34272a924cbe1ccc2b8e0ca001b4/kfactory-2.4.5-py3-none-any.whl", hash = "sha256:ca1ee429438e222e76f48fe82db70ed9208f0895eed3b2668be00476549de44a", size = 252876, upload-time = "2026-02-27T20:56:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/e9/42a782df19f608d19d796f5cd2487cbf3ded5c6e602410ef0556aae5bac5/kfactory-2.5.0-py3-none-any.whl", hash = "sha256:11f6010cbf350a18ed78fc46a7671ae6017fbdb753df36b4e8a634eb630415a6", size = 252976, upload-time = "2026-04-29T00:32:42.458Z" },
 ]
 
 [package.optional-dependencies]
@@ -2349,31 +2349,31 @@ wheels = [
 
 [[package]]
 name = "klayout"
-version = "0.30.5"
+version = "0.30.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/a9/04d916676303309c7d3ca78f63f7a8641a2d9bd10ca7a1c075763ac02381/klayout-0.30.5.tar.gz", hash = "sha256:579e4eecd763c3760e85ef0e2ac1dcc05878413e7649cacfe75eb8c0d3f8e207", size = 4135426, upload-time = "2025-11-12T23:46:11.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/57/b6f3287cc6ec3afbdf2810c58cc1b71b517724f8beea1e53f14b6d6df2f7/klayout-0.30.8.tar.gz", hash = "sha256:a3c63b98a2a918269e9fb8db3fc4bf6c6e10ac3068d4c3156900f9276c6e4b8d", size = 4463826, upload-time = "2026-04-16T22:16:00.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/d5/50016574d348aca66f3b07594174bc82cac552732acf025767b16b37dd36/klayout-0.30.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:09c27eed9ca802e92c2dbc7699507ea57f21313118f4fc9ca811936d8aa2f043", size = 22467790, upload-time = "2025-11-12T23:44:35.675Z" },
-    { url = "https://files.pythonhosted.org/packages/65/2a/914064f4135d46605f6c2911647fec862f5a384ba5d829415df31d0cd9b1/klayout-0.30.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:961639210694254dd6d6b0371fa20bf292142e5cf651a202f5d3b20a200bcdde", size = 20531152, upload-time = "2025-11-12T23:44:37.956Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0d/9f8de368707e36907af921739e970fbc27f22c965d5150e71c9f472004e2/klayout-0.30.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48a753617a612959f60c7a74366095e230a3de8b9887d5fd30c45a2b97d87a69", size = 24857739, upload-time = "2025-11-12T23:44:40.755Z" },
-    { url = "https://files.pythonhosted.org/packages/73/0a/ad160223ed99dfd7018cdf130844692e02d9c31cb1ef9c72dc88ba02b270/klayout-0.30.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fa3541fa4e63b4b6fbeadc07d9b2840b8aba2194ecb4208f5b0c82065e89500d", size = 26782754, upload-time = "2025-11-12T23:44:43.373Z" },
-    { url = "https://files.pythonhosted.org/packages/82/00/ee191fefab2cce8926673c4e5d80c512bd4dbb848bedaaea5ee2c3a0f3b3/klayout-0.30.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6c006eeae38ddee42fbb13ce766301ce7d07ea025ea2b4c2fc3b9fc8ede26d0", size = 28312297, upload-time = "2025-11-12T23:44:45.876Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/70/c8bc217615cc61b7c6ae0a91c15d1202cd9851ecda2baac0f7b5152e63de/klayout-0.30.5-cp311-cp311-win32.whl", hash = "sha256:1b133197f056d8073211024e541b63e17c49e4a3c4916a5ab75ccd74384d9e0d", size = 11981599, upload-time = "2025-11-13T02:47:01.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/80/daa28eaf867282ede2e5f362c00fed82b98bf84a1a8dea703c16efdf6a13/klayout-0.30.5-cp311-cp311-win_amd64.whl", hash = "sha256:29ac703810382aafaef20529195bd9a9b1fc0420c3122ead3800b39e06b8b327", size = 13723791, upload-time = "2025-11-13T02:47:04.259Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f1/c6d9c1eb914c0bd654b181e39f57cde809b2d90f6cfad31b79aa3931211c/klayout-0.30.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0ca7552609802e462989df7e2b4f3d0d244257a14e63aa01b223a88a66437618", size = 22046172, upload-time = "2025-11-12T23:44:48.298Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/84/1c9294605223aaccaa73c119ae06f4b8172b028262c80334e7e9f390c34b/klayout-0.30.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:831e55ba1432ae96512adcf7a6e29a6f0239264e1350f0815bd4dcadbed7c73b", size = 20531429, upload-time = "2025-11-12T23:44:51.281Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f2/1fceb496096f7f9b9939ce8f2e79b54a569c7fced9db4b93c392d4dfaa23/klayout-0.30.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7bd33bc4ffe2befe9277aee5aa98d59d06e9316021a2eef843525a42a4fa8cbb", size = 24874084, upload-time = "2025-11-12T23:44:53.918Z" },
-    { url = "https://files.pythonhosted.org/packages/55/17/ab3a667695cb4456fce45455724d24cddd86d7525001e1b218dbb54a1c01/klayout-0.30.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:395c803b1a48c50094afadc15094c65bb3b29f59ab8660810cfe7e456c50000d", size = 26802251, upload-time = "2025-11-12T23:44:57.393Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1e/d1ddf199d76a329ab4b0b324831246eeebbde72a58ebe9ccd4df20738c05/klayout-0.30.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0961760dd31afb3f234a71a869a7badf370cc9f0422ee5af7098a0148007b2d1", size = 28335526, upload-time = "2025-11-12T23:45:00.433Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/6d/daa1e7d9d7726ad40ef1b17a027180ff797141614d2722ae07344670e939/klayout-0.30.5-cp312-cp312-win32.whl", hash = "sha256:8153c920978878d1938f615c758355d3aef2d2bece580c68c7111031fbd442e6", size = 11982053, upload-time = "2025-11-13T02:47:08.281Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/4b/0841b123470d0869df92d24cc9df90c2df496aaf9f7c1332628159b97d84/klayout-0.30.5-cp312-cp312-win_amd64.whl", hash = "sha256:a07884870a4190042dafd5d414e6146f4f7c0fe54ec3082a3c113f77efc8d274", size = 13723476, upload-time = "2025-11-13T02:47:10.355Z" },
-    { url = "https://files.pythonhosted.org/packages/66/44/96fc689fcba5506aa840286866185ce5d6bb43df9dc33350128e2d7fbd93/klayout-0.30.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f73fd5575e55768c2dcbe7a4370dc86e138c6c6321a2f7edba5694889c822696", size = 22046091, upload-time = "2025-11-12T23:45:03.534Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7b/b96ffac84012ee7adcce171ae7632cb9228e0274e4e28c9b2587a0a7a23a/klayout-0.30.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f694e6c86f1445e58015c4635b5847369c38be1825673dfb941e56e0d1d3b67", size = 20531338, upload-time = "2025-11-12T23:45:05.899Z" },
-    { url = "https://files.pythonhosted.org/packages/00/50/899ead3f20520df6ace7738070ce738b4bc9a5d52cafa0400c0a01c10226/klayout-0.30.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24ee7724f3871c1c469cd8994337b42cd784445d4414482aaf08809523f237ad", size = 24874077, upload-time = "2025-11-12T23:45:08.751Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0a/df726d14586987968c00c6af10a6694b7fa6b652e316218cff3f8e10607a/klayout-0.30.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd601badf644ea1d7e93bb7ea43dce0231661c082c7dd25064489696a282ee63", size = 26802265, upload-time = "2025-11-12T23:45:11.317Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/38/3810fac2274ccee453b8b39cb4953e692219181c4021291f9d89652e7b8a/klayout-0.30.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e57fa2b039cc1714be1a4ae2252f6b7c80572192db8b2c906aefe6df26316560", size = 28335531, upload-time = "2025-11-12T23:45:14.281Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/85/a5a8876a98028b2748231723f03551a0f6ea60bbb0a210ee059ce852e2f6/klayout-0.30.5-cp313-cp313-win32.whl", hash = "sha256:89fde645dbced23ceeb54cbf895e109da364fb406ecc647f53b7ab3990d6b295", size = 11982054, upload-time = "2025-11-13T02:47:12.241Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6d/ee53d0b6ead3bfb998659301eaacf827265dbbeceac75c65dfb9d2d2e0fd/klayout-0.30.5-cp313-cp313-win_amd64.whl", hash = "sha256:6cace034e42f13dfddf67c4e747f6e839f415073d7faa30e0eec9f6b4c369bf2", size = 13723626, upload-time = "2025-11-13T02:47:15.899Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1f/f61b3680b2f953d267e97ccd2fdfeb3f3dbb12f44c63c2df1543c6da012d/klayout-0.30.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74d42036f0765e51c22e9cae253d7d3d733ae70df4ae7642cd7922aa3590f69e", size = 21363077, upload-time = "2026-04-16T22:14:35.282Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/12/e77c8b58589b3e8ea3cfd50c532bb29f6858e348885d7f3b16cf77657f04/klayout-0.30.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0ab01d58cd88e5de0d457a54d15c3a380a81ed1537b7ce65c64d641c9abc7fa0", size = 21117792, upload-time = "2026-04-16T22:14:38.685Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/60/c993ba484ffe1f85d59dcfe17adedc5062b6c92f806c3bf88e8165afaa4a/klayout-0.30.8-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c24f72488088cef9affa49eef0602d43e53c0849f14e0ffc5731640ffea547d", size = 25137781, upload-time = "2026-04-16T22:14:42.152Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d2/31c8e54382d5548068871ca072e7580176efd264476d3ca37858c9c701ba/klayout-0.30.8-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c60d545c1f6381a9dc55184d97b4ea8f8229c7841930b97deb8219f34816948", size = 27121427, upload-time = "2026-04-16T22:14:45.732Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/dc/f26e9e2ad099cb66ca1b59d5ea74a3382a7c383e1dbd1fe74b97e366d32c/klayout-0.30.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c690c9bb4010e8876fff3565ce8ff0840be59305fa199f17687026aab785f67", size = 28675402, upload-time = "2026-04-16T22:14:49.164Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bc/bf9b2232788e0e6b2578a55e527a8fdac79364fb6d333a9ed0ca80058faf/klayout-0.30.8-cp311-cp311-win32.whl", hash = "sha256:503b7feadd4fb65bddd23222ba87b78f9eb82f9376312449ce1c7d7d1c2bf823", size = 12178778, upload-time = "2026-04-16T22:08:42.1Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b8/d5c199dc2249c41b5faf435c0bf1a0af08d1abf259de6fb87199bcefb7ab/klayout-0.30.8-cp311-cp311-win_amd64.whl", hash = "sha256:4242b808c4fd16f672aeaa2a3020a07940a8fdd0ae6b79226ba4046d4c68662f", size = 13744123, upload-time = "2026-04-16T22:08:44.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4a/32aa0c7464e8df7d0636851ebb79a1b613e9e7cdd162555e9ae12384a45e/klayout-0.30.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dfa717995fdadf2b35a2b34cad906858b1e36713e67c02116abe3da2de9a6629", size = 20966792, upload-time = "2026-04-16T22:14:52.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/3f6440cb2a23d461fc07ab598c3076b06c0b8e08c3aa4a9566794dcd1d27/klayout-0.30.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:28d22287730ac87cfe24d172cf24691c14e58c5765d55e1c3667c3291002168b", size = 21117952, upload-time = "2026-04-16T22:14:55.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/40/de3da84baae380d83a3d208ba724b13935538f02c7736ba1673d005b62b6/klayout-0.30.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b3edd84599e3655dbf63a9675c9ceb07bf35a4919a75d457aa190e24b3c6d7e", size = 25150089, upload-time = "2026-04-16T22:14:59.219Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/93b7966902008a992a9ddda97a90d45f3b022106d98115524853c8bb90ef/klayout-0.30.8-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3600ade76868685b5d13f8a3e30d9590e757818e64e7c4f8285fc7855e284cc8", size = 27137378, upload-time = "2026-04-16T22:15:02.624Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ca/8ac13c26e700e13a6e9749ca872048103848f20e1fb30ad8691a8a41a954/klayout-0.30.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6e8daa072a3ff6b3d0025d18a9f06f195df9f5a391e107b824749ca625aaf54a", size = 28694181, upload-time = "2026-04-16T22:15:05.986Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c1/c1fb77b678abe7ef384a3110c2186228d9e774b855e3285b28f049ecd8b9/klayout-0.30.8-cp312-cp312-win32.whl", hash = "sha256:a9728e15e2148203caa27c2de72bbf5d4b544d925756eed68133d0499966d909", size = 12179992, upload-time = "2026-04-16T22:08:46.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d8/f49b35aff203b77f33432820a7471370e18fb5416adac37fd5e6b636428e/klayout-0.30.8-cp312-cp312-win_amd64.whl", hash = "sha256:7ff36de2d1cac859a4aff15d7ec18ad47a438c92247fe6d1431674f68fbcda66", size = 13743498, upload-time = "2026-04-16T22:08:48.858Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/89eb6abbab83f40563bc8234e49933c420603509295a7cb1354221e8ed98/klayout-0.30.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feec35f7f23ff66a98c07ce4c82ab5ad273808f394d22543cb98f2a4112f0f2b", size = 20966804, upload-time = "2026-04-16T22:15:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7c/15e13597d00da6b579a3f407512025024f6bf6056286f208142a4e753fac/klayout-0.30.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a6422a0f4042d32156485d3c88e30e127fae8132f38cdf25223c80ea22290d4", size = 21117897, upload-time = "2026-04-16T22:15:12.553Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/4a23ac2971928f2d8bd16358f7e36292a2d9277d7d10dfeb48c92fd152d4/klayout-0.30.8-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad348c13bb351a0ce332f35bb81949adad77e7a0ee5320bc3f7a430ad533ebfb", size = 25150086, upload-time = "2026-04-16T22:15:15.991Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0b/fe3893448da23b1d948c15c7f42d2493ffd3df1cf98db88020f39df1b2d9/klayout-0.30.8-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b6ae23efdee88898740cf6d842eda897fdedac88832add4ef414ffb77f8cc9", size = 27137396, upload-time = "2026-04-16T22:15:19.513Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/72/f36a5dd02070a8f3d62b8802d7bc53735c97871cdbb94416b139793111c2/klayout-0.30.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3ebacf718ec0dcdbee991d1bb24312b173bc7bf4018417433f1af20ee4f1fd07", size = 28694187, upload-time = "2026-04-16T22:15:22.929Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/9921cdf76d66f89a81b8867c4181783b036391a84744f21deb9937574784/klayout-0.30.8-cp313-cp313-win32.whl", hash = "sha256:a99efe92ff80ea1ef982b263fde191b50b4f745153d8ee62196a78c54cac3743", size = 12179959, upload-time = "2026-04-16T22:08:51.173Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/68/d50453cb62d86b126db4bc7f3123712d48969c85f45fd9285964a436b5a2/klayout-0.30.8-cp313-cp313-win_amd64.whl", hash = "sha256:3edc4bcf10a8fac0e24d39de718b9483f40993d0c94be1a2100add74a423d258", size = 13743508, upload-time = "2026-04-16T22:08:53.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Make `layer_slit` default to `None` instead of `"SLAB150"`
- When `layer_slit` is `None`, use `gf.boolean(..., operation="not")` to cut slits directly from the rectangle geometry
- When `layer_slit` is provided, place slits on that layer (previous behavior)
- Cast `np.floor` results to `int` for array columns/rows

## Test plan
- [x] Verify `rectangle_with_slits()` with default `layer_slit=None` produces correct boolean-subtracted geometry
- [x] Verify `rectangle_with_slits(layer_slit="SLAB150")` still places slits on the specified layer
- [x] Run existing tests for pad components

## Summary by Sourcery

Adjust rectangle_with_slits to use boolean subtraction by default when creating slits and make slit layer optional.

New Features:
- Allow rectangle_with_slits to omit a dedicated slit layer and instead boolean-subtract slits directly from the rectangle geometry when no slit layer is provided.

Bug Fixes:
- Ensure slit array column and row counts are integers by casting np.floor results to int for rectangle_with_slits.

Enhancements:
- Preserve the existing behavior of placing slits on an explicit slit layer when layer_slit is provided, while adding support for centered slit arrays in both modes.