### PR TITLE
Export rich_output from gdsfactory

### DIFF
--- a/gdsfactory/__init__.py
+++ b/gdsfactory/__init__.py
@@ -28,7 +28,7 @@ from gdsfactory.component import (
     ComponentReference,
     container,
 )
-from gdsfactory.config import CONF, PATH, __version__
+from gdsfactory.config import CONF, PATH, __version__, rich_output
 from gdsfactory.port import Port
 from gdsfactory.typings import Pin
 from gdsfactory.read.import_gds import import_gds
@@ -171,6 +171,7 @@ __all__ = (
     "path",
     "port",
     "read",
+    "rich_output",
     "routing",
     "schematic_cell",
     "show",

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.config import rich_output
+
+
+def test_rich_output_top_level_export() -> None:
+    assert gf.rich_output is rich_output


### PR DESCRIPTION
Closes #4017.

Exports `rich_output` from the top-level `gdsfactory` module and includes it in `__all__`, so `gf.rich_output()` is visible to static analysis and language servers. Adds a direct export regression.

## Validation
- `uv run pytest -q tests/test_top_level_exports.py`
- pre-commit checks on changed files

## Summary by Sourcery

Export the rich_output helper at the gdsfactory top level and verify its availability via a regression test.

New Features:
- Expose rich_output via the top-level gdsfactory namespace and __all__ for easier access and tooling support.

Tests:
- Add a regression test ensuring gf.rich_output matches the rich_output export from gdsfactory.config.