### PR TITLE
Add heater_width parameter to straight_heater_metal_simple

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agents
+
+## Code Standards
+
+### Required Before Each Commit
+
+- **ALWAYS** run `pre-commit run --all-files` before committing any changes
+- Pre-commit hooks will automatically run code formatting (ruff), linting, and other quality checks
+- All pre-commit hooks must pass before any changes can be committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -206,14 +206,17 @@ def straight_heater_metal_simple(
         heater_width: optional heater width override. Defaults to cross_section_heater width.
     """
     c = Component()
+    x = gf.get_cross_section(cross_section_heater)
+    heater_width = heater_width or x.width
+
     straight_heater_section = gf.components.straight(
-        cross_section=cross_section_waveguide_heater,
+        cross_section=gf.get_cross_section(
+            cross_section_waveguide_heater, heater_width=heater_width
+        ),
         length=length,
     )
 
     c.add_ref(straight_heater_section)
-    x = gf.get_cross_section(cross_section_heater)
-    heater_width = heater_width or x.width
     c.add_ports(straight_heater_section.ports)
 
     if via_stack:

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -187,6 +187,7 @@ def straight_heater_metal_simple(
     port_orientation2: int | None = None,
     heater_taper_length: float = 5.0,
     ohms_per_square: float | None = None,
+    heater_width: float | None = None,
 ) -> Component:
     """Returns a thermal phase shifter that has properly fixed electrical connectivity to extract a suitable electrical netlist and models.
 
@@ -202,6 +203,7 @@ def straight_heater_metal_simple(
         port_orientation2: right via stack port orientation. None adds all orientations.
         heater_taper_length: minimizes current concentrations from heater to via_stack.
         ohms_per_square: to calculate resistance.
+        heater_width: optional heater width override. Defaults to cross_section_heater width.
     """
     c = Component()
     straight_heater_section = gf.components.straight(
@@ -211,7 +213,7 @@ def straight_heater_metal_simple(
 
     c.add_ref(straight_heater_section)
     x = gf.get_cross_section(cross_section_heater)
-    heater_width = x.width
+    heater_width = heater_width or x.width
     c.add_ports(straight_heater_section.ports)
 
     if via_stack:

--- a/tests/test-data-regression/test_settings_straight_heater_metal_simple_.yml
+++ b/tests/test-data-regression/test_settings_straight_heater_metal_simple_.yml
@@ -1,6 +1,6 @@
 info:
   length: 320
-name: straight_heater_metal_simple_gdsfactorypcomponentspwave_f2bcc892
+name: straight_heater_metal_simple_gdsfactorypcomponentspwave_4c4c67fb
 settings:
   cross_section_heater: heater_metal
   cross_section_waveguide_heater: strip_heater_metal


### PR DESCRIPTION
## Summary
- Adds an optional `heater_width` parameter to `straight_heater_metal_simple` so callers can override the heater width instead of always deriving it from the `cross_section_heater`.
- Falls back to `cross_section_heater.width` when not provided (`heater_width or x.width`).

## Test plan
- [ ] Verify `straight_heater_metal_simple()` still works with default parameters
- [ ] Verify passing `heater_width=10` overrides the cross-section width

## Summary by Sourcery

New Features:
- Allow straight_heater_metal_simple callers to specify an explicit heater_width independent of the cross_section_heater configuration.