### PR TITLE
fix: deduplicate cell names before writing layout

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -71,18 +71,22 @@ def _deduplicate_cell_names(layout: kdb.Layout) -> None:
     KLayout's writer rejects layouts with duplicate cell names, so we append
     ``_1``, ``_2``, … to the duplicates (keeping the first occurrence as-is).
     """
-    name_counts: Counter[str] = Counter()
+    existing_names = {c.name for c in layout.each_cell()}
     cells_by_name: dict[str, list[kdb.Cell]] = {}
     for c in layout.each_cell():
-        n = c.name
-        name_counts[n] += 1
-        cells_by_name.setdefault(n, []).append(c)
+        cells_by_name.setdefault(c.name, []).append(c)
 
-    for n, count in name_counts.items():
-        if count <= 1:
+    for name, cells in cells_by_name.items():
+        if len(cells) <= 1:
             continue
-        for i, c in enumerate(cells_by_name[n][1:], start=1):
-            c.name = f"{n}_{i}"
+        for i, c in enumerate(cells[1:], start=1):
+            while True:
+                new_name = f"{name}_{i}"
+                if new_name not in existing_names:
+                    c.name = new_name
+                    existing_names.add(new_name)
+                    break
+                i += 1
 
 
 class AddPortError(ValueError):

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pathlib
 import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, cast, overload
 
@@ -60,6 +61,28 @@ def _fix_pin_metadata(cell: kf.kcell.ProtoTKCell[Any]) -> None:
         cell.remove_meta_info(name)
         value["ports"] = [str(p) for p in value["ports"]]
         cell.add_meta_info(kdb.LayoutMetaInfo(name, value, None, True))
+
+
+def _deduplicate_cell_names(layout: kdb.Layout) -> None:
+    """Rename cells that share the same name so the layout can be written.
+
+    Some component factories (e.g. spiral_racetrack_fixed_length) create
+    multiple internal cells with the same name due to failed routing retries.
+    KLayout's writer rejects layouts with duplicate cell names, so we append
+    ``_1``, ``_2``, … to the duplicates (keeping the first occurrence as-is).
+    """
+    name_counts: Counter[str] = Counter()
+    cells_by_name: dict[str, list[kdb.Cell]] = {}
+    for c in layout.each_cell():
+        n = c.name
+        name_counts[n] += 1
+        cells_by_name.setdefault(n, []).append(c)
+
+    for n, count in name_counts.items():
+        if count <= 1:
+            continue
+        for i, c in enumerate(cells_by_name[n][1:], start=1):
+            c.name = f"{n}_{i}"
 
 
 class AddPortError(ValueError):
@@ -701,6 +724,7 @@ class Component(ComponentBase, kf.DKCell):
                 self.convert_to_static(recursive=True)
             self.set_meta_data()
             _fix_pin_metadata(self)
+        _deduplicate_cell_names(self.kcl.layout)
         super().write(
             filename,
             save_options=save_options,

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pathlib
 import warnings
 from abc import ABC, abstractmethod
-from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, cast, overload
 


### PR DESCRIPTION
## Summary
- Some component factories (e.g. `spiral_racetrack_fixed_length`) create multiple internal cells with the same name due to failed routing retries
- KLayout's writer rejects layouts with duplicate cell names, causing write failures
- Before writing, rename duplicates by appending `_1`, `_2`, … (keeping the first occurrence unchanged)

## Test plan
- [ ] Verify `Component.write()` succeeds for components that previously failed with duplicate cell names
- [ ] Confirm existing components write identically (no regressions)

## Summary by Sourcery

Ensure layout cell names are deduplicated before writing components to avoid KLayout write failures.

Bug Fixes:
- Prevent GDS writing from failing when component layouts contain duplicate internal cell names by renaming duplicates before write.

Enhancements:
- Introduce a layout helper that normalizes cell names by appending numeric suffixes to duplicates while preserving the first occurrence.