### PR TITLE
fix: generate redirects for legacy documentation URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ nbdocs: ## Convert notebooks to markdown
 docs: nbdocs ## Build documentation
 	uv run python docs/write_cells.py
 	uv run --extra docs zensical build --strict -f docs/zensical.yml
+	uv run python docs/write_legacy_redirects.py docs/_build/html
 
 docs-serve: nbdocs ## Serve documentation locally
 	uv run python docs/write_cells.py

--- a/docs/write_legacy_redirects.py
+++ b/docs/write_legacy_redirects.py
@@ -1,0 +1,41 @@
+"""Generate redirects from legacy ``.html`` documentation URLs."""
+
+from __future__ import annotations
+
+import argparse
+import html
+from pathlib import Path
+
+
+def write_legacy_redirects(site_dir: Path) -> list[Path]:
+    """Create ``page.html`` redirects for directory-style documentation pages."""
+    redirects = []
+    for index_file in site_dir.rglob("index.html"):
+        if index_file.parent == site_dir:
+            continue
+
+        redirect_file = index_file.parent.with_suffix(".html")
+        target = f"{index_file.parent.name}/"
+        escaped_target = html.escape(target, quote=True)
+        redirect_file.write_text(
+            "<!doctype html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            f'  <meta http-equiv="refresh" content="0; url={escaped_target}">\n'
+            f'  <link rel="canonical" href="{escaped_target}">\n'
+            "  <script>\n"
+            f"    location.replace({target!r} + location.search + location.hash);\n"
+            "  </script>\n"
+            "</head>\n"
+            f'<body><a href="{escaped_target}">Continue to the documentation</a>.</body>\n'
+            "</html>\n"
+        )
+        redirects.append(redirect_file)
+    return redirects
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("site_dir", type=Path)
+    args = parser.parse_args()
+    write_legacy_redirects(args.site_dir)

--- a/tests/test_doc_redirects.py
+++ b/tests/test_doc_redirects.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from docs.write_legacy_redirects import write_legacy_redirects
+
+
+def test_write_legacy_redirects(tmp_path: Path) -> None:
+    page = tmp_path / "notebooks" / "03_layer_stack"
+    page.mkdir(parents=True)
+    (page / "index.html").write_text("canonical page")
+    (tmp_path / "index.html").write_text("home page")
+
+    redirects = write_legacy_redirects(tmp_path)
+
+    redirect = tmp_path / "notebooks" / "03_layer_stack.html"
+    assert redirects == [redirect]
+    assert 'content="0; url=03_layer_stack/"' in redirect.read_text()
+    assert "location.search + location.hash" in redirect.read_text()
+    assert not tmp_path.with_suffix(".html").exists()


### PR DESCRIPTION
## Summary
- generate `page.html` redirect documents for every directory-style `page/index.html` documentation page
- preserve query strings and URL fragments during client navigation
- add the generator to `make docs`, which is used by the GitHub Pages workflow after notebook conversion
- add unit coverage using the reported nested notebook URL shape and root-page exclusion

## Verification
- `uv run pytest -q tests/test_doc_redirects.py`
- `uv run pre-commit run --files Makefile docs/write_legacy_redirects.py tests/test_doc_redirects.py`
- strict Zensical build completed successfully
- verified a generated redirect from the real build output (`developer.html` → `developer/`)

Closes #4671

## Summary by Sourcery

Generate static HTML redirects for legacy documentation URLs and integrate them into the docs build.

New Features:
- Create a script to generate page.html redirect files for directory-style documentation pages while preserving query strings and fragments on navigation.

Enhancements:
- Hook the legacy redirect generator into the docs build pipeline via the Makefile.

Tests:
- Add unit tests covering redirect generation, root-page exclusion, and preservation of query strings and fragments in redirect pages.