### PR TITLE
fix: parse LYP files without brightness fields

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -755,8 +755,8 @@ class LayerView(BaseModel):
             layer=cls._process_layer(element.find("source").text, layer_pattern),  # type: ignore[union-attr,arg-type]
             fill_color=getattr(element.find("fill-color"), "text", None),
             frame_color=getattr(element.find("frame-color"), "text", None),
-            fill_brightness=element.find("fill-brightness").text or 0,  # type: ignore[union-attr]
-            frame_brightness=element.find("frame-brightness").text or 0,  # type: ignore[union-attr]
+            fill_brightness=getattr(element.find("fill-brightness"), "text", 0) or 0,
+            frame_brightness=getattr(element.find("frame-brightness"), "text", 0) or 0,
             hatch_pattern=hatch_pattern or None,
             line_style=line_style
             if line_style is not None and len(line_style) > 0

--- a/tests/technology/test_layer_map.py
+++ b/tests/technology/test_layer_map.py
@@ -42,3 +42,20 @@ def test_lyp_to_dataclass(tmp_path: pathlib.Path) -> None:
 
     with pytest.raises(FileNotFoundError):
         lyp_to_dataclass("nonexistent.lyp")
+
+
+def test_lyp_to_dataclass_without_brightness(tmp_path: pathlib.Path) -> None:
+    lyp_content = """<?xml version="1.0" encoding="utf-8"?>
+<layer-properties>
+ <properties>
+  <dither-pattern>1</dither-pattern>
+  <name>M1</name>
+  <source>1/0@1</source>
+ </properties>
+</layer-properties>"""
+    lyp_file = tmp_path / "without_brightness.lyp"
+    lyp_file.write_text(lyp_content)
+
+    script = lyp_to_dataclass(lyp_file)
+
+    assert "M1: Layer = (1, 0)" in script


### PR DESCRIPTION
## Summary
- treat `fill-brightness` and `frame-brightness` as optional LYP fields
- default missing or empty brightness values to zero
- add a minimal `lyp_to_dataclass` regression with both tags omitted

## Testing
- `uv run pytest -q tests/technology` (30 passed, 1 skipped)
- `uv run pre-commit run --files gdsfactory/technology/layer_views.py tests/technology/test_layer_map.py`

Closes #4365

## Summary by Sourcery

Handle LYP layer view files that omit brightness fields without errors and add regression coverage for this case.

Bug Fixes:
- Treat missing or empty fill-brightness and frame-brightness fields in LYP files as zero-valued brightness instead of causing attribute errors.

Tests:
- Add a regression test ensuring lyp_to_dataclass correctly parses LYP files where brightness tags are omitted.