### PR TITLE
fix: restore npoints floor so small-radius bends stay curved

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1941,7 +1941,7 @@ def euler(
     else:
         if not npoints:
             npoints = abs(int(angle / 360 * radius / pdk.bend_points_distance / 2))
-            npoints = max(int(npoints), _bend_npoints_floor(angle), 2)
+            npoints = max(npoints, _bend_npoints_floor(angle), 2)
         else:
             npoints = max(int(npoints), 2)
         # Use simplified form: sp/(s0/2) = 2p/(p+1), avoids 0/0 at alpha=0

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1738,6 +1738,19 @@ def _cut_path_with_ray(
     return np.array(points)
 
 
+# Floor on the angular resolution of an auto-computed bend, in degrees per point.
+# The arc-length based npoints formula underflows for small radii, so a tight bend
+# would otherwise collapse to a 2-point chord (#4557). This floor keeps it curved.
+# It is bounded (<= 360 / _MAX_DEG_PER_BEND_POINT points per turn) so it can't blow
+# up near angle=0, unlike the inverted 360 / abs(angle) floor removed in #4337.
+_MAX_DEG_PER_BEND_POINT = 5.0
+
+
+def _bend_npoints_floor(angle: float) -> int:
+    """Minimum points for an auto-computed bend so it stays a curve, not a chord."""
+    return math.ceil(abs(angle) / _MAX_DEG_PER_BEND_POINT) + 1
+
+
 def arc(
     radius: float | None = 10.0,
     angle: float = 90,
@@ -1779,10 +1792,10 @@ def arc(
 
     if angular_step is not None:
         npoints = math.ceil(abs(angle / angular_step)) + 1
+    elif not npoints:
+        npoints = int(abs(angle) / 360 * radius / PDK.bend_points_distance / 2)
+        npoints = max(int(npoints), _bend_npoints_floor(angle), 2)
     else:
-        npoints = npoints or int(
-            abs(angle) / 360 * radius / PDK.bend_points_distance / 2
-        )
         npoints = max(int(npoints), 2)
 
     t = np.linspace(
@@ -1926,10 +1939,11 @@ def euler(
             2 * num_pts_euler + num_pts_arc - 2
         )  # Total points (avoiding duplicates)
     else:
-        npoints = npoints or abs(
-            int(angle / 360 * radius / pdk.bend_points_distance / 2)
-        )
-        npoints = max(int(npoints), 2)
+        if not npoints:
+            npoints = abs(int(angle / 360 * radius / pdk.bend_points_distance / 2))
+            npoints = max(int(npoints), _bend_npoints_floor(angle), 2)
+        else:
+            npoints = max(int(npoints), 2)
         # Use simplified form: sp/(s0/2) = 2p/(p+1), avoids 0/0 at alpha=0
         num_pts_euler = int(np.round(2 * p / (p + 1) * npoints))
         num_pts_arc = npoints - num_pts_euler

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1794,7 +1794,7 @@ def arc(
         npoints = math.ceil(abs(angle / angular_step)) + 1
     elif not npoints:
         npoints = int(abs(angle) / 360 * radius / PDK.bend_points_distance / 2)
-        npoints = max(int(npoints), _bend_npoints_floor(angle), 2)
+        npoints = max(npoints, _bend_npoints_floor(angle), 2)
     else:
         npoints = max(int(npoints), 2)
 

--- a/gdsfactory/samples/small_bends.py
+++ b/gdsfactory/samples/small_bends.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+import gdsfactory as gf
+
+_LAYER = gf.gpdk.LAYER.WG
+
+_CALLS: list[tuple[list[tuple[float, float]], float, float]] = [
+    (
+        [(0.0, 7.5), (0.0, 38.5), (-4.0, 38.5), (-6.0, 38.5), (-6.0, 43.0)],
+        1.0,
+        0.5,
+    ),
+    (
+        [(0.0, 7.5), (0.0, -4.0), (0.0, -5.0), (1.0, -6.0)],
+        1.0,
+        0.5,
+    ),
+    (
+        [
+            (0.0, 0.0),
+            (0.0, -2.5),
+            (-2.5, -4.0),
+            (-2.5, -7.5),
+            (-1.5, -9.0),
+            (-1.5, -9.5),
+        ],
+        1.5,
+        0.5,
+    ),
+    (
+        [(0.0, -11.0), (0.0, -38.5), (4.0, -38.5), (6.0, -38.5), (6.0, -43.0)],
+        1.0,
+        0.5,
+    ),
+]
+
+
+def _smooth_path(
+    points: list[tuple[float, float]],
+    width: float,
+    radius: float,
+) -> gf.Component:
+    path = gf.path.smooth(points=np.array(points), radius=radius, bend=gf.path.euler)
+    section = gf.Section(width=width, offset=0.0, layer=_LAYER, port_names=(None, None))
+    return gf.path.extrude(path, gf.CrossSection(sections=(section,)))
+
+
+def _main() -> None:
+    label = sys.argv[1] if len(sys.argv) > 1 else "out"
+    out = gf.Component()
+    for index, (points, width, radius) in enumerate(_CALLS):
+        ref = out.add_ref(_smooth_path(points, width, radius))
+        ref.ymin = 0.0
+        ref.dmove((index * 10.0, 0.0))
+
+    Path("breakage_artifacts").mkdir(exist_ok=True)
+    out.write_gds(f"breakage_artifacts/mwe_round_{label}.gds")
+    print(f"gdsfactory={gf.__version__}  wrote mwe_round_{label}.gds")
+    out.show()
+
+
+if __name__ == "__main__":
+    gf.gpdk.PDK.activate()
+    _main()

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -638,3 +638,36 @@ def test_rotation_preserves_path_length(angle: float) -> None:
     original_length = p.length()
     p.rotate(angle)
     assert np.isclose(p.length(), original_length, rtol=1e-6)
+
+
+@pytest.mark.parametrize("bend", [gf.path.arc, gf.path.euler])
+def test_small_radius_bend_stays_curved(bend: Any) -> None:
+    """Small-radius bends must keep enough points to be a curve, not a chord (#4557).
+
+    The arc-length npoints formula underflows for small radii, so before the floor
+    a tight bend collapsed to 2-3 points (a straight chord).
+    """
+    # a tight 90 degree bend should be sampled as a curve
+    assert len(bend(radius=0.5, angle=90).points) > 10
+    # even a shallow tight bend should not be a bare 2-point chord
+    assert len(bend(radius=0.5, angle=10).points) >= 3
+
+
+@pytest.mark.parametrize("bend", [gf.path.arc, gf.path.euler])
+def test_bend_npoints_floor_does_not_change_default_radius(bend: Any) -> None:
+    """The floor must not alter default-radius bends (arc-length count dominates)."""
+    # radius=10 is the default; the arc-length count (>50) already dominates the
+    # angular floor (19 points for a 90 degree bend), so geometry is unchanged.
+    assert len(bend(radius=10, angle=90).points) > 50
+
+
+@pytest.mark.parametrize("bend", [gf.path.arc, gf.path.euler])
+def test_bend_zero_angle_does_not_explode(bend: Any) -> None:
+    """A near-zero angle must not blow up npoints (the #4337 failure mode)."""
+    assert len(bend(radius=0.5, angle=0).points) <= 3
+    assert len(bend(radius=0.5, angle=1e-4).points) <= 5
+
+
+def test_bend_explicit_npoints_is_honored() -> None:
+    """An explicit npoints must win over the floor, unchanged from prior behavior."""
+    assert len(gf.path.arc(radius=0.5, angle=90, npoints=4).points) == 4


### PR DESCRIPTION
Fixes #4557.

## Problem

Between 9.31 and 9.32, #4337 replaced the angle-dependent `npoints` floor in `arc()` and `euler()` with a flat minimum of 2. The auto-`npoints` formula is arc-length based:

```python
int(abs(angle) / 360 * radius / PDK.bend_points_distance / 2)
```

For small radii this underflows, so the floor of 2 dominates and a tight bend renders as a straight chord instead of a curve. With the generic PDK (`bend_points_distance=0.02`):

| call | before | after |
|------|-------:|------:|
| `arc(radius=0.5, angle=90)` | 3 | 19 |
| `euler(radius=0.5, angle=90)` | 3 | 35 |
| `arc(radius=0.5, angle=10)` | 2 (chord) | 3 |
| `arc(radius=10, angle=90)` | 62 | 62 |
| `euler(radius=10, angle=90)` | 121 | 121 |

## Fix

Add a bounded angular-resolution floor — one point per 5°, `ceil(|angle|/5)+1` — applied only when `npoints` is auto-computed (an explicit `npoints` is still honored unchanged). It:

- keeps small-radius bends curved;
- leaves default-radius geometry **untouched**, since the arc-length count already dominates the floor there (verified: the `radius=25` euler in `test_path.py::transition` is byte-identical);
- is bounded (`<= 360/5` points per turn), so unlike the inverted `360/abs(angle)` floor that #4337 removed, it cannot explode near `angle=0` (e.g. `angle=1e-4` stays at 2 points).

## Note on the design choice

In the issue I sketched two directions and asked which you preferred. This implements the conservative one (option 1) because it is the lowest blast radius — it does not change any existing default-radius geometry. If you would rather match 9.31’s exact small-radius density, the alternative is a radius-aware arc-length floor; that is a one-line swap in `_bend_npoints_floor`, happy to switch. The `5.0` degrees-per-point constant is also easy to tune.

## Tests

`test_path.py` gains regression tests asserting small-radius bends stay curved (red before this change), default-radius counts are unaffected, near-zero angles do not explode, and explicit `npoints` is honored.

## Summary by Sourcery

Restore a minimum point density for auto-computed bend paths so small-radius arcs and eulers remain curved while preserving existing default-radius geometries and avoiding blow-ups for near-zero angles.

Bug Fixes:
- Ensure small-radius arc and euler bends use enough points to render as curves instead of collapsing into straight chords.
- Prevent the bend point auto-computation from exploding for near-zero angles while still honoring explicitly provided npoints.

Tests:
- Add regression tests covering small-radius bend curvature, default-radius point counts, stability for near-zero angles, and precedence of explicit npoints over the auto-computed floor.