### PR TITLE
ci(pages): bump docs artifact retention to 7 days

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: "./docs/_build/html/"
+          retention-days: 7
   deploy-docs:
     needs: build-docs
     if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
The docs pages workflow last failed on 2026-07-03 because the deploy-docs job was re-run by itself 3 days after the original build. actions/upload-pages-artifact defaults to `retention-days: 1`, so by then the `github-pages` artifact had already been GC'd and deploy-pages@v5 failed with:

> No artifacts named "github-pages" were found for this workflow run.

Bumping retention to 7 days gives a comfortable window for a manual re-run without needing to re-execute the ~10 min Sphinx build.

Kicked a fresh full re-run of the failing run (28663914165) in parallel so main gets its docs updated.

## Summary by Sourcery

CI:
- Set docs GitHub Pages upload artifact retention to 7 days in the pages workflow.