### PR TITLE
fix: type get_component as AnyComponent

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -25,9 +25,11 @@ from gdsfactory.serialization import clean_value_json
 from gdsfactory.symbols import floorplan_with_block_letters
 from gdsfactory.technology import LayerStack, LayerViews, klayout_tech
 from gdsfactory.typings import (
+    AnyComponent,
     CellAllAngleSpec,
     CellSpec,
     ComponentAllAngleFactory,
+    ComponentAllAngleSpec,
     ComponentFactory,
     ComponentSpec,
     ConnectivitySpec,
@@ -385,11 +387,11 @@ class Pdk(BaseModel):
 
     def get_component(
         self,
-        component: ComponentSpec,
+        component: ComponentSpec | ComponentAllAngleSpec,
         settings: Mapping[str, Any] | None = None,
         include_containers: bool = True,
         **kwargs: Any,
-    ) -> Component:
+    ) -> AnyComponent:
         """Returns component from a component spec."""
         if include_containers:
             if isinstance(component, str):
@@ -434,11 +436,11 @@ class Pdk(BaseModel):
 
     def _get_component(
         self,
-        component: ComponentSpec,
+        component: ComponentSpec | ComponentAllAngleSpec,
         cells: dict[str, ComponentFactory],
         settings: Mapping[str, Any] | None = None,
         **kwargs: Any,
-    ) -> Component:
+    ) -> AnyComponent:
         """Returns component from a component spec.
 
         Args:
@@ -762,8 +764,10 @@ def get_material_index(material: MaterialSpec, *args: Any, **kwargs: Any) -> Com
 
 
 def get_component(
-    component: ComponentSpec, settings: Mapping[str, Any] | None = None, **kwargs: Any
-) -> Component:
+    component: ComponentSpec | ComponentAllAngleSpec,
+    settings: Mapping[str, Any] | None = None,
+    **kwargs: Any,
+) -> AnyComponent:
     return get_active_pdk().get_component(component, settings=settings, **kwargs)
 
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -19,6 +19,12 @@ def test_get_cross_section() -> None:
     assert xs.sections[0].width == 1
 
 
+def test_get_component_all_angle() -> None:
+    component = gf.get_component(gf.components.bend_euler_all_angle, angle=45)
+
+    assert isinstance(component, gf.ComponentAllAngle)
+
+
 def test_get_layer() -> None:
     assert gf.get_layer(1) == LAYER.WG
     assert gf.get_layer((1, 0)) == LAYER.WG


### PR DESCRIPTION
## Summary
- accept both regular and all-angle component specs at the PDK and module-level `get_component` boundaries
- return `AnyComponent` from public and internal resolution methods
- add a runtime regression resolving an all-angle component factory

## Testing
- `uv run pytest -q tests/test_pdk.py` (20 passed)
- `uv run pre-commit run --files gdsfactory/pdk.py tests/test_pdk.py` (includes full-project pyright)
- `uv run pytest -q tests --ignore=tests/components/test_components.py -n auto` (976 passed, 2 skipped, 1 xfailed)

Closes #4327

## Summary by Sourcery

Allow PDK-level and global get_component APIs to resolve both regular and all-angle component specifications and standardize their return type to AnyComponent.

New Features:
- Support resolving all-angle component specs via PDK.get_component and top-level get_component.
- Add a regression test ensuring bend_euler_all_angle can be resolved through the public get_component API.

Enhancements:
- Unify public and internal get_component resolution methods to return AnyComponent instead of a concrete Component type.