### PR TITLE
Fix component plot generation in write_cells.py

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -116,7 +116,7 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
             if name not in skip_plot:
                 img_path = img_dir / f"{name}.png"
                 try:
-                    c = gf.components.__getattr__(name)().copy()
+                    c = cell().copy()
                     c.draw_ports()
                     fig = c.plot(return_fig=True)
                     fig.savefig(


### PR DESCRIPTION
## Summary

- Fix `write_cells.py` to use `cell()` from the `get_cells()` dict instead of `gf.components.__getattr__(name)()` which doesn't exist as a module method
- This was causing every component plot to fail silently and fall back to static code blocks

Closes #4654

Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.

## Test plan

- [ ] Verify `make docs` generates PNG images in `docs/components_images/`
- [ ] Check the components page shows rendered component plots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct component plot generation in write_cells so docs can render component PNGs instead of silently failing.