### PR TITLE
perf: speed up component lookup and path extrusion

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1056,6 +1056,7 @@ def extrude(
 
     xsection_points: list[list[float | npt.NDArray[np.floating[Any]]]] = []
     c = ComponentAllAngle() if all_angle else Component()
+    path_length = p.length()
 
     layer = get_layer(layer or x.layer)
 
@@ -1251,7 +1252,7 @@ def extrude(
         # Join points together
         points_poly = np.concatenate([points1, points2[::-1, :]])
 
-        if not hidden and p_sec.length() > 1e-3:
+        if not hidden and (p_sec.length() if path_changed else path_length) > 1e-3:
             c.add_polygon(points_poly, layer=layer)
 
         # Add port_names if they were specified
@@ -1296,7 +1297,7 @@ def extrude(
                 register_cross_section=register_cross_section,
             )
 
-    c.info["length"] = float(np.round(p.length(), 3))
+    c.info["length"] = path_length
 
     for via in x.components_along_path:
         if via.offset:
@@ -1394,6 +1395,7 @@ def extrude_transition(
     dx = np.diff(p.points[:, 0])
     dy = np.diff(p.points[:, 1])
     lengths = np.cumsum(np.sqrt(dx**2 + dy**2))
+    path_length = float(np.round(lengths[-1], 3))
     lengths = np.concatenate([[0], lengths]) / lengths[-1]
 
     for section_name in common_sections:
@@ -1513,7 +1515,7 @@ def extrude_transition(
         # Join points together
         points_poly = np.concatenate([points1, points2[::-1, :]])
 
-        if not hidden and p.length() > 1e-3:
+        if not hidden and path_length > 1e-3:
             c.add_polygon(points_poly, layer=layer)
 
         # Add port_names if they were specified

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1251,8 +1251,11 @@ def extrude(
 
         # Join points together
         points_poly = np.concatenate([points1, points2[::-1, :]])
+        # Unchanged sections use the original path, so this preserves the old
+        # per-section threshold without recomputing the same length each time.
+        section_length = p_sec.length() if path_changed else path_length
 
-        if not hidden and (p_sec.length() if path_changed else path_length) > 1e-3:
+        if not hidden and section_length > 1e-3:
             c.add_polygon(points_poly, layer=layer)
 
         # Add port_names if they were specified

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -394,7 +394,16 @@ class Pdk(BaseModel):
     ) -> Component:
         """Returns component from a component spec."""
         if include_containers:
-            cells = self._get_cells_and_containers()
+            if isinstance(component, str):
+                self.validate_cells_and_containers_unique()
+                if component in self.cells:
+                    cells = self.cells
+                elif component in self.containers:
+                    cells = self.containers
+                else:
+                    cells = self._get_cells_and_containers()
+            else:
+                cells = self._get_cells_and_containers()
         else:
             cells = self.cells
 
@@ -402,15 +411,17 @@ class Pdk(BaseModel):
             component=component, cells=cells, settings=settings, **kwargs
         )
 
-    def _get_cells_and_containers(self) -> dict[str, ComponentFactory]:
-        """Returns a dictionary of cells and containers."""
-        cells_and_containers = {**self.cells, **self.containers}
-        conflicting_names = set(self.cells.keys()).intersection(self.containers.keys())
+    def validate_cells_and_containers_unique(self) -> None:
+        conflicting_names = self.cells.keys() & self.containers.keys()
         if conflicting_names:
             raise ValueError(
                 f"PDK {self.name!r} has overlapping cell names between cells and containers: {list(conflicting_names)}. "
             )
-        return cells_and_containers
+
+    def _get_cells_and_containers(self) -> dict[str, ComponentFactory]:
+        """Returns a dictionary of cells and containers."""
+        self.validate_cells_and_containers_unique()
+        return {**self.cells, **self.containers}
 
     def get_symbol(self, component: ComponentSpec, **kwargs: Any) -> Component:
         """Returns a component's symbol from a component spec."""
@@ -438,8 +449,6 @@ class Pdk(BaseModel):
             settings: settings to override.
             kwargs: settings to override.
         """
-        cell_names = sorted(cells)
-
         settings = settings or {}
         kwargs = kwargs or {}
         kwargs.update(settings)
@@ -451,7 +460,7 @@ class Pdk(BaseModel):
             _component = component(**kwargs)
             return type(_component)(base=_component.base)  # type: ignore[call-overload,no-any-return]
         if isinstance(component, str):
-            if component not in cell_names:
+            if component not in cells:
                 substring = component
                 matching_cells: list[str] = []
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -42,6 +42,23 @@ def test_container_cell_conflict_raises_error() -> None:
         pdk.get_component("add_pads_top")
 
 
+def test_container_cell_conflict_raises_for_string_fast_path() -> None:
+    """String lookups must still validate global cell/container name conflicts."""
+    pdk = gf.Pdk(
+        name="test",
+        layers=LAYER,
+        cross_sections={"strip": gf.cross_section.strip},
+        cells={
+            "straight": gf.components.straight,
+            "add_pads_top": gf.containers.add_pads_top,
+        },
+        containers={"add_pads_top": gf.containers.add_pads_top},
+    )
+
+    with pytest.raises(ValueError, match=r".* overlapping cell names .*add_pads_top.*"):
+        pdk.get_component("straight")
+
+
 def _make_pdk() -> gf.Pdk:
     return gf.Pdk(
         name="test",


### PR DESCRIPTION
## Summary

- Speed up common string component lookups in `Pdk.get_component()` by avoiding merged cell/container map construction when the component is found directly in `cells` or `containers`.
- Preserve existing global cell/container conflict validation for string lookups, including fast-path hits.
- Remove unnecessary per-call sorting from successful `Pdk._get_component()` string lookups.
- Cache path length inside `extrude()` and `extrude_transition()` loops to avoid repeated recomputation.

Local benchmarks with the generic PDK:
- `gf.get_component("straight", length=10, cross_section="strip")` x5000: ~0.087s old path to ~0.035s current.
- `route_single` batch x300: ~0.183s old path to ~0.178s current.
- `gf.path.extrude(..., cross_section="rib_with_trenches")` x200: small/noisy improvement, ~0.813s to ~0.797s median.

## Test Plan

- `uv run pytest tests/test_pdk.py tests/test_get_factories.py tests/test_paths_extrude.py tests/test_paths_transition.py tests/test_path.py tests/routing/test_routing_route_bundle.py`
- `uv run pytest`
- `uv run ruff check gdsfactory/pdk.py gdsfactory/path.py tests/test_pdk.py`
- `uv run ruff format --check gdsfactory/pdk.py gdsfactory/path.py tests/test_pdk.py`

## Summary by Sourcery

Optimize component lookup and path extrusion performance while preserving existing validation behavior.

Bug Fixes:
- Ensure string-based fast-path component lookups still validate overlapping cell and container names.

Enhancements:
- Speed up Pdk.get_component() for string lookups by avoiding unnecessary merged cell/container map construction and per-call sorting.
- Extract cell/container name conflict detection into a dedicated validation helper reused across code paths.
- Cache and reuse path length calculations in extrude() and extrude_transition() to avoid repeated recomputation and streamline length metadata handling.

Tests:
- Add regression test to confirm that fast-path string lookups respect global cell/container name conflict validation.