### PR TITLE
docs: improve cells notebook and add tags example

### DIFF
--- a/docs/notebooks/03_cells_autoname_and_cache.ipynb
+++ b/docs/notebooks/03_cells_autoname_and_cache.ipynb
@@ -7,45 +7,20 @@
    "source": [
     "# Cell decorator\n",
     "\n",
-    "A `@cell` is a decorator for functions that return a Component. Make sure you add the `@cell` decorator to each function that returns a Component so you avoid having multiple components with the same name.\n",
+    "The `@cell` decorator is for functions that return a Component. Always add it to avoid duplicate component names.\n",
     "\n",
-    "Why do you need to add the `@cell` decorator?\n",
+    "Why?\n",
     "\n",
-    "- In GDS each component must have a unique name. Ideally the name is also consistent from run to run, in case you want to merge GDS files that were created at different times or computers.\n",
-    "- Two components stored in the GDS file cannot have the same name. They need to be references (instances) of the same component. See `References tutorial`. That way we only have to store the component in memory once and all the references are just pointers to that component.\n",
+    "- In GDS each component must have a unique name, consistent across runs so you can merge GDS files created at different times.\n",
+    "- Two components in a GDS file cannot have the same name — they must be references (instances) of the same component.\n",
     "\n",
-    "What does the `@cell` decorator do?\n",
+    "What does `@cell` do?\n",
     "\n",
-    "1. Gives the component a unique name depending on the parameters that you pass to it.\n",
-    "2. Creates a cache of components where we use the name as the key. The first time the function runs, the cache stores the component, so the second time, you get the component directly from the cache, so you do not create the same component twice.\n",
+    "1. Gives the component a unique name based on the function name and its parameters.\n",
+    "2. Caches components by name, so calling the same function with the same parameters returns the cached component instead of rebuilding it.\n",
+    "3. Optionally tags the cell with categories for organization (e.g. `@gf.cell(tags=[\"mmi\", \"coupler\"])`).\n",
     "\n",
-    "\n",
-    "What is a decorator?\n",
-    "\n",
-    "A decorator is a function that runs over another function, so when you do:\n",
-    "\n",
-    "```python\n",
-    "@gf.cell\n",
-    "def mzi_with_bend():\n",
-    "    c = gf.Component()\n",
-    "    mzi = c << gf.components.mzi()\n",
-    "    bend = c << gf.components.bend_euler()\n",
-    "    return c\n",
-    "```\n",
-    "it's equivalent to:\n",
-    "\n",
-    "```python\n",
-    "def mzi_with_bend():\n",
-    "    c = gf.Component()\n",
-    "    mzi = c << gf.components.mzi()\n",
-    "    bend = c << gf.components.bend_euler(radius=radius)\n",
-    "    return c\n",
-    "\n",
-    "\n",
-    "mzi_with_bend_decorated = gf.cell(mzi_with_bend)\n",
-    "```\n",
-    "\n",
-    "Let us see how it works."
+    "Let's see how it works."
    ]
   },
   {
@@ -100,6 +75,7 @@
     "    return c\n",
     "\n",
     "\n",
+    "c = mzi_with_bend()\n",
     "print(f\"this cell {c.name!r} gets automatic name thanks to the `cell` decorator\")\n",
     "c.plot()"
    ]
