### PR TITLE
Add placement arguments to Component.add_ref

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -809,6 +809,10 @@ class Component(ComponentBase, kf.DKCell):
         rows: int = 1,
         column_pitch: float = 0.0,
         row_pitch: float = 0.0,
+        x: float = 0.0,
+        y: float = 0.0,
+        rotation: float = 0.0,
+        mirror: bool = False,
     ) -> ComponentReference:
         """Adds a component instance reference to a Component.
 
@@ -819,6 +823,10 @@ class Component(ComponentBase, kf.DKCell):
             rows: Number of rows in the array.
             column_pitch: column pitch.
             row_pitch: row pitch.
+            x: x displacement in um.
+            y: y displacement in um.
+            rotation: rotation in degrees, applied before mirroring and translation.
+            mirror: mirror across the x axis before translation.
         """
         if isinstance(component, ComponentAllAngle):
             raise ValueError(
@@ -830,6 +838,7 @@ class Component(ComponentBase, kf.DKCell):
         if self.locked:
             raise LockedError(self)
 
+        transform = kf.kdb.DCplxTrans(1, rotation, mirror, x, y)
         if rows > 1 or columns > 1:
             if rows > 1 and row_pitch == 0:
                 raise ValueError(f"rows = {rows} > 1 require {row_pitch=} > 0")
@@ -840,9 +849,11 @@ class Component(ComponentBase, kf.DKCell):
             a = kf.kdb.DVector(column_pitch, 0)
             b = kf.kdb.DVector(0, row_pitch)
 
-            inst = self.create_inst(component, na=columns, nb=rows, a=a, b=b)
+            inst = self.create_inst(
+                component, trans=transform, na=columns, nb=rows, a=a, b=b
+            )
         else:
-            inst = self.create_inst(component)
+            inst = self.create_inst(component, trans=transform)
         if name is not None:
             inst.name = name
         return ComponentReference(kcl=self.kcl, instance=inst.instance)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -106,6 +106,17 @@ def test_remove_layers() -> None:
     assert c.area((2, 0)) == 0, f"{c.area((2, 0))}"
 
 
+def test_add_ref_placement() -> None:
+    component = gf.Component()
+    reference = component.add_ref(
+        gf.components.straight(), x=20, y=30, rotation=90, mirror=True
+    )
+
+    assert reference.dcplx_trans.disp == gf.kdb.DVector(20, 30)
+    assert reference.dcplx_trans.angle == 90
+    assert reference.dcplx_trans.is_mirror()
+
+
 def test_remove_layers_recursive_multiple_layers() -> None:
     child = gf.Component()
     child.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))


### PR DESCRIPTION
Closes #4009.

Adds optional `x`, `y`, `rotation`, and `mirror` arguments to `Component.add_ref`. They are composed into the instance transform in the documented rotation → mirror → translation order and work for both scalar and array references. Existing calls retain the identity transform.

## Validation
- `uv run pytest -q tests/test_component.py` (48 passed)
- pre-commit checks on changed files

## Summary by Sourcery

Add optional placement parameters to component reference creation and verify their effect with tests.

New Features:
- Allow specifying x, y, rotation, and mirror placement options when adding a component reference.

Tests:
- Add a unit test to confirm the new placement arguments correctly set the reference transform.