### PR TITLE
Fix incorrect route_bundle separation docstring

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -206,7 +206,7 @@ def route_bundle(
         ports2: end port or list of end ports.
         cross_section: CrossSection or function that returns a cross_section.
         layer: layer to use for the route.
-        separation: bundle separation (center to center). Defaults to cross_section.width + cross_section.gap
+        separation: bundle separation (center to center), in um.
         bend: function for the bend. Defaults to euler.
         sort_ports: sort port coordinates.
         start_straight_length: straight length at the beginning of the route. If None, uses default value for the routing CrossSection.


### PR DESCRIPTION
## Summary
- The `separation` parameter docstring in `route_bundle` claimed it "Defaults to cross_section.width + cross_section.gap", but `CrossSection` no longer has a `gap` attribute (it's in the deprecated field set in `gdsfactory/cross_section/base.py`), and `separation` is actually a plain `float = 3.0` default unrelated to the cross section.
- Updated the docstring to describe the actual behavior.

Fixes #3662

## Test plan
- [x] `python -m py_compile gdsfactory/routing/route_bundle.py`
- Docstring-only change, no behavior affected.

## Summary by Sourcery

Documentation:
- Update the route_bundle separation parameter docstring to describe it as a center-to-center spacing in micrometers without referencing deprecated CrossSection fields.