### PR TITLE
docs: activate generic PDK in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ gfi install
 ```python
 import gdsfactory as gf
 
+# Activate the built-in generic process design kit
+gf.gpdk.PDK.activate()
+
 # Create a new component
 c = gf.Component()
 


### PR DESCRIPTION
## Summary

- activate the built-in generic PDK before the README quick-start creates geometry
- keep the explicit-PDK behavior documented by the runtime error

The `_ACTIVE_PDK` `NameError` itself was fixed earlier by #4560; this fixes the remaining executable-example problem described in #4469.

## Verification

- ran the full quick-start construction locally
- resulting component bbox: `(0,0;77.076,53.16)`
- pre-commit checks for `README.md`

Closes #4469

## Summary by Sourcery

Documentation:
- Clarify quick-start instructions by showing how to activate the built-in generic PDK prior to component creation.