### PR TITLE
feat: add length_increment to AWG

### DIFF
--- a/gdsfactory/components/filters/awg.py
+++ b/gdsfactory/components/filters/awg.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import gdsfactory as gf
 from gdsfactory.component import Component
-from gdsfactory.typings import ComponentSpec, CrossSectionSpec
+from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Step
 
 
 @gf.cell_with_module_name(tags=["filters"])
@@ -108,9 +108,10 @@ def awg(
     free_propagation_region_output_function: ComponentSpec = free_propagation_region_output,
     fpr_spacing: float = 50.0,
     arm_spacing: float = 1.0,
+    length_increment: float = 0.0,
     cross_section: CrossSectionSpec = "strip",
 ) -> Component:
-    """Returns a basic Arrayed Waveguide grating.
+    """Returns an Arrayed Waveguide grating.
 
     To simulate you can use
     https://github.com/dnrobin/awg-python
@@ -121,7 +122,10 @@ def awg(
         free_propagation_region_input_function: for input.
         free_propagation_region_output_function: for output.
         fpr_spacing: x separation between input/output free propagation region.
-        arm_spacing: y separation between arms.
+        arm_spacing: y separation between arms (used when length_increment == 0).
+        length_increment: constant length step dL (um); when > 0 the arms form a
+            nested fan where arm i is exactly i*dL longer than arm 0 -- the property
+            that makes an AWG disperse light by wavelength.
         cross_section: cross_section function.
     """
     c = Component()
@@ -141,21 +145,52 @@ def awg(
     fpr_in_ref = c.add_ref(fpr_in)
     fpr_out_ref = c.add_ref(fpr_out)
 
-    fpr_in_ref.rotate(90)
-    fpr_out_ref.rotate(90)
-
-    fpr_out_ref.x += fpr_spacing
-    _ = gf.routing.route_bundle(
-        c,
-        gf.port.get_ports_list(fpr_out_ref, prefix="E"),
-        gf.port.get_ports_list(fpr_in_ref, prefix="E"),
-        sort_ports=True,
-        separation=arm_spacing,
-        cross_section=cross_section,
-    )
+    if length_increment <= 0:
+        fpr_in_ref.rotate(90)
+        fpr_out_ref.rotate(90)
+        fpr_out_ref.x += fpr_spacing
+        _ = gf.routing.route_bundle(
+            c,
+            gf.port.get_ports_list(fpr_out_ref, prefix="E"),
+            gf.port.get_ports_list(fpr_in_ref, prefix="E"),
+            sort_ports=True,
+            separation=arm_spacing,
+            cross_section=cross_section,
+        )
+    else:
+        # Nested fan: arm i rises earlier and higher than arm i-1 so the bumps nest
+        # without crossing, while the net x-span stays equal to the gap -> each arm is
+        # exactly i*length_increment longer than arm 0.
+        fpr_out_ref.mirror_x()
+        e0 = fpr_in_ref.ports["E0"]
+        fpr_out_ref.movex(e0.x + fpr_spacing - fpr_out_ref.ports["E0"].x)
+        fpr_out_ref.movey(e0.y - fpr_out_ref.ports["E0"].y)
+        gap = fpr_out_ref.ports["E0"].x - e0.x
+        margin = 4.0
+        stagger = min(4.0, (0.4 * gap - margin) / max(arms - 1, 1))
+        lengths: list[float] = []
+        for i in range(arms):
+            p_in = fpr_in_ref.ports[f"E{i}"]
+            p_out = fpr_out_ref.ports[f"E{i}"]
+            rise_x = margin + (arms - 1 - i) * stagger
+            h = i * length_increment / 2.0
+            if h > 0:
+                steps: list[Step] = [
+                    {"dx": rise_x},
+                    {"dy": h},
+                    {"dx": gap - 2 * rise_x},
+                    {"dy": -h},
+                    {"dx": rise_x},
+                ]
+            else:
+                steps = [{"dx": gap}]
+            route = gf.routing.route_single(
+                c, p_in, p_out, cross_section=cross_section, steps=steps
+            )
+            lengths.append(route.length_backbone / 1000.0)
+        c.info["arm_lengths"] = [round(x, 4) for x in lengths]
 
     c.add_port("o1", port=fpr_in_ref.ports["o1"])
-
     for i, port in enumerate(gf.port.get_ports_list(fpr_out_ref, prefix="W")):
         c.add_port(f"E{i}", port=port)
 

--- a/tests/components/test_awg.py
+++ b/tests/components/test_awg.py
@@ -1,0 +1,22 @@
+"""Tests for the AWG length_increment feature."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from gdsfactory.components.filters.awg import awg
+
+
+def test_awg_default_builds() -> None:
+    c = awg()
+    names = [p.name for p in c.ports]
+    assert "o1" in names
+    assert "arm_lengths" not in c.info  # default keeps original behavior
+
+
+def test_awg_constant_length_increment() -> None:
+    """Each arm is exactly length_increment longer than the previous one."""
+    dl = 12.5
+    c = awg(arms=8, length_increment=dl)
+    lengths = np.asarray(c.info["arm_lengths"])
+    assert np.allclose(np.diff(lengths), dl, atol=1e-3), lengths

--- a/tests/test-data-regression/test_settings_awg_.yml
+++ b/tests/test-data-regression/test_settings_awg_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: awg_gdsfactorypcomponentspfilterspawg_A10_O3_FPRIFFfree_290103a6
+name: awg_gdsfactorypcomponentspfilterspawg_A10_O3_FPRIFFfree_c8e43e3e
 settings:
   arm_spacing: 1
   arms: 10
@@ -7,4 +7,5 @@ settings:
   fpr_spacing: 50
   free_propagation_region_input_function: Ffree_propagation_region_Mgdsfactorypcomponentspfilterspawg_SI1
   free_propagation_region_output_function: Ffree_propagation_region_Mgdsfactorypcomponentspfilterspawg_SI10_W10_W20
+  length_increment: 0
   outputs: 3


### PR DESCRIPTION
## Summary

The `awg()` sample component didn't set how much longer each arm is than the
last. That length step (dL) is the point of an AWG. It's what creates the
phase ramp across the arms that sorts light by wavelength, so without it the
sample doesn't really behave like a grating.

This adds a `length_increment` parameter. When it's 0 (the default) nothing
changes. The geometry is identical to before, so existing layouts and regression
tests are untouched. When it's greater than 0, the arms are laid out as a nested
fan: each arm rises a little earlier and higher than the one below it, so the
detours nest without the arms crossing. Because the net horizontal span is fixed,
every arm comes out to exactly i*dL longer than arm 0. The realized arm lengths are
stored in `c.info["arm_lengths"]`.

On scope: the free propagation regions are still the original
simple triangles, not full Rowland star couplers. So this is the layout building
block (the constant length increment), not a fully optimized AWG device. The star
couplers would be the natural follow up.

Closes #3041.

## Test Plan

- Added `tests/components/test_awg.py`:
  - `test_awg_default_builds`: the default AWG still builds and keeps the original
    behavior (no `arm_lengths`).
  - `test_awg_constant_length_increment`: asserts each arm is exactly
    `length_increment` longer than the previous one (`np.diff` of the arm lengths
    is constant to 1e-3 um).
- Ran the repo CI locally: `ruff` clean, `mypy --strict` clean.
- Regenerated `tests/test-data-regression/test_settings_awg_.yml` for the new
  parameter (the cell name hash changes because a setting was added). The GDS and
  netlist regressions are unchanged since the default geometry is identical.

## Summary by Sourcery

Add configurable arm length increment to the AWG component while preserving the previous default geometry.

New Features:
- Introduce a length_increment parameter to the AWG component to generate arms with a constant length step and expose realized arm lengths via component info.

Enhancements:
- Maintain backward-compatible AWG layout when length_increment is zero and document the new parameter in the AWG API docstring.

Tests:
- Add AWG tests to validate the default behavior and verify that arm lengths increase by the specified constant increment.