### PR TITLE
fix: deduplicate cell names in write_gds before writing

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -62,6 +62,28 @@ def _fix_pin_metadata(cell: kf.kcell.ProtoTKCell[Any]) -> None:
         cell.add_meta_info(kdb.LayoutMetaInfo(name, value, None, True))
 
 
+def _rename_duplicate_cell_names(layout: kdb.Layout) -> list[tuple[int, str]]:
+    """Temporarily rename duplicate cells before writing a layout."""
+    seen: set[str] = set()
+    renamed_cells: list[tuple[int, str]] = []
+    for layout_cell in layout.each_cell():
+        cell_name = layout_cell.name
+        if cell_name in seen:
+            cell_index = layout_cell.cell_index()
+            renamed_cells.append((cell_index, cell_name))
+            layout.rename_cell(cell_index, layout.unique_cell_name(cell_name))
+        else:
+            seen.add(cell_name)
+    return renamed_cells
+
+
+def _restore_cell_names(
+    layout: kdb.Layout, renamed_cells: list[tuple[int, str]]
+) -> None:
+    for cell_index, cell_name in reversed(renamed_cells):
+        layout.rename_cell(cell_index, cell_name)
+
+
 class AddPortError(ValueError):
     """Error raised when adding a port fails."""
 
@@ -486,22 +508,11 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
-        # Deduplicate cell names before writing — duplicate names can arise
-        # from import_gds or pack, and kfactory raises a RuntimeError when
-        # multiple cells share the same name.
-        seen: dict[str, int] = {}
-        duplicates: list[tuple[int, str]] = []
-        for layout_cell in self.kcl.layout.each_cell():
-            cell_name = layout_cell.name
-            if cell_name in seen:
-                duplicates.append((layout_cell.cell_index(), cell_name))
-            else:
-                seen[cell_name] = layout_cell.cell_index()
-        for cell_index, name in duplicates:
-            new_name = self.kcl.layout.unique_cell_name(name)
-            self.kcl.layout.rename_cell(cell_index, new_name)
-
-        self.write(filename=gdspath, save_options=save_options)
+        renamed_cells = _rename_duplicate_cell_names(self.kcl.layout)
+        try:
+            self.write(filename=gdspath, save_options=save_options)
+        finally:
+            _restore_cell_names(self.kcl.layout, renamed_cells)
         return pathlib.Path(gdspath)
 
     def pprint_ports(self, **kwargs: Any) -> None:

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -491,12 +491,12 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         # multiple cells share the same name.
         seen: dict[str, int] = {}
         duplicates: list[tuple[int, str]] = []
-        for cell in self.kcl.layout.each_cell():
-            name = cell.name
-            if name in seen:
-                duplicates.append((cell.cell_index(), name))
+        for layout_cell in self.kcl.layout.each_cell():
+            cell_name = layout_cell.name
+            if cell_name in seen:
+                duplicates.append((layout_cell.cell_index(), cell_name))
             else:
-                seen[name] = cell.cell_index()
+                seen[cell_name] = layout_cell.cell_index()
         for cell_index, name in duplicates:
             new_name = self.kcl.layout.unique_cell_name(name)
             self.kcl.layout.rename_cell(cell_index, new_name)

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -486,6 +486,21 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
+        # Deduplicate cell names before writing — duplicate names can arise
+        # from import_gds or pack, and kfactory raises a RuntimeError when
+        # multiple cells share the same name.
+        seen: dict[str, int] = {}
+        duplicates: list[tuple[int, str]] = []
+        for cell in self.kcl.layout.each_cell():
+            name = cell.name
+            if name in seen:
+                duplicates.append((cell.cell_index(), name))
+            else:
+                seen[name] = cell.cell_index()
+        for cell_index, name in duplicates:
+            new_name = self.kcl.layout.unique_cell_name(name)
+            self.kcl.layout.rename_cell(cell_index, new_name)
+
         self.write(filename=gdspath, save_options=save_options)
         return pathlib.Path(gdspath)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -482,6 +482,48 @@ def test_component_write_gds() -> None:
     assert path.name == "custom_name.gds"
 
 
