### PR TITLE
Add missing docstrings in API docs

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -619,6 +619,19 @@ class Path(UMGeometricObject):
         transition: Transition | TransitionAsymmetric,
         all_angle: bool = False,
     ) -> AnyComponent:
+        """Extrudes a path along a transition.
+
+        Allows different transition methods for the upper and lower edges.
+
+        Args:
+            transition: Transition or TransitionAsymmetric object describing the \
+                cross-sections and default transition types.
+            all_angle: if True, returns a ComponentAllAngle.
+
+        Returns:
+            Component: The extruded component with the specified transition methods \
+                for each edge.
+        """
         return extrude_transition(p=self, transition=transition, all_angle=all_angle)
 
     def copy(self) -> Path:

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -624,12 +624,12 @@ class Path(UMGeometricObject):
         Allows different transition methods for the upper and lower edges.
 
         Args:
-            transition: Transition or TransitionAsymmetric object describing the \
+            transition: Transition or TransitionAsymmetric object describing the
                 cross-sections and default transition types.
             all_angle: if True, returns a ComponentAllAngle.
 
         Returns:
-            Component: The extruded component with the specified transition methods \
+            AnyComponent: The extruded component with the specified transition methods
                 for each edge.
         """
         return extrude_transition(p=self, transition=transition, all_angle=all_angle)

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -413,6 +413,7 @@ class Schematic(BaseModel):
     def to_yaml_graph_networkx(
         self,
     ) -> tuple[nx.Graph, dict[str, str], dict[str, tuple[float, float]]]:
+        """Generates a netlist graph using NetworkX."""
         return to_yaml_graph_networkx(self.netlist, self.nets)
 
     def plot_graphviz(self, interactive: bool = False, splines: str = "ortho") -> None:


### PR DESCRIPTION
Fixes https://github.com/gdsfactory/gdsfactory/issues/4576

## Summary by Sourcery

Add missing API documentation for path extrusion transitions and schematic netlist graph generation.

Documentation:
- Document the path.Path.extrude_transition method parameters, behavior, and return type.
- Add a brief description for schematic.to_yaml_graph_networkx indicating it generates a NetworkX netlist graph.