### PR TITLE
fix: deduplicate cell names in write_gds

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -27,6 +27,7 @@ from gdsfactory.component import (
     ComponentAllAngle,
     ComponentReference,
     container,
+    deduplicate_cell_names,
 )
 from gdsfactory.config import CONF, PATH, __version__
 from gdsfactory.port import Port
@@ -141,6 +142,7 @@ __all__ = (
     "container",
     "containers",
     "cross_section",
+    "deduplicate_cell_names",
     "diff",
     "difftest",
     "export",

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -487,12 +487,17 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
-        # Deduplicate cell names to avoid write errors
+        # Deduplicate cell names within this component's hierarchy
+        called = set(self.kdb_cell.called_cells())
+        called.add(self.kdb_cell.cell_index())
+        hierarchy_cells = [self.kcl[ci] for ci in called]
         dupes = [
-            s for s, n in Counter(c.name for c in self.kcl.cells("*")).items() if n > 1
+            s
+            for s, n in Counter(c.name for c in hierarchy_cells).items()
+            if n > 1
         ]
         for dup in dupes:
-            dup_cells = self.kcl.cells(dup)[1:]
+            dup_cells = [c for c in hierarchy_cells if c.name == dup][1:]
             for kcell in dup_cells:
                 was_locked = kcell.locked
                 kcell.locked = False

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -159,8 +159,12 @@ ComponentReference: TypeAlias = DInstance
 ComponentReferences: TypeAlias = DInstances
 
 
-def _deduplicate_cell_names(component: ComponentBase) -> None:
-    """Rename duplicate cell names in the component hierarchy before writing."""
+def deduplicate_cell_names(component: ComponentBase) -> None:
+    """Rename duplicate cell names in the component hierarchy so it can be written.
+
+    Call this before ``write_gds`` when the component may contain cells with
+    colliding names (e.g. after ``import_gds`` or ``pack``).
+    """
     if hasattr(component, "kdb_cell"):
         called = set(component.kdb_cell.called_cells())
         called.add(component.kdb_cell.cell_index())
@@ -505,8 +509,6 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         if not with_metadata:
             save_options.write_context_info = False
-
-        _deduplicate_cell_names(self)
 
         self.write(filename=gdspath, save_options=save_options)
         return pathlib.Path(gdspath)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -165,12 +165,10 @@ def deduplicate_cell_names(component: ComponentBase) -> None:
     Call this before ``write_gds`` when the component may contain cells with
     colliding names (e.g. after ``import_gds`` or ``pack``).
     """
-    if hasattr(component, "kdb_cell"):
-        called = set(component.kdb_cell.called_cells())
-        called.add(component.kdb_cell.cell_index())
-        cells = [component.kcl[ci] for ci in called]
-    else:
-        cells = list(component.kcl.cells("*"))
+    kdb_cell: kdb.Cell = component.kdb_cell  # type: ignore[attr-defined]
+    called = set(kdb_cell.called_cells())
+    called.add(kdb_cell.cell_index())
+    cells = [component.kcl[ci] for ci in called]
 
     dupes = [s for s, n in Counter(c.name for c in cells).items() if n > 1]
     for dup in dupes:
@@ -180,6 +178,7 @@ def deduplicate_cell_names(component: ComponentBase) -> None:
             kcell.name = component.kcl.unique_cell_name(dup)
             if was_locked:
                 kcell.locked = True
+
 
 
 class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
@@ -510,7 +509,31 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
-        self.write(filename=gdspath, save_options=save_options)
+        kdb_cell: kdb.Cell = self.kdb_cell  # type: ignore[attr-defined]
+        called = set(kdb_cell.called_cells())
+        called.add(kdb_cell.cell_index())
+        cells = [self.kcl[ci] for ci in called]
+
+        renamed: list[tuple[kf.KCell, str, bool]] = []
+        dupes = [s for s, n in Counter(c.name for c in cells).items() if n > 1]
+        for dup in dupes:
+            for kcell in [c for c in cells if c.name == dup][1:]:
+                was_locked = kcell.locked
+                original_name = kcell.name
+                kcell.locked = False
+                kcell.name = self.kcl.unique_cell_name(dup)
+                if was_locked:
+                    kcell.locked = True
+                renamed.append((kcell, original_name, was_locked))
+
+        try:
+            self.write(filename=gdspath, save_options=save_options)
+        finally:
+            for kcell, original_name, was_locked in renamed:
+                kcell.locked = False
+                kcell.name = original_name
+                if was_locked:
+                    kcell.locked = True
         return pathlib.Path(gdspath)
 
     def pprint_ports(self, **kwargs: Any) -> None:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pathlib
 import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias, cast, overload
 
@@ -485,6 +486,19 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         if not with_metadata:
             save_options.write_context_info = False
+
+        # Deduplicate cell names to avoid write errors
+        dupes = [
+            s for s, n in Counter(c.name for c in self.kcl.cells("*")).items() if n > 1
+        ]
+        for dup in dupes:
+            dup_cells = self.kcl.cells(dup)[1:]
+            for kcell in dup_cells:
+                was_locked = kcell.locked
+                kcell.locked = False
+                kcell.name = self.kcl.unique_cell_name(dup)
+                if was_locked:
+                    kcell.locked = True
 
         self.write(filename=gdspath, save_options=save_options)
         return pathlib.Path(gdspath)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -159,6 +159,25 @@ ComponentReference: TypeAlias = DInstance
 ComponentReferences: TypeAlias = DInstances
 
 
+def _deduplicate_cell_names(component: ComponentBase) -> None:
+    """Rename duplicate cell names in the component hierarchy before writing."""
+    if hasattr(component, "kdb_cell"):
+        called = set(component.kdb_cell.called_cells())
+        called.add(component.kdb_cell.cell_index())
+        cells = [component.kcl[ci] for ci in called]
+    else:
+        cells = list(component.kcl.cells("*"))
+
+    dupes = [s for s, n in Counter(c.name for c in cells).items() if n > 1]
+    for dup in dupes:
+        for kcell in [c for c in cells if c.name == dup][1:]:
+            was_locked = kcell.locked
+            kcell.locked = False
+            kcell.name = component.kcl.unique_cell_name(dup)
+            if was_locked:
+                kcell.locked = True
+
+
 class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
     """Canvas where you add polygons, instances and ports.
 
@@ -487,23 +506,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
-        # Deduplicate cell names within this component's hierarchy
-        called = set(self.kdb_cell.called_cells())
-        called.add(self.kdb_cell.cell_index())
-        hierarchy_cells = [self.kcl[ci] for ci in called]
-        dupes = [
-            s
-            for s, n in Counter(c.name for c in hierarchy_cells).items()
-            if n > 1
-        ]
-        for dup in dupes:
-            dup_cells = [c for c in hierarchy_cells if c.name == dup][1:]
-            for kcell in dup_cells:
-                was_locked = kcell.locked
-                kcell.locked = False
-                kcell.name = self.kcl.unique_cell_name(dup)
-                if was_locked:
-                    kcell.locked = True
+        _deduplicate_cell_names(self)
 
         self.write(filename=gdspath, save_options=save_options)
         return pathlib.Path(gdspath)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Any
 
 import kfactory as kf
@@ -480,6 +481,20 @@ def test_component_write_gds() -> None:
     path = c.write_gds(gdspath=GDSDIR_TEMP / "custom_name.gds")
     assert path.exists()
     assert path.name == "custom_name.gds"
+
+
+def test_write_gds_deduplicates_cell_names(tmp_path: pathlib.Path) -> None:
+    """write_gds should rename duplicate cells instead of raising."""
+    straight = gf.components.straight(cross_section="strip")
+    gdspath = tmp_path / "straight.gds"
+    straight.write_gds(gdspath)
+    imported = gf.import_gds(gdspath)
+
+    c = gf.Component()
+    c << straight
+    c << imported
+    out = c.write_gds(tmp_path / "merged.gds")
+    assert out.exists()
 
 
 def test_component_copy_child_info() -> None:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -483,8 +483,8 @@ def test_component_write_gds() -> None:
     assert path.name == "custom_name.gds"
 
 
-def test_write_gds_deduplicates_cell_names(tmp_path: pathlib.Path) -> None:
-    """write_gds should rename duplicate cells instead of raising."""
+def test_deduplicate_cell_names(tmp_path: pathlib.Path) -> None:
+    """deduplicate_cell_names should rename duplicate cells so write_gds succeeds."""
     straight = gf.components.straight(cross_section="strip")
     gdspath = tmp_path / "straight.gds"
     straight.write_gds(gdspath)
@@ -493,6 +493,7 @@ def test_write_gds_deduplicates_cell_names(tmp_path: pathlib.Path) -> None:
     c = gf.Component()
     c << straight
     c << imported
+    gf.deduplicate_cell_names(c)
     out = c.write_gds(tmp_path / "merged.gds")
     assert out.exists()
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -483,9 +483,10 @@ def test_component_write_gds() -> None:
     assert path.name == "custom_name.gds"
 
 
-def test_deduplicate_cell_names(tmp_path: pathlib.Path) -> None:
-    """deduplicate_cell_names should rename duplicate cells so write_gds succeeds."""
+def test_write_gds_deduplicates_cell_names(tmp_path: pathlib.Path) -> None:
+    """write_gds should handle duplicate cell names without polluting the cache."""
     straight = gf.components.straight(cross_section="strip")
+    original_name = straight.name
     gdspath = tmp_path / "straight.gds"
     straight.write_gds(gdspath)
     imported = gf.import_gds(gdspath)
@@ -493,9 +494,9 @@ def test_deduplicate_cell_names(tmp_path: pathlib.Path) -> None:
     c = gf.Component()
     c << straight
     c << imported
-    gf.deduplicate_cell_names(c)
     out = c.write_gds(tmp_path / "merged.gds")
     assert out.exists()
+    assert straight.name == original_name
 
 
 def test_component_copy_child_info() -> None:


### PR DESCRIPTION
## Summary
- Adds cell name deduplication in `write_gds` before writing to prevent `RuntimeError` when duplicate cell names exist (e.g. from `import_gds` or `pack`)
- Uses `kcl.cells("*")` to find duplicates and `kcl.unique_cell_name()` to rename them
- Properly unlocks/relocks cells during rename
- Adds test covering the duplicate cell name scenario

Fixes #4603
Related: https://github.com/doplaydo/gdsfactoryplus/issues/3008

## Test plan
- [x] Added `test_write_gds_deduplicates_cell_names` that creates a duplicate cell scenario via `import_gds` and verifies `write_gds` succeeds
- [x] Pre-commit hooks pass (ruff check, ruff format, pyright, codespell)

## Summary by Sourcery

Deduplicate component cell names before writing GDS files to prevent runtime errors when duplicates exist and add test coverage for the behavior.

Bug Fixes:
- Prevent GDS writing from failing with a runtime error when duplicate cell names are present by renaming duplicates before write.

Tests:
- Add a test that creates duplicate cells via GDS import and verifies that write_gds succeeds and produces an output file.