### PR TITLE
Remove duplicated ellipse function from pack.py

### DIFF
--- a/gdsfactory/pack.py
+++ b/gdsfactory/pack.py
@@ -288,11 +288,3 @@ def pack(
         df.to_csv(csvpath, index=True)
 
     return components_packed_list
-
-
-@gf.cell
-def ellipse(number: int = 0) -> Component:
-    """Example component to pack."""
-    n = number
-    radii = (np.random.rand() * n + 2, np.random.rand() * n + 2)
-    return gf.components.ellipse(radii=radii)


### PR DESCRIPTION
## Summary
- Remove the `ellipse` helper function from `gdsfactory/pack.py` that duplicates `gf.components.ellipse`
- The function used random radii and was unused — the canonical `ellipse` component already exists in `gf.components`

## Test plan
- [x] Verify no other code references `pack.ellipse`
- [x] Existing tests pass

## Summary by Sourcery

Enhancements:
- Simplify the pack module by deleting a redundant ellipse helper that duplicated gf.components.ellipse.