### PR TITLE
fix: make components-along-path container a deterministic cell (#4598)

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -18,11 +18,13 @@ import kfactory as kf
 import klayout.db as kdb
 import numpy as np
 import numpy.typing as npt
+from kfactory.conf import CheckInstances
 from kfactory.geometry import UMGeometricObject
 from numpy import mod
 from scipy import optimize
 
 import gdsfactory as gf
+from gdsfactory._cell import cell
 from gdsfactory.component import Component, ComponentAllAngle
 from gdsfactory.component_layout import (
     rotate_points,
@@ -891,6 +893,7 @@ def transition_asymmetric(
     )
 
 
+@cell(check_instances=CheckInstances.IGNORE)
 def along_path(
     p: Path,
     component: ComponentSpec,

--- a/tests/test_paths_extrude.py
+++ b/tests/test_paths_extrude.py
@@ -278,6 +278,31 @@ def test_extrude_component_along_path() -> None:
     assert c
 
 
+def test_extrude_component_along_path_deterministic_name() -> None:
+    # The container holding the components placed along the path must get a
+    # deterministic, content-based cell name rather than a session-counter
+    # ``Unnamed_N`` one, otherwise the GDS and netlist output is
+    # nondeterministic (it depends on what was built earlier in the session).
+    # See https://github.com/gdsfactory/gdsfactory/issues/4598
+    via = gf.cross_section.ComponentAlongPath(
+        component=gf.c.rectangle(size=(1, 1), centered=True), spacing=5, padding=2
+    )
+    s = gf.Section(width=0.5, offset=0, layer=(1, 0), port_names=("in", "out"))
+    x = gf.CrossSection(sections=(s,), components_along_path=(via,))
+
+    # build some unrelated cells first so the global "Unnamed" counter advances
+    for length in (1.0, 2.0, 3.0):
+        gf.components.straight(length=length)
+
+    c = gf.path.extrude(gf.path.straight(length=20), cross_section=x)
+    instance_cell_names = [inst.cell.name for inst in c.insts]
+
+    assert instance_cell_names, "expected a components-along-path container instance"
+    assert all(not name.startswith("Unnamed") for name in instance_cell_names), (
+        instance_cell_names
+    )
+
+
 def test_extrude_cross_section_list_of_sections() -> None:
     s = gf.Section(width=0.5, offset=0.5, layer="WG")
     xs = gf.CrossSection(sections=(s,))


### PR DESCRIPTION
## Problem

`CrossSection.components_along_path` produces nondeterministic cell names (#4598).

`gf.path.extrude` places the repeated components via `along_path()` in `gdsfactory/path.py`, which was a **plain function**, not a `@cell`: it created a bare `Component()` whose name autogenerates to `Unnamed_N`, where `N` is the global session counter. The container's name therefore depends on what was built earlier in the process, which means:

- GDS files written from the same component differ run to run (the embedded cell name changes), breaking byte-level golden-file regression tests.
- `get_netlist()` exposes the container as an instance named `Unnamed_N`, so netlist regression files are nondeterministic too.
- `gf.read.from_yaml` can never rebuild such a netlist, because `Unnamed_N` is not a registered factory.

## Fix

Decorate `along_path()` with `@cell(check_instances=False)` so it goes through the normal deterministic, content-based naming and caching machinery, exactly as the issue suggests. The container now gets a stable name like `along_path_PPath...__<hash>` derived from its inputs (path, component, spacing, padding), so the same cross-section always yields the same GDS bytes and netlist.

`check_instances=False` is required because the components are intentionally placed off-grid along the path (unchanged behavior); the default off-grid check would otherwise reject them.

## Verification

- New regression test `test_extrude_component_along_path_deterministic_name` warms up the global `Unnamed` counter, then asserts the components-along-path container instance does **not** get an `Unnamed_*` name. It fails on `main` and passes with this fix.
- Confirmed the content hash is stable across counter states and distinct for distinct paths/spacings (no collisions).
- All existing path/extrude tests pass.

Thanks @thanojo for the precise diagnosis and root-cause pointer.

---
*Authored with AI assistance under my direction; I verified the diagnosis, the fix, and the tests empirically.*

## Summary by Sourcery

Make components placed along a path use a deterministic cell container name instead of a session-dependent one to ensure stable GDS and netlist output.

Bug Fixes:
- Fix nondeterministic container cell naming for components placed along a path by turning the along-path container into a deterministic cell.

Tests:
- Add a regression test verifying that the components-along-path container no longer uses Unnamed_* session-counter cell names and remains deterministic across runs.