### PR TITLE
fix: support negative bend_s_offset values

### DIFF
--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = ["bend_s", "bend_s_offset", "bezier"]
 
+import math
 import warnings
 from typing import Any
 
@@ -292,8 +293,9 @@ def bend_s_offset(
 
     xs.validate_radius(radius)
     angle, middle_length = _get_euler_sbend_angle_middle_length_from_jog(
-        jog=offset / 2, radius=radius, p=p, use_eff=with_arc_floorplan
+        jog=abs(offset) / 2, radius=radius, p=p, use_eff=with_arc_floorplan
     )
+    angle = math.copysign(angle, offset)
     path = gf.path.euler(
         radius=radius,
         angle=+angle,

--- a/tests/components/test_bend_s_offset.py
+++ b/tests/components/test_bend_s_offset.py
@@ -1,0 +1,16 @@
+import pytest
+
+import gdsfactory as gf
+
+
+@pytest.mark.parametrize("offset", [40.0, -40.0])
+def test_bend_s_offset_supports_signed_offsets(offset: float) -> None:
+    component = gf.components.bend_s_offset(offset=offset, radius=10)
+    ports = list(component.ports)
+
+    assert len(component.get_polygons()) == 1
+    assert ports[0].dcenter == (0.0, 0.0)
+    assert ports[1].dcenter[0] > 0
+    assert ports[1].dcenter[1] == pytest.approx(offset)
+    assert ports[0].orientation == 180
+    assert ports[1].orientation == 0


### PR DESCRIPTION
## Summary

- calculate S-bend size from the absolute offset
- apply the offset sign to the bend angles
- verify positive and negative offsets produce real geometry with the expected endpoints and port orientations

## Tests

- `pytest -q tests/components/test_bend_s_offset.py`
- pre-commit checks for changed files

Closes #4610

## Summary by Sourcery

Support signed offsets in bend_s_offset while preserving correct geometry and port orientations.

Bug Fixes:
- Correct bend_s_offset geometry computation to handle negative offsets by basing S-bend size on the absolute offset and applying the offset sign to the bend angle.

Tests:
- Add parametrized tests to verify bend_s_offset produces valid geometry and expected endpoints for both positive and negative offsets.