### PR TITLE
fix: round-trip all-angle netlists through YAML

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -555,6 +555,15 @@ class Pdk(BaseModel):
                 radius_min=kf.kcl.to_um(cross_section_.radius_min),
             )
             xs_._name = cross_section_.name
+            for name, factory in self.cross_sections.items():
+                registered = factory()
+                if (
+                    registered.sections == xs_.sections
+                    and registered.bbox_layers == xs_.bbox_layers
+                    and registered.bbox_offsets == xs_.bbox_offsets
+                ):
+                    xs_._name = name
+                    break
             return xs_
         raise ValueError(
             "get_cross_section expects a CrossSectionSpec (CrossSection, "

--- a/tests/read/test_from_yaml_all_angle.py
+++ b/tests/read/test_from_yaml_all_angle.py
@@ -1,0 +1,25 @@
+import yaml
+
+import gdsfactory as gf
+
+
+@gf.vcell
+def extend_all_angle(component: gf.Component) -> gf.ComponentAllAngle:
+    extended = gf.ComponentAllAngle()
+    extended.add_ref_off_grid(component)
+    extension = extended.add_ref_off_grid(
+        gf.components.straight_all_angle(
+            cross_section=gf.get_cross_section(component.ports["o2"].cross_section)
+        )
+    )
+    extension.connect("o2", component.ports["o1"])
+    return extended
+
+
+def test_all_angle_netlist_yaml_round_trip() -> None:
+    component = extend_all_angle(gf.components.straight())
+    serialized = yaml.safe_dump(component.get_netlist())
+
+    restored = gf.read.from_yaml(serialized)
+
+    assert len(restored.vinsts) == 2


### PR DESCRIPTION
## Summary

- resolve kfactory port cross-sections back to registered PDK names by structural profile
- prevent transient kfactory hash names from leaking into all-angle component settings
- add an end-to-end virtual-cell netlist → YAML → component regression

The original float-truncation case in #4450 is already fixed. This addresses the remaining all-angle failure documented in the issue comments.

## Tests

- `pytest -q tests/read/test_from_yaml_all_angle.py tests/read/test_component_from_yaml.py tests/test_pdk.py -n auto` (38 passed, 1 skipped)
- pre-commit checks for changed files

Closes #4450

## Summary by Sourcery

Ensure all-angle components round-trip correctly between virtual-cell netlists and YAML by resolving cross-sections back to registered PDK names.

Bug Fixes:
- Resolve kfactory-derived cross-sections back to their registered PDK names based on structural equality to avoid transient hash-based names leaking into all-angle components.

Tests:
- Add an end-to-end regression test that serializes an all-angle virtual-cell netlist to YAML and restores it, verifying the expected number of instances.