### PR TITLE
Fix exception-safe cleanup for temporary KCLayout helpers

### DIFF
--- a/gdsfactory/_kcl.py
+++ b/gdsfactory/_kcl.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import kfactory as kf
+
+
+@contextmanager
+def temporary_kcl(name: str) -> Iterator[kf.KCLayout]:
+    """Yield a temporary KCLayout and unregister it on every exit path."""
+    kcl = kf.KCLayout(name=name)
+    try:
+        yield kcl
+    finally:
+        try:
+            kcl.library.delete()
+        finally:
+            if kf.layout.kcls.get(kcl.name) is kcl:
+                del kf.layout.kcls[kcl.name]

--- a/gdsfactory/_kcl.py
+++ b/gdsfactory/_kcl.py
@@ -10,11 +10,19 @@ import kfactory as kf
 def temporary_kcl(name: str) -> Iterator[kf.KCLayout]:
     """Yield a temporary KCLayout and unregister it on every exit path."""
     kcl = kf.KCLayout(name=name)
+    had_error = False
     try:
         yield kcl
+    except BaseException:
+        had_error = True
+        raise
     finally:
         try:
-            kcl.library.delete()
+            if kcl.library is not None:
+                kcl.library.delete()
+        except Exception:
+            if not had_error:
+                raise
         finally:
             if kf.layout.kcls.get(kcl.name) is kcl:
                 del kf.layout.kcls[kcl.name]

--- a/gdsfactory/read/import_gds.py
+++ b/gdsfactory/read/import_gds.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import Any
 
 import kfactory as kf
-from kfactory import KCLayout, utilities
+from kfactory import utilities
 
+from gdsfactory._kcl import temporary_kcl
 from gdsfactory.component import Component, _fix_pin_metadata
 from gdsfactory.typings import PostProcesses
 