+def test_component_write_gds_duplicate_cell_names() -> None:
+    """write_gds deduplicates cell names to prevent kfactory write errors.
+
+    When cells with duplicate names exist (from import_gds or pack),
+    write_gds should rename them to unique names before writing.
+    """
+    import tempfile
+    from pathlib import Path
+
+    # Create a GDS with a named cell
+    td = tempfile.mkdtemp()
+    gdspath = Path(td) / "test.gds"
+    layout = kf.kdb.Layout()
+    layout.dbu = 0.001
+    c1 = layout.create_cell("dup_cell")
+    c1.shapes(layout.layer(1, 0)).insert(kf.kdb.Box(0, 0, 1000, 1000))
+    layout.write(str(gdspath))
+
+    # Import it twice into kf.kcl to create duplicate cell names
+    def _import_to_kcl(path: str) -> None:
+        temp_kcl = kf.KCLayout(name=f"temp_{hash(str(path))}")
+        temp_kcl.read(path)
+        kcell = temp_kcl[temp_kcl.layout.top_cell().name]
+        c = kf.DKCell()
+        c.kdb_cell.copy_tree(kcell.kdb_cell)
+        c.name = kcell.name
+
+    _import_to_kcl(str(gdspath))
+    _import_to_kcl(str(gdspath))
+
+    # At this point kf.kcl has two cells named 'dup_cell'
+    # write_gds should deduplicate them and succeed
+    c = gf.Component(name="test_dup_write")
+    out_path = c.write_gds(gdspath=Path(td) / "out.gds")
+    assert out_path.exists()
+
+    # Clean up temp
+    import shutil
+
+    shutil.rmtree(td)
+
+
 def test_component_copy_child_info() -> None:
     c1 = gf.Component()
     c2 = gf.Component()

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import kfactory as kf
@@ -482,18 +483,13 @@ def test_component_write_gds() -> None:
     assert path.name == "custom_name.gds"
 
 
-def test_component_write_gds_duplicate_cell_names() -> None:
+def test_component_write_gds_duplicate_cell_names(tmp_path: Path) -> None:
     """write_gds deduplicates cell names to prevent kfactory write errors.
 
     When cells with duplicate names exist (from import_gds or pack),
-    write_gds should rename them to unique names before writing.
+    write_gds should temporarily rename them to unique names before writing.
     """
-    import tempfile
-    from pathlib import Path
-
-    # Create a GDS with a named cell
-    td = tempfile.mkdtemp()
-    gdspath = Path(td) / "test.gds"
+    gdspath = tmp_path / "test.gds"
     layout = kf.kdb.Layout()
     layout.dbu = 0.001
     c1 = layout.create_cell("dup_cell")
@@ -515,13 +511,14 @@ def test_component_write_gds_duplicate_cell_names() -> None:
     # At this point kf.kcl has two cells named 'dup_cell'
     # write_gds should deduplicate them and succeed
     c = gf.Component(name="test_dup_write")
-    out_path = c.write_gds(gdspath=Path(td) / "out.gds")
+    names_before = {cell.cell_index(): cell.name for cell in c.kcl.layout.each_cell()}
+    assert list(names_before.values()).count("dup_cell") >= 2
+
+    out_path = c.write_gds(gdspath=tmp_path / "out.gds")
     assert out_path.exists()
-
-    # Clean up temp
-    import shutil
-
-    shutil.rmtree(td)
+    assert {
+        cell.cell_index(): cell.name for cell in c.kcl.layout.each_cell()
+    } == names_before
 
 
 def test_component_copy_child_info() -> None:


### PR DESCRIPTION
Fixes #4603.

When cells with duplicate names exist (from `import_gds` or `pack`), `write_gds` fails because kfactory's `write()` raises:

    RuntimeError: The following cell name(s) are used for more than one cell

This PR adds a deduplication step in `write_gds` that renames duplicate-named cells to unique names via `layout.unique_cell_name()` before calling `self.write()`.

Built with GdsFactory under my direction.

## Summary by Sourcery

Deduplicate layout cell names before writing GDS files to prevent kfactory write-time errors when duplicate cell names exist.

Bug Fixes:
- Ensure write_gds renames duplicate-named cells to unique names using the layout’s cell name generator before invoking the underlying writer to avoid RuntimeError from kfactory.
- Add a regression test that imports a GDS twice to create duplicate cell names and verifies write_gds completes successfully.