### PR TITLE
fix: preserve nested virtual instances when flattening

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -663,6 +663,27 @@ class Component(ComponentBase, kf.DKCell):
 
     routes: dict[str, Route] = Field(default_factory=dict)
 
+    @override
+    def flatten(self, merge: bool = True) -> None:
+        """Flatten the component, including nested virtual instances.
+
+        Args:
+            merge: Merge the shapes on all layers.
+        """
+        called_cell_indexes = set(self.kdb_cell.called_cells())
+        for called_cell in sorted(
+            (
+                self.kcl[cell_index]
+                for cell_index in called_cell_indexes & self.kcl.tkcells.keys()
+                if not self.kcl[cell_index].kdb_cell._destroyed()
+            ),
+            key=lambda called_cell: called_cell.hierarchy_levels(),
+        ):
+            for virtual_instance in called_cell.vinsts:
+                virtual_instance.insert_into_flat(called_cell)
+            called_cell.vinsts.clear()
+        super().flatten(merge=merge)
+
     def dup(self, new_name: str | None = None) -> Self:
         """Copy the full cell.
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -737,6 +737,26 @@ def test_component_all_angle_flatten() -> None:
     assert poly2.bbox().right == 5
 
 
+def test_component_flatten_nested_virtual_instances() -> None:
+    c1 = gf.Component()
+    c1.add_polygon([(0, 0), (1, 0), (1, 1), (0, 1)], layer=(1, 0))
+
+    c2 = gf.Component()
+    c2.add_ref(c1).dmovex(-10)
+    c2.create_vinst(c1).dmovex(10)
+
+    c3 = gf.Component()
+    c3.add_ref(c2).dmovey(10)
+    c3.create_vinst(c2).dmovey(-10)
+
+    c3.flatten()
+
+    assert len(c3.insts) == 0
+    assert len(c3.vinsts) == 0
+    assert len(c3.get_polygons(by="tuple", layers=[(1, 0)])[(1, 0)]) == 4
+    assert c3.bbox_np().tolist() == [[-10.0, -10.0], [11.0, 11.0]]
+
+
 def test_component_all_angle_add_polygon_get_polygon() -> None:
     c = gf.ComponentAllAngle()
     c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))


### PR DESCRIPTION
## Summary
- flatten virtual instances in called cells before flattening the top component
- process nested cells bottom-up so virtual geometry at every hierarchy depth is retained
- keep nameless all-angle virtual cells compatible by inserting their geometry directly instead of converting them to regular instances
- add a regression covering mixed regular and virtual instances at two hierarchy levels

## Testing
- `uv run pytest -q tests/test_component.py -k flatten`
- `uv run pytest -q tests/components/test_netlists.py::test_netlists\[ring_double_pn\]`
- `uv run pre-commit run --files gdsfactory/component.py tests/test_component.py`
- `uv run pytest -q tests --ignore=tests/components/test_components.py -n auto` (976 passed, 2 skipped, 1 xfailed)

Closes #4438

## Summary by Sourcery

Preserve virtual geometry across hierarchy levels when flattening components.

Bug Fixes:
- Ensure nested virtual instances in called cells are preserved when flattening the top-level component.

Enhancements:
- Flatten virtual instances in called cells bottom-up before invoking the standard flatten logic.

Tests:
- Add a regression test covering flattening of mixed regular and virtual instances across two hierarchy levels.