### PR TITLE
Set up GitHub-native code coverage reporting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/test_code.yml:
+    ignore:
+      - 'unknown permission scope "code-quality"'

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -66,6 +66,7 @@ jobs:
           file: coverage.xml
           language: Python
           label: code-coverage/pytest
+          fail-on-error: false
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -40,8 +40,13 @@ jobs:
 
   test_code_coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -54,6 +59,13 @@ jobs:
       - name: Test with pytest
         run: |
           make cov
+      - name: Upload coverage to GitHub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage.xml
+          language: Python
+          label: code-coverage/pytest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-force: ## Run tests with force-regen
 	uv run pytest -n logical --force-regen -s
 
 cov: ## Run tests with coverage
-	uv run pytest --cov=gdsfactory --cov-report=term-missing:skip-covered
+	uv run pytest --cov=gdsfactory --cov-report=xml --cov-report=term-missing:skip-covered
 
 dev-cov: ## Run tests in parallel with coverage
 	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered --durations=10

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-force: ## Run tests with force-regen
 	uv run pytest -n logical --force-regen -s
 
 cov: ## Run tests with coverage
-	uv run pytest --cov=gdsfactory --cov-report=xml --cov-report=term-missing:skip-covered
+	uv run pytest --cov=gdsfactory --cov-report=xml:coverage.xml --cov-report=term-missing:skip-covered
 
 dev-cov: ## Run tests in parallel with coverage
 	uv run pytest -s -n logical --cov=gdsfactory --cov-report=term-missing:skip-covered --durations=10


### PR DESCRIPTION
Set up GitHub-native code coverage reporting according to https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/

## Summary by Sourcery

Configure GitHub-native code coverage reporting for Python tests and integrate it into the existing CI workflow.

New Features:
- Enable uploading pytest coverage reports to GitHub using the upload-code-coverage action.

Enhancements:
- Adjust pytest coverage configuration to generate XML reports compatible with GitHub coverage ingestion.
- Ensure workflow checkout uses the pull request head SHA to align coverage with the correct commit.
- Add workflow permissions for code-quality write access required by GitHub coverage reporting.

CI:
- Introduce an actionlint configuration to suppress warnings about the code-quality permission in the test workflow.

Tests:
- Update coverage test target to emit XML coverage reports for CI consumption.