### PR TITLE
fix: skip metadata generation when disabled

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -498,6 +498,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
         self.write(
             filename=gdspath,
             save_options=save_options,
+            set_meta_data=with_metadata,
             deduplicate_cell_names=deduplicate_cell_names,
         )
         return pathlib.Path(gdspath)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Any
 
 import kfactory as kf
@@ -501,6 +502,23 @@ def test_component_write_gds() -> None:
     path = c.write_gds(gdspath=GDSDIR_TEMP / "custom_name.gds")
     assert path.exists()
     assert path.name == "custom_name.gds"
+
+
+def test_component_write_gds_without_metadata_skips_metadata_generation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    def fail_on_metadata_generation(component: gf.Component) -> None:
+        raise AssertionError(f"metadata generated for {component.name}")
+
+    monkeypatch.setattr(
+        "gdsfactory.component._fix_pin_metadata", fail_on_metadata_generation
+    )
+
+    path = gf.components.straight().write_gds(
+        tmp_path / "without_metadata.gds", with_metadata=False
+    )
+
+    assert path.exists()
 
 
 def test_component_copy_child_info() -> None:


### PR DESCRIPTION
## Summary

- forward `with_metadata` to the lower-level write path
- skip Python-side metadata generation when metadata output is disabled
- add a regression test that fails if pin metadata normalization runs

## Tests

- `pytest -q tests/test_component.py::test_component_write_gds_without_metadata_skips_metadata_generation`
- pre-commit checks for changed files

Closes #4646

## Summary by Sourcery

Ensure GDS writing respects the metadata flag to avoid generating metadata when disabled.

Bug Fixes:
- Prevent Python-side pin metadata normalization from running when GDS is written with metadata disabled.

Tests:
- Add a regression test verifying that writing GDS with metadata disabled does not trigger metadata generation.