### PR TITLE
Enforce route_bundle mismatch flags

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 from functools import partial
+from math import isclose
 from typing import Any, Literal, cast
 from warnings import warn
 
@@ -444,6 +445,27 @@ def route_bundle(
         bboxes.append(bbox2)
         # component.shapes(component.kcl.layer(1,0)).insert(bbox)
 
+    route_layer = gf.get_layer(xs.layer)
+
+    def validate_ports() -> None:
+        for port in [*ports1_, *ports2_]:
+            if allow_width_mismatch is False and not isclose(port.width, width):
+                raise ValueError(
+                    f"Port {port.name!r} has width {port.width}, but the route width is "
+                    f"{width}. Set allow_width_mismatch=True to route anyway."
+                )
+            if allow_layer_mismatch is False and port.layer != route_layer:
+                raise ValueError(
+                    f"Port {port.name!r} is on layer {port.layer}, but the route is on "
+                    f"layer {route_layer}. Set allow_layer_mismatch=True to route anyway."
+                )
+            if allow_type_mismatch is False and port.port_type != port_type:
+                raise ValueError(
+                    f"Port {port.name!r} has type {port.port_type!r}, but the route "
+                    f"port type is {port_type!r}. Set allow_type_mismatch=True to "
+                    "route anyway."
+                )
+
     if steps and waypoints:
         raise ValueError("Provide only one of steps or waypoints")
 
@@ -559,6 +581,7 @@ def route_bundle(
         route_constraints = list(constraints or [])
 
     try:
+        validate_ports()
         kf_on_collision = "error" if on_collision == "warning" else on_collision
         kf_on_placer_error = (
             "error" if on_placer_error == "warning" else on_placer_error

--- a/tests/routing/test_routing_route_bundle.py
+++ b/tests/routing/test_routing_route_bundle.py
@@ -59,6 +59,46 @@ def test_route_bundle(
             difftest(c)
 
 
+@pytest.mark.parametrize(
+    ("port_kwargs", "allow_kwarg", "message"),
+    [
+        ({"width": 1.0}, "allow_width_mismatch", "route width"),
+        ({"layer": "M3"}, "allow_layer_mismatch", "route is on layer"),
+        ({"port_type": "electrical"}, "allow_type_mismatch", "route port type"),
+    ],
+)
+def test_route_bundle_rejects_port_mismatch(
+    port_kwargs: dict[str, float | str], allow_kwarg: str, message: str
+) -> None:
+    layer = gf.get_layer(port_kwargs.get("layer", "WG"))
+    port1 = Port(
+        name="port1",
+        center=(0, 0),
+        width=0.5,
+        orientation=0,
+        layer=gf.get_layer("WG"),
+    )
+    port2 = Port(
+        name="port2",
+        center=(50, 0),
+        width=float(port_kwargs.get("width", 0.5)),
+        orientation=180,
+        layer=layer,
+        port_type=str(port_kwargs.get("port_type", "optical")),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        route_bundle(
+            Component(),
+            [port1],
+            [port2],
+            cross_section="strip",
+            auto_taper=False,
+            raise_on_error=True,
+            **{allow_kwarg: False},
+        )
+
+
 @pytest.mark.parametrize("config", ["A", "C"])
 def test_connect_corner(
     config: str, data_regression: DataRegressionFixture, check: bool = True, n: int = 6


### PR DESCRIPTION
Closes #4269.

## Summary
- validate routed ports against the resolved route width, layer, and port type
- raise actionable errors when the corresponding `allow_*_mismatch` flag is explicitly false
- perform validation after auto-taper insertion so compatible transitions remain supported
- add focused regressions for width, layer, and type mismatches

## Validation
- `uv run pytest -q tests/routing/test_routing_route_bundle.py` (14 passed)
- routing suite: 91 passed, 1 xfailed; two GDS comparisons failed only because this workspace contains the already-updated #4693 golden layouts while this branch is based on `main`
- pre-commit checks on changed files

## Summary by Sourcery

Enforce strict validation of routed ports against route bundle width, layer, and port type, and add regression coverage for mismatch handling.

New Features:
- Add explicit validation that route_bundle ports match the resolved route width, layer, and port type when mismatch flags are disabled.

Bug Fixes:
- Prevent route_bundle from silently routing between incompatible ports by raising clear errors when width, layer, or type mismatches occur and the corresponding allow_*_mismatch flag is False.

Tests:
- Add parameterized regression tests ensuring route_bundle rejects width, layer, and type mismatches when the corresponding allow_*_mismatch flags are disabled.