### PR TITLE
Improve exception handling in `pdk.py`

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -533,7 +533,7 @@ class Pdk(BaseModel):
             try:
                 layer = self.get_layer_name(layer)
             except ValueError:
-                pass
+                logger.debug("Could not resolve layer name for %r, using as-is", layer)
 
             section_ = Section(
                 name="_default",
@@ -573,11 +573,13 @@ class Pdk(BaseModel):
         assert self.layers is not None
         try:
             return str(self.layers[layer_index])  # type: ignore[index]
-        except Exception:
+        except (KeyError, IndexError, TypeError):
             try:
                 return str(self.layers(layer_index))  # type: ignore[call-arg]
-            except Exception:
-                raise ValueError(f"Could not find name for layer {layer_index}")
+            except (KeyError, TypeError, ValueError) as inner_exc:
+                raise ValueError(
+                    f"Could not find name for layer {layer_index}"
+                ) from inner_exc
 
     def get_layer_views(self) -> LayerViews:
         if self._layer_views_cache is not None:
@@ -598,9 +600,9 @@ class Pdk(BaseModel):
     def get_constant(self, key: str) -> Any:
         try:
             return getattr(self.constants, key)
-        except AttributeError:
+        except AttributeError as e:
             constants = list(self.constants.model_dump().keys())
-            raise AttributeError(f"{key!r} not in {constants}")
+            raise AttributeError(f"{key!r} not in {constants}") from e
 
     def to_updk(self, exclude: Sequence[str] | None = None) -> str:
         """Export to uPDK YAML definition."""

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -151,3 +151,14 @@ def test_pdk_same_dbu_with_existing_cells_allowed(restore_kcl_state: None) -> No
         dbu=existing_dbu,
     )
     pdk.activate(force=True)
+
+
+def test_get_layer_name_exception_chaining() -> None:
+    pdk = _make_pdk()
+    with pytest.raises(ValueError) as exc_info:
+        pdk.get_layer_name((999, 999))
+
+    assert "Could not find name for layer" in str(exc_info.value)
+    # Ensure that exception chaining has occurred with the inner exception, which should be ValueError
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, (ValueError, KeyError, TypeError))


### PR DESCRIPTION
This pull request improves error handling and logging in the `gdsfactory/pdk.py`

* [`get_layer_name`](diffhunk://#diff-6e20162dd198cd70a338e095f619fa324ee92cc422d5189ebff8ee7cf0ef5ea6L576-R582): Now catches specific exceptions (`KeyError`, `IndexError`, `TypeError`) instead of a generic `Exception`, and includes the original exception as context when raising a `ValueError` for missing layer names.
* [`get_constant`](diffhunk://#diff-6e20162dd198cd70a338e095f619fa324ee92cc422d5189ebff8ee7cf0ef5ea6L601-R605): When an `AttributeError` is raised for a missing constant, the original exception is chained for better traceback information.

**Logging enhancements:**

* [`get_cross_section`](diffhunk://#diff-6e20162dd198cd70a338e095f619fa324ee92cc422d5189ebff8ee7cf0ef5ea6L536-R536): Adds a debug log message when a layer name cannot be resolved, making it clear when the code falls back to using the layer as-is.

## Summary by Sourcery

Improve robustness and debuggability of PDK utilities by tightening exception handling and enhancing logging for unresolved layers and missing constants.

Bug Fixes:
- Handle only specific lookup-related exceptions in get_layer_name and preserve original error context when a layer name cannot be resolved.
- Preserve the original AttributeError context when reporting missing constants in get_constant.

Enhancements:
- Log a debug message when get_cross_section fails to resolve a layer name and falls back to using the provided layer spec as-is.