### PR TITLE
Add skip_transition field to Section

### DIFF
--- a/docs/notebooks/03_Path_CrossSection.ipynb
+++ b/docs/notebooks/03_Path_CrossSection.ipynb
@@ -1526,6 +1526,89 @@
    "id": "96",
    "metadata": {},
    "source": [
+    "### Avoiding transitions for specific layers\n",
+    "\n",
+    "`transition()` and `extrude_transition()` match sections between the two cross-sections **by `name`**. Only sections whose `name` appears in **both** cross-sections will be transitioned — any section present in only one cross-section is skipped.\n",
+    "\n",
+    "You can use this to avoid transitioning a specific layer: simply give it a different `name` in each cross-section (or omit it from one)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "p = gf.path.straight(length=10, npoints=101)\n",
+    "\n",
+    "# Cross-section 1: core + slab (both named)\n",
+    "s0 = gf.Section(width=0.5, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=3, offset=0, layer=(3, 0), name=\"slab\")\n",
+    "x1 = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "# Cross-section 2: wider core + wider slab\n",
+    "s0 = gf.Section(width=1.0, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=5, offset=0, layer=(3, 0), name=\"slab\")\n",
+    "x2 = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "# Both \"core\" and \"slab\" are transitioned\n",
+    "t_both = gf.path.transition(x1, x2, width_type=\"linear\")\n",
+    "c_both = gf.path.extrude_transition(p, t_both)\n",
+    "c_both.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now avoid transitioning the slab by giving it different names\n",
+    "s0 = gf.Section(width=0.5, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=3, offset=0, layer=(3, 0), name=\"slab_in\")  # different name\n",
+    "x1_no_slab = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "s0 = gf.Section(width=1.0, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=5, offset=0, layer=(3, 0), name=\"slab_out\")  # different name\n",
+    "x2_no_slab = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "# Only \"core\" is transitioned, slab sections are skipped\n",
+    "t_core_only = gf.path.transition(x1_no_slab, x2_no_slab, width_type=\"linear\")\n",
+    "c_core_only = gf.path.extrude_transition(p, t_core_only)\n",
+    "c_core_only.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or use skip_transition=True on the Section you want to keep constant\n",
+    "s0 = gf.Section(width=0.5, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=3, offset=0, layer=(3, 0), name=\"slab\", skip_transition=True)\n",
+    "x1_skip = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "s0 = gf.Section(width=1.0, offset=0, layer=(1, 0), name=\"core\", port_names=(\"o1\", \"o2\"))\n",
+    "s1 = gf.Section(width=5, offset=0, layer=(3, 0), name=\"slab\", skip_transition=True)\n",
+    "x2_skip = gf.CrossSection(sections=(s0, s1))\n",
+    "\n",
+    "# Only \"core\" is transitioned, slab is skipped\n",
+    "t_skip = gf.path.transition(x1_skip, x2_skip, width_type=\"linear\")\n",
+    "c_skip = gf.path.extrude_transition(p, t_skip)\n",
+    "c_skip.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "100",
+   "metadata": {},
+   "source": [
     "## Creating new cross_sections\n",
     "\n",
     "You can create functions that return a cross_section in 2 ways:\n",
@@ -1540,7 +1623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1550,7 +1633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,7 +1674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1602,7 +1685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1613,7 +1696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1623,7 +1706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "106",
    "metadata": {},
    "source": [
     "Finally, you can also pass the dictionary (dict) of most components that define the cross-section."
@@ -1632,7 +1715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1671,7 +1754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1690,7 +1773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1706,7 +1789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1716,7 +1799,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "107",
+   "id": "111",
    "metadata": {},
    "source": [
     "The port location, width and orientation remains the same for a sheared component. However, an additional property, `shear_angle` is set to the value of the shear angle. In general, shear ports can be safely connected together."
@@ -1724,7 +1807,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "108",
+   "id": "112",
    "metadata": {},
    "source": [
     "## bbox_layers vs cladding_layers\n",
@@ -1738,7 +1821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1750,7 +1833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1761,7 +1844,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111",
+   "id": "115",
    "metadata": {},
    "source": [
     "## Insets\n",
@@ -1772,7 +1855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1802,7 +1885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -36,7 +36,7 @@ def taper_cross_section(
         linear: shape of the transition, sine when False.
         width_type: shape of the transition ONLY IF linear is False
         exclude_layers: layers to exclude from the transition.
-            Sections on these layers will not be tapered.
+            Sections on these layers will be omitted from the component.
 
 
     .. code::

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -11,7 +11,7 @@ from functools import partial
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import CrossSectionSpec
+from gdsfactory.typings import CrossSectionSpec, LayerSpecs
 
 from .._schematic import transition_schematic
 
@@ -24,6 +24,7 @@ def taper_cross_section(
     npoints: int = 100,
     linear: bool = False,
     width_type: str = "sine",
+    exclude_layers: LayerSpecs | None = None,
 ) -> Component:
     r"""Returns taper transition between cross_section1 and cross_section2.
 
@@ -34,6 +35,8 @@ def taper_cross_section(
         npoints: number of points.
         linear: shape of the transition, sine when False.
         width_type: shape of the transition ONLY IF linear is False
+        exclude_layers: layers to exclude from the transition.
+            Sections on these layers will not be tapered.
 
 
     .. code::
@@ -51,6 +54,24 @@ def taper_cross_section(
     """
     x1 = gf.get_cross_section(cross_section1)
     x2 = gf.get_cross_section(cross_section2)
+
+    if x1 == x2:
+        return gf.components.straight(length=length, cross_section=x1)
+
+    if exclude_layers:
+        excluded = {gf.get_layer(layer) for layer in exclude_layers}
+
+        def _mark_skip(sections: tuple[gf.Section, ...]) -> tuple[gf.Section, ...]:
+            return tuple(
+                s.model_copy(update={"skip_transition": True})
+                if gf.get_layer(s.layer) in excluded
+                else s
+                for s in sections
+            )
+
+        x1 = x1.model_copy(update={"sections": _mark_skip(x1.sections)})
+        x2 = x2.model_copy(update={"sections": _mark_skip(x2.sections)})
+
     transition = gf.path.transition(
         cross_section1=x1,
         cross_section2=x2,

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -55,11 +55,9 @@ def taper_cross_section(
     x1 = gf.get_cross_section(cross_section1)
     x2 = gf.get_cross_section(cross_section2)
 
-    if x1 == x2:
-        return gf.components.straight(length=length, cross_section=x1)
-
     if exclude_layers:
-        excluded = {gf.get_layer(layer) for layer in exclude_layers}
+        layers = exclude_layers if isinstance(exclude_layers, (list, tuple)) and not (len(exclude_layers) == 2 and isinstance(exclude_layers[0], int)) else [exclude_layers]
+        excluded = {gf.get_layer(layer) for layer in layers}
 
         def _mark_skip(sections: tuple[gf.Section, ...]) -> tuple[gf.Section, ...]:
             return tuple(
@@ -71,6 +69,9 @@ def taper_cross_section(
 
         x1 = x1.model_copy(update={"sections": _mark_skip(x1.sections)})
         x2 = x2.model_copy(update={"sections": _mark_skip(x2.sections)})
+
+    if x1 == x2 and not exclude_layers:
+        return gf.components.straight(length=length, cross_section=x1)
 
     transition = gf.path.transition(
         cross_section1=x1,

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -85,6 +85,8 @@ class Section(BaseModel):
         simplify: Optional Tolerance value for the simplification algorithm. \
                 All points that can be removed without changing the resulting. \
                 polygon by more than the value listed here will be removed.
+        skip_transition: if True, this section is excluded from cross-section \
+                transitions (will not be tapered between two CrossSections).
         width_function: parameterized function from 0 to 1.
         offset_function: parameterized function from 0 to 1.
 
@@ -115,6 +117,7 @@ class Section(BaseModel):
     name: str | None = None
     hidden: bool = False
     simplify: float | None = None
+    skip_transition: bool = False
 
     width_function: typings.WidthFunction | None = None
     offset_function: typings.OffsetFunction | None = None

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -952,6 +952,8 @@ def along_path(
 def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
     named_sections: dict[str, Section] = {}
     for section in sections:
+        if section.skip_transition:
+            continue
         name = section.name or get_layer_name(section.layer)
         if name in named_sections:
             raise ValueError(

--- a/tests/test-data-regression/test_netlists_cdsem_straight_.yml
+++ b/tests/test-data-regression/test_netlists_cdsem_straight_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_adaa3144
+      route_info_type: xs_c284ebda
       route_info_weight: 420
-      route_info_xs_adaa3144_length: 420
+      route_info_xs_c284ebda_length: 420
       width: 0.45
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_8c55ac53
+      route_info_type: xs_dd2e6447
       route_info_weight: 420
-      route_info_xs_8c55ac53_length: 420
+      route_info_xs_dd2e6447_length: 420
       width: 0.6
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_86790892
+      route_info_type: xs_a1e27c19
       route_info_weight: 420
-      route_info_xs_86790892_length: 420
+      route_info_xs_a1e27c19_length: 420
       width: 1
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_83e87d78
+      route_info_type: xs_caa9c64e
       route_info_weight: 420
-      route_info_xs_83e87d78_length: 420
+      route_info_xs_caa9c64e_length: 420
       width: 0.4
     settings:
       cross_section: strip_no_ports
@@ -60,9 +60,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_876c1755
+      route_info_type: xs_9b17039c
       route_info_weight: 420
-      route_info_xs_876c1755_length: 420
+      route_info_xs_9b17039c_length: 420
       width: 0.8
     settings:
       cross_section: strip_no_ports

--- a/tests/test-data-regression/test_netlists_cdsem_straight_density_.yml
+++ b/tests/test-data-regression/test_netlists_cdsem_straight_density_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -60,9 +60,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -74,9 +74,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -88,9 +88,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -102,9 +102,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -116,9 +116,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -130,9 +130,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 420
-      route_info_xs_f6f850f9_length: 420
+      route_info_xs_28f5a27d_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports

--- a/tests/test-data-regression/test_netlists_dbr_tapered_.yml
+++ b/tests/test-data-regression/test_netlists_dbr_tapered_.yml
@@ -18,9 +18,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_028869fe
+      route_info_type: xs_ff979da3
       route_info_weight: 10
-      route_info_xs_028869fe_length: 10
+      route_info_xs_ff979da3_length: 10
       width: 0.4
     settings:
       cross_section: strip

--- a/tests/test-data-regression/test_netlists_mzit_.yml
+++ b/tests/test-data-regression/test_netlists_mzit_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_a8cce106
+      route_info_type: xs_6701e932
       route_info_weight: 16.637
-      route_info_xs_a8cce106_length: 16.637
+      route_info_xs_6701e932_length: 16.637
       width: 0.45
     settings:
       allow_min_radius_violation: false
@@ -34,9 +34,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_a8cce106
+      route_info_type: xs_6701e932
       route_info_weight: 16.637
-      route_info_xs_a8cce106_length: 16.637
+      route_info_xs_6701e932_length: 16.637
       width: 0.45
     settings:
       allow_min_radius_violation: false
@@ -59,9 +59,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 16.637
-      route_info_xs_38994ff5_length: 16.637
+      route_info_xs_38085465_length: 16.637
       width: 0.55
     settings:
       allow_min_radius_violation: false
@@ -84,9 +84,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 16.637
-      route_info_xs_38994ff5_length: 16.637
+      route_info_xs_38085465_length: 16.637
       width: 0.55
     settings:
       allow_min_radius_violation: false
@@ -130,9 +130,9 @@ instances:
     info:
       length: 1
       route_info_length: 1
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 1
-      route_info_xs_38994ff5_length: 1
+      route_info_xs_38085465_length: 1
       width: 0.55
     settings:
       cross_section: strip
@@ -144,9 +144,9 @@ instances:
     info:
       length: 1
       route_info_length: 1
-      route_info_type: xs_a8cce106
+      route_info_type: xs_6701e932
       route_info_weight: 1
-      route_info_xs_a8cce106_length: 1
+      route_info_xs_6701e932_length: 1
       width: 0.45
     settings:
       cross_section: strip
@@ -158,9 +158,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 3
-      route_info_xs_38994ff5_length: 3
+      route_info_xs_38085465_length: 3
       width: 0.55
     settings:
       cross_section: strip
@@ -172,9 +172,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 3
-      route_info_xs_38994ff5_length: 3
+      route_info_xs_38085465_length: 3
       width: 0.55
     settings:
       cross_section: strip
@@ -186,9 +186,9 @@ instances:
     info:
       length: 4
       route_info_length: 4
-      route_info_type: xs_38994ff5
+      route_info_type: xs_38085465
       route_info_weight: 4
-      route_info_xs_38994ff5_length: 4
+      route_info_xs_38085465_length: 4
       width: 0.55
     settings:
       cross_section: strip

--- a/tests/test-data-regression/test_netlists_resonator_lumped_.yml
+++ b/tests/test-data-regression/test_netlists_resonator_lumped_.yml
@@ -78,13 +78,13 @@ instances:
       size:
       - 5
       - 5
-  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__8a614a6f_52000_0:
+  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__6ca19ef0_52000_0:
     component: spiral
     info:
       length: 977.644
     settings:
       bend: bend_euler
-      cross_section: xs_2d91f81c
+      cross_section: xs_4a304818
       length: 100
       n_loops: 3
       spacing: 3
@@ -118,7 +118,7 @@ placements:
     rotation: 0
     x: -10
     y: 10
-  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__8a614a6f_52000_0:
+  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__6ca19ef0_52000_0:
     mirror: false
     rotation: 0
     x: 52

--- a/tests/test-data-regression/test_netlists_terminator_.yml
+++ b/tests/test-data-regression/test_netlists_terminator_.yml
@@ -1,5 +1,5 @@
 instances:
-  taper_cross_section_gdsfactorypcomponentsptapersptaper__cd0d4475_0_0:
+  taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0:
     component: taper_cross_section
     info:
       route_info_length: 50
@@ -9,17 +9,18 @@ instances:
       route_info_weight: 50
     settings:
       cross_section1: strip
-      cross_section2: xs_70ec971f
+      cross_section2: xs_91a65ea3
+      exclude_layers: null
       length: 50
       linear: false
       npoints: 100
       width_type: sine
 nets: []
 placements:
-  taper_cross_section_gdsfactorypcomponentsptapersptaper__cd0d4475_0_0:
+  taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: taper_cross_section_gdsfactorypcomponentsptapersptaper__cd0d4475_0_0,o1
+  o1: taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0,o1

--- a/tests/test-data-regression/test_netlists_verniers_.yml
+++ b/tests/test-data-regression/test_netlists_verniers_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_f6f850f9
+      route_info_type: xs_28f5a27d
       route_info_weight: 100
-      route_info_xs_f6f850f9_length: 100
+      route_info_xs_28f5a27d_length: 100
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_78831902
+      route_info_type: xs_1f5bd993
       route_info_weight: 100
-      route_info_xs_78831902_length: 100
+      route_info_xs_1f5bd993_length: 100
       width: 0.2
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_94d99b41
+      route_info_type: xs_6f4217dd
       route_info_weight: 100
-      route_info_xs_94d99b41_length: 100
+      route_info_xs_6f4217dd_length: 100
       width: 0.1
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_83e87d78
+      route_info_type: xs_caa9c64e
       route_info_weight: 100
-      route_info_xs_83e87d78_length: 100
+      route_info_xs_caa9c64e_length: 100
       width: 0.4
     settings:
       cross_section: strip_no_ports

--- a/tests/test-data-regression/test_settings_taper_cross_section_.yml
+++ b/tests/test-data-regression/test_settings_taper_cross_section_.yml
@@ -4,7 +4,7 @@ info:
   route_info_strip_rib_tip_taper_length: 10
   route_info_type: strip_rib_tip
   route_info_weight: 10
-name: taper_cross_section_gdsfactorypcomponentsptapersptaper__6613f3bc
+name: taper_cross_section_gdsfactorypcomponentsptapersptaper__aaaeb4e9
 settings:
   cross_section1: strip_rib_tip
   cross_section2: rib2

--- a/tests/test-data-regression/test_settings_taper_cross_section_linear_.yml
+++ b/tests/test-data-regression/test_settings_taper_cross_section_linear_.yml
@@ -4,7 +4,7 @@ info:
   route_info_strip_rib_tip_taper_length: 10
   route_info_type: strip_rib_tip
   route_info_weight: 10
-name: taper_cross_section_gdsfactorypcomponentsptapersptaper__e425c93b
+name: taper_cross_section_gdsfactorypcomponentsptapersptaper__a8929b2f
 settings:
   cross_section1: strip_rib_tip
   cross_section2: rib2

--- a/tests/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
+++ b/tests/test-data-regression/test_settings_taper_cross_section_parabolic_.yml
@@ -4,7 +4,7 @@ info:
   route_info_strip_rib_tip_taper_length: 10
   route_info_type: strip_rib_tip
   route_info_weight: 10
-name: taper_cross_section_gdsfactorypcomponentsptapersptaper__444fdc64
+name: taper_cross_section_gdsfactorypcomponentsptapersptaper__7af4fcd8
 settings:
   cross_section1: strip_rib_tip
   cross_section2: rib2

--- a/tests/test-data-regression/test_settings_taper_cross_section_sine_.yml
+++ b/tests/test-data-regression/test_settings_taper_cross_section_sine_.yml
@@ -4,7 +4,7 @@ info:
   route_info_strip_rib_tip_taper_length: 10
   route_info_type: strip_rib_tip
   route_info_weight: 10
-name: taper_cross_section_gdsfactorypcomponentsptapersptaper__a83c9929
+name: taper_cross_section_gdsfactorypcomponentsptapersptaper__66194c71
 settings:
   cross_section1: strip_rib_tip
   cross_section2: rib2


### PR DESCRIPTION
## Summary
- Adds `skip_transition: bool = False` field to `Section` so users can mark specific sections to be excluded from cross-section transitions
- Updates `_get_named_sections` in `path.py` to skip sections with `skip_transition=True`
- Adds `exclude_layers` parameter to `taper_cross_section` component
- Documents both approaches (name mismatch + `skip_transition`) in `03_Path_CrossSection.ipynb`

## Test plan
- [ ] Verify `skip_transition=True` sections are excluded from `extrude_transition`
- [ ] Verify `taper_cross_section(exclude_layers=...)` skips specified layers
- [ ] Verify existing transitions still work unchanged (default is `False`)

## Summary by Sourcery

Introduce a mechanism to exclude specific cross-section sections from geometric transitions and expose it via the taper_cross_section API and documentation.

New Features:
- Add a skip_transition flag on Section to mark sections that should be excluded from cross-section transitions.
- Add an exclude_layers parameter to taper_cross_section to avoid tapering specified layers by marking their sections as skipped.

Enhancements:
- Update cross-section transition logic to ignore sections marked with skip_transition when matching named sections.
- Extend path cross-section documentation with examples showing how to avoid transitions using name mismatches and skip_transition.