@@ -130,6 +106,44 @@
   {
    "cell_type": "markdown",
    "id": "5",
+   "metadata": {},
+   "source": [
+    "## Tags\n",
+    "\n",
+    "You can tag cells with categories using the `tags` parameter. This helps organize your component library and enables programmatic filtering by category."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import kfactory as kf\n",
+    "\n",
+    "\n",
+    "@gf.cell(tags=[\"mmi\", \"coupler\"])\n",
+    "def mmi1x2(width: float = 0.5, length_mmi: float = 5.0) -> gf.Component:\n",
+    "    return gf.components.mmi1x2(width=width, length_mmi=length_mmi)\n",
+    "\n",
+    "\n",
+    "@gf.cell(tags=[\"coupler\"])\n",
+    "def coupler_ring(gap: float = 0.2, radius: float = 5.0) -> gf.Component:\n",
+    "    return gf.components.coupler_ring(gap=gap, radius=radius)\n",
+    "\n",
+    "\n",
+    "# You can retrieve all registered cell factories that share a tag\n",
+    "coupler_factories = kf.kcl.factories.get_by_tag(\"coupler\")\n",
+    "print(\"Cells tagged 'coupler':\", [f.name for f in coupler_factories])\n",
+    "\n",
+    "mmi_factories = kf.kcl.factories.get_by_tag(\"mmi\")\n",
+    "print(\"Cells tagged 'mmi':\", [f.name for f in mmi_factories])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -142,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -180,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "source": [
     "Another option is to just delete the cell after creating it."
@@ -189,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Settings and Info\n",
@@ -214,35 +228,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#.info: This is an attribute of the component that acts like a dictionary. \n",
-    "# It is a place to store extra, non-geometrical information about the component, such as test data, measurement results, or documentation links.\n",
-    "c.info"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c.info['area']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# .settings: This is an attribute of the component that stores a dictionary of all the parameters that were used to create it. \n",
-    "# This is how gdsfactory keeps track of the properties of a parametric cell (PCell).\n",
-    "c.settings"
+    "c.info"
    ]
   },
   {
@@ -252,12 +242,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "c.info['area']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "c.settings['length']"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "Components also have pretty print for ports `c.pprint_ports()`"
@@ -266,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -278,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "19",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -292,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "20",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -305,25 +315,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "# @gf.cell: This decorator registers the straight function as a parametric cell generator.\n",
-    "#  A key feature it enables is caching; gdsfactory will store the generated component so it does not have to rebuild it if called again with the same parameters.\n",
     "@gf.cell\n",
     "def straight(length=10, width=1):\n",
     "    c = gf.Component()\n",
     "    c.add_polygon([(0, 0), (length, 0), (length, width), (0, width)], layer=(1, 0))\n",
-    "    # This line prints a message to the console, including the length of the waveguide being built.\n",
     "    print(f\"BUILDING {length}um long straight waveguide\")\n",
     "    return c"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "22",
    "metadata": {},
    "source": [
     "If you run the cell below multiple times it will print a message because we are deleting the CACHE every single time and every time the cell will have a different Unique Identifier (UID)."
@@ -332,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "24",
    "metadata": {},
    "source": [
     "If you run the cell below multiple times it will NOT print a message because we are hitting CACHE every single time and every time the cell will have the SAME Unique Identifier (UID) because it's the same cell."
@@ -351,21 +357,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "25",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
     "wg2 = straight(length=10)\n",
-    "# Cell returns the same straight as before without having to run the function.\n",
-    "print(id(wg2))  # Notice that they have the same uuid (unique identifier)."
+    "print(id(wg2))  # Same id as wg1 — returned from cache"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Create cells without `cell` decorator\n",
@@ -418,7 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,18 +434,15 @@
     "def wg(length: float = 3):\n",
     "    return gf.components.straight(length=length)\n",
     "\n",
-    "# Clear the cache to ensure that the components will be built fresh, not loaded from a previous run.\n",
     "gf.clear_cache()\n",
     "\n",
-    "# This deterministic naming scheme ensures that every geometrically unique component has a unique name, \n",
-    "# which is essential for creating reliable and reproducible designs.\n",
-    "print(wg(length=5).name) # The name attribute becomes wg_length5.\n",
-    "print(wg(length=10).name) # The name attribute becomes wg_length10."
+    "print(wg(length=5).name)\n",
+    "print(wg(length=10).name)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Avoid Unnamed cells. Use `cell` decorator\n",
@@ -455,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "source": [
     "Notice how gdsfactory raises a Warning when you save this `Unnamed` Component."
@@ -477,20 +479,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
-    "# .write_gds(): This is a method that takes the component's geometry and writes it to a GDSII (.gds) file.\n",
-    "# This file is the final \"blueprint\" that is sent to a foundry for manufacturing.\n",
-    "c1.write_gds() "
+    "c1.write_gds()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "33",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "34",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -530,7 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary
- Add a **Tags** section demonstrating `@gf.cell(tags=["mmi", "coupler"])` for categorizing components and retrieving them with `kf.kcl.factories.get_by_tag()`
- Clean up verbose inline comments throughout the notebook
- Concise the intro markdown to focus on key points

## Test plan
- [ ] Run the notebook end-to-end to verify all cells execute without errors

## Summary by Sourcery

Simplify the cells notebook introduction and showcase tagging and retrieval of cell factories.

Documentation:
- Add a tags section illustrating how to categorize cells with the @gf.cell(tags=...) parameter and retrieve them via kfactory tag queries.
- Streamline notebook prose and inline explanations to focus on core concepts of the cell decorator, caching, and naming behavior.