### PR TITLE
Add Component.remove_port

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -332,6 +332,18 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         return _port
 
+    def remove_port(self, name: str) -> Self:
+        """Removes one named port from the Component.
+
+        Args:
+            name: name of the port to remove.
+        """
+        if self.locked:
+            raise LockedError(self)
+        port = self.ports[name]
+        self.ports.bases.remove(port.base)
+        return self
+
     def copy(self) -> Component:
         """Copy the full cell."""
         return self.dup()  # type: ignore[return-value]

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -106,6 +106,18 @@ def test_remove_layers() -> None:
     assert c.area((2, 0)) == 0, f"{c.area((2, 0))}"
 
 
+def test_remove_port() -> None:
+    component = gf.components.straight().copy()
+
+    assert "o1" in component.ports
+    assert component.remove_port("o1") is component
+    assert "o1" not in component.ports
+    assert "o2" in component.ports
+
+    with pytest.raises(KeyError):
+        component.remove_port("missing")
+
+
 def test_remove_layers_recursive_multiple_layers() -> None:
     child = gf.Component()
     child.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -117,6 +117,9 @@ def test_remove_port() -> None:
     with pytest.raises(KeyError):
         component.remove_port("missing")
 
+    with pytest.raises(LockedError):
+        gf.components.straight().remove_port("o1")
+
 
 def test_remove_layers_recursive_multiple_layers() -> None:
     child = gf.Component()


### PR DESCRIPTION
Closes #3795.

Adds a public, locked-cell-aware `Component.remove_port(name)` method for removing one specific port without clearing the entire collection. It returns the component for chaining and raises `KeyError` for an unknown name.

## Validation
- `uv run pytest -q tests/test_component.py` (48 passed)
- pre-commit checks on changed files

## Summary by Sourcery

Add a public method to remove a single port from a component while respecting cell locking.

New Features:
- Introduce Component.remove_port(name) to remove an individual port and return the component for chaining.

Enhancements:
- Ensure port removal respects locked components by raising LockedError when the component is locked.

Tests:
- Add tests verifying successful port removal, method chaining behavior, and KeyError on unknown port names.