### PR TITLE
fix: use electrical ports for analog components

### DIFF
--- a/gdsfactory/components/analog/interdigital_capacitor.py
+++ b/gdsfactory/components/analog/interdigital_capacitor.py
@@ -18,7 +18,7 @@ def interdigital_capacitor(
     finger_length: float | int = 20.0,
     finger_gap: float | int = 2.0,
     thickness: float | int = 5.0,
-    layer: LayerSpec = "WG",
+    layer: LayerSpec = "M1",
 ) -> Component:
     """Generate an interdigital capacitor component with ports on both ends.
 
@@ -44,7 +44,7 @@ def interdigital_capacitor(
 
     Returns:
         Component: A gdsfactory component with the interdigital capacitor geometry
-        and two ports ('o1' and 'o2') on opposing sides.
+        and two electrical ports ('e1' and 'e2') on opposing sides.
     """
     c = Component()
 
@@ -109,17 +109,19 @@ def interdigital_capacitor(
     c.add_polygon(points_1, layer=layer)
     c.add_polygon(points_2, layer=layer)
     c.add_port(
-        name="o1",
+        name="e1",
         center=(0, height / 2),
         width=thickness,
         orientation=180,
         layer=layer,
+        port_type="electrical",
     )
     c.add_port(
-        name="o2",
+        name="e2",
         center=(width, height / 2),
         width=thickness,
         orientation=0,
         layer=layer,
+        port_type="electrical",
     )
     return c

--- a/gdsfactory/components/spirals/spiral_inductor.py
+++ b/gdsfactory/components/spirals/spiral_inductor.py
@@ -4,6 +4,7 @@ __all__ = ["spiral_inductor"]
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+from gdsfactory.typings import LayerSpec
 
 from .._schematic import spiral_schematic
 
@@ -15,6 +16,7 @@ def spiral_inductor(
     turns: int = 16,
     outer_diameter: float = 800,
     tail: float = 50.0,
+    layer: LayerSpec = "M1",
 ) -> Component:
     """Generates a spiral inductor for superconducting resonator applications, particularly in qubit readout circuits.
 
@@ -30,6 +32,7 @@ def spiral_inductor(
         turns: Number of complete spiral turns. Higher values increase inductance but require more space.
         outer_diameter: Overall size of the inductor in microns. Defines the maximum extent of the spiral.
         tail: Length of the inner and outer connection tails in microns. Used for connecting to other circuit elements.
+        layer: Metal layer for the inductor geometry and ports.
 
     Returns:
         Component: A GDSFactory component containing the spiral inductor pattern.
@@ -45,7 +48,13 @@ def spiral_inductor(
     P += gf.path.straight(length=tail)
 
     # Store the path length in component info
-    c = gf.path.extrude(P, layer=(1, 0), width=width)
+    cross_section = gf.cross_section.cross_section(
+        width=width,
+        layer=layer,
+        port_names=("e1", "e2"),
+        port_types=("electrical", "electrical"),
+    )
+    c = gf.path.extrude(P, cross_section=cross_section)
     c.info["length"] = P.length()
     return c
 

--- a/tests/components/test_analog_ports.py
+++ b/tests/components/test_analog_ports.py
@@ -1,0 +1,32 @@
+from collections.abc import Callable
+
+import pytest
+
+import gdsfactory as gf
+
+
+@pytest.mark.parametrize(
+    "component_factory",
+    [gf.components.interdigital_capacitor, gf.components.spiral_inductor],
+)
+def test_analog_component_defaults_to_electrical_ports_on_metal(
+    component_factory: Callable[..., gf.Component],
+) -> None:
+    component = component_factory()
+
+    assert component.layers == [(41, 0)]
+    assert [port.name for port in component.ports] == ["e1", "e2"]
+    assert all(port.port_type == "electrical" for port in component.ports)
+
+
+@pytest.mark.parametrize(
+    "component_factory",
+    [gf.components.interdigital_capacitor, gf.components.spiral_inductor],
+)
+def test_analog_component_accepts_custom_layer(
+    component_factory: Callable[..., gf.Component],
+) -> None:
+    component = component_factory(layer="M2")
+
+    assert component.layers == [(45, 0)]
+    assert all(port.layer == gf.get_layer("M2") for port in component.ports)

--- a/tests/test-data-regression/test_settings_interdigital_capacitor_.yml
+++ b/tests/test-data-regression/test_settings_interdigital_capacitor_.yml
@@ -1,8 +1,8 @@
 info: {}
-name: interdigital_capacitor_gdsfactorypcomponentspanalogpint_2ca89435
+name: interdigital_capacitor_gdsfactorypcomponentspanalogpint_db9e85de
 settings:
   finger_gap: 2
   finger_length: 20
   fingers: 4
-  layer: WG
+  layer: M1
   thickness: 5

--- a/tests/test-data-regression/test_settings_spiral_inductor_.yml
+++ b/tests/test-data-regression/test_settings_spiral_inductor_.yml
@@ -1,7 +1,8 @@
 info:
   length: 35637.695
-name: spiral_inductor_gdsfactorypcomponentspspiralspspiral_in_6605842d
+name: spiral_inductor_gdsfactorypcomponentspspiralspspiral_in_2442ed4f
 settings:
+  layer: M1
   outer_diameter: 800
   pitch: 3
   tail: 50


### PR DESCRIPTION
## Summary

- default `interdigital_capacitor` and `spiral_inductor` geometry to the M1 metal layer
- expose `e1`/`e2` electrical ports instead of optical ports
- make the spiral inductor layer configurable
- add regression coverage for default and custom metal layers
- update settings regression data

## Tests

- `pytest -q tests/components/test_analog_ports.py`
- affected component GDS/settings tests
- affected netlist tests
- pre-commit checks for changed source and test files

## Dependency

Golden GDS updates: gdsfactory/gdsfactory-test-data#5

Closes #4499

## Summary by Sourcery

Default analog spiral inductor and interdigital capacitor components to use metal layers with electrical ports instead of optical ports, and add test coverage for these behaviors.

New Features:
- Allow configuring the metal layer used for the spiral inductor geometry and ports.

Bug Fixes:
- Expose electrical ports e1/e2 instead of optical ports on analog capacitor and inductor components to reflect their intended usage.

Enhancements:
- Default the interdigital capacitor and spiral inductor to the M1 metal layer and update regression settings accordingly.

Tests:
- Add regression tests to verify default electrical ports on metal layers and support for custom metal layers on analog components.