### PR TITLE
broaden the typehint of add_ref_off_grid component to include ComponentAllAngle

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from gdsfactory.technology.layer_views import LayerViews
     from gdsfactory.typings import (
         AngleInDegrees,
+        AnyComponent,
         ComponentSpec,
         Coordinates,
         CornerMode,
@@ -611,7 +612,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         )
 
     def add_ref_off_grid(
-        self, component: kf.ProtoTKCell[Any], name: str | None = None
+        self, component: AnyComponent, name: str | None = None
     ) -> VInstance:
         """Adds a component instance reference to a Component without snapping to grid.
 

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -121,16 +121,16 @@ def ring_double_pn(
 
     r = gf.ComponentAllAngle()
     left_doped_ring_ref = r.add_ref_off_grid(
-        doped_path.extrude(cross_section=pn_cross_section_, all_angle=True)  # type: ignore[arg-type]
+        doped_path.extrude(cross_section=pn_cross_section_, all_angle=True)
     )
     right_doped_ring_ref = r.add_ref_off_grid(
-        doped_path.extrude(cross_section=pn_cross_section_, all_angle=True)  # type: ignore[arg-type]
+        doped_path.extrude(cross_section=pn_cross_section_, all_angle=True)
     )
     bottom_undoped_ring_ref = r.add_ref_off_grid(
-        undoped_path.extrude(cross_section=cross_section_, all_angle=True)  # type: ignore[arg-type]
+        undoped_path.extrude(cross_section=cross_section_, all_angle=True)
     )
     top_undoped_ring_ref = r.add_ref_off_grid(
-        undoped_path.extrude(cross_section=cross_section_, all_angle=True)  # type: ignore[arg-type]
+        undoped_path.extrude(cross_section=cross_section_, all_angle=True)
     )
 
     bottom_undoped_ring_ref.rotate(-undoping_angle / 2)
@@ -140,7 +140,7 @@ def ring_double_pn(
     right_doped_ring_ref.connect("o2", bottom_undoped_ring_ref.ports["o2"])
     top_undoped_ring_ref.connect("o2", left_doped_ring_ref.ports["o2"])
 
-    ring = c.add_ref_off_grid(r)  # type: ignore[arg-type]
+    ring = c.add_ref_off_grid(r)
     ring.center = (0, 0)
 
     drop_waveguide_dy = (

--- a/gdsfactory/get_netlist.py
+++ b/gdsfactory/get_netlist.py
@@ -859,11 +859,11 @@ def _sample_circuit() -> Component:
     ring = c.add_ref(gf.c.ring_single(), name="ring").move((100, 0))
     mzi = c.add_ref_off_grid(gf.c.mzi()).rotate(33).move((0, 20))
     mzi.name = "mzi"
-    s1 = c.add_ref_off_grid(gf.c.bend_euler_all_angle(angle=90 - 33)).connect(  # type: ignore[arg-type]
+    s1 = c.add_ref_off_grid(gf.c.bend_euler_all_angle(angle=90 - 33)).connect(
         "o1", mzi["o1"]
     )
     s1.name = "s1"
-    s2 = c.add_ref_off_grid(gf.c.bend_euler_all_angle(angle=33)).connect(  # type: ignore[arg-type]
+    s2 = c.add_ref_off_grid(gf.c.bend_euler_all_angle(angle=33)).connect(
         "o2", mzi["o2"]
     )
     s2.name = "s2"

--- a/gdsfactory/routing/route_dubins.py
+++ b/gdsfactory/routing/route_dubins.py
@@ -280,7 +280,7 @@ def place_dubins_path(
             # Length and radius are in um, convert to nm for gdsfactory
             arc_angle = 180 * length / (m.pi * radius)
             bend = c.add_ref_off_grid(
-                bend_circular_all_angle(angle=arc_angle, cross_section=xs)  # type: ignore[arg-type]
+                bend_circular_all_angle(angle=arc_angle, cross_section=xs)
             )
             bend.connect("o1", current_position)
             current_position = bend.ports["o2"]
@@ -289,7 +289,7 @@ def place_dubins_path(
         elif mode == "R":
             arc_angle = -(180 * length / (m.pi * radius))
             bend = c.add_ref_off_grid(
-                bend_circular_all_angle(angle=arc_angle, cross_section=xs)  # type: ignore[arg-type]
+                bend_circular_all_angle(angle=arc_angle, cross_section=xs)
             )
             bend.connect("o1", current_position)
             current_position = bend.ports["o2"]
@@ -297,7 +297,7 @@ def place_dubins_path(
 
         elif mode == "S":
             straight = c.add_ref_off_grid(
-                straight_all_angle(length=length, cross_section=xs)  # type: ignore[arg-type]
+                straight_all_angle(length=length, cross_section=xs)
             )
             straight.connect("o1", current_position)
             current_position = straight.ports["o2"]


### PR DESCRIPTION
Unless I'm missing something? We use `add_ref` and `add_ref_off_grid` instead of chevrons, so maybe this went under radar? In my mind `add_ref_off_grid` is _for_ `ComponentAllAngle`, but you just happen to also be able to put a `Component` in and then transform the ref non-Manhattan.

## Summary by Sourcery

Enhancements:
- Relax the type hint for add_ref_off_grid to use AnyComponent, supporting ComponentAllAngle and other compatible component types.