### PR TITLE
Support kfactory anchor references in YAML placements

### DIFF
--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -849,6 +849,9 @@ def _get_dependency_graph(net: Netlist) -> nx.DiGraph:
     # Use set lookup for allowed keys, and perform checks with minimal nesting
     for i1, pl in net.placements.items():
         for k, v in pl:
+            if isinstance(v, kf.schematic.AnchorRef):
+                g.add_edge(v.instance, i1)
+                continue
             if k not in allowed_keys or not isinstance(v, str) or "," not in v:
                 continue
             i2 = v.split(",", 1)[0]
@@ -1141,7 +1144,10 @@ def _update_reference_by_placement(
         raise ValueError(
             f"Can only set one of x, xmin, xmax. Got: {x=}, {xmin=}, {xmax=}"
         )
-    if isinstance(x, str):
+    if isinstance(x, kf.schematic.AnchorRefX):
+        bbox = refs[x.instance].dbbox()
+        ref.x += {"left": bbox.left, "right": bbox.right}.get(x.x, bbox.center().x)
+    elif isinstance(x, str):
         i, q = x.split(",")
         if q in valid_anchor_value_keywords:
             _dx = _get_anchor_value_from_name(refs[i], q, "x")
@@ -1176,7 +1182,10 @@ def _update_reference_by_placement(
         raise ValueError(
             f"Can only set one of y, ymin, ymax. Got: {y=}, {ymin=}, {ymax=}"
         )
-    if isinstance(y, str):
+    if isinstance(y, kf.schematic.AnchorRefY):
+        bbox = refs[y.instance].dbbox()
+        ref.y += {"bottom": bbox.bottom, "top": bbox.top}.get(y.y, bbox.center().y)
+    elif isinstance(y, str):
         i, q = y.split(",")
         if q in valid_anchor_value_keywords:
             _dy = _get_anchor_value_from_name(refs[i], q, "y")

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -6,6 +6,7 @@ from typing import Any, Self
 import networkx as nx
 import yaml
 from graphviz import Digraph
+from kfactory.schematic import AnchorRefX, AnchorRefY
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 import gdsfactory as gf
@@ -119,8 +120,8 @@ class Instance(BaseModel):
 
 
 class Placement(BaseModel):
-    x: str | float | None = None
-    y: str | float | None = None
+    x: str | float | AnchorRefX | None = None
+    y: str | float | AnchorRefY | None = None
     xmin: str | float | None = None
     ymin: str | float | None = None
     xmax: str | float | None = None

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -7,6 +7,39 @@ from pytest_regressions.data_regression import DataRegressionFixture
 from gdsfactory.difftest import difftest
 from gdsfactory.read.from_yaml import from_yaml, sample_mmis
 
+
+def test_kfactory_anchor_references() -> None:
+    component = from_yaml(
+        """
+instances:
+  struct2:
+    component: rectangle
+    settings:
+      size: [10, 4]
+  lbl2:
+    component: rectangle
+    settings:
+      size: [2, 2]
+placements:
+  struct2:
+    x: 100
+    y: 20
+  lbl2:
+    x:
+      instance: struct2
+      x: center
+    y:
+      instance: struct2
+      y: top
+"""
+    )
+
+    struct2 = component.insts["struct2"]
+    lbl2 = component.insts["lbl2"]
+    assert lbl2.xmin == struct2.x
+    assert lbl2.ymin == struct2.ymax
+
+
 sample_connections = """
 name: sample_connections
 


### PR DESCRIPTION
Closes #4271.

## Summary
- accept kfactory-style `AnchorRefX` and `AnchorRefY` objects in gdsfactory placement validation
- include referenced instances in YAML placement dependency ordering
- resolve left/center/right and bottom/center/top anchors from the referenced instance bbox
- retain the existing gdsfactory string-reference syntax

## Validation
- `uv run pytest -q tests/read/test_component_from_yaml.py` (19 passed, 1 skipped)
- pre-commit checks on changed files

## Summary by Sourcery

Support kfactory-style anchor references in YAML-driven placements and ensure they participate correctly in placement resolution and dependency ordering.

New Features:
- Allow Placement.x and Placement.y to accept kfactory AnchorRefX and AnchorRefY objects in addition to existing string and numeric values.

Enhancements:
- Include kfactory anchor reference instances in the placement dependency graph to ensure correct ordering during netlist processing.
- Resolve left/center/right and bottom/center/top anchors from the referenced instance bounding box when applying placements.
- Add a YAML-based test case covering kfactory anchor references for instance placements.

Tests:
- Introduce a new YAML placement test validating that labels positioned via kfactory anchor references align correctly with their referenced rectangles.