### PR TITLE
Make bend_s npoints default to None

### DIFF
--- a/gdsfactory/components/bends/bend_s.py
+++ b/gdsfactory/components/bends/bend_s.py
@@ -166,7 +166,7 @@ def find_min_curv_bezier_control_points(
 @gf.cell_with_module_name(schematic_function=sbend_schematic, tags=["bends"])
 def bend_s(
     size: Size = (11.0, 1.8),
-    npoints: int = 99,
+    npoints: int | None = None,
     cross_section: CrossSectionSpec = "strip",
     allow_min_radius_violation: bool = False,
     width: float | None = None,
@@ -178,13 +178,14 @@ def bend_s(
 
     Args:
         size: in x and y direction.
-        npoints: number of points.
+        npoints: number of points. Defaults to 99.
         cross_section: spec.
         allow_min_radius_violation: bool.
         width: width to use. Defaults to cross_section.width.
 
     """
     dx, dy = size
+    npoints = npoints or 99
 
     if dy == 0:
         return gf.components.straight(

--- a/tests/components/bends/test_bends.py
+++ b/tests/components/bends/test_bends.py
@@ -208,6 +208,7 @@ def test_bend_s() -> None:
     assert len(c.ports) == 2
     assert "length" in c.info
     assert "min_bend_radius" in c.info
+    assert c.settings["npoints"] is None
 
     c2 = bend_s(size=(10, 0))
     assert isinstance(c2, gf.Component)
@@ -222,6 +223,7 @@ def test_bend_s() -> None:
     )
     assert isinstance(c3, gf.Component)
     assert len(c3.ports) == 2
+    assert c3.settings["npoints"] == 150
 
 
 def test_get_min_sbend_size() -> None:

--- a/tests/test-data-regression/test_netlists_coupler_symmetric_.yml
+++ b/tests/test-data-regression/test_netlists_coupler_symmetric_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_367:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_367:
     component: bend_s
     info:
       end_angle: 0
@@ -15,12 +15,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 10
       - 1.633
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_m367_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_m367_M:
     component: bend_s
     info:
       end_angle: 0
@@ -36,25 +36,25 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 10
       - 1.633
       width: null
 nets: []
 placements:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_367:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_367:
     mirror: false
     rotation: 0
     x: 0
     y: 0.367
-  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_m367_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_m367_M:
     mirror: true
     rotation: 0
     x: 0
     y: -0.367
 ports:
-  o1: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_m367_M,o1
-  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_367,o1
-  o3: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_367,o2
-  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_N99_77ca5fd8_0_m367_M,o2
+  o1: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_m367_M,o1
+  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_367,o1
+  o3: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_367,o2
+  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S10_1p633_NNo_c1c6adb5_0_m367_M,o2

--- a/tests/test-data-regression/test_netlists_delay_snake_sbend_.yml
+++ b/tests/test-data-regression/test_netlists_delay_snake_sbend_.yml
@@ -49,7 +49,7 @@ instances:
       radius: 5
       width: null
       with_arc_floorplan: true
-  bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_N99_CS_980b37fc_m100000_m5000_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_NNone__d3a866a5_m100000_m5000_M:
     component: bend_s
     info:
       end_angle: 0
@@ -65,7 +65,7 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 100
       - 5
@@ -100,12 +100,12 @@ instances:
       width: null
 nets:
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R5_A1_2e206d34_0_m10000,o1
-  p2: bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_N99_CS_980b37fc_m100000_m5000_M,o2
+  p2: bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_NNone__d3a866a5_m100000_m5000_M,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R5_A1_2e206d34_m178681_m5000_A180,o1
   p2: s2,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R5_A1_2e206d34_m178681_m5000_A180,o2
   p2: s3,o1
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_N99_CS_980b37fc_m100000_m5000_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_NNone__d3a866a5_m100000_m5000_M,o1
   p2: s2,o2
 placements:
   bend_euler_gdsfactorypcomponentspbendspbend_euler_R5_A1_2e206d34_0_m10000:
@@ -118,7 +118,7 @@ placements:
     rotation: 180
     x: -178.681
     y: -5
-  bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_N99_CS_980b37fc_m100000_m5000_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S100_5_NNone__d3a866a5_m100000_m5000_M:
     mirror: true
     rotation: 0
     x: -100

--- a/tests/test-data-regression/test_netlists_mode_converter_.yml
+++ b/tests/test-data-regression/test_netlists_mode_converter_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_0_1050_A180_M:
     component: bend_s
     info:
       end_angle: 0
@@ -15,12 +15,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 25
       - 3
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_10000_1050:
     component: bend_s
     info:
       end_angle: 0
@@ -36,7 +36,7 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 25
       - 3
@@ -93,21 +93,21 @@ instances:
       with_bbox: true
       with_two_ports: true
 nets:
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_0_1050_A180_M,o1
   p2: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_10000_1050,o1
   p2: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o3
 - p1: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o1
   p2: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_0_0_A180,o1
 - p1: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o4
   p2: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_10000_0,o1
 placements:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_0_1050_A180_M:
     mirror: true
     rotation: 180
     x: 0
     y: 1.05
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_10000_1050:
     mirror: false
     rotation: 0
     x: 10
@@ -129,6 +129,6 @@ placements:
     y: 0
 ports:
   o1: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_0_0_A180,o2
-  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M,o2
+  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_0_1050_A180_M,o2
   o3: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_10000_0,o2
-  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050,o2
+  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_NNone_C_630722fd_10000_1050,o2

--- a/tests/test-data-regression/test_netlists_splitter_chain_.yml
+++ b/tests/test-data-regression/test_netlists_splitter_chain_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_15500_625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_15500_625:
     component: bend_s
     info:
       end_angle: 0
@@ -15,12 +15,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 11
       - 1.8
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_52000_3050:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_52000_3050:
     component: bend_s
     info:
       end_angle: 0
@@ -36,7 +36,7 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 11
       - 1.8
@@ -81,21 +81,21 @@ instances:
       width_mmi: 2.5
       width_taper: 1
 nets:
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_15500_625,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_15500_625,o1
   p2: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_0_0,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_15500_625,o2
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_15500_625,o2
   p2: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_36500_2425,o1
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_52000_3050,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_52000_3050,o1
   p2: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_36500_2425,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_52000_3050,o2
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_52000_3050,o2
   p2: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_73000_4850,o1
 placements:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_15500_625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_15500_625:
     mirror: false
     rotation: 0
     x: 15.5
     y: 0.625
-  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c_52000_3050:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330_52000_3050:
     mirror: false
     rotation: 0
     x: 52

--- a/tests/test-data-regression/test_netlists_splitter_tree_.yml
+++ b/tests/test-data-regression/test_netlists_splitter_tree_.yml
@@ -99,7 +99,7 @@ instances:
       radius: 10
       width: 0.5
       with_arc_floorplan: true
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_24375_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_24375_M:
     component: bend_s
     info:
       end_angle: 0
@@ -115,12 +115,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 90
       - 11.875
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_25625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_25625:
     component: bend_s
     info:
       end_angle: 0
@@ -136,12 +136,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 90
       - 11.875
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m24375:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m24375:
     component: bend_s
     info:
       end_angle: 0
@@ -157,12 +157,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 90
       - 11.875
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m25625_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m25625_M:
     component: bend_s
     info:
       end_angle: 0
@@ -178,7 +178,7 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 90
       - 11.875
@@ -295,13 +295,13 @@ nets:
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L44p_ec613ee3_35500_m25000,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_35500_m25000_A180_M,o2
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L4p3_d26c6f77_25500_m10625_A270,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_24375_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_24375_M,o1
   p2: coupler_1_1,o3
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_25625,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_25625,o1
   p2: coupler_1_1,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m24375,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m24375,o1
   p2: coupler_1_0,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m25625_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m25625_M,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L44p_ec613ee3_35500_m25000,o2
@@ -328,22 +328,22 @@ placements:
     rotation: 180
     x: 35.5
     y: -25
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_24375_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_24375_M:
     mirror: true
     rotation: 0
     x: 105.5
     y: 24.375
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_25625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_25625:
     mirror: false
     rotation: 0
     x: 105.5
     y: 25.625
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m24375:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m24375:
     mirror: false
     rotation: 0
     x: 105.5
     y: -24.375
-  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m25625_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m25625_M:
     mirror: true
     rotation: 0
     x: 105.5
@@ -385,7 +385,7 @@ placements:
     y: -10.625
 ports:
   o1_0_0: coupler_0_0,o1
-  o2_1_1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m24375,o2
-  o2_1_2: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_m25625_M,o2
-  o2_1_3: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_25625,o2
-  o2_1_4: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_N9_bd3e5121_105500_24375_M,o2
+  o2_1_1: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m24375,o2
+  o2_1_2: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_m25625_M,o2
+  o2_1_3: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_25625,o2
+  o2_1_4: bend_s_gdsfactorypcomponentspbendspbend_s_S90_11p875_NN_c09f0011_105500_24375_M,o2

--- a/tests/test-data-regression/test_netlists_switch_tree_.yml
+++ b/tests/test-data-regression/test_netlists_switch_tree_.yml
@@ -99,7 +99,7 @@ instances:
       radius: 10
       width: 0.5
       with_arc_floorplan: true
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_49375_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_49375_M:
     component: bend_s
     info:
       end_angle: 0
@@ -115,12 +115,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 500
       - 24.375
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_50625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_50625:
     component: bend_s
     info:
       end_angle: 0
@@ -136,12 +136,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 500
       - 24.375
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m49375:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m49375:
     component: bend_s
     info:
       end_angle: 0
@@ -157,12 +157,12 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 500
       - 24.375
       width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m50625_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m50625_M:
     component: bend_s
     info:
       end_angle: 0
@@ -178,7 +178,7 @@ instances:
     settings:
       allow_min_radius_violation: false
       cross_section: strip
-      npoints: 99
+      npoints: null
       size:
       - 500
       - 24.375
@@ -346,13 +346,13 @@ nets:
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L69__450ef387_421000_m50000,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_421000_m50000_A180_M,o2
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L29p_d5b7e51f_411000_m10625_A270,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_49375_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_49375_M,o1
   p2: coupler_1_1,o3
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_50625,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_50625,o1
   p2: coupler_1_1,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m49375,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m49375,o1
   p2: coupler_1_0,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m50625_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m50625_M,o1
   p2: coupler_1_0,o3
 - p1: coupler_1_0,o1
   p2: straight_gdsfactorypcomponentspwaveguidespstraight_L69__450ef387_421000_m50000,o2
@@ -379,22 +379,22 @@ placements:
     rotation: 180
     x: 421
     y: -50
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_49375_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_49375_M:
     mirror: true
     rotation: 0
     x: 901
     y: 49.375
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_50625:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_50625:
     mirror: false
     rotation: 0
     x: 901
     y: 50.625
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m49375:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m49375:
     mirror: false
     rotation: 0
     x: 901
     y: -49.375
-  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m50625_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m50625_M:
     mirror: true
     rotation: 0
     x: 901
@@ -460,7 +460,7 @@ ports:
   e8_1_12: coupler_1_0,e8
   e8_1_22: coupler_1_1,e8
   o1_0_0: coupler_0_0,o1
-  o2_1_17: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m49375,o2
-  o2_1_18: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_m50625_M,o2
-  o2_1_27: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_50625,o2
-  o2_1_28: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_23c8b359_901000_49375_M,o2
+  o2_1_17: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m49375,o2
+  o2_1_18: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_m50625_M,o2
+  o2_1_27: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_50625,o2
+  o2_1_28: bend_s_gdsfactorypcomponentspbendspbend_s_S500_24p375_N_d0dd644a_901000_49375_M,o2

--- a/tests/test-data-regression/test_settings_bend_s_.yml
+++ b/tests/test-data-regression/test_settings_bend_s_.yml
@@ -9,11 +9,10 @@ info:
   route_info_type: strip
   route_info_weight: 11.206
   start_angle: 0
-name: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_N99_C_42908c8c
+name: bend_s_gdsfactorypcomponentspbendspbend_s_S11_1p8_NNone_57b75330
 settings:
   allow_min_radius_violation: false
   cross_section: strip
-  npoints: 99
   size:
   - 11
   - 1.8


### PR DESCRIPTION
Closes #4611.

Aligns the public `bend_s` API with the circular and Euler bend APIs by using `None` as the default for `npoints`. Internally, an omitted value retains the established 99-point discretization, avoiding an unintended geometry change. Explicit point counts continue to be honored.

## Validation
- `uv run pytest -q tests/components/bends/test_bends.py` (16 passed)
- pre-commit checks on changed files

## Summary by Sourcery

Align bend_s API default npoints behavior with other bend components while preserving the existing geometric discretization when the parameter is omitted.

Enhancements:
- Change bend_s npoints parameter to accept None by default, mapping omitted values to the existing 99-point discretization internally.

Tests:
- Extend bend_s tests to verify settings reflect None when using the default and the explicit point count when provided.