### PR TITLE
fix: preserve internal corners when applying path insets

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1193,7 +1193,7 @@ def extrude(
             new_stop_point = v_stop_inset + p_pts[stop_diff_idx, :]
 
             _path_points = [new_start_point]
-            _path_points.extend(p_pts[start_diff_idx + 1 : stop_diff_idx])
+            _path_points.extend(p_pts[start_diff_idx + 1 : stop_diff_idx + 1])
             _path_points.append(new_stop_point)
 
             p_sec = Path(np.array(_path_points, dtype=np.float64))

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -475,6 +475,18 @@ def test_path_smooth() -> None:
     assert np.isclose(c.area((1, 0)), 3404.6317885)
 
 
+def test_path_extrude_insets_preserve_internal_corner() -> None:
+    cross_section = gf.CrossSection(
+        sections=(gf.Section(width=6, layer=(2, 0), insets=(-2, -2)),)
+    )
+    path = Path([(0, 0), (40, 0), (40, 40)])
+
+    component = path.extrude(cross_section=cross_section)
+
+    assert component.dbbox() == kdb.DBox(-2, -3, 43, 42)
+    assert component.area((2, 0)) == 504
+
+
 def test_path_angle() -> None:
     p = gf.path.euler(
         radius=5,


### PR DESCRIPTION
## Summary
- retain the final internal path point when slicing a section path for start/end insets
- prevent adjacent-segment insets from replacing a sharp corner with a diagonal
- add a regression for negative insets around a 90-degree path

## Testing
- `uv run pytest -q tests/test_path.py` (60 passed)
- `uv run pre-commit run --files gdsfactory/path.py tests/test_path.py`
- `uv run pytest -q tests --ignore=tests/components/test_components.py -n auto` (976 passed, 2 skipped, 1 xfailed)

Closes #4428

## Summary by Sourcery

Preserve internal corners when applying path insets during extrusion to avoid altering sharp geometry at section boundaries.

Bug Fixes:
- Ensure internal path points are retained when slicing section paths for start/end insets so sharp corners are not replaced by diagonals.

Tests:
- Add a regression test verifying negative insets around a 90-degree path preserve the internal corner and expected area/bbox.