### PR TITLE
fix(gpdk): activate generic PDK lazily on PDK attribute access

### DIFF
--- a/gdsfactory/gpdk/__init__.py
+++ b/gdsfactory/gpdk/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from functools import cache, partial
 
-from gdsfactory.config import PATH
+from gdsfactory.config import CONF, PATH
 from gdsfactory.gpdk.layer_map import LAYER
 from gdsfactory.gpdk.layer_stack import LAYER_STACK
 from gdsfactory.typings import RoutingStrategy
@@ -12,6 +12,8 @@ if typing.TYPE_CHECKING:
     from gdsfactory.pdk import Pdk
 
     PDK: Pdk
+
+CONF.pdk = "generic"
 
 __all__ = ["LAYER", "LAYER_STACK", "get_generic_pdk"]
 

--- a/gdsfactory/gpdk/__init__.py
+++ b/gdsfactory/gpdk/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from functools import cache, partial
 
-from gdsfactory.config import CONF, PATH
+from gdsfactory.config import PATH
 from gdsfactory.gpdk.layer_map import LAYER
 from gdsfactory.gpdk.layer_stack import LAYER_STACK
 from gdsfactory.typings import RoutingStrategy
@@ -12,8 +12,6 @@ if typing.TYPE_CHECKING:
     from gdsfactory.pdk import Pdk
 
     PDK: Pdk
-
-CONF.pdk = "generic"
 
 __all__ = ["LAYER", "LAYER_STACK", "get_generic_pdk"]
 
@@ -93,14 +91,21 @@ def get_generic_pdk() -> Pdk:
     )
 
 
-# Lazy PDK instantiation to avoid circular imports
+# Lazy PDK instantiation to avoid circular imports and import-time side effects.
+# Accessing `gdsfactory.gpdk.PDK` activates the generic PDK on first access,
+# so users can do `from gdsfactory.gpdk import PDK; PDK.get_component(...)`
+# without an explicit `PDK.activate()` call -- mirroring how cspdk packages
+# behave when their own package is imported -- while *importing* gdsfactory
+# (which imports gdsfactory.gpdk) still has no global side effect on CONF.pdk.
 _PDK = None
 
 
 def _get_pdk() -> Pdk:
     global _PDK
     if _PDK is None:
-        _PDK = get_generic_pdk()
+        pdk = get_generic_pdk()
+        pdk.activate()
+        _PDK = pdk
     return _PDK
 
 


### PR DESCRIPTION
Closes #4552.

## Problem

`cspdk` packages seed `CONF.pdk` on import, so you can do:

```python
from cspdk.si220.cband import PDK
PDK.get_component("straight")  # works without PDK.activate()
```

The generic PDK didn't support this pattern — and a naive fix of adding `CONF.pdk = "generic"` at module level would reintroduce the import-time side effect deliberately removed in e09c695b6 ("don't activate pdk"), clobbering any user-set `CONF.pdk` / `GDSFACTORY_PDK` whenever `import gdsfactory` is called (since `gdsfactory.__init__` imports `gdsfactory.gpdk`).

## Solution

Activate the generic PDK lazily inside the existing `__getattr__("PDK")` path instead of at import time:

```python
def _get_pdk() -> Pdk:
    global _PDK
    if _PDK is None:
        pdk = get_generic_pdk()
        pdk.activate()   # only runs when user accesses .PDK
        _PDK = pdk
    return _PDK

def __getattr__(name: str) -> Pdk:
    if name == "PDK":
        return _get_pdk()
    raise AttributeError(...)
```

This means:
- `import gdsfactory` (which imports `gdsfactory.gpdk`) has **zero side effects** on `CONF.pdk`.
- `from gdsfactory.gpdk import PDK; PDK.get_component("straight")` **works without `PDK.activate()`**, matching cspdk's UX.
- Users who set `CONF.pdk` explicitly (or via env var) are never clobbered.