### PR TITLE
Update kf

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -442,6 +442,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         with_metadata: bool = True,
         exclude_layers: Sequence[LayerSpec] | None = None,
         no_empty_cells: bool = False,
+        deduplicate_cell_names: bool = True,
     ) -> pathlib.Path:
         """Write component to GDS and returns gdspath.
 
@@ -452,6 +453,8 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             with_metadata: if True, writes metadata (ports, settings) to the GDS file.
             exclude_layers: list of layers to exclude from the GDS file.
             no_empty_cells: if True, does not save empty cells.
+            deduplicate_cell_names: if True, renames cells with identical names to
+                `cell_name$1`, `cell_name$2` etc.
         """
         from gdsfactory.pdk import get_layer
 
@@ -486,7 +489,11 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         if not with_metadata:
             save_options.write_context_info = False
 
-        self.write(filename=gdspath, save_options=save_options)
+        self.write(
+            filename=gdspath,
+            save_options=save_options,
+            deduplicate_cell_names=deduplicate_cell_names,
+        )
         return pathlib.Path(gdspath)
 
     def pprint_ports(self, **kwargs: Any) -> None:
@@ -685,6 +692,7 @@ class Component(ComponentBase, kf.DKCell):
         convert_external_cells: bool = False,
         set_meta_data: bool = True,
         autoformat_from_file_extension: bool = True,
+        deduplicate_cell_names: bool = True,
     ) -> None:
         """Write component to GDS, fixing pin metadata for kfactory compat."""
         if set_meta_data:
@@ -707,6 +715,7 @@ class Component(ComponentBase, kf.DKCell):
             convert_external_cells=False,
             set_meta_data=False,
             autoformat_from_file_extension=autoformat_from_file_extension,
+            deduplicate_cell_names=deduplicate_cell_names,
         )
 
     @property

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -119,7 +119,7 @@ def write_cells_recursively(
     for cell_index in gf.kcl.each_cell_bottom_up():
         component = gf.kcl[cell_index]
         gdspath = dirpath / f"{component.name}.gds"
-        component.write(gdspath)
+        component.write(gdspath, deduplicate_cell_names=True)
         gdspaths[component.name] = gdspath
     return gdspaths
 
@@ -149,6 +149,6 @@ def write_cells(
 
     for component in components:
         gdspath = dirpath / f"{component.name}.gds"
-        component.write(gdspath)
+        component.write(gdspath, deduplicate_cell_names=True)
         gdspaths[component.name] = gdspath
     return gdspaths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]~=2.6.0",
+  "kfactory[ipy]~=2.6.1",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "toolz<2",
   "types-PyYAML",
   "typer<1",
-  "kfactory[ipy]~=2.5.0",
+  "kfactory[ipy]~=2.6.0",
   "watchdog<7",
   "freetype-py",
   "mapbox_earcut",


### PR DESCRIPTION
## Summary

update to kf2.6.1 and introduce deduplicate_cell_names in write functions

## Summary by Sourcery

Update kfactory dependency and add support for optional cell name deduplication when writing GDS files and cell libraries.

New Features:
- Add a deduplicate_cell_names option to component GDS write helpers to automatically rename duplicate cell names in outputs.

Enhancements:
- Enable cell name deduplication by default in recursive and batch cell write utilities to avoid naming collisions.

Build:
- Bump kfactory[ipy] dependency from version 2.5.0 to 2.6.1.