### PR TITLE
fix pre-commit: TypeAlias for ComponentReference + import ordering

### DIFF
--- a/docs/write_cells.py
+++ b/docs/write_cells.py
@@ -14,11 +14,11 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+
+import gdsfactory as gf
 from gdsfactory.config import PATH
 from gdsfactory.get_factories import get_cells
 from gdsfactory.serialization import clean_value_json
-
-import gdsfactory as gf
 
 components = PATH.module / "components"
 filepath = PATH.repo / "docs" / "components.md"

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Literal,
     Self,
+    TypeAlias,
     cast,
     overload,
     override,
@@ -160,7 +161,7 @@ def copy(region: kdb.Region) -> kdb.Region:
     return region.dup()
 
 
-ComponentReference = DInstance
+ComponentReference: TypeAlias = DInstance  # noqa: UP040
 
 
 class ComponentBase(ProtoKCell[float, BaseKCell], ABC):


### PR DESCRIPTION
## Summary

Fixes pre-commit failures on the `replace-old-kfactory-routing-strategies` branch.

- **`gdsfactory/component.py`**: Annotate `ComponentReference` with `TypeAlias` so pyright recognizes it as a valid type form. Adds `noqa: UP040` because the Python 3.12 `type` keyword creates a `TypeAliasType` that breaks runtime `isinstance()` checks and constructor usage.
- **`docs/write_cells.py`**: Fix ruff I001 import ordering — `import gdsfactory as gf` must come before `from gdsfactory...` imports.

Closes #4661
Related: #4515

## Summary by Sourcery

Fix pre-commit issues by updating a type alias annotation and adjusting import order.

Enhancements:
- Annotate ComponentReference as a TypeAlias to satisfy static type checking while preserving runtime behavior.

Chores:
- Reorder imports in docs/write_cells.py to comply with linting rules.