### PR TITLE
Skip metadata generation when writing without metadata

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -492,6 +492,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         self.write(
             filename=gdspath,
             save_options=save_options,
+            set_meta_data=with_metadata,
             deduplicate_cell_names=deduplicate_cell_names,
         )
         return pathlib.Path(gdspath)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -513,9 +513,7 @@ def test_component_write_gds_without_metadata_skips_metadata_generation(
     def fail_fix_pin_metadata(cell: Any) -> None:
         raise AssertionError("pin metadata should not be fixed when metadata is off")
 
-    monkeypatch.setattr(
-        "gdsfactory.component._fix_pin_metadata", fail_fix_pin_metadata
-    )
+    monkeypatch.setattr("gdsfactory.component._fix_pin_metadata", fail_fix_pin_metadata)
 
     path = c.write_gds(gdspath=tmp_path / "no_metadata.gds", with_metadata=False)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import kfactory as kf
@@ -501,6 +502,24 @@ def test_component_write_gds() -> None:
     path = c.write_gds(gdspath=GDSDIR_TEMP / "custom_name.gds")
     assert path.exists()
     assert path.name == "custom_name.gds"
+
+
+def test_component_write_gds_without_metadata_skips_metadata_generation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    c = gf.Component()
+    c.add_polygon([(0, 0), (1, 0), (1, 1), (0, 1)], layer=(1, 0))
+
+    def fail_fix_pin_metadata(cell: Any) -> None:
+        raise AssertionError("pin metadata should not be fixed when metadata is off")
+
+    monkeypatch.setattr(
+        "gdsfactory.component._fix_pin_metadata", fail_fix_pin_metadata
+    )
+
+    path = c.write_gds(gdspath=tmp_path / "no_metadata.gds", with_metadata=False)
+
+    assert path.exists()
 
 
 def test_component_copy_child_info() -> None:


### PR DESCRIPTION
## Summary

- Forward `write_gds(with_metadata=False)` to the lower-level `write(..., set_meta_data=False)` path.
- Add a regression test that verifies metadata generation is skipped, not just omitted from serialization.

Fixes #4646.

## Summary by Sourcery

Ensure GDS writes without metadata skip metadata generation and add coverage for this behavior.

Bug Fixes:
- Route write_gds(with_metadata=False) through the lower-level write path with metadata disabled to prevent unnecessary metadata handling.

Tests:
- Add a regression test asserting that write_gds(with_metadata=False) completes successfully without invoking metadata-fixing logic.