### PR TITLE
perf: use Python round for scalar serialization

### DIFF
--- a/gdsfactory/serialization.py
+++ b/gdsfactory/serialization.py
@@ -47,8 +47,8 @@ def clean_dict(
 def complex_encoder(
     obj: complex | np.complexfloating, digits: int = DEFAULT_SERIALIZATION_MAX_DIGITS
 ) -> dict[str, Any]:
-    real_part = np.round(obj.real, digits)
-    imag_part = np.round(obj.imag, digits)
+    real_part = round(float(obj.real), digits)
+    imag_part = round(float(obj.imag), digits)
     return {"real": real_part, "imag": imag_part}
 
 
@@ -116,7 +116,7 @@ def clean_value_json(
     if isinstance(value, float | np.floating):
         if value == round(value):
             return int(value)
-        return float(np.round(value, serialization_max_digits))
+        return round(float(value), serialization_max_digits)
 
     if isinstance(value, complex | np.complexfloating):
         return complex_encoder(value)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -48,12 +48,17 @@ def test_clean_dict() -> None:
 def test_complex_encoder() -> None:
     result = complex_encoder(1 + 2j, digits=2)
     assert result == {"real": 1.0, "imag": 2.0}
+    assert complex_encoder(np.complex128(1.23456 + 2.34567j), digits=3) == {
+        "real": 1.235,
+        "imag": 2.346,
+    }
 
 
 def test_clean_value_json() -> None:
     assert clean_value_json(1) == 1
     assert clean_value_json(True) is True
     assert clean_value_json(1.23456) == 1.235
+    assert clean_value_json(np.float64(1.23456)) == 1.235
     assert clean_value_json(1.0) == 1
     assert clean_value_json(complex(1, 2)) == {"real": 1.0, "imag": 2.0}
     assert clean_value_json(np.array([1.23456])) == [1.235]


### PR DESCRIPTION
## Summary

- Use Python `round()` for scalar float serialization instead of `np.round()`
- Use the same scalar fast path for complex real/imaginary parts
- Keep NumPy rounding for ndarray serialization
- Add regression coverage for NumPy scalar float and complex values

## Performance

On a synthetic nested serialization payload with many scalar floats, `clean_value_json()` improved from about `0.204s` to `0.091s`.

A direct scalar rounding microbenchmark showed Python `round()` is about 10x faster than `np.round()` for individual float values.

## Tests

- `uv run pytest tests/test_serialization.py tests/test_get_netlist.py tests/test_name.py tests/test_component.py`
- `uv run ruff check gdsfactory/serialization.py tests/test_serialization.py`
- `uv run ruff format --check gdsfactory/serialization.py tests/test_serialization.py`

## Summary by Sourcery

Switch scalar float and complex serialization to use Python’s built-in rounding while adding regression coverage for NumPy scalar values.

Bug Fixes:
- Ensure NumPy scalar floats and complex numbers are correctly rounded and serialized using the scalar fast path.

Enhancements:
- Use Python round() for scalar float and complex real/imag serialization to improve performance while retaining NumPy rounding for ndarrays.

Tests:
- Add serialization tests for NumPy scalar float and complex values to guard against regressions.