### PR TITLE
Fix grid_factor being ignored in snap_to_grid when nm is set

### DIFF
--- a/gdsfactory/snap.py
+++ b/gdsfactory/snap.py
@@ -80,13 +80,10 @@ def snap_to_grid(
 
     Args:
         x: value to snap.
-        nm: Optional grid size in nm. If None, it will use the default grid size from PDK multiplied by grid_factor.
-        grid_factor: snap to grid_factor * grid_size.
+        nm: Optional grid size in nm. If None, uses the default grid size from the PDK.
+        grid_factor: multiplies the grid size (`nm`, or the PDK default if `nm` is None) by this factor.
     """
-    if nm is None:
-        grid_um = gf.kcl.dbu * grid_factor
-    else:
-        grid_um = nm / 1000
+    grid_um = (nm / 1000 if nm is not None else gf.kcl.dbu) * grid_factor
 
     # Round half up
     res = grid_um * np.floor(np.asarray(x, dtype=np.float64) / grid_um + 0.5)

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -38,7 +38,7 @@ def test_snap_to_grid2x_idempotent(x: float) -> None:
 def test_snap_to_grid_bounded_error(x: float, nm: float, grid_factor: int) -> None:
     """The snap error must not exceed half the effective grid size."""
     snapped = gf.snap.snap_to_grid(x, nm=nm, grid_factor=grid_factor)
-    grid_um = nm / 1000
+    grid_um = (nm / 1000) * grid_factor
     assert abs(snapped - x) <= grid_um / 2 + 1e-12
 
 
@@ -104,3 +104,16 @@ def test_snap_to_grid_rounding() -> None:
     assert gf.snap.snap_to_grid(-0.00149, nm=1) == -0.001
     assert gf.snap.snap_to_grid(-0.0015, nm=1) == -0.001
     assert gf.snap.snap_to_grid(-0.00151, nm=1) == -0.002
+
+
+def test_snap_to_grid_grid_factor_applies_with_explicit_nm() -> None:
+    """grid_factor must scale the grid even when nm is explicitly set."""
+    assert gf.snap.snap_to_grid(0.0012, nm=2) == 0.002
+    assert gf.snap.snap_to_grid(0.0012, grid_factor=2) == 0.002
+    assert gf.snap.snap_to_grid(0.0012, nm=1, grid_factor=2) == 0.002
+    assert gf.snap.snap_to_grid2x(0.0012, nm=2) == 0.0
+    assert (
+        gf.snap.snap_to_grid(0.0037, nm=4)
+        == gf.snap.snap_to_grid2x(0.0037, nm=2)
+        == 0.004
+    )


### PR DESCRIPTION
## Summary
- `snap_to_grid(x, nm=..., grid_factor=...)` silently ignored `grid_factor` whenever `nm` was explicitly provided — it only multiplied the *default* PDK grid (`gf.kcl.dbu`) by `grid_factor`, using `nm/1000` verbatim otherwise.
- This broke the documented relationship `snap_to_grid(v, nm=2*x) == snap_to_grid2x(v, nm=x)` and any caller combining `nm` with `grid_factor` (`snap_to_grid2x` itself passes `grid_factor=2`, so `snap_to_grid2x(x, nm=...)` was affected too).
- Fixed by always computing the effective grid as `(nm/1000 if nm is not None else gf.kcl.dbu) * grid_factor`, and clarified the docstring accordingly.
- No existing component in the codebase calls `snap_to_grid`/`snap_to_grid2x` with both `nm` and a non-default `grid_factor`, so this does not change any generated geometry — confirmed via a full-repo search.
- Updated `test_snap_to_grid_bounded_error`, which had encoded the buggy behavior (it computed the expected grid as `nm/1000`, ignoring `grid_factor`), and added a regression test covering the exact cases from the issue.

Fixes #4258

## Test plan
- [x] `pytest tests/test_snap.py -q` (12 passed)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] Manually verified all assertions from the issue now hold:
```python
from gdsfactory.snap import snap_to_grid, snap_to_grid2x
assert snap_to_grid(0.0012) == 0.001
assert snap_to_grid(0.0012, nm=2) == 0.002
assert snap_to_grid(0.0012, grid_factor=2) == 0.002
assert snap_to_grid(0.0012, nm=1, grid_factor=2) == 0.002
assert snap_to_grid2x(0.0012, nm=2) == 0.0
```

## Summary by Sourcery

Ensure snap_to_grid respects grid_factor when nm is provided and add regression coverage for the corrected snapping behavior.

Bug Fixes:
- Fix snap_to_grid to apply grid_factor to both explicit nm values and the default PDK grid, preserving the documented relationship with snap_to_grid2x.

Tests:
- Update bounded error test to use the effective grid including grid_factor and add regression tests covering combinations of nm and grid_factor for snap_to_grid and snap_to_grid2x.