### PR TITLE
preserve source port info in Component.add_port (#4554)

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -6,7 +6,6 @@ import pathlib
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, cast, overload
 
 import kfactory as kf
@@ -292,20 +291,21 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         layer = get_layer(layer)
 
+        # preserve metadata from the source port (a resolved cross_section
+        # below takes precedence over any inherited one); deep copy so list/
+        # dict info values aren't shared with the source port.
+        info = (
+            port.info.model_copy(deep=True).model_dump() if port is not None else None
+        )
+
         _port = DPorts(kcl=self.kcl, bases=self.ports.bases).create_port(
             name=name,
             width=width,
             layer=layer,
             port_type=port_type,
             dcplx_trans=trans,
+            info=info,
         )
-
-        if port is not None:
-            # preserve metadata from the source port (a resolved cross_section
-            # below takes precedence over any inherited one). deepcopy so list/
-            # dict info values aren't shared with the source port.
-            for key, value in dict(port.info).items():
-                _port.info[key] = deepcopy(value)
 
         if xs_name:
             _port.info["cross_section"] = xs_name

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -299,6 +299,12 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             dcplx_trans=trans,
         )
 
+        if port is not None:
+            # preserve metadata from the source port (a resolved cross_section
+            # below takes precedence over any inherited one).
+            for key, value in dict(port.info).items():
+                _port.info[key] = value
+
         if xs_name:
             _port.info["cross_section"] = xs_name
             if register_cross_section:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -6,6 +6,7 @@ import pathlib
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, cast, overload
 
 import kfactory as kf
@@ -301,9 +302,10 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         if port is not None:
             # preserve metadata from the source port (a resolved cross_section
-            # below takes precedence over any inherited one).
+            # below takes precedence over any inherited one). deepcopy so list/
+            # dict info values aren't shared with the source port.
             for key, value in dict(port.info).items():
-                _port.info[key] = value
+                _port.info[key] = deepcopy(value)
 
         if xs_name:
             _port.info["cross_section"] = xs_name

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -85,3 +85,25 @@ def test_rename_ports(port_type: str, data_regression: DataRegressionFixture) ->
 def test_port() -> None:
     p = gf.Port(name="foo", orientation=359, center=(0, 0), width=5, layer=0)
     assert p.orientation == 359
+
+
+def test_add_port_preserves_info() -> None:
+    """Component.add_port(port=...) must keep the source port's info (#4554)."""
+    gf.gpdk.PDK.activate()
+
+    child = gf.Component()
+    child.add_polygon([(0, 0), (1, 0), (1, 1), (0, 1)], layer=(1, 0))
+    child.add_port(
+        name="signal",
+        center=(1, 0.5),
+        width=1.0,
+        orientation=0,
+        layer=(1, 0),
+    )
+    child.ports["signal"].info["my_extra"] = "value"
+
+    parent = gf.Component()
+    parent.add_ref(child)
+    promoted = parent.add_port(port=child.ports["signal"])
+
+    assert promoted.info["my_extra"] == "value"

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -101,9 +101,15 @@ def test_add_port_preserves_info() -> None:
         layer=(1, 0),
     )
     child.ports["signal"].info["my_extra"] = "value"
+    child.ports["signal"].info["tags"] = ["a", "b"]
 
     parent = gf.Component()
     parent.add_ref(child)
     promoted = parent.add_port(port=child.ports["signal"])
 
     assert promoted.info["my_extra"] == "value"
+    assert promoted.info["tags"] == ["a", "b"]
+
+    # mutable info values are deep-copied, not shared with the source port
+    promoted.info["tags"].append("c")
+    assert child.ports["signal"].info["tags"] == ["a", "b"]


### PR DESCRIPTION
Closes #4554.

## Problem

`Component.add_port(port=...)` discards the `info` of the incoming port:

```python
import gdsfactory as gf
gf.gpdk.PDK.activate()

child = gf.Component()
child.add_polygon([(0, 0), (1, 0), (1, 1), (0, 1)], layer=(1, 0))
child.add_port(name="signal", center=(1, 0.5), width=1.0, orientation=0, layer=(1, 0))
child.ports["signal"].info["my_extra"] = "value"

parent = gf.Component()
parent.add_ref(child)
promoted = parent.add_port(port=child.ports["signal"])
print(dict(promoted.info))   # {'cross_section': ...} -- 'my_extra' is gone
```

## Cause

When `port` is given, `add_port` inherits its `center`, `width`, `orientation`, `layer`, `port_type`, `name` and `cross_section`, but builds the new port with `DPorts(...).create_port(...)`, which starts with empty `info`. Only the resolved `cross_section` is then written back, so any other metadata on the source port is lost. (`kfactory`'s own `add_port` preserves it.)

## Fix

When `port` is provided, copy its `info` onto the new port before the cross-section block runs, so a resolved `cross_section` still takes precedence over an inherited one.

## Test

Added `test_add_port_preserves_info` in `tests/test_port.py` (fails on `main`, passes here). `tests/test_port.py`, `test_port_cross_section.py`, `test_add_ports.py` and `test_cross_section.py` all pass.

## Summary by Sourcery

Preserve metadata when promoting ports via Component.add_port and ensure behavior is covered by tests.

Bug Fixes:
- Ensure Component.add_port(port=...) retains the source port's info metadata instead of discarding it.

Tests:
- Add regression test verifying that Component.add_port preserves custom info fields from the source port.