@@ -27,7 +28,6 @@ def import_gds(
         skip_new_cells: if True, skip new cells that conflict with existing ones.
 
     """
-    temp_kcl = KCLayout(name=str(gdspath))
     options = utilities.load_layout_options()
     options.warn_level = 0
 
@@ -40,29 +40,28 @@ def import_gds(
             kf.kdb.LoadLayoutOptions.CellConflictResolution.RenameCell
         )
 
-    temp_kcl.read(gdspath, options=options)
+    with temporary_kcl(str(gdspath)) as temp_kcl:
+        temp_kcl.read(gdspath, options=options)
 
-    if cellname is None:
-        if len(temp_kcl.layout.top_cells()) > 1:
-            raise ValueError(
-                "GDS file has multiple top cells. Use cellname to select a specific one, or use gf.read.import_gds_multiple_top_cells instead.\n"
-                + f"Top cells: {[c.name for c in temp_kcl.layout.top_cells()]}"
-            )
-        cellname = temp_kcl.layout.top_cell().name
+        if cellname is None:
+            if len(temp_kcl.layout.top_cells()) > 1:
+                raise ValueError(
+                    "GDS file has multiple top cells. Use cellname to select a specific one, or use gf.read.import_gds_multiple_top_cells instead.\n"
+                    + f"Top cells: {[c.name for c in temp_kcl.layout.top_cells()]}"
+                )
+            cellname = temp_kcl.layout.top_cell().name
 
-    kcell = temp_kcl[cellname]
+        kcell = temp_kcl[cellname]
 
-    if hasattr(temp_kcl, "cross_sections"):
-        for cross_section in temp_kcl.cross_sections.cross_sections.values():
-            kf.kcl.get_symmetrical_cross_section(cross_section)
+        if hasattr(temp_kcl, "cross_sections"):
+            for cross_section in temp_kcl.cross_sections.cross_sections.values():
+                kf.kcl.get_symmetrical_cross_section(cross_section)
 
-    c = kcell_to_component(kcell)
-    for pp in post_process or []:
-        pp(c)
+        c = kcell_to_component(kcell)
+        for pp in post_process or []:
+            pp(c)
 
-    temp_kcl.library.delete()
-    del kf.layout.kcls[temp_kcl.name]
-    return c
+        return c
 
 
 def kcell_to_component(kcell: kf.kcell.ProtoTKCell[Any]) -> Component:
@@ -127,7 +126,6 @@ def import_gds_multiple_top_cells(
         ValueError: if any of the provided cellnames are not found among the top cells.
 
     """
-    temp_kcl = KCLayout(name=str(gdspath))
     options = utilities.load_layout_options()
     options.warn_level = 0
 
@@ -140,35 +138,34 @@ def import_gds_multiple_top_cells(
             kf.kdb.LoadLayoutOptions.CellConflictResolution.RenameCell
         )
 
-    temp_kcl.read(gdspath, options=options)
+    with temporary_kcl(str(gdspath)) as temp_kcl:
+        temp_kcl.read(gdspath, options=options)
 
-    components = {}
+        components = {}
 
-    kcells = temp_kcl.layout.top_cells()
+        kcells = temp_kcl.layout.top_cells()
 
-    if cellnames is not None:
-        # Validate provided cellnames and surface all invalid names at once
-        available_cellnames = {kcell.name for kcell in kcells}
-        missing = set(cellnames) - available_cellnames
-        if missing:
-            raise ValueError(
-                "Unknown cellnames requested. These names are not present in the GDS top cells: "
-                + ", ".join(sorted(missing))
-                + ".\n"
-                + f"Available top cells: {sorted(available_cellnames)}"
-            )
-        # Filter kcells to include only those specified in cellnames
-        kcells = [kcell for kcell in kcells if kcell.name in cellnames]
+        if cellnames is not None:
+            # Validate provided cellnames and surface all invalid names at once
+            available_cellnames = {kcell.name for kcell in kcells}
+            missing = set(cellnames) - available_cellnames
+            if missing:
+                raise ValueError(
+                    "Unknown cellnames requested. These names are not present in the GDS top cells: "
+                    + ", ".join(sorted(missing))
+                    + ".\n"
+                    + f"Available top cells: {sorted(available_cellnames)}"
+                )
+            # Filter kcells to include only those specified in cellnames
+            kcells = [kcell for kcell in kcells if kcell.name in cellnames]
 
-    for kcell in kcells:
-        components[kcell.name] = kcell_to_component(
-            temp_kcl[kcell.name]
-        )  # Convert each kcell to Component class and store in dictionary using its name as the key
+        for kcell in kcells:
+            components[kcell.name] = kcell_to_component(
+                temp_kcl[kcell.name]
+            )  # Convert each kcell to Component class and store in dictionary using its name as the key
 
-    for pp in post_process or []:
-        for c in components.values():
-            pp(c)
+        for pp in post_process or []:
+            for c in components.values():
+                pp(c)
 
-    temp_kcl.library.delete()
-    del kf.layout.kcls[temp_kcl.name]
-    return components
+        return components

--- a/gdsfactory/write_cells.py
+++ b/gdsfactory/write_cells.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import pathlib
 from pathlib import Path
 
-import kfactory as kf
-
 from gdsfactory import logger
+from gdsfactory._kcl import temporary_kcl
 from gdsfactory.name import clean_name
 from gdsfactory.typings import PathType
 
@@ -110,24 +109,19 @@ def write_cells_recursively(
     Returns:
         gdspaths: dict of cell name to gdspath.
     """
-    temp_kcl = kf.KCLayout(name=str(gdspath))
-    temp_kcl.read(gdspath)
-    dirpath = dirpath or pathlib.Path.cwd()
-    dirpath = pathlib.Path(dirpath).absolute()
-    dirpath.mkdir(exist_ok=True, parents=True)
+    with temporary_kcl(str(gdspath)) as temp_kcl:
+        temp_kcl.read(gdspath)
+        dirpath = dirpath or pathlib.Path.cwd()
+        dirpath = pathlib.Path(dirpath).absolute()
+        dirpath.mkdir(exist_ok=True, parents=True)
 
-    gdspaths: dict[str, Path] = {}
-
-    try:
+        gdspaths: dict[str, Path] = {}
         for cell_index in temp_kcl.each_cell_bottom_up():
             component = temp_kcl[cell_index]
             gdspath = dirpath / f"{component.name}.gds"
             component.write(gdspath, deduplicate_cell_names=True)
             gdspaths[component.name] = gdspath
         return gdspaths
-    finally:
-        temp_kcl.library.delete()
-        del kf.layout.kcls[temp_kcl.name]
 
 
 def write_cells(
@@ -144,22 +138,19 @@ def write_cells(
     Returns:
         gdspaths: dict of cell name to gdspath.
     """
-    temp_kcl = kf.KCLayout(name=str(gdspath))
-    temp_kcl.read(gdspath)
-    components = [temp_kcl[top_cell.cell_index()] for top_cell in temp_kcl.top_cells()]
+    with temporary_kcl(str(gdspath)) as temp_kcl:
+        temp_kcl.read(gdspath)
+        components = [
+            temp_kcl[top_cell.cell_index()] for top_cell in temp_kcl.top_cells()
+        ]
 
-    dirpath = dirpath or pathlib.Path.cwd()
-    dirpath = pathlib.Path(dirpath).absolute()
-    dirpath.mkdir(exist_ok=True, parents=True)
+        dirpath = dirpath or pathlib.Path.cwd()
+        dirpath = pathlib.Path(dirpath).absolute()
+        dirpath.mkdir(exist_ok=True, parents=True)
 
-    gdspaths: dict[str, Path] = {}
-
-    try:
+        gdspaths: dict[str, Path] = {}
         for component in components:
             gdspath = dirpath / f"{component.name}.gds"
             component.write(gdspath, deduplicate_cell_names=True)
             gdspaths[component.name] = gdspath
         return gdspaths
-    finally:
-        temp_kcl.library.delete()
-        del kf.layout.kcls[temp_kcl.name]

--- a/tests/read/test_import_gds.py
+++ b/tests/read/test_import_gds.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
+from pathlib import Path
 
 import jsondiff
+import kfactory as kf
 import pandas as pd
+import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
 from gdsfactory.gpdk.layer_map import LAYER
-from gdsfactory.read.import_gds import import_gds
+from gdsfactory.read.import_gds import import_gds, import_gds_multiple_top_cells
 from gdsfactory.serialization import clean_value_json
 
 
@@ -31,6 +35,44 @@ def test_import_gds_hierarchy() -> None:
 
     c = import_gds(gdspath)
     assert c.name == c0.name, c.name
+
+
+@pytest.mark.parametrize("reader", [import_gds, import_gds_multiple_top_cells])
+def test_import_gds_cleans_up_temp_kcl_on_read_error(
+    tmp_path: Path, reader: Callable[..., object]
+) -> None:
+    gdspath = tmp_path / "missing.gds"
+
+    with pytest.raises(RuntimeError):
+        reader(gdspath)
+
+    assert str(gdspath) not in kf.layout.kcls
+
+
+@pytest.mark.parametrize("reader", [import_gds, import_gds_multiple_top_cells])
+def test_import_gds_cleans_up_temp_kcl_on_post_process_error(
+    tmp_path: Path, reader: Callable[..., object]
+) -> None:
+    gdspath = gf.components.straight().write_gds(tmp_path / "straight.gds")
+
+    def fail_post_process(component: gf.Component) -> None:
+        raise RuntimeError("post process failed")
+
+    with pytest.raises(RuntimeError, match="post process failed"):
+        reader(gdspath, post_process=(fail_post_process,))
+
+    assert str(gdspath) not in kf.layout.kcls
+
+
+def test_import_gds_multiple_top_cells_cleans_up_temp_kcl_on_cellname_error(
+    tmp_path: Path,
+) -> None:
+    gdspath = gf.components.straight().write_gds(tmp_path / "straight.gds")
+
+    with pytest.raises(ValueError, match="Unknown cellnames requested"):
+        import_gds_multiple_top_cells(gdspath, cellnames=["missing"])
+
+    assert str(gdspath) not in kf.layout.kcls
 
 
 def test_import_json_label(data_regression: DataRegressionFixture) -> None:

--- a/tests/test_kcl.py
+++ b/tests/test_kcl.py
@@ -1,0 +1,60 @@
+from typing import ClassVar
+
+import pytest
+
+from gdsfactory import _kcl
+
+
+class _CleanupError(RuntimeError):
+    pass
+
+
+class _PrimaryError(RuntimeError):
+    pass
+
+
+class _FailingLibrary:
+    def delete(self) -> None:
+        raise _CleanupError("cleanup failed")
+
+
+class _FakeLayout:
+    kcls: ClassVar[dict[str, "_FakeKcl"]] = {}
+
+
+class _FakeKcl:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.library = _FailingLibrary()
+        _FakeLayout.kcls[name] = self
+
+
+class _FakeKFactory:
+    KCLayout = _FakeKcl
+    layout = _FakeLayout
+
+
+def test_temporary_kcl_preserves_body_exception_on_cleanup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeLayout.kcls.clear()
+    monkeypatch.setattr(_kcl, "kf", _FakeKFactory)
+
+    with pytest.raises(_PrimaryError, match="primary failed"):
+        with _kcl.temporary_kcl("temporary"):
+            raise _PrimaryError("primary failed")
+
+    assert "temporary" not in _FakeLayout.kcls
+
+
+def test_temporary_kcl_raises_cleanup_error_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeLayout.kcls.clear()
+    monkeypatch.setattr(_kcl, "kf", _FakeKFactory)
+
+    with pytest.raises(_CleanupError, match="cleanup failed"):
+        with _kcl.temporary_kcl("temporary"):
+            pass
+
+    assert "temporary" not in _FakeLayout.kcls

--- a/tests/test_kcl.py
+++ b/tests/test_kcl.py
@@ -18,6 +18,11 @@ class _FailingLibrary:
         raise _CleanupError("cleanup failed")
 
 
+class _SuccessfulLibrary:
+    def delete(self) -> None:
+        pass
+
+
 class _FakeLayout:
     kcls: ClassVar[dict[str, "_FakeKcl"]] = {}
 
@@ -58,3 +63,17 @@ def test_temporary_kcl_raises_cleanup_error_after_success(
             pass
 
     assert "temporary" not in _FakeLayout.kcls
+
+
+def test_temporary_kcl_does_not_unregister_replaced_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeLayout.kcls.clear()
+    monkeypatch.setattr(_kcl, "kf", _FakeKFactory)
+    replacement = object()
+
+    with _kcl.temporary_kcl("temporary") as kcl:
+        kcl.library = _SuccessfulLibrary()
+        _FakeLayout.kcls[kcl.name] = replacement  # type: ignore[assignment]
+
+    assert _FakeLayout.kcls["temporary"] is replacement

--- a/tests/test_write_cells.py
+++ b/tests/test_write_cells.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable
+from pathlib import Path
+
+import kfactory as kf
 import pytest
 
 import gdsfactory as gf
@@ -22,6 +26,32 @@ def test_write_cells() -> None:
     gf.clear_cache()
     gdspaths = write_cells(gdspath=gdspath, dirpath=GDSDIR_TEMP)
     assert len(gdspaths) == 3, len(gdspaths)
+
+
+@pytest.mark.parametrize("writer", [write_cells, write_cells_recursively])
+def test_write_cells_cleans_up_temp_kcl_on_read_error(
+    tmp_path: Path, writer: Callable[..., dict[str, Path]]
+) -> None:
+    gdspath = tmp_path / "missing.gds"
+
+    with pytest.raises(RuntimeError):
+        writer(gdspath=gdspath, dirpath=tmp_path / "out")
+
+    assert str(gdspath) not in kf.layout.kcls
+
+
+@pytest.mark.parametrize("writer", [write_cells, write_cells_recursively])
+def test_write_cells_cleans_up_temp_kcl_on_output_dir_error(
+    tmp_path: Path, writer: Callable[..., dict[str, Path]]
+) -> None:
+    gdspath = gf.components.straight().write_gds(tmp_path / "straight.gds")
+    dirpath = tmp_path / "not_a_directory"
+    dirpath.write_text("file blocks directory creation")
+
+    with pytest.raises(FileExistsError):
+        writer(gdspath=gdspath, dirpath=dirpath)
+
+    assert str(gdspath) not in kf.layout.kcls
 
 
 def test_write_cells_route_collision_preserves_cached_ports() -> None:


### PR DESCRIPTION
Fixes #4639.

This adds a small internal `temporary_kcl()` context manager and uses it for GDS import/write helpers that create temporary `KCLayout` instances.

Previously, temporary layouts were manually unregistered only after successful processing. If `read(...)`, validation, post-processing, or output directory setup failed, the temporary layout could remain registered in `kf.layout.kcls`.

Changes:
- Add a private `temporary_kcl()` helper for scoped temporary `KCLayout` ownership.
- Use it in:
  - `import_gds`
  - `import_gds_multiple_top_cells`
  - `write_cells`
  - `write_cells_recursively`
- Keep the full temporary layout lifecycle inside the context, including reads, validation, conversion, post-processing, and writes.
- Unregister only if `kf.layout.kcls[name]` still points to the temporary layout instance.
- Add regression tests for read failures, post-process failures, validation failures, and output directory failures.

## Summary by Sourcery

Ensure temporary KCLayout instances used for GDS import and write helpers are always cleaned up, even when errors occur during processing.

Bug Fixes:
- Prevent temporary KCLayout instances from remaining registered in kf.layout.kcls when GDS reading, validation, post-processing, or output directory setup fails in import and write helpers.

Enhancements:
- Introduce a temporary_kcl context manager to encapsulate creation and lifecycle management of scoped temporary KCLayout instances used by GDS import and write utilities.

Tests:
- Add regression tests verifying temporary KCLayout cleanup on read errors, post-process errors, cellname validation errors, and output directory failures for GDS import and write helpers.