### PR TITLE
Copy containers when using base_pdks

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -211,20 +211,22 @@ class Pdk(BaseModel):
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
 
-        # update the cross sections and cells from base pdks
+        # update the cross sections, cells and containers from base pdks
         # precedence goes from first to last base PDK, and then finally to this PDK
         # (duplicates in the last base PDK will overwrite the others, and this PDK will overwrite that)
-        cross_sections = {}
-        cells = {}
+        cross_sections, cells, containers = {}, {}, {}
         for pdk in self.base_pdks:
             cross_sections.update(pdk.cross_sections)
             cells.update(pdk.cells)
+            containers.update(pdk.containers)
 
         cross_sections.update(self.cross_sections)
         cells.update(self.cells)
+        containers.update(self.containers)
 
         self.cross_sections = cross_sections
         self.cells = cells
+        self.containers = containers
 
     def xsection(
         self, func: Callable[..., CrossSection]


### PR DESCRIPTION
## Summary

Not copied.

## Test Plan

Manually.

## Summary by Sourcery

Enhancements:
- Ensure containers from base PDKs are merged with and overridden by containers defined in the derived PDK, following the same precedence rules as cross sections and cells.