### PR TITLE
Honor mode_converter single-mode width in bends

### DIFF
--- a/gdsfactory/components/filters/mode_converter.py
+++ b/gdsfactory/components/filters/mode_converter.py
@@ -65,7 +65,7 @@ def mode_converter(
         cross_section=cross_section,
     )
 
-    bend = gf.get_component(bend, cross_section=cross_section)
+    bend = gf.get_component(bend, cross_section=cross_section, width=sm_width)
 
     bot_taper = gf.get_component(
         taper,

--- a/tests/components/test_mode_converter.py
+++ b/tests/components/test_mode_converter.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+import gdsfactory as gf
+
+
+@pytest.mark.parametrize("sm_width", [0.45, 0.55])
+def test_mode_converter_sm_width(sm_width: float) -> None:
+    component = gf.components.mode_converter(sm_width=sm_width)
+
+    assert component.ports["o2"].width == sm_width
+    assert component.ports["o4"].width == sm_width

--- a/tests/test-data-regression/test_netlists_mode_converter_.yml
+++ b/tests/test-data-regression/test_netlists_mode_converter_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_0_1050_A180_M:
     component: bend_s
     info:
       end_angle: 0
@@ -19,8 +19,8 @@ instances:
       size:
       - 25
       - 3
-      width: null
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050:
+      width: 0.5
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_10000_1050:
     component: bend_s
     info:
       end_angle: 0
@@ -40,7 +40,7 @@ instances:
       size:
       - 25
       - 3
-      width: null
+      width: 0.5
   coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0:
     component: coupler_straight_asymmetric
     info: {}
@@ -93,21 +93,21 @@ instances:
       with_bbox: true
       with_two_ports: true
 nets:
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_0_1050_A180_M,o1
   p2: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o2
-- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050,o1
+- p1: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_10000_1050,o1
   p2: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o3
 - p1: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o1
   p2: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_0_0_A180,o1
 - p1: coupler_straight_asymmetric_gdsfactorypcomponentspcoupl_fd8c78fd_0_0,o4
   p2: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_10000_0,o1
 placements:
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_0_1050_A180_M:
     mirror: true
     rotation: 180
     x: 0
     y: 1.05
-  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050:
+  bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_10000_1050:
     mirror: false
     rotation: 0
     x: 10
@@ -129,6 +129,6 @@ placements:
     y: 0
 ports:
   o1: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_0_0_A180,o2
-  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_0_1050_A180_M,o2
+  o2: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_0_1050_A180_M,o2
   o3: taper_gdsfactorypcomponentsptapersptaper_L25_W1_W1p2_LN_97c68b0b_10000_0,o2
-  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_0eac67c5_10000_1050,o2
+  o4: bend_s_gdsfactorypcomponentspbendspbend_s_S25_3_N99_CSs_f21bac83_10000_1050,o2


### PR DESCRIPTION
Closes #4207.

Passes `sm_width` through to the S-bends used on the single-mode arm, so non-default single-mode widths connect without a port-width mismatch. Adds regression coverage above and below the default width.

## Validation
- `uv run pytest -q tests/components/test_mode_converter.py` (2 passed)
- pre-commit checks on changed files

## Summary by Sourcery

Ensure mode_converter uses the specified single-mode width for its bend geometry and add tests to validate port widths.

Bug Fixes:
- Propagate sm_width to the bend component in mode_converter to prevent port width mismatches for non-default single-mode widths.

Tests:
- Add parametrized regression tests to verify mode_converter ports match the configured single-mode width above and below the default.