### PR TITLE
Vectorize Archimedean spiral path generation

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -2282,7 +2282,9 @@ def spiral_archimedean(
 
     Args:
         min_bend_radius: Inner radius of the spiral.
-        separation: Separation between the loops in um.
+        separation: Half the radial separation between loops in um. The
+            current formula is retained for compatibility with existing
+            layouts, so adjacent turns are separated by ``2 * separation``.
         number_of_loops: number of loops.
         npoints: number of Points.
 
@@ -2295,7 +2297,7 @@ def spiral_archimedean(
         p.plot()
 
     """
-    theta = np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+    theta = np.linspace(0, number_of_loops * 2 * np.pi, int(npoints))
     points = (separation / np.pi * theta + min_bend_radius)[:, None] * np.column_stack(
         (np.sin(theta), np.cos(theta))
     )

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -2295,15 +2295,10 @@ def spiral_archimedean(
         p.plot()
 
     """
-    return Path(
-        np.array(
-            [
-                (separation / np.pi * theta + min_bend_radius)
-                * np.array((np.sin(theta), np.cos(theta)))
-                for theta in np.linspace(0, number_of_loops * 2 * np.pi, npoints)
-            ]
-        )
-    )
+    theta = np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+    radius = separation / np.pi * theta + min_bend_radius
+    points = np.column_stack((radius * np.sin(theta), radius * np.cos(theta)))
+    return Path(points)
 
 
 def _compute_segments(

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -2296,8 +2296,9 @@ def spiral_archimedean(
 
     """
     theta = np.linspace(0, number_of_loops * 2 * np.pi, npoints)
-    radius = separation / np.pi * theta + min_bend_radius
-    points = np.column_stack((radius * np.sin(theta), radius * np.cos(theta)))
+    points = (separation / np.pi * theta + min_bend_radius)[:, None] * np.column_stack(
+        (np.sin(theta), np.cos(theta))
+    )
     return Path(points)
 
 

--- a/gdsfactory/routing/route_quad.py
+++ b/gdsfactory/routing/route_quad.py
@@ -78,7 +78,7 @@ def route_quad(
     center = np.mean(vertices, axis=0)
     displacements = vertices - center
     # sort vertices by angle from center of quadrilateral to make convex polygon
-    angles = np.array([np.arctan2(disp[0], disp[1]) for disp in displacements])
+    angles = np.arctan2(displacements[:, 0], displacements[:, 1])
     sorted_vertices: npt.NDArray[np.floating[Any]] = np.array(
         [
             vert

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -278,7 +278,8 @@ def path_V(port1: typings.Port, port2: typings.Port) -> Path:
 
     # Solve for intersection
     e = np.column_stack((e1, -1 * e2))
-    pt2 = np.matmul(np.linalg.inv(e), np.array(pt3) - np.array(pt1))[0] * e1 + pt1
+    distance = np.linalg.solve(e, np.asarray(pt3) - pt1)[0]
+    pt2 = distance * e1 + pt1
     return Path(np.array([pt1, pt2, pt3]))
 
 

--- a/gdsfactory/routing/route_sharp.py
+++ b/gdsfactory/routing/route_sharp.py
@@ -29,7 +29,7 @@ def path_straight(port1: typings.Port, port2: typings.Port) -> Path:
         np.abs(np.mod(port1.orientation - port2.orientation, 360)), 3
     )
     e1, e2 = _get_rotated_basis(port1.orientation)
-    displacement = np.array(port2.center) - np.array(port1.center)
+    displacement = np.asarray(port2.center) - np.asarray(port1.center)
     xrel = np.round(
         np.dot(displacement, e1), 3
     )  # relative position of port 2, forward/backward
@@ -59,7 +59,7 @@ def path_L(port1: typings.Port, port2: typings.Port) -> Path:
     e1, _e2 = _get_rotated_basis(port1.orientation)
 
     # assemble waypoints
-    pt1 = np.array(port1.center)
+    pt1 = np.asarray(port1.center)
     pt3 = port2.center
     delta_vec = pt3 - pt1
     pt2 = pt1 + np.dot(delta_vec, e1) * e1
@@ -172,7 +172,7 @@ def path_manhattan(port1: typings.Port, port2: typings.Port, radius: float) -> P
     """
     radius += 0.1
     e1, e2 = _get_rotated_basis(port1.orientation)
-    displacement = np.array(port2.center) - np.array(port1.center)
+    displacement = np.asarray(port2.center) - np.asarray(port1.center)
     xrel = np.round(
         np.dot(displacement, e1), 3
     )  # port2 position, forward(+)/backward(-) from port 1

--- a/tests/routing/test_route_sharp.py
+++ b/tests/routing/test_route_sharp.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+import gdsfactory as gf
+from gdsfactory.routing.route_sharp import path_V
+
+
+def test_path_v_intersection() -> None:
+    port1 = gf.Port("p1", center=(0, 0), width=0.5, orientation=0, layer=1)
+    port2 = gf.Port("p2", center=(10, -10), width=0.5, orientation=90, layer=1)
+
+    path = path_V(port1, port2)
+
+    np.testing.assert_allclose(path.points, ((0, 0), (10, 0), (10, -10)))

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -24,6 +24,28 @@ def test_path_zero_length() -> None:
     assert c.area((1, 0)) == 0
 
 
+@pytest.mark.parametrize("npoints", [17, 100])
+def test_spiral_archimedean_matches_reference(npoints: int) -> None:
+    min_bend_radius = 5.0
+    separation = 2.0
+    number_of_loops = 3.0
+    theta = np.linspace(0, number_of_loops * 2 * np.pi, npoints)
+    expected = np.array(
+        [
+            (separation / np.pi * t + min_bend_radius)
+            * np.array((np.sin(t), np.cos(t)))
+            for t in theta
+        ]
+    )
+
+    actual = gf.path.spiral_archimedean(
+        min_bend_radius, separation, number_of_loops, npoints
+    ).points
+
+    np.testing.assert_allclose(actual, expected, rtol=0, atol=1e-14)
+    assert actual.shape == (npoints, 2)
+
+
 def test_path_append() -> None:
     """Append paths."""
     P = gf.Path()


### PR DESCRIPTION
## Summary
- vectorize `spiral_archimedean` point generation with NumPy
- remove per-point temporary arrays and Python-level iteration

## Validation
- `uv run pytest tests/test_path.py -q`
- 57 passed

## Summary by Sourcery

Vectorize Archimedean spiral path generation and tighten geometric routing computations while adding tests for correctness.

New Features:
- Add tests validating Archimedean spiral points against a reference implementation.
- Add a routing test for path_V to ensure the intersection point is computed correctly.

Enhancements:
- Vectorize spiral_archimedean point generation with NumPy to eliminate per-point Python iteration and temporary arrays.
- Clarify the meaning of the separation parameter in spiral_archimedean while preserving existing layout behavior.
- Simplify and make routing geometry calculations more numerically robust by using np.asarray for centers and np.linalg.solve for intersections.
- Vectorize angle computation for quadrilateral port edges in route_quad to avoid explicit Python loops.

Tests:
- Expand path tests to check spiral_archimedean against a numerically defined reference for multiple point counts.
- Introduce a dedicated routing test for path_V to verify the computed polyline matches expected waypoints.