### PR TITLE
Avoid mutating shared cells in remove_layers

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1068,12 +1068,14 @@ class Component(ComponentBase, kf.DKCell):
 
         Args:
             layers: list of layers to remove.
-            recursive: if True, removes layers recursively and temporarily unlocks components.
+            recursive: if True, flattens this component before removing layers so
+                referenced cells shared with other components remain unchanged.
         """
         from gdsfactory import get_layer
 
         if recursive:
             self.locked = False
+            self.flatten()
 
         if self.locked:
             raise LockedError(self)
@@ -1090,18 +1092,6 @@ class Component(ComponentBase, kf.DKCell):
         for layer_index in layer_indices:
             kdb_cell.shapes(layer_index).clear()
 
-        if recursive:
-            for ci in kdb_cell.called_cells():
-                child = self.kcl[ci]
-                child_cell = child.kdb_cell
-                was_locked = child.locked
-                child.locked = False
-                try:
-                    for layer_idx in layer_indices:
-                        child_cell.shapes(layer_idx).clear()
-                finally:
-                    if was_locked:
-                        child.locked = True
         return self
 
     def remap_layers(

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -123,6 +123,8 @@ def test_remove_layers_recursive_multiple_layers() -> None:
     assert c.area((1, 0)) == 200, f"{c.area((1, 0))}"
     assert c.area((2, 0)) == 0, f"{c.area((2, 0))}"
     assert c.area((3, 0)) == 0, f"{c.area((3, 0))}"
+    assert child.area((2, 0)) == 100, "recursive removal mutated a shared child"
+    assert child.area((3, 0)) == 100, "recursive removal mutated a shared child"
     c.delete()
     child.delete()
 


### PR DESCRIPTION
Closes #4054.

## Summary
- flatten only the target component before recursive layer removal
- stop clearing shapes from referenced child cells, which may be cached and shared by other components
- preserve recursive visual removal while isolating the mutation to the caller
- extend the recursive removal regression to verify shared child geometry remains intact

## Validation
- `uv run pytest -q tests/test_component.py` (47 passed)
- pre-commit checks on changed files

## Summary by Sourcery

Prevent recursive layer removal from mutating shared child cells by flattening only the target component before clearing layers.

Bug Fixes:
- Ensure recursive remove_layers does not clear shapes from referenced child cells that may be shared or cached by other components.

Enhancements:
- Clarify the remove_layers recursive mode docstring to describe the new flatten-only behavior.
- Extend regression tests for recursive remove_layers to verify shared child geometry remains intact.