### PR TITLE
fix: preserve cladding in cross-section round trips

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -255,6 +255,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         # Apply CrossSection overrides
         xs_name = None
+        port_cross_section: kf.DCrossSection | None = None
         if cross_section:
             xs = get_cross_section(cross_section)
             xs_name = xs.name
@@ -262,6 +263,28 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
                 layer = xs.layer
             if width is None:
                 width = xs.width
+            enclosure_sections = [
+                (
+                    self.kcl.layout.get_info(get_layer(section.layer)),
+                    (section.width - xs.width) / 2,
+                )
+                for section in xs.sections[1:]
+                if section.offset == 0 and section.width >= xs.width
+            ]
+            if (
+                enclosure_sections
+                and width == xs.width
+                and get_layer(layer) == get_layer(xs.layer)
+            ):
+                port_cross_section = kf.DCrossSection(
+                    kcl=self.kcl,
+                    width=xs.width,
+                    layer=self.kcl.layout.get_info(get_layer(xs.layer)),
+                    sections=enclosure_sections,
+                    radius=None,
+                    radius_min=None,
+                    name=None,
+                )
 
         # Apply defaults if None
         if port_type is None:
@@ -311,6 +334,7 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
             layer=layer,
             port_type=port_type,
             dcplx_trans=trans,
+            cross_section=port_cross_section,
             info=info,
         )
 

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -534,10 +534,12 @@ class Pdk(BaseModel):
         if isinstance(cross_section, kf.DCrossSection | kf.SymmetricalCrossSection):
             if isinstance(cross_section, kf.DCrossSection):
                 cross_section_ = cross_section.base
+                kcl = cross_section.kcl
             else:
                 cross_section_ = cross_section
+                kcl = kf.kcl
 
-            layer: LayerSpec = kf.kcl.layout.layer(cross_section_.main_layer)
+            layer: LayerSpec = kcl.layout.layer(cross_section_.main_layer)
             try:
                 layer = self.get_layer_name(layer)
             except ValueError:
@@ -545,14 +547,38 @@ class Pdk(BaseModel):
 
             section_ = Section(
                 name="_default",
-                width=kf.kcl.to_um(cross_section_.width),
+                width=kcl.to_um(cross_section_.width),
                 layer=layer,
                 port_names=("o1", "o2"),
             )
+            sections = [section_]
+            for (
+                layer_info,
+                layer_section,
+            ) in cross_section_.enclosure.layer_sections.items():
+                section_layer: LayerSpec = kcl.layout.layer(layer_info)
+                try:
+                    section_layer = self.get_layer_name(section_layer)
+                except ValueError:
+                    logger.debug(
+                        "Could not resolve layer name for %r, using as-is",
+                        section_layer,
+                    )
+                sections.extend(
+                    Section(
+                        width=kcl.to_um(
+                            cross_section_.width + 2 * enclosure_section.d_max
+                        ),
+                        offset=0,
+                        layer=section_layer,
+                    )
+                    for enclosure_section in layer_section.sections
+                    if enclosure_section.d_min is None
+                )
             xs_ = CrossSection(
-                sections=(section_,),
-                radius=kf.kcl.to_um(cross_section_.radius),
-                radius_min=kf.kcl.to_um(cross_section_.radius_min),
+                sections=tuple(sections),
+                radius=kcl.to_um(cross_section_.radius),
+                radius_min=kcl.to_um(cross_section_.radius_min),
             )
             xs_._name = cross_section_.name
             return xs_

--- a/tests/test_paths_transition.py
+++ b/tests/test_paths_transition.py
@@ -93,3 +93,33 @@ def test_taper_cross_section_round_tripped_layer_spec() -> None:
 
     t2 = gf.components.taper_cross_section(xs1_rt, xs2, length=10, linear=True)
     assert any(t2.get_polygons(merge=False).values())
+
+
+def test_taper_cross_section_round_tripped_with_cladding() -> None:
+    xs1 = gf.cross_section.cross_section(
+        width=0.5,
+        layer="WG",
+        cladding_layers=("WGCLAD",),
+        cladding_offsets=(2.0,),
+    )
+    xs2 = gf.cross_section.cross_section(
+        width=1.0,
+        layer="WG",
+        cladding_layers=("WGCLAD",),
+        cladding_offsets=(2.0,),
+    )
+
+    taper = gf.components.taper_cross_section(xs1, xs2, length=10, linear=True)
+    round_tripped = gf.get_cross_section(taper.ports["o1"].cross_section)
+
+    assert len(round_tripped.sections) == 2
+    assert round_tripped.sections[0].layer == xs1.sections[0].layer
+    assert round_tripped.sections[0].width == xs1.sections[0].width
+    assert round_tripped.sections[1].layer == xs1.sections[1].layer
+    assert round_tripped.sections[1].width == xs1.sections[1].width
+    assert round_tripped.sections[1].offset == 0
+
+    second_taper = gf.components.taper_cross_section(
+        round_tripped, xs2, length=10, linear=True
+    )
+    assert any(second_taper.get_polygons(merge=False).values())


### PR DESCRIPTION
## Summary

- encode centered GF cladding sections as kfactory layer-enclosure sections on main ports
- reconstruct GF cladding sections when resolving a kfactory cross-section
- use the originating KCLayout for layer and DBU conversion
- avoid overriding secondary-section ports in multi-port cross-sections
- add the exact regression reported in #4548

## Tests

- `pytest -q tests/test_paths_transition.py tests/test_pdk.py tests/test_port.py tests/test_component.py -n auto` (84 passed)
- `pytest -q tests --ignore=tests/components/test_components.py -n auto` (976 passed, 2 skipped, 1 xfailed)
- pre-commit checks for changed files

This is a focused compatibility fix; it does not attempt the broader cross-section replacement proposed in #4418.

Closes #4548

## Summary by Sourcery

Preserve cladding information when converting between gdsfactory and kfactory cross-sections, ensuring taper cross-section round-trips remain geometrically consistent.

New Features:
- Support reconstruction of cladding sections from kfactory layer enclosures when resolving a gdsfactory cross-section.
- Encode cladding-like enclosure data into kfactory cross-sections on ports when adding ports with multi-section cross-sections.

Bug Fixes:
- Fix loss of cladding layers and widths when taper cross-sections are round-tripped through kfactory cross-sections.
- Ensure radius and radius_min conversions use the originating KCLayout to avoid unit or layout mismatches.

Tests:
- Add a regression test that verifies taper cross-sections with cladding survive round-trip conversion and remain usable in subsequent tapers.