### PR TITLE
test: cover bend_s width override

### DIFF
--- a/tests/components/bends/test_bends.py
+++ b/tests/components/bends/test_bends.py
@@ -224,6 +224,21 @@ def test_bend_s() -> None:
     assert len(c3.ports) == 2
 
 
+def test_bend_s_width_overrides_cross_section_width() -> None:
+    cross_section = gf.cross_section.cross_section(width=0.5, layer="M2")
+
+    component = bend_s(
+        size=(50, 10),
+        npoints=120,
+        cross_section=cross_section,
+        allow_min_radius_violation=True,
+        width=0.8,
+    )
+
+    assert component.layers == [(45, 0)]
+    assert all(port.dwidth == 0.8 for port in component.ports)
+
+
 def test_get_min_sbend_size() -> None:
     size_x = get_min_sbend_size(size=(None, 10.0))
     assert isinstance(size_x, float)

--- a/tests/components/bends/test_bends.py
+++ b/tests/components/bends/test_bends.py
@@ -225,7 +225,7 @@ def test_bend_s() -> None:
 
 
 def test_bend_s_width_overrides_cross_section_width() -> None:
-    cross_section = gf.cross_section.cross_section(width=0.5, layer="M2")
+    cross_section = gf.cross_section.cross_section(width=0.5, layer=(2, 0))
 
     component = bend_s(
         size=(50, 10),
@@ -235,7 +235,7 @@ def test_bend_s_width_overrides_cross_section_width() -> None:
         width=0.8,
     )
 
-    assert component.layers == [(45, 0)]
+    assert (2, 0) in component.layers
     assert all(port.dwidth == 0.8 for port in component.ports)
 
 


### PR DESCRIPTION
## Summary

- verify `bend_s(width=...)` overrides the supplied cross-section width
- verify the supplied cross-section layer is preserved
- cover the exact usage reported in #4612

The implementation on current `main` already performs this override via `get_cross_section(..., width=width)`; this regression test protects that behavior.

## Tests

- `pytest -q tests/components/bends/test_bends.py -k bend_s`
- pre-commit checks for the changed test

Closes #4612

## Summary by Sourcery

Tests:
- Add coverage for bend_s to confirm the explicit width argument overrides the cross-section width and that the expected layer and port widths are produced.