### PR TITLE
Prune leftover layers when activating a custom PDK (#4595)

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -832,12 +832,41 @@ def _set_active_pdk(pdk: Pdk) -> None:
         kf.kcl.infos = kf.LayerInfos(
             **{v.name: kf.kdb.LayerInfo(v.layer, v.datatype) for v in pdk.layers},  # type: ignore[attr-defined]
         )
+        _prune_foreign_layers(pdk)
     else:
         kf.kcl.infos = kf.LayerInfos()
         kf.kcl.layers = kf.kcl.layerenum_from_dict(layers=kf.kcl.infos)
 
     if pdk.dbu != kf.kcl.dbu:
         kf.kcl.layout.dbu = pdk.dbu
+
+
+def _prune_foreign_layers(pdk: Pdk) -> None:
+    """Remove physical layers left over from a previously active PDK.
+
+    Defining a ``LayerMap`` registers every one of its layers into the shared
+    ``kf.kcl.layout`` (``LayerEnum.__new__`` calls ``layout.layer(...)``), so the
+    generic layermap registered when ``gdsfactory`` is imported persists after a
+    custom PDK is activated and keeps being written out and shown even though it is
+    no longer active (https://github.com/gdsfactory/gdsfactory/issues/4595).
+    Reassigning ``kf.kcl.layers``/``infos`` only updates the name bookkeeping, not
+    the layout's physical layer slots, so drop any registered layer that is not
+    part of the active PDK. Empty layers are removed; layers that already hold
+    geometry are kept so activating a PDK after building cells never silently
+    discards shapes (and the on-demand error layer is always kept).
+    """
+    if pdk.layers is None:
+        return
+    layout = kf.kcl.layout
+    keep = {(layer.layer, layer.datatype) for layer in pdk.layers}  # type: ignore[attr-defined]
+    keep.add(tuple(CONF.layer_error_path))
+    for index in list(layout.layer_indexes()):
+        info = layout.get_info(index)
+        if (info.layer, info.datatype) in keep:
+            continue
+        if any(not cell.shapes(index).is_empty() for cell in layout.each_cell()):
+            continue
+        layout.delete_layer(index)
 
 
 def get_routing_strategies() -> RoutingStrategies:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -829,16 +829,75 @@ def _set_active_pdk(pdk: Pdk) -> None:
 
     if pdk.layers is not None:
         kf.kcl.layers = pdk.layers
+        # LayerInfos registers missing physical layers, so restore enum indexes first.
+        _ensure_pdk_layers_registered(pdk)
         kf.kcl.infos = kf.LayerInfos(
             **{v.name: kf.kdb.LayerInfo(v.layer, v.datatype) for v in pdk.layers},  # type: ignore[attr-defined]
         )
         _prune_foreign_layers(pdk)
+        _ensure_pdk_layers_registered(pdk)
     else:
         kf.kcl.infos = kf.LayerInfos()
         kf.kcl.layers = kf.kcl.layerenum_from_dict(layers=kf.kcl.infos)
 
     if pdk.dbu != kf.kcl.dbu:
         kf.kcl.layout.dbu = pdk.dbu
+
+
+def _ensure_pdk_layers_registered(pdk: Pdk) -> None:
+    """Restore active PDK physical layers at their LayerEnum indexes."""
+    if pdk.layers is None:
+        return
+    layout = kf.kcl.layout
+    for layer in pdk.layers:  # type: ignore[attr-defined]
+        target_index = int(layer)
+        info = kf.kdb.LayerInfo(layer.layer, layer.datatype)
+        existing_index = layout.find_layer(info)
+        if existing_index == target_index:
+            continue
+        if existing_index is not None:
+            if not layout.is_valid_layer(target_index):
+                layout.insert_layer_at(target_index, info)
+            else:
+                existing_info = layout.get_info(target_index)
+                if (existing_info.layer, existing_info.datatype) != (
+                    info.layer,
+                    info.datatype,
+                ):
+                    logger.debug(
+                        "Layer index %s is already occupied by %s; cannot restore %s",
+                        target_index,
+                        existing_info,
+                        info,
+                    )
+                    continue
+            try:
+                layout.move_layer(existing_index, target_index)
+                layout.delete_layer(existing_index)
+            except RuntimeError:
+                logger.debug(
+                    "Could not move layer %s from index %s to %s",
+                    info,
+                    existing_index,
+                    target_index,
+                    exc_info=True,
+                )
+            continue
+        if layout.is_valid_layer(target_index):
+            existing_info = layout.get_info(target_index)
+            if (existing_info.layer, existing_info.datatype) == (
+                info.layer,
+                info.datatype,
+            ):
+                continue
+            logger.debug(
+                "Layer index %s is already occupied by %s; cannot restore %s",
+                target_index,
+                existing_info,
+                info,
+            )
+            continue
+        layout.insert_layer_at(target_index, info)
 
 
 def _prune_foreign_layers(pdk: Pdk) -> None:
@@ -860,13 +919,23 @@ def _prune_foreign_layers(pdk: Pdk) -> None:
     layout = kf.kcl.layout
     keep = {(layer.layer, layer.datatype) for layer in pdk.layers}  # type: ignore[attr-defined]
     keep.add(CONF.layer_error_path)
+    delete_indexes: list[int] = []
     for index in list(layout.layer_indexes()):
         info = layout.get_info(index)
         if (info.layer, info.datatype) in keep:
             continue
         if any(not cell.shapes(index).is_empty() for cell in layout.each_cell()):
             continue
-        layout.delete_layer(index)
+        delete_indexes.append(index)
+
+    for index in sorted(delete_indexes, reverse=True):
+        info = layout.get_info(index)
+        try:
+            layout.delete_layer(index)
+        except RuntimeError:
+            logger.debug(
+                "Could not delete empty inactive layer %s", info, exc_info=True
+            )
 
 
 def get_routing_strategies() -> RoutingStrategies:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -859,7 +859,7 @@ def _prune_foreign_layers(pdk: Pdk) -> None:
         return
     layout = kf.kcl.layout
     keep = {(layer.layer, layer.datatype) for layer in pdk.layers}  # type: ignore[attr-defined]
-    keep.add(tuple(CONF.layer_error_path))
+    keep.add(CONF.layer_error_path)
     for index in list(layout.layer_indexes()):
         info = layout.get_info(index)
         if (info.layer, info.datatype) in keep:

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -259,6 +259,35 @@ def test_activate_custom_pdk_preserves_error_layer(
     assert (1, 0) not in _registered_layers()  # but generic layers still pruned
 
 
+def test_reactivate_pdk_moves_wrong_index_layer_with_geometry(
+    restore_kcl_state: None,
+) -> None:
+    """Restoring a PDK moves wrongly registered geometry back to enum indexes."""
+
+    class MyFabLayers(LayerMap):
+        MY_WG = (10, 0)
+
+    custom_pdk = gf.Pdk(
+        name="wrong_index_fab",
+        layers=MyFabLayers,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    custom_pdk.activate(force=True)
+
+    no_layers_pdk = gf.Pdk(name="no_layers")
+    no_layers_pdk.activate(force=True)
+
+    c = gf.Component()
+    c.add_polygon([(0, 0), (5, 0), (5, 5), (0, 5)], layer=(1, 0))
+    wrong_index = gf.kcl.layout.find_layer(1, 0)
+    assert wrong_index != int(LAYER.WG)
+
+    gf.gpdk.PDK.activate(force=True)
+
+    assert gf.kcl.layout.find_layer(1, 0) == int(LAYER.WG)
+    assert not c.shapes(int(LAYER.WG)).is_empty()
+
+
 def test_get_layer_name_exception_chaining() -> None:
     pdk = _make_pdk()
     with pytest.raises(ValueError) as exc_info:

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,9 +1,11 @@
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER
+from gdsfactory.technology import LayerMap
 
 
 def test_get_cross_section() -> None:
@@ -151,6 +153,78 @@ def test_pdk_same_dbu_with_existing_cells_allowed(restore_kcl_state: None) -> No
         dbu=existing_dbu,
     )
     pdk.activate(force=True)
+
+
+def _registered_layers() -> set[tuple[int, int]]:
+    layout = gf.kcl.layout
+    return {
+        (layout.get_info(i).layer, layout.get_info(i).datatype)
+        for i in layout.layer_indexes()
+    }
+
+
+def test_activate_custom_pdk_prunes_generic_layers(
+    restore_kcl_state: None, tmp_path: Path
+) -> None:
+    """Activating a custom PDK drops the import-time generic layermap (#4595).
+
+    The generic layers are then no longer registered, written out, or shown.
+    """
+
+    class MyFabLayers(LayerMap):
+        MY_WG = (10, 0)
+        MY_SLAB = (11, 0)
+
+    pdk = gf.Pdk(
+        name="prune_fab",
+        layers=MyFabLayers,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    pdk.activate(force=True)
+
+    registered = _registered_layers()
+    assert (1, 0) not in registered  # generic WG no longer registered
+    assert {(10, 0), (11, 0)} <= registered  # the active PDK's layers remain
+
+    c = gf.Component()
+    c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=(10, 0))
+    path = tmp_path / "prune_fab.oas"
+    c.write(path)
+
+    import klayout.db as kdb
+
+    layout = kdb.Layout()
+    layout.read(str(path))
+    written = {
+        (layout.get_info(i).layer, layout.get_info(i).datatype)
+        for i in layout.layer_indexes()
+    }
+    assert (10, 0) in written  # the active layer is written
+    assert (1, 0) not in written  # generic layers are not
+
+
+def test_activate_custom_pdk_keeps_layers_with_geometry(
+    restore_kcl_state: None,
+) -> None:
+    """A layer outside the new PDK that holds shapes is kept, not pruned (#4595).
+
+    Switching PDKs must never silently discard geometry.
+    """
+    gf.gpdk.PDK.activate(force=True)
+    c = gf.Component()
+    c.add_polygon([(0, 0), (5, 0), (5, 5), (0, 5)], layer=(1, 0))  # WG holds geometry
+
+    class MyFabLayers(LayerMap):
+        MY_WG = (10, 0)
+
+    pdk = gf.Pdk(
+        name="keep_fab",
+        layers=MyFabLayers,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    pdk.activate(force=True)
+
+    assert (1, 0) in _registered_layers()  # kept because it still holds shapes
 
 
 def test_get_layer_name_exception_chaining() -> None:

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 import gdsfactory as gf
+from gdsfactory.config import CONF
 from gdsfactory.gpdk import LAYER
 from gdsfactory.technology import LayerMap
 
@@ -225,6 +226,37 @@ def test_activate_custom_pdk_keeps_layers_with_geometry(
     pdk.activate(force=True)
 
     assert (1, 0) in _registered_layers()  # kept because it still holds shapes
+
+
+def test_activate_custom_pdk_preserves_error_layer(
+    restore_kcl_state: None,
+) -> None:
+    """The on-demand routing-error layer is never pruned (#4595).
+
+    Even with no geometry on it, ``CONF.layer_error_path`` is kept when a custom
+    PDK that omits it is activated, so routing-error markers still have a home.
+    """
+    import klayout.db as kdb
+
+    gf.gpdk.PDK.activate(force=True)
+    error_layer = tuple(CONF.layer_error_path)
+    # Register the error layer slot with no shapes, so only the explicit keep --
+    # not the holds-geometry fallback -- can save it from pruning.
+    gf.kcl.layout.layer(kdb.LayerInfo(error_layer[0], error_layer[1]))
+    assert error_layer in _registered_layers()
+
+    class MyFabLayers(LayerMap):
+        MY_WG = (10, 0)
+
+    pdk = gf.Pdk(
+        name="error_layer_fab",
+        layers=MyFabLayers,
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    pdk.activate(force=True)
+
+    assert error_layer in _registered_layers()  # error layer is always kept
+    assert (1, 0) not in _registered_layers()  # but generic layers still pruned
 
 
 def test_get_layer_name_exception_chaining() -> None:


### PR DESCRIPTION
## What

Fixes #4595. After activating a custom `Pdk`, the generic gdsfactory layers (`WG 1/0`, `WGN 34/0`, `SLAB150 2/0`, …) stayed registered in the shared `gf.kcl.layout` and kept being written to output files and shown in the KLayout layer panel, even though only the custom PDK was active.

## Why

Defining a `LayerMap` registers each of its layers into the shared `kf.kcl.layout` — `LayerEnum.__new__` calls `layout.layer(...)`, which physically creates a layer slot. So importing `gdsfactory` registers the whole generic layermap (47 slots). `_set_active_pdk` then only reassigned `kf.kcl.layers`/`kf.kcl.infos`, which updates the *name* bookkeeping but never removes those physical slots, so the generic layers persisted and were emitted on write (even when empty).

Thanks to @mmcmurray123 and @sequoiap for the precise diagnosis and repro in the issue.

## How

`_set_active_pdk` now drops any registered layer that is not part of the active PDK, via a small `_prune_foreign_layers` helper. Two safeguards:

- **No data loss.** Only *empty* layers are removed. A layer that already holds geometry is kept, so activating a PDK after building cells never silently discards shapes.
- **Error layer preserved.** The on-demand routing-error layer (`CONF.layer_error_path`) is always kept.

Re-activating the generic PDK over itself keeps every generic layer (they're all in the active set), so the default behaviour is unchanged — pruning only happens when you switch to a PDK that doesn't define a previously-registered layer.

## Result

Running the issue's repro before vs. after:

```
# before
after activating custom pdk: (49, True)
generic names in OAS file: ['DEVREC', 'GE', 'HEATER', 'SLAB150', 'WAFER', 'WG', 'WGN']
# after
after activating custom pdk: (2, False)
generic names in OAS file: []
```

## Tests

`tests/test_pdk.py`:
- `test_activate_custom_pdk_prunes_generic_layers` — generic layers are gone from `gf.kcl.layout` and from a written `.oas` once a custom PDK is active, while the custom layers remain (fails on `main`).
- `test_activate_custom_pdk_keeps_layers_with_geometry` — a non-PDK layer that holds shapes is kept, guarding the no-data-loss path.

Both use the existing `restore_kcl_state` fixture. Full `tests/test_pdk.py`, plus `test_add_pins`, `test_component`, `test_cross_section`, `tests/technology`, `test_add_ports`, `test_component_layout` and `tests/export` pass locally.

## Summary by Sourcery

Ensure layout layers reflect the active PDK by pruning inactive layers and restoring active layers to their correct indexes.

Bug Fixes:
- Remove leftover generic layers from the shared layout when activating a custom PDK so they are no longer written to output or shown in viewers.
- Preserve layers that contain geometry and the routing-error layer when pruning inactive layers to avoid data loss and maintain error reporting.
- Realign layers with geometry to their correct LayerEnum indexes when reactivating a PDK after misregistration.

Tests:
- Add regression tests covering pruning of generic layers when a custom PDK is activated, retention of layers with geometry, preservation of the error layer, and correction of misindexed layers on PDK reactivation.