### PR TITLE
Add new code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @sebastian-goeldi @nikosavola
+* @joamatab @sebastian-goeldi @nikosavola @thanojo @ThomasPluck @flaport


### PR DESCRIPTION
## Summary
- Add @thanojo, @ThomasPluck, and @flaport to CODEOWNERS

## Summary by Sourcery

Chores:
- Add additional code owners in the CODEOWNERS configuration file.