### PR TITLE
Support mirror_y in YAML placements

### DIFF
--- a/gdsfactory/read/from_yaml.py
+++ b/gdsfactory/read/from_yaml.py
@@ -102,6 +102,7 @@ valid_placement_keys = [
     "dy",
     "rotation",
     "mirror",
+    "mirror_y",
     "port",
 ]
 
@@ -1091,6 +1092,7 @@ def _update_reference_by_placement(
     port = p.port
     rotation = p.rotation
     mirror = p.mirror
+    mirror_y = p.mirror_y
     port_names = [port.name for port in ref.ports]
 
     if rotation:
@@ -1118,6 +1120,9 @@ def _update_reference_by_placement(
                 raise ValueError(
                     f"{mirror!r} should be bool | float | str in {port_names}. Got: {mirror}."
                 ) from e
+
+    if mirror_y:
+        ref.dmirror_y(y=0 if mirror_y is True else float(mirror_y))
 
     if isinstance(port, str):
         if xmin is not None or xmax is not None or ymin is not None or ymax is not None:

--- a/gdsfactory/schematic.py
+++ b/gdsfactory/schematic.py
@@ -130,6 +130,7 @@ class Placement(BaseModel):
     port: str | Anchor | None = None
     rotation: float = 0
     mirror: bool | str | float = False
+    mirror_y: bool | float = False
 
     def __getitem__(self, key: str) -> Any:
         """Allows to access the placement attributes as a dictionary."""

--- a/tests/read/test_component_from_yaml.py
+++ b/tests/read/test_component_from_yaml.py
@@ -7,6 +7,27 @@ from pytest_regressions.data_regression import DataRegressionFixture
 from gdsfactory.difftest import difftest
 from gdsfactory.read.from_yaml import from_yaml, sample_mmis
 
+
+def test_mirror_y_placement() -> None:
+    component = from_yaml(
+        """
+instances:
+  rectangle:
+    component: rectangle
+    settings:
+      size: [2, 4]
+placements:
+  rectangle:
+    y: 10
+    mirror_y: true
+"""
+    )
+
+    rectangle = component.insts["rectangle"]
+    assert rectangle.ymin == 6
+    assert rectangle.ymax == 10
+
+
 sample_connections = """
 name: sample_connections
 


### PR DESCRIPTION
Closes #3809.

Adds a `mirror_y` placement option to gdsfactory YAML. `mirror_y: true` reflects an instance around `y=0`; a numeric value selects a different horizontal mirror axis. The existing `mirror` behavior remains unchanged.

## Validation
- `uv run pytest -q tests/read/test_component_from_yaml.py` (19 passed, 1 skipped)
- pre-commit checks on changed files

## Summary by Sourcery

Add support for a vertical-axis mirroring option in YAML-driven component placements.

New Features:
- Introduce a mirror_y placement attribute in YAML to mirror instances across a configurable horizontal axis.

Tests:
- Add a YAML-based placement test to validate mirror_y behavior and resulting instance bounds.