### PR TITLE
fix port orientation for pins flush with one component boundary

### DIFF
--- a/gdsfactory/add_ports.py
+++ b/gdsfactory/add_ports.py
@@ -72,6 +72,20 @@ def _infer_port_direction(
         (0=east, 90=north, 180=west, 270=south) and x, y are the center
         coordinates (unchanged from input for non-inside mode).
     """
+    boundaries = [
+        (0.0, dy, dxmax - pxmax),  # East
+        (180.0, dy, pxmin - dxmin),  # West
+        (90.0, dx, dymax - pymax),  # North
+        (270.0, dx, pymin - dymin),  # South
+    ]
+
+    # Pin flush with exactly one component boundary: port faces outward from it.
+    # Aspect ratio cannot decide here, pins can align long or short side.
+    flush = [b for b in boundaries if b[2] < tol]
+    if len(flush) == 1:
+        orientation, width, _ = flush[0]
+        return orientation, width, x, y
+
     is_horizontal = (dy < dx) if ports_on_short_side else (dx < dy)
     is_vertical = (dy > dx) if ports_on_short_side else (dx > dy)
 
@@ -81,14 +95,7 @@ def _infer_port_direction(
     if is_vertical:
         return (90.0 if y > yc else 270.0), dx, x, y
 
-    # Square ports: Check boundary proximity
-    boundaries = [
-        (0.0, dy, dxmax - pxmax),  # East
-        (180.0, dy, pxmin - dxmin),  # West
-        (90.0, dx, dymax - pymax),  # North
-        (270.0, dx, pymin - dymin),  # South
-    ]
-
+    # Square ports near multiple boundaries: first flush boundary wins
     for orientation, width, distance in boundaries:
         if distance < tol:
             return orientation, width, x, y

--- a/tests/test_add_ports.py
+++ b/tests/test_add_ports.py
@@ -51,6 +51,51 @@ def test_add_ports_from_pins_path() -> None:
     assert math.isclose(c2.ports["o2"].center[0], x), c2.ports["o2"].center[0]
 
 
+def test_add_ports_from_boxes_rect_pin_flush_with_boundary() -> None:
+    """Pin flush with one component boundary points outward from that boundary.
+
+    Aspect ratio alone would classify this 1x2 pin as north/south with
+    ports_on_short_side=True, but the pin is flush with the east edge.
+    """
+    c = gf.Component()
+    c.add_polygon([(0, -10), (100, -10), (100, 10), (0, 10)], layer=(1, 0))
+    c.shapes(gf.get_layer((2, 0))).insert(gf.kdb.DBox(99, -1, 100, 1))
+    gf.add_ports.add_ports_from_boxes(
+        c,
+        pin_layer=(2, 0),
+        inside=True,
+        use_opposite_side=True,
+        ports_on_short_side=True,
+    )
+    port = c.ports["o1"]
+    assert port.orientation == 0, port.orientation
+    assert port.width == 2, port.width
+    assert port.center == (99, 0), port.center
+
+
+def test_add_ports_from_boxes_square_pin_float_noise() -> None:
+    """Square pin with float noise near a cell corner keeps boundary orientation.
+
+    dy = -1.7 - (-2.7) = 1.0000000000000002 != dx = 1.0, so an exact dx/dy
+    comparison misclassifies the pin as a vertical rectangle and flips the
+    port to the closest axis instead of the flush east boundary.
+    """
+    c = gf.Component()
+    c.add_polygon([(0, -10), (100, -10), (100, 30), (0, 30)], layer=(1, 0))
+    c.shapes(gf.get_layer((2, 0))).insert(gf.kdb.DBox(99, -2.7, 100, -1.7))
+    gf.add_ports.add_ports_from_boxes(
+        c,
+        pin_layer=(2, 0),
+        inside=True,
+        use_opposite_side=True,
+        ports_on_short_side=True,
+    )
+    port = c.ports["o1"]
+    assert port.orientation == 0, port.orientation
+    assert port.width == 1, port.width
+    assert port.center == (99, -2.2), port.center
+
+
 def test_add_ports_from_labels() -> None:
     x = 1.238
     c = gf.components.straight(length=x)


### PR DESCRIPTION
Fixes #4593

`_infer_port_direction` now checks boundary alignment first: pin box flush (within `tol`) with exactly one component bbox edge means the port faces outward from that edge, width is the pin dimension parallel to that edge. Aspect ratio logic unchanged as fallback for pins flush with zero or multiple boundaries.

Fixes two failure modes:

1. Near-square pins with float noise (`dy = 1.0000000000000002`, `dx = 1.0`) misclassified as vertical rectangles, flipping ports near cell corners to the wrong axis.
2. Rectangular pins flush with a boundary but oriented against the aspect ratio heuristic (e.g. 1x2 pin at east edge with `ports_on_short_side=True`).

Two regression tests added. Full test suite passes (1575 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust port direction inference for pins flush with a single component boundary and add regression coverage for boundary-aligned and near-square pins with float noise.

Bug Fixes:
- Correct port orientation and width inference when rectangular pins are flush with exactly one component boundary, regardless of aspect ratio heuristics.
- Prevent misclassification of near-square pins with floating-point noise that previously caused ports near cell corners to flip to the wrong axis.

Tests:
- Add regression tests covering rectangular pins flush with a single boundary and square-like pins with float noise to ensure stable boundary-based port orientation inference.