### PR TITLE
Fix CI failures on #4515: port names, write_cells, ComponentReference

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -14,11 +14,11 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-
-import gdsfactory as gf
 from gdsfactory.config import PATH
 from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json
+
+import gdsfactory as gf
 
 components = PATH.module / "components"
 filepath = PATH.repo / "docs" / "components.md"
@@ -116,7 +116,7 @@ By doing so, you'll possess a versatile, retargetable PDK, empowering you to des
             if name not in skip_plot:
                 img_path = img_dir / f"{name}.png"
                 try:
-                    c = gf.components.__getattr__(name)().copy()
+                    c = getattr(gf.components, name)().copy()
                     c.draw_ports()
                     fig = c.plot(return_fig=True)
                     fig.savefig(

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -24,9 +24,7 @@ import numpy.typing as npt
 import yaml
 from graphviz import Digraph
 from kfactory import (
-    DInstance as ComponentReference,
-)
-from kfactory import (
+    DInstance,
     DPort,
     DPorts,
     VInstance,
@@ -160,6 +158,9 @@ boolean_operations = {
 
 def copy(region: kdb.Region) -> kdb.Region:
     return region.dup()
+
+
+ComponentReference = DInstance
 
 
 class ComponentBase(ProtoKCell[float, BaseKCell], ABC):

--- a/gdsfactory/samples/37_path_length_matching_center.py
+++ b/gdsfactory/samples/37_path_length_matching_center.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
 
     start_ports = [
         gf.Port(
+            name=f"start_{i}",
             center=(i * 300, -i * 150),
             orientation=90,
             layer=layer,
@@ -28,12 +29,13 @@ if __name__ == "__main__":
     ]
     end_ports = [
         gf.Port(
+            name=f"end_{i}",
             center=(x, 500),
             orientation=270,
             layer=layer,
             width=0.5,
         )
-        for x in [230, 700, 1000]
+        for i, x in enumerate([230, 700, 1000])
     ]
 
     c = gf.Component()

--- a/gdsfactory/samples/37_path_length_matching_end.py
+++ b/gdsfactory/samples/37_path_length_matching_end.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
 
     start_ports = [
         gf.Port(
+            name=f"start_{i}",
             center=(i * 300, -i * 150),
             orientation=90,
             layer=layer,
@@ -26,12 +27,13 @@ if __name__ == "__main__":
     ]
     end_ports = [
         gf.Port(
+            name=f"end_{i}",
             center=(x, 500),
             orientation=270,
             layer=layer,
             width=0.5,
         )
-        for x in [230, 700, 1000]
+        for i, x in enumerate([230, 700, 1000])
     ]
 
     c = gf.Component()


### PR DESCRIPTION
## Summary

Fixes the 4 failing CI checks on #4515:

- **test_samples**: Add required `name` parameter to `Port()` calls in `37_path_length_matching_center.py` and `37_path_length_matching_end.py` — kfactory `DPort` now requires a name.
- **Build docs** (`write_cells.py`): Replace `gf.components.__getattr__(name)` with `getattr(gf.components, name)` — the components module has no `__getattr__` defined.
- **Build docs** (`component.py`): Use `ComponentReference = DInstance` instead of `from kfactory import DInstance as ComponentReference` to avoid griffe `AliasResolutionError`.
- **test_code / test_code_coverage** (`greek_cross_with_pads`): Reference GDS needs regeneration — see gdsfactory/gdsfactory-test-data#4.

## Test plan
- [x] `test_gds[greek_cross_with_pads]` passes locally with regenerated reference
- [x] `test_script_execution[37_path_length_matching_end]` passes
- [x] `test_script_execution[37_path_length_matching_center]` passes
- [x] `getattr(gf.components, name)` resolves components correctly
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Fix CI failures by updating component references, documentation tooling, and sample port definitions to align with the latest kfactory and component APIs.

Bug Fixes:
- Define ComponentReference as an alias of kfactory.DInstance to avoid documentation alias resolution issues.
- Use getattr on gf.components when generating docs to correctly resolve component factories without relying on a non-existent __getattr__.
- Add explicit names to sample Ports and fix end-port enumeration in path length matching examples to satisfy the updated Port API and tests.

Tests:
- Regenerate and update the greek_cross_with_pads reference GDS to make the corresponding tests pass against the current implementation.