### PR TITLE
Bug archimedean spiral

### DIFF
--- a/gdsfactory/components/spirals/spiral_archimedes.py
+++ b/gdsfactory/components/spirals/spiral_archimedes.py
@@ -45,17 +45,30 @@ def spiral_archimedes(
     ty = dr * np.sin(theta) + r_center * np.cos(theta)
     t_len = np.sqrt(tx**2 + ty**2)
     t_len = np.where(t_len == 0, 1.0, t_len)
-    # Unit normal (perpendicular to tangent, pointing outward).
+    # Unit normal (perpendicular to tangent, pointing inward).
     nx = -ty / t_len
     ny = tx / t_len
 
     x_center = r_center * np.cos(theta)
     y_center = r_center * np.sin(theta)
 
-    outer_x = x_center + nx * hw
-    outer_y = y_center + ny * hw
-    inner_x = x_center - nx * hw
-    inner_y = y_center - ny * hw
+    outer_x = x_center - nx * hw
+    outer_y = y_center - ny * hw
+    inner_x = x_center + nx * hw
+    inner_y = y_center + ny * hw
+
+    # Find the point of the inner edge which has the minimum distance from the start of the outer edge.
+    distances_from_edge_point = np.sqrt(
+        (inner_x - outer_x[0]) ** 2 + (inner_y - outer_y[0]) ** 2
+    )
+    min_to_edge_id = np.argmin(distances_from_edge_point)
+    # For a smooth spiral, the point of interest is the start of the inner edge, with distance = width.
+    # If that is not the case, then end the spiral at the point which violates its smoothness.
+    if min_to_edge_id != 0:
+        outer_x = outer_x[min_to_edge_id:]
+        outer_y = outer_y[min_to_edge_id:]
+        inner_x = inner_x[min_to_edge_id:]
+        inner_y = inner_y[min_to_edge_id:]
 
     # Close the polygon: outer path forward, inner path reversed.
     points_x = np.concatenate([outer_x, inner_x[::-1]])

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.42.0"
+version = "9.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

This PR fixes #4530 .

The bug arises because the curvature of the spiral is high, depending on the values for width and separation.

An example in which there is no problem, `separation=10`:
<img width="816" height="616" alt="image" src="https://github.com/user-attachments/assets/b2209817-092b-4505-b452-8a12f57575c9" />

I thus see two solutions:
1. Increase the separation enough so that there are no edges
2. End the spiral at the point where the issue arises (if it does)

For this PR I implemented solution 2, as we might want the spiral to have low footprint, especially if it is meant as beamdump.

## Logic
To identify the point where the issue starts we look at the minimum distance of the inner spiral to the start of the outer spiral.
- If there are no issues, then this distance is minimum at the start, and equal to the waveguide's width
<img width="547" height="413" alt="output2" src="https://github.com/user-attachments/assets/c4a5af4e-201b-4082-b596-70c14fa0801e" />

- Otherwise there is some other point which has the minimum distance from the start of the outer spiral
<img width="546" height="413" alt="output" src="https://github.com/user-attachments/assets/735172fd-e1a7-43a6-bd7c-1590128b4ee1" />

## Results
- `c = gf.components.spiral_archimedes(separation=2)
c.plot()`
<img width="816" height="616" alt="image" src="https://github.com/user-attachments/assets/2d9f04b8-7d24-44d1-bbf8-be8df100937d" />

- `c = gf.components.spiral_archimedes(separation=0.5)
c.plot()`
<img width="816" height="616" alt="image" src="https://github.com/user-attachments/assets/12939807-e898-48bc-a09f-2c38462e32b3" />

## Comments
Please let me know in case you are looking for a different solution, and let me know about further restrictions :)

## Summary by Sourcery

Bug Fixes:
- Correct the orientation of inner and outer spiral edges and truncate the spiral when the inner edge approaches the outer start too closely, avoiding self-intersections and edge artifacts for small separations.