### PR TITLE
Render component plots as images in docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 mask*
 components.md
+components_images/
 notebooks/*.md
 _build/

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -13,7 +13,9 @@ import os
 import matplotlib
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # noqa: E402
+
+import gdsfactory as gf  # noqa: E402
 
 from gdsfactory.config import PATH
 from gdsfactory.get_factories import get_cells
@@ -57,8 +59,6 @@ skip_plot = [
 
 skip_settings = {"vias"}
 skip_partials = False
-
-import gdsfactory as gf
 
 gf.gpdk.PDK.activate()
 
@@ -120,7 +120,9 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
                     c = gf.components.__getattr__(name)().copy()
                     c.draw_ports()
                     fig = c.plot(return_fig=True)
-                    fig.savefig(str(img_path), bbox_inches="tight", pad_inches=0, dpi=80)
+                    fig.savefig(
+                        str(img_path), bbox_inches="tight", pad_inches=0, dpi=80
+                    )
                     plt.close(fig)
                     f.write(f"![{name}](components_images/{name}.png)\n\n")
                     print(f"  Plotted {name}")

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -13,10 +13,9 @@ import os
 import matplotlib
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt  # noqa: E402
+import matplotlib.pyplot as plt
 
-import gdsfactory as gf  # noqa: E402
-
+import gdsfactory as gf
 from gdsfactory.config import PATH
 from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json

--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -3,12 +3,17 @@
 - Walks through the `gdsfactory/components` directory
 - Finds all component modules (subfolders with __init__.py)
 - Extracts all cell functions from each module
-- Generates Markdown with mkdocstrings directives and component plots
+- Generates Markdown with mkdocstrings directives and rendered component plots
 - Writes to `docs/components.md`
 """
 
 import inspect
 import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from gdsfactory.config import PATH
 from gdsfactory.get_factories import get_cells
@@ -16,6 +21,8 @@ from gdsfactory.serialization import clean_value_json
 
 components = PATH.module / "components"
 filepath = PATH.repo / "docs" / "components.md"
+img_dir = PATH.repo / "docs" / "components_images"
+img_dir.mkdir(exist_ok=True)
 
 skip = {
     "bbox",
@@ -50,6 +57,10 @@ skip_plot = [
 
 skip_settings = {"vias"}
 skip_partials = False
+
+import gdsfactory as gf
+
+gf.gpdk.PDK.activate()
 
 with open(filepath, "w+", encoding="utf-8") as f:
     f.write(
@@ -104,8 +115,19 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
             f.write(f"::: {module_path}.{name}\n\n")
 
             if name not in skip_plot:
-                f.write(
-                    f"""```python
+                img_path = img_dir / f"{name}.png"
+                try:
+                    c = gf.components.__getattr__(name)().copy()
+                    c.draw_ports()
+                    fig = c.plot(return_fig=True)
+                    fig.savefig(str(img_path), bbox_inches="tight", pad_inches=0, dpi=80)
+                    plt.close(fig)
+                    f.write(f"![{name}](components_images/{name}.png)\n\n")
+                    print(f"  Plotted {name}")
+                except Exception as e:
+                    print(f"  Error plotting {name}: {e}")
+                    f.write(
+                        f"""```python
 import gdsfactory as gf
 
 gf.gpdk.PDK.activate()
@@ -116,4 +138,4 @@ c.plot()
 ```
 
 """
-                )
+                    )


### PR DESCRIPTION
## Summary

- `write_cells.py` now executes each component's `plot(return_fig=True)` at build time, saves the result as a PNG in `components_images/`, and embeds it as `![name](components_images/name.png)` in the markdown
- Falls back to showing the code block if a component fails to render
- Added `components_images/` to `.gitignore` (generated at build time)

Closes #4654

Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.

## Test plan

- [ ] Verify `make docs` generates images in `docs/components_images/`
- [ ] Check the components page shows rendered plots instead of code blocks
- [ ] Confirm components that fail to render fall back to code blocks gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Render component plots as images in the components documentation while keeping a fallback to code examples.

New Features:
- Generate PNG images for each component plot at docs build time and embed them into the components markdown page.

Enhancements:
- Automatically activate the gpdk PDK and use a non-interactive matplotlib backend to support headless docs builds.
- Create a dedicated components_images directory for generated plot assets and ensure it exists during docs generation.

Documentation:
- Ignore the generated components_images directory in docs/.gitignore to avoid committing build artifacts.