### PR TITLE
Fixing issues from mismatch between GF/KF cross-section

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1062,7 +1062,7 @@ def extrude(
         width_value: float | npt.NDArray[np.floating[Any]] = section.width
         width_function = section.width_function
         offset_function = section.offset_function
-        layer = section.layer
+        layer = get_layer(section.layer)
 
         xsection_points.append([width_value, offset_value])
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1447,14 +1447,14 @@ def extrude_transition(
         else:
             raise NotImplementedError
 
-        if section1.layer != section2.layer:
+        layer1 = get_layer(section1.layer)
+        layer2 = get_layer(section2.layer)
+        if layer1 != layer2:
             hidden = True
-            layer1 = get_layer(section1.layer)
-            layer2 = get_layer(section2.layer)
             layers = [layer1, layer2]
         else:
             hidden = section1.hidden
-            layer = get_layer(section1.layer)
+            layer = layer1
             layers = [layer, layer]
 
         end_angle = p.end_angle

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -524,10 +524,17 @@ class Pdk(BaseModel):
                 cross_section_ = cross_section.base
             else:
                 cross_section_ = cross_section
+
+            layer: LayerSpec = kf.kcl.layout.layer(cross_section_.main_layer)
+            try:
+                layer = self.get_layer_name(layer)
+            except ValueError:
+                pass
+
             section_ = Section(
                 name="_default",
                 width=kf.kcl.to_um(cross_section_.width),
-                layer=kf.kcl.layout.layer(cross_section_.main_layer),
+                layer=layer,
                 port_names=("o1", "o2"),
             )
             xs_ = CrossSection(

--- a/tests/test_paths_transition.py
+++ b/tests/test_paths_transition.py
@@ -81,3 +81,15 @@ def test_transition_asymmetric_ports() -> None:
 
     assert c.ports["o1"].width == width1, c.ports["o1"].width
     assert c.ports["o2"].width == width2, c.ports["o2"].width
+
+
+def test_taper_cross_section_round_tripped_layer_spec() -> None:
+    xs1 = gf.cross_section.strip(width=0.5)
+    xs2 = gf.cross_section.strip(width=1.0)
+
+    t1 = gf.components.taper_cross_section(xs1, xs2, length=10, linear=True)
+    xs1_rt = gf.get_cross_section(t1.ports["o1"].cross_section)
+    assert xs1_rt.sections[0].layer == xs1.sections[0].layer
+
+    t2 = gf.components.taper_cross_section(xs1_rt, xs2, length=10, linear=True)
+    assert any(t2.get_polygons(merge=False).values())


### PR DESCRIPTION
## Summary

Trying to extrude between two cross-sections, one coming from port (KF) and one created (GF) leads to no output...

## Test Plan

Unit test.

## Summary by Sourcery

Fix taper and path extrusion behavior when combining cross-sections from different sources by normalizing layer specifications and add regression coverage.

Bug Fixes:
- Ensure path extrusion uses normalized layer specifications for sections to avoid mismatches between GF and KF cross-sections.
- Normalize and compare cross-section layers consistently when creating transitions, preventing hidden or incorrect geometry from mismatched layer formats.
- Preserve and round-trip layer specifications when converting KF cross-sections to GF cross-sections via the PDK helper, avoiding layer resolution errors.

Tests:
- Add a regression test verifying that taper_cross_section works when a cross-section is round-tripped through get_cross_section and still produces polygons.