### PR TITLE
Improve route_astar path search performance

### DIFF
--- a/docs/notebooks/04_routing.ipynb
+++ b/docs/notebooks/04_routing.ipynb
@@ -725,7 +725,7 @@
     "# By setting it to None, the router will simply ignore any collisions.\n",
     "left_ports.reverse()\n",
     "routes = gf.routing.route_bundle(\n",
-    "    c, right_ports, left_ports, radius=5, on_collision=None, cross_section=\"strip\"\n",
+    "    c, right_ports, left_ports, radius=5, on_collision='warning', cross_section=\"strip\"\n",
     ")\n",
     "\n",
     "c"
@@ -1627,14 +1627,6 @@
     ")\n",
     "c"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/gdsfactory/routing/route_astar.py
+++ b/gdsfactory/routing/route_astar.py
@@ -165,9 +165,9 @@ def nearest_open_node(
     blocked: npt.NDArray[np.bool_],
 ) -> tuple[int, int]:
     """Return the closest unblocked grid node using local breadth-first search."""
-    nx, ny = blocked.shape
-    i = min(max(node[0], 0), nx - 1)
-    j = min(max(node[1], 0), ny - 1)
+    shape_x, shape_y = blocked.shape
+    i = min(max(node[0], 0), shape_x - 1)
+    j = min(max(node[1], 0), shape_y - 1)
     if not blocked[i, j]:
         return i, j
 
@@ -181,7 +181,7 @@ def nearest_open_node(
             (ci, cj - 1),
             (ci, cj + 1),
         ):
-            if ni < 0 or nj < 0 or ni >= nx or nj >= ny or (ni, nj) in seen:
+            if ni < 0 or nj < 0 or ni >= shape_x or nj >= shape_y or (ni, nj) in seen:
                 continue
             if not blocked[ni, nj]:
                 return ni, nj
@@ -280,13 +280,14 @@ def count_bends(waypoints: Sequence[DPoint]) -> int:
     if len(waypoints) < 3:
         return 0
     bends = 0
-    previous_direction: tuple[int, int] | None = None
+    previous_direction: tuple[float, float] | None = None
     for p1, p2 in pairwise(waypoints):
         dx = p2.x - p1.x
         dy = p2.y - p1.y
-        direction = (0 if abs(dx) < 1e-9 else int(dx > 0) * 2 - 1, 0)
-        if abs(dy) >= 1e-9:
-            direction = (0, int(dy > 0) * 2 - 1)
+        if abs(dx) < 1e-9 and abs(dy) < 1e-9:
+            continue
+        length = np.hypot(dx, dy)
+        direction = (round(dx / length, 4), round(dy / length, 4))
         if previous_direction is not None and direction != previous_direction:
             bends += 1
         previous_direction = direction
@@ -461,7 +462,7 @@ def route_astar(
         distance: Clearance distance from obstacles in microns.
         cross_section: Cross-section specification for the routed waveguide.
         bend: Component to use for bends (e.g. ``wire_corner`` or ``bend_euler``).
-        **kwargs: Additional keyword arguments forwarded to the cross-section.
+        **kwargs: Additional keyword arguments forwarded to the cross-section or route_bundle.
 
     Returns:
         Route: The route generated using the start/end node pairing
@@ -471,7 +472,13 @@ def route_astar(
         RuntimeError: If all A* attempts fail for all start/end node combinations.
         ValueError: If a port has an unsupported orientation.
     """
-    cross_section = gf.get_cross_section(cross_section, **kwargs)
+    route_bundle_kwargs = {
+        key: value for key, value in kwargs.items() if key in ROUTE_BUNDLE_KWARGS
+    }
+    cross_section_kwargs = {
+        key: value for key, value in kwargs.items() if key not in ROUTE_BUNDLE_KWARGS
+    }
+    cross_section = gf.get_cross_section(cross_section, **cross_section_kwargs)
     grid, x, y = _generate_grid(component, resolution, avoid_layers, distance)
     blocked_grid = grid == 1
 
@@ -629,4 +636,5 @@ def route_astar(
         waypoints=optimized_waypoints,
         cross_section=cross_section,
         bend=bend,
+        **route_bundle_kwargs,
     )[0]

--- a/gdsfactory/routing/route_astar.py
+++ b/gdsfactory/routing/route_astar.py
@@ -391,13 +391,17 @@ def route_astar_single(
         A single `Route` object created from the computed A* path.
 
     Raises:
-        ValueError: If start_node or end_node is None.
+        ValueError: If any required grid input is None.
         nx.NetworkXNoPath: If no valid A* route exists between the nodes.
     """
-    assert x is not None, "x array must not be None"
-    assert y is not None, "y array must not be None"
-    assert start_node is not None, "start_node must not be None"
-    assert end_node is not None, "end_node must not be None"
+    if x is None:
+        raise ValueError("x array must not be None")
+    if y is None:
+        raise ValueError("y array must not be None")
+    if start_node is None:
+        raise ValueError("start_node must not be None")
+    if end_node is None:
+        raise ValueError("end_node must not be None")
 
     waypoints_ = route_astar_waypoints(
         port1=port1,

--- a/gdsfactory/routing/route_astar.py
+++ b/gdsfactory/routing/route_astar.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import heapq
+import inspect
+from collections import deque
 from collections.abc import Sequence
-from typing import Any, cast
+from itertools import pairwise
+from typing import Any
 
 import klayout.dbcore as kdb
 import networkx as nx
@@ -155,52 +159,111 @@ def simplify_path(waypoints: Coordinates, tolerance: float) -> list[Coordinate]:
     return list(simplified_line.coords)
 
 
-def route_astar_single(
-    component: Component,
-    port1: Port,
-    port2: Port,
-    resolution: float = 1,
-    cross_section: CrossSectionSpec = "strip",
-    bend: ComponentSpec = "wire_corner",
-    G: nx.Graph | None = None,
-    x: npt.NDArray[np.number[Any]] | None = None,
-    y: npt.NDArray[np.number[Any]] | None = None,
-    start_node: tuple[int, int] | None = None,
-    end_node: tuple[int, int] | None = None,
-    **kwargs: Any,
-) -> Route:
-    """Runs a single A* routing attempt between two ports.
+def nearest_open_node(
+    node: tuple[int, int],
+    blocked: npt.NDArray[np.bool_],
+) -> tuple[int, int]:
+    """Return the closest unblocked grid node using local breadth-first search."""
+    nx, ny = blocked.shape
+    i = min(max(node[0], 0), nx - 1)
+    j = min(max(node[1], 0), ny - 1)
+    if not blocked[i, j]:
+        return i, j
 
-    Uses explicitly provided start and end grid-node indices.
+    queue: deque[tuple[int, int]] = deque([(i, j)])
+    seen = {(i, j)}
+    while queue:
+        ci, cj = queue.popleft()
+        for ni, nj in (
+            (ci - 1, cj),
+            (ci + 1, cj),
+            (ci, cj - 1),
+            (ci, cj + 1),
+        ):
+            if ni < 0 or nj < 0 or ni >= nx or nj >= ny or (ni, nj) in seen:
+                continue
+            if not blocked[ni, nj]:
+                return ni, nj
+            seen.add((ni, nj))
+            queue.append((ni, nj))
 
-    Args:
-        component: Component in which the final route geometry will be inserted.
-        port1: Start port of the route.
-        port2: End port of the route.
-        resolution: Grid discretization step in microns.
-        cross_section: Cross-section specification for the routed waveguide.
-        bend: Component used for bends (e.g. wire_corner or bend_euler).
-        G: Precomputed NetworkX grid graph with obstacle nodes removed.
-        x: 1D array of x-coordinates for grid columns.
-        y: 1D array of y-coordinates for grid rows.
-        start_node: Approximate (i, j) index of the start grid cell.
-        end_node: Approximate (i, j) index of the end grid cell.
-        **kwargs: Additional arguments passed into the cross-section.
+    raise RuntimeError("No open grid nodes available for A* routing.")
 
-    Returns:
-        A single `Route` object created from the computed A* path.
 
-    Raises:
-        ValueError: If start_node or end_node is None.
-        nx.NetworkXNoPath: If no valid A* route exists between the nodes.
-    """
+def astar_grid(
+    blocked: npt.NDArray[np.bool_],
+    start_node: tuple[int, int],
+    end_node: tuple[int, int],
+) -> list[tuple[int, int]]:
+    """Find a shortest Manhattan grid path without constructing a NetworkX graph."""
+    start = nearest_open_node(start_node, blocked)
+    end = nearest_open_node(end_node, blocked)
+    if start == end:
+        return [start]
+
+    nx_, ny_ = blocked.shape
+    g_score = np.full(blocked.shape, np.inf)
+    closed = np.zeros(blocked.shape, dtype=bool)
+    came_from: dict[tuple[int, int], tuple[int, int]] = {}
+
+    def heuristic(node: tuple[int, int]) -> int:
+        return abs(node[0] - end[0]) + abs(node[1] - end[1])
+
+    g_score[start] = 0
+    heap: list[tuple[float, int, tuple[int, int]]] = [(heuristic(start), 0, start)]
+
+    while heap:
+        _, current_g, current = heapq.heappop(heap)
+        if closed[current]:
+            continue
+        if current == end:
+            path = [current]
+            while current in came_from:
+                current = came_from[current]
+                path.append(current)
+            path.reverse()
+            return path
+
+        closed[current] = True
+        ci, cj = current
+        for neighbor in (
+            (ci - 1, cj),
+            (ci + 1, cj),
+            (ci, cj - 1),
+            (ci, cj + 1),
+        ):
+            ni, nj = neighbor
+            if (
+                ni < 0
+                or nj < 0
+                or ni >= nx_
+                or nj >= ny_
+                or blocked[neighbor]
+                or closed[neighbor]
+            ):
+                continue
+            tentative_g = current_g + 1
+            if tentative_g < g_score[neighbor]:
+                came_from[neighbor] = current
+                g_score[neighbor] = tentative_g
+                heapq.heappush(
+                    heap, (tentative_g + heuristic(neighbor), tentative_g, neighbor)
+                )
+
+    raise nx.NetworkXNoPath(f"No path between {start_node} and {end_node}.")
+
+
+def path_from_nodes(
+    *,
+    G: nx.Graph | None,
+    blocked_grid: npt.NDArray[np.bool_] | None,
+    start_node: tuple[int, int],
+    end_node: tuple[int, int],
+) -> list[tuple[int, int]]:
+    if blocked_grid is not None:
+        return astar_grid(blocked_grid, start_node, end_node)
+
     assert G is not None, "route_astar_with_nodes: G must not be None"
-    assert x is not None, "x array must not be None"
-    assert y is not None, "y array must not be None"
-    assert start_node is not None, "start_node must not be None"
-    assert end_node is not None, "end_node must not be None"
-
-    # Find the indices of the closest valid nodes
     start_node = min(
         G.nodes,
         key=lambda node: float(np.linalg.norm(np.array(node) - np.array(start_node))),
@@ -209,8 +272,44 @@ def route_astar_single(
         G.nodes,
         key=lambda node: float(np.linalg.norm(np.array(node) - np.array(end_node))),
     )
+    return nx.astar_path(G, start_node, end_node)
 
-    path = nx.astar_path(G, start_node, end_node)  # Find shortest path
+
+def count_bends(waypoints: Sequence[DPoint]) -> int:
+    if len(waypoints) < 3:
+        return 0
+    bends = 0
+    previous_direction: tuple[int, int] | None = None
+    for p1, p2 in pairwise(waypoints):
+        dx = p2.x - p1.x
+        dy = p2.y - p1.y
+        direction = (0 if abs(dx) < 1e-9 else int(dx > 0) * 2 - 1, 0)
+        if abs(dy) >= 1e-9:
+            direction = (0, int(dy > 0) * 2 - 1)
+        if previous_direction is not None and direction != previous_direction:
+            bends += 1
+        previous_direction = direction
+    return bends
+
+
+def route_astar_waypoints(
+    *,
+    port1: Port,
+    port2: Port,
+    resolution: float,
+    G: nx.Graph | None,
+    blocked_grid: npt.NDArray[np.bool_] | None,
+    x: npt.NDArray[np.number[Any]],
+    y: npt.NDArray[np.number[Any]],
+    start_node: tuple[int, int],
+    end_node: tuple[int, int],
+) -> list[DPoint]:
+    path = path_from_nodes(
+        G=G,
+        blocked_grid=blocked_grid,
+        start_node=start_node,
+        end_node=end_node,
+    )
 
     # Convert path to waypoints, move to center of grid cell
     waypoints = [(x[i] + resolution / 2, y[j] + resolution / 2) for i, j in path]
@@ -228,6 +327,8 @@ def route_astar_single(
     ]
 
     for port, closest_index, second_closest_index in port_data:
+        if len(my_waypoints) < 2:
+            continue
         # If the orientation of the port is vertical and the path leading to it is vertical
         if (
             port.orientation in [90, 270]
@@ -247,15 +348,89 @@ def route_astar_single(
             my_waypoints[second_closest_index][1] = port.y
             my_waypoints[closest_index][1] = port.y
 
-    # Convert to native floats or Point instances
     waypoints_ = [DPoint(x, y) for x, y in my_waypoints]
+    return gf.kf.routing.manhattan.clean_points(waypoints_)
+
+
+def route_astar_single(
+    component: Component,
+    port1: Port,
+    port2: Port,
+    resolution: float = 1,
+    cross_section: CrossSectionSpec = "strip",
+    bend: ComponentSpec = "wire_corner",
+    G: nx.Graph | None = None,
+    x: npt.NDArray[np.number[Any]] | None = None,
+    y: npt.NDArray[np.number[Any]] | None = None,
+    start_node: tuple[int, int] | None = None,
+    end_node: tuple[int, int] | None = None,
+    blocked_grid: npt.NDArray[np.bool_] | None = None,
+    **kwargs: Any,
+) -> Route:
+    """Runs a single A* routing attempt between two ports.
+
+    Uses explicitly provided start and end grid-node indices.
+
+    Args:
+        component: Component in which the final route geometry will be inserted.
+        port1: Start port of the route.
+        port2: End port of the route.
+        resolution: Grid discretization step in microns.
+        cross_section: Cross-section specification for the routed waveguide.
+        bend: Component used for bends (e.g. wire_corner or bend_euler).
+        G: Precomputed NetworkX grid graph with obstacle nodes removed.
+        x: 1D array of x-coordinates for grid columns.
+        y: 1D array of y-coordinates for grid rows.
+        start_node: Approximate (i, j) index of the start grid cell.
+        end_node: Approximate (i, j) index of the end grid cell.
+        blocked_grid: Precomputed grid with blocked obstacle cells.
+        **kwargs: Additional arguments passed into the cross-section or route_bundle.
+
+    Returns:
+        A single `Route` object created from the computed A* path.
+
+    Raises:
+        ValueError: If start_node or end_node is None.
+        nx.NetworkXNoPath: If no valid A* route exists between the nodes.
+    """
+    assert x is not None, "x array must not be None"
+    assert y is not None, "y array must not be None"
+    assert start_node is not None, "start_node must not be None"
+    assert end_node is not None, "end_node must not be None"
+
+    waypoints_ = route_astar_waypoints(
+        port1=port1,
+        port2=port2,
+        resolution=resolution,
+        G=G,
+        blocked_grid=blocked_grid,
+        x=x,
+        y=y,
+        start_node=start_node,
+        end_node=end_node,
+    )
+    route_bundle_parameters = inspect.signature(gf.routing.route_bundle).parameters
+    route_bundle_kwargs = {
+        key: value for key, value in kwargs.items() if key in route_bundle_parameters
+    }
+    cross_section_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key not in route_bundle_parameters
+    }
+    cross_section = (
+        gf.get_cross_section(cross_section, **cross_section_kwargs)
+        if cross_section_kwargs
+        else cross_section
+    )
     return gf.routing.route_bundle(
         component=component,
         ports1=[port1],
         ports2=[port2],
-        waypoints=gf.kf.routing.manhattan.clean_points(waypoints_),
+        waypoints=waypoints_,
         cross_section=cross_section,
         bend=bend,
+        **route_bundle_kwargs,
     )[0]
 
 
@@ -272,8 +447,8 @@ def route_astar(
 ) -> Route:
     """A* router that evaluates several start/end node options and returns the best route.
 
-    All candidates are computed on a temporary copy of the component;
-    only the optimized route is rebuilt on the real one.
+    Candidate paths are computed on a grid, validated on a scratch component,
+    and only the optimized route is built on the real component.
 
     Args:
         component: Component on which the final (optimized) route will be built.
@@ -294,18 +469,9 @@ def route_astar(
         RuntimeError: If all A* attempts fail for all start/end node combinations.
         ValueError: If a port has an unsupported orientation.
     """
-    # Create a copy of the component to run preliminary A* attempts
-    copy_of_component = component.copy()
     cross_section = gf.get_cross_section(cross_section, **kwargs)
     grid, x, y = _generate_grid(component, resolution, avoid_layers, distance)
-    G_ = nx.grid_2d_graph(len(x), len(y))
-    G = cast("nx.Graph", G_)
-
-    # Remove nodes representing obstacles
-    for i in range(len(x)):
-        for j in range(len(y)):
-            if grid[i, j] == 1:
-                G.remove_node((i, j))
+    blocked_grid = grid == 1
 
     distance_from_node_to_port = 3 * (cross_section.radius or 3)  # in um
 
@@ -386,14 +552,13 @@ def route_astar(
     else:
         raise ValueError("port2 orientation must be in [0, 90, 180, 270]")
 
-    # List of all attempted routes with their start/end coordinates, in order to select the one with fewest bends
-    candidates: list[tuple[Route, tuple[float, float], tuple[float, float]]] = []
+    # Score candidate paths without placing temporary geometry.
+    candidates: list[tuple[int, int, list[DPoint]]] = []
 
     for start_coords in start_node_coordinates:
         for end_coords in end_node_coordinates:
             try:
-                route = route_astar_single(
-                    component=copy_of_component,
+                waypoints = route_astar_waypoints(
                     port1=port1,
                     port2=port2,
                     start_node=(
@@ -405,47 +570,61 @@ def route_astar(
                         round((end_coords[1] - y.min()) / resolution),
                     ),
                     resolution=resolution,
-                    cross_section=cross_section,
-                    bend=bend,
-                    G=G,
+                    G=None,
+                    blocked_grid=blocked_grid,
                     x=x,
                     y=y,
-                    **kwargs,
                 )
-                candidates.append((route, start_coords, end_coords))
+                candidates.append(
+                    (
+                        count_bends(waypoints),
+                        len(waypoints),
+                        waypoints,
+                    )
+                )
 
-            except Exception as e:
-                print(f"Attempt failed: {e}")
+            except Exception:
                 continue
 
     if not candidates:
         raise RuntimeError("All A* routing attempts failed.")
 
-    # Choose the route with the fewest bends
-    _, optimized_start_coords, optimized_end_coords = min(
-        candidates, key=lambda item: get_route_bend_count(item[0])
+    # Validate generated waypoints against route_bundle before selecting a route.
+    # A low-bend A* path can still be unbuildable once bend-radius and collision
+    # constraints are applied downstream.
+    valid_candidates: list[tuple[int, int, list[DPoint]]] = []
+    for _, waypoint_count, waypoints in sorted(
+        candidates, key=lambda item: (item[0], item[1])
+    ):
+        try:
+            route = gf.routing.route_bundle(
+                component=gf.Component(),
+                ports1=[port1],
+                ports2=[port2],
+                waypoints=waypoints,
+                cross_section=cross_section,
+                bend=bend,
+                raise_on_error=True,
+            )
+        except Exception:
+            continue
+        valid_candidates.append(
+            (get_route_bend_count(route[0]), waypoint_count, waypoints)
+        )
+
+    if not valid_candidates:
+        raise RuntimeError("All A* routing attempts failed.")
+
+    _, _, optimized_waypoints = min(
+        valid_candidates, key=lambda item: (item[0], item[1])
     )
 
     # Build optimized route on real component
-    return route_astar_single(
+    return gf.routing.route_bundle(
         component=component,
-        port1=port1,
-        port2=port2,
-        start_node=(
-            round((optimized_start_coords[0] - x.min()) / resolution),
-            round((optimized_start_coords[1] - y.min()) / resolution),
-        ),
-        end_node=(
-            round((optimized_end_coords[0] - x.min()) / resolution),
-            round((optimized_end_coords[1] - y.min()) / resolution),
-        ),
-        resolution=resolution,
-        avoid_layers=avoid_layers,
-        distance=distance,
+        ports1=[port1],
+        ports2=[port2],
+        waypoints=optimized_waypoints,
         cross_section=cross_section,
         bend=bend,
-        G=G,
-        x=x,
-        y=y,
-        **kwargs,
-    )
+    )[0]

--- a/gdsfactory/routing/route_astar.py
+++ b/gdsfactory/routing/route_astar.py
@@ -4,7 +4,7 @@ import heapq
 from collections import deque
 from collections.abc import Sequence
 from itertools import pairwise
-from typing import Any
+from typing import Any, cast
 
 import klayout.dbcore as kdb
 import networkx as nx
@@ -273,7 +273,7 @@ def path_from_nodes(
         G.nodes,
         key=lambda node: float(np.linalg.norm(np.array(node) - np.array(end_node))),
     )
-    return nx.astar_path(G, start_node, end_node)
+    return cast("list[tuple[int, int]]", nx.astar_path(G, start_node, end_node))
 
 
 def count_bends(waypoints: Sequence[DPoint]) -> int:

--- a/gdsfactory/routing/route_astar.py
+++ b/gdsfactory/routing/route_astar.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import heapq
-import inspect
 from collections import deque
 from collections.abc import Sequence
 from itertools import pairwise
@@ -27,6 +26,8 @@ from gdsfactory.typings import (
     Port,
     Route,
 )
+
+ROUTE_BUNDLE_KWARGS = {"raise_on_error"}
 
 
 def get_route_bend_count(route: Route) -> int:
@@ -409,14 +410,11 @@ def route_astar_single(
         start_node=start_node,
         end_node=end_node,
     )
-    route_bundle_parameters = inspect.signature(gf.routing.route_bundle).parameters
     route_bundle_kwargs = {
-        key: value for key, value in kwargs.items() if key in route_bundle_parameters
+        key: value for key, value in kwargs.items() if key in ROUTE_BUNDLE_KWARGS
     }
     cross_section_kwargs = {
-        key: value
-        for key, value in kwargs.items()
-        if key not in route_bundle_parameters
+        key: value for key, value in kwargs.items() if key not in ROUTE_BUNDLE_KWARGS
     }
     cross_section = (
         gf.get_cross_section(cross_section, **cross_section_kwargs)

--- a/gdsfactory/samples/sample_route_astar.py
+++ b/gdsfactory/samples/sample_route_astar.py
@@ -1,0 +1,45 @@
+"""Sample demonstrating the A* router for obstacle-aware waveguide routing."""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+
+gf.gpdk.PDK.activate()
+
+
+if __name__ == "__main__":
+    c = gf.Component()
+    cross_section = gf.get_cross_section("strip", radius=5)
+    bend = gf.components.bend_euler
+
+    straight = gf.components.straight(cross_section=cross_section)
+    left = c << straight
+    right = c << straight
+    right.rotate(90)
+    right.move((168, 63))
+
+    obstacle = gf.components.rectangle(size=(250, 3), layer="M2")
+    obstacle1 = c << obstacle
+    obstacle2 = c << obstacle
+    obstacle3 = c << obstacle
+    obstacle4 = c << obstacle
+    obstacle4.rotate(90)
+    obstacle1.ymin = 50
+    obstacle1.xmin = -10
+    obstacle2.xmin = 35
+    obstacle3.ymin = 42
+    obstacle3.xmin = 72.23
+    obstacle4.xmin = 200
+    obstacle4.ymin = 55
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o1"],
+        port2=right.ports["o2"],
+        cross_section=cross_section,
+        resolution=15,
+        distance=12,
+        avoid_layers=("M2",),
+        bend=bend,
+    )
+    c.show()

--- a/tests/routing/test_route_astar.py
+++ b/tests/routing/test_route_astar.py
@@ -1,0 +1,210 @@
+import importlib
+from itertools import pairwise
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import gdsfactory as gf
+
+route_astar_module = importlib.import_module("gdsfactory.routing.route_astar")
+
+
+def segment_crosses_box(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    box: tuple[float, float, float, float],
+) -> bool:
+    x1, y1 = p1
+    x2, y2 = p2
+    xmin, ymin, xmax, ymax = box
+    if x1 == x2:
+        return xmin <= x1 <= xmax and max(min(y1, y2), ymin) <= min(max(y1, y2), ymax)
+    if y1 == y2:
+        return ymin <= y1 <= ymax and max(min(x1, x2), xmin) <= min(max(x1, x2), xmax)
+    raise ValueError("route_astar backbone segments should be Manhattan")
+
+
+def expanded_dbbox(
+    ref: gf.ComponentReference,
+    distance: float,
+) -> tuple[float, float, float, float]:
+    box = ref.dbbox()
+    return (
+        box.left - distance,
+        box.bottom - distance,
+        box.right + distance,
+        box.top + distance,
+    )
+
+
+def test_route_astar_obstacle_route() -> None:
+    c = gf.Component()
+    cross_section = gf.get_cross_section("strip", radius=5)
+    straight = gf.components.straight(cross_section=cross_section)
+    left = c << straight
+    right = c << straight
+    right.rotate(90)
+    right.move((168, 63))
+
+    obstacle = gf.components.rectangle(size=(250, 3), layer="M2")
+    obstacle1 = c << obstacle
+    obstacle2 = c << obstacle
+    obstacle3 = c << obstacle
+    obstacle4 = c << obstacle
+    obstacles = [obstacle1, obstacle2, obstacle3, obstacle4]
+    obstacle4.rotate(90)
+    obstacle1.ymin = 50
+    obstacle1.xmin = -10
+    obstacle2.xmin = 35
+    obstacle3.ymin = 42
+    obstacle3.xmin = 72.23
+    obstacle4.xmin = 200
+    obstacle4.ymin = 55
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o1"],
+        port2=right.ports["o2"],
+        cross_section=cross_section,
+        resolution=15,
+        distance=12,
+        avoid_layers=("M2",),
+        bend=gf.components.bend_euler,
+    )
+
+    assert route.length > 0
+    route_backbone = [(point.x / 1000, point.y / 1000) for point in route.backbone]
+    expanded_obstacles = [expanded_dbbox(ref, distance=12) for ref in obstacles]
+    assert not any(
+        segment_crosses_box(p1, p2, box)
+        for p1, p2 in pairwise(route_backbone)
+        for box in expanded_obstacles
+    )
+
+
+def test_route_astar_accepts_cross_section_kwargs() -> None:
+    c = gf.Component()
+    straight = gf.components.straight(width=1)
+    left = c << straight
+    right = c << straight
+    right.move((80, 0))
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o2"],
+        port2=right.ports["o1"],
+        cross_section="strip",
+        width=1,
+        resolution=10,
+        distance=5,
+        bend=gf.components.bend_euler,
+    )
+
+    assert route.length > 0
+
+
+def test_route_astar_does_not_copy_input_component(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = gf.Component()
+    straight = gf.components.straight()
+    left = c << straight
+    right = c << straight
+    right.move((80, 0))
+
+    def fail_copy() -> None:
+        raise AssertionError("route_astar should not copy the full input component")
+
+    monkeypatch.setattr(c, "copy", fail_copy)
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o2"],
+        port2=right.ports["o1"],
+        cross_section="strip",
+        resolution=10,
+        distance=5,
+        bend=gf.components.bend_euler,
+    )
+
+    assert route.length > 0
+
+
+def test_route_astar_selects_fewest_actual_bends() -> None:
+    c = gf.Component()
+    cross_section = gf.get_cross_section("strip", radius=5)
+    straight = gf.components.straight(cross_section=cross_section)
+    left = c << straight
+    right = c << straight
+    right.rotate(90)
+    right.move((20, -50))
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o2"],
+        port2=right.ports["o1"],
+        cross_section=cross_section,
+        resolution=10,
+        distance=8,
+        bend=gf.components.bend_euler,
+    )
+
+    assert route.n_bend90 == 3
+
+
+def test_route_astar_single_preserves_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_route_bundle(
+        component: gf.Component,
+        ports1: object = None,
+        ports2: object = None,
+        waypoints: object = None,
+        cross_section: object = None,
+        bend: object = "bend_euler",
+        raise_on_error: bool | None = None,
+        **kwargs: object,
+    ) -> list[SimpleNamespace]:
+        captured_kwargs.update(
+            {
+                "component": component,
+                "ports1": ports1,
+                "ports2": ports2,
+                "waypoints": waypoints,
+                "cross_section": cross_section,
+                "bend": bend,
+                "raise_on_error": raise_on_error,
+                **kwargs,
+            }
+        )
+        return [SimpleNamespace(length=1)]
+
+    monkeypatch.setattr(route_astar_module.gf.routing, "route_bundle", fake_route_bundle)
+
+    c = gf.Component()
+    straight = gf.components.straight(width=1)
+    left = c << straight
+    right = c << straight
+    right.move((80, 0))
+    route = route_astar_module.route_astar_single(
+        component=gf.Component(),
+        port1=left.ports["o2"],
+        port2=right.ports["o1"],
+        cross_section="strip",
+        width=1,
+        raise_on_error=True,
+        resolution=10,
+        blocked_grid=np.zeros((20, 5), dtype=bool),
+        x=np.arange(0, 200, 10, dtype=float),
+        y=np.arange(-20, 30, 10, dtype=float),
+        start_node=(1, 2),
+        end_node=(8, 2),
+    )
+
+    assert route.length == 1
+    assert captured_kwargs["cross_section"].width == 1
+    assert captured_kwargs["raise_on_error"] is True
+    assert "width" not in captured_kwargs

--- a/tests/routing/test_route_astar.py
+++ b/tests/routing/test_route_astar.py
@@ -182,7 +182,9 @@ def test_route_astar_single_preserves_kwargs(
         )
         return [SimpleNamespace(length=1)]
 
-    monkeypatch.setattr(route_astar_module.gf.routing, "route_bundle", fake_route_bundle)
+    monkeypatch.setattr(
+        route_astar_module.gf.routing, "route_bundle", fake_route_bundle
+    )
 
     c = gf.Component()
     straight = gf.components.straight(width=1)
@@ -195,6 +197,8 @@ def test_route_astar_single_preserves_kwargs(
         port2=right.ports["o1"],
         cross_section="strip",
         width=1,
+        layer="M2",
+        radius=7,
         raise_on_error=True,
         resolution=10,
         blocked_grid=np.zeros((20, 5), dtype=bool),
@@ -206,5 +210,9 @@ def test_route_astar_single_preserves_kwargs(
 
     assert route.length == 1
     assert captured_kwargs["cross_section"].width == 1
+    assert captured_kwargs["cross_section"].layer == "M2"
+    assert captured_kwargs["cross_section"].radius == 7
     assert captured_kwargs["raise_on_error"] is True
     assert "width" not in captured_kwargs
+    assert "layer" not in captured_kwargs
+    assert "radius" not in captured_kwargs

--- a/tests/routing/test_route_astar.py
+++ b/tests/routing/test_route_astar.py
@@ -104,6 +104,45 @@ def test_route_astar_accepts_cross_section_kwargs() -> None:
     assert route.length > 0
 
 
+def test_route_astar_forwards_route_bundle_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_raise_on_error: list[bool | None] = []
+    route_bundle = route_astar_module.gf.routing.route_bundle
+
+    def wrapped_route_bundle(*args: object, **kwargs: object) -> object:
+        raise_on_error = kwargs.get("raise_on_error")
+        captured_raise_on_error.append(
+            raise_on_error if isinstance(raise_on_error, bool) else None
+        )
+        return route_bundle(*args, **kwargs)
+
+    monkeypatch.setattr(
+        route_astar_module.gf.routing, "route_bundle", wrapped_route_bundle
+    )
+
+    c = gf.Component()
+    straight = gf.components.straight(width=1)
+    left = c << straight
+    right = c << straight
+    right.move((80, 0))
+
+    route = gf.routing.route_astar(
+        component=c,
+        port1=left.ports["o2"],
+        port2=right.ports["o1"],
+        cross_section="strip",
+        width=1,
+        raise_on_error=False,
+        resolution=10,
+        distance=5,
+        bend=gf.components.bend_euler,
+    )
+
+    assert route.length > 0
+    assert captured_raise_on_error[-1] is False
+
+
 def test_route_astar_does_not_copy_input_component(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -129,6 +168,18 @@ def test_route_astar_does_not_copy_input_component(
     )
 
     assert route.length > 0
+
+
+def test_count_bends_skips_duplicate_points_and_handles_non_manhattan() -> None:
+    waypoints = [
+        gf.kdb.DPoint(0, 0),
+        gf.kdb.DPoint(0, 0),
+        gf.kdb.DPoint(1, 1),
+        gf.kdb.DPoint(2, 2),
+        gf.kdb.DPoint(2, 3),
+    ]
+
+    assert route_astar_module.count_bends(waypoints) == 1
 
 
 def test_route_astar_selects_fewest_actual_bends() -> None:


### PR DESCRIPTION
## Summary
- Replace `route_astar` candidate path search with a direct blocked-grid A* implementation instead of building and pruning a NetworkX grid graph
- Avoid copying the full input component for preliminary route attempts
- Split waypoint generation from final route construction so candidates can be scored cheaply, then validated on a scratch component before building the selected route
- Add regression coverage for obstacle avoidance, cross-section kwargs, bend-count selection, and direct `route_astar_single` kwarg handling

## Performance Notes
This reduces overhead from:
- constructing a full `nx.grid_2d_graph`
- removing obstacle nodes from that graph
- copying the full component before candidate evaluation
- placing temporary geometry for every candidate route

The final route is still built through `route_bundle`, and candidates are still validated before selection.

## Tests
- `uv run pytest tests/routing/test_route_astar.py`
- `uv run ruff check gdsfactory/routing/route_astar.py tests/routing/test_route_astar.py`
- `uv run ruff format --check gdsfactory/routing/route_astar.py tests/routing/test_route_astar.py`

## Summary by Sourcery

Improve A* routing in route_astar by using a direct blocked-grid search, scoring candidate paths by bend count, and validating them before building the final route.

New Features:
- Add a grid-based A* pathfinder that operates directly on a blocked-cell matrix without constructing a NetworkX grid graph.

Bug Fixes:
- Ensure the selected route minimizes actual bend count after applying bend-radius and collision constraints.
- Preserve and correctly forward route_bundle-specific kwargs such as raise_on_error while separating cross-section kwargs from routing kwargs.

Enhancements:
- Avoid copying the full input component and placing temporary geometry when evaluating candidate A* routes.
- Refactor route_astar_single to reuse waypoint generation logic, support grid-based paths, and cleanly separate path scoring from final route construction.

Tests:
- Add regression tests for obstacle avoidance, cross-section kwargs handling, component copy avoidance, bend-count selection, and route_astar_single kwarg preservation.