### PR TITLE
Update dependabot config to use uv and monthly schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,16 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/" # Location of Python package manifests (e.g., requirements.txt or pyproject.toml)
+  - package-ecosystem: "uv"
+    cooldown:
+      default-days: 7
+    directory: "/"
     schedule:
-      interval: "daily" # Check for updates daily
-    commit-message:
-      prefix: "deps" # Customize commit message prefix for Python updates
-    open-pull-requests-limit: 10 # Limit the number of open PRs to avoid overload
-    labels:
-      - "dependencies"
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of GitHub Actions workflows
+      interval: monthly
+    ignore:
+      - dependency-name: "jupyter-book"
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
+    directory: /
     schedule:
-      interval: "daily" # Check for updates daily
-    commit-message:
-      prefix: "deps" # Customize commit message prefix for GitHub Actions updates
-    open-pull-requests-limit: 5 # Limit the number of open PRs for GitHub Actions
-    labels:
-      - "github-actions"
+      interval: monthly


### PR DESCRIPTION
## Summary
- Switch package ecosystem from `pip` to `uv`
- Reduce update frequency from daily to monthly
- Add 7-day cooldown periods for both ecosystems
- Ignore `jupyter-book` dependency updates

## Test plan
- [ ] Verify dependabot picks up the new `uv` ecosystem correctly
- [ ] Confirm monthly schedule and cooldown are applied

## Summary by Sourcery

Update Dependabot configuration to use the uv ecosystem and reduce update frequency across dependencies.

Build:
- Switch Python dependency updates from the pip ecosystem to uv with a monthly schedule and a 7-day cooldown, ignoring jupyter-book updates.
- Change GitHub Actions dependency updates to run on a monthly schedule with a 7-day cooldown.