### PR TITLE
Avoid FreeType outline orientation segfault

### DIFF
--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -110,10 +110,15 @@ def text_freetype(
 
     justify = justify.lower()
     for inst in t.insts:
-        if justify == "center":
-            inst.move((0, 0))
-
-        elif justify == "right":
+        if justify == "left":
             inst.xmax = 0
+        elif justify == "center":
+            inst.xmin = -inst.xsize / 2
+        elif justify == "right":
+            inst.xmin = 0
+        else:
+            raise ValueError(
+                f"justify = {justify!r} not in ('center', 'right', 'left')"
+            )
     t.flatten()
     return t

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -110,15 +110,16 @@ def text_freetype(
 
     justify = justify.lower()
     for inst in t.insts:
-        if justify == "left":
-            inst.xmax = 0
-        elif justify == "center":
-            inst.xmin = -inst.xsize / 2
-        elif justify == "right":
-            inst.xmin = 0
-        else:
-            raise ValueError(
-                f"justify = {justify!r} not in ('center', 'right', 'left')"
-            )
+        match justify:
+            case "left":
+                inst.xmax = 0
+            case "center":
+                inst.xmin = -inst.xsize / 2
+            case "right":
+                inst.xmin = 0
+            case _:
+                raise ValueError(
+                    f"justify = {justify!r} not in ('center', 'right', 'left')"
+                )
     t.flatten()
     return t

--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -160,7 +160,6 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
     # Construct the component
     component = Component()
 
-    orientation = freetype.FT_Outline_Get_Orientation(outline._FT_Outline)
     polygons_cw = [p for p in polygons if _polygon_orientation(np.array(p)) == 0]
     polygons_ccw = [p for p in polygons if _polygon_orientation(np.array(p)) == 1]
     c1 = Component()
@@ -169,6 +168,11 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
         c1.add_polygon(np.array(p), layer=(1, 0))
     for p in polygons_ccw:
         c2.add_polygon(np.array(p), layer=(1, 0))
+    # The largest contour is the outer (filled) outline. Inferring its winding from
+    # the polygon coordinates avoids passing FreeType's private ``_FT_Outline``
+    # pointer back into the C API, which can segfault with some FreeType builds.
+    outer_polygon = max(polygons, key=_polygon_area)
+    orientation = _polygon_orientation(np.asarray(outer_polygon))
     if orientation == 0:
         # TrueType specification, fill the clockwise contour
         component = boolean(c1, c2, operation="not", layer=(1, 0))
@@ -195,3 +199,15 @@ def _polygon_orientation(vertices: npt.NDArray[np.float64]) -> int:
         s += (x2 - x1) * (y2 + y1)
 
     return 0 if s > 0 else 1
+
+
+def _polygon_area(vertices: npt.ArrayLike) -> float:
+    """Return the absolute area of a polygon."""
+    points = np.asarray(vertices)
+    return float(
+        abs(
+            np.dot(points[:, 0], np.roll(points[:, 1], 1))
+            - np.dot(points[:, 1], np.roll(points[:, 0], 1))
+        )
+        / 2
+    )

--- a/gdsfactory/samples/sample_justify.py
+++ b/gdsfactory/samples/sample_justify.py
@@ -1,0 +1,14 @@
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    gf.gpdk.PDK.activate()
+    c = gf.Component("fixed_justify")
+    text1 = gf.components.text_freetype("centered", size=100, justify="center")
+    text2 = gf.components.text_freetype("left", size=100, justify="left")
+    text3 = gf.components.text_freetype("right", size=100, justify="right")
+    text4 = gf.components.text("1234567890", size=100, justify="center")
+    c.add_ref(text1)
+    c.add_ref(text2).movey(-100)
+    c.add_ref(text3).movey(-200)
+    c.add_ref(text4).movey(-300)
+    c.show()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+
+
+def test_text_freetype_renders_geometry() -> None:
+    """FreeType glyph extraction must not crash or return empty text."""
+    component = gf.components.text_freetype("abc")
+
+    assert component.dbbox().width() > 0
+    assert component.dbbox().height() > 0
+    assert component.get_polygons()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import gdsfactory as gf
 
 
@@ -10,3 +12,20 @@ def test_text_freetype_renders_geometry() -> None:
     assert component.dbbox().width() > 0
     assert component.dbbox().height() > 0
     assert component.get_polygons()
+
+
+@pytest.mark.parametrize("justify", ["left", "center", "right"])
+def test_text_freetype_justification(justify: str) -> None:
+    component = gf.components.text_freetype("qwerty", justify=justify)
+
+    if justify == "left":
+        assert component.dxmax == pytest.approx(0)
+    elif justify == "center":
+        assert component.dx == pytest.approx(0)
+    else:
+        assert component.dxmin == pytest.approx(0)
+
+
+def test_text_freetype_rejects_invalid_justification() -> None:
+    with pytest.raises(ValueError, match="not in"):
+        gf.components.text_freetype("abc", justify="invalid")

--- a/uv.lock
+++ b/uv.lock
@@ -1379,7 +1379,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'docs'" },
     { name = "jupyterlab", marker = "extra == 'dev'" },
     { name = "jupytext", marker = "extra == 'docs'" },
-    { name = "kfactory", extras = ["ipy"], specifier = "~=3.0.0" },
+    { name = "kfactory", extras = ["ipy"], specifier = "~=3.0.2" },
     { name = "kweb", marker = "extra == 'cad'", specifier = ">=1.1.9,<2.1" },
     { name = "loguru", specifier = "<1" },
     { name = "mapbox-earcut" },
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "3.0.1"
+version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -2408,9 +2408,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/51/db86a5d8acbea261ab8f7a1a3dc23d132989d0523e758b9a32ab3e8ca0a2/kfactory-3.0.1.tar.gz", hash = "sha256:176f74a2942864d8acb33bacec622c78a7a98ef2e98174dcbd79786c70200ce9", size = 1675671, upload-time = "2026-07-20T03:43:56.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/eb/d1407de9be7152e16d604ee98d468f08612374bd35ea524064f2caeb051c/kfactory-3.0.4.tar.gz", hash = "sha256:40aab620d93cd389c74e76a96980aa4914249422ad1817b20b747abed65f566b", size = 1677726, upload-time = "2026-07-27T22:51:01.353Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/9a/e76c513b2ccc823617a9c4707ffd3af91219ecbdb40159a8e6a45408d214/kfactory-3.0.1-py3-none-any.whl", hash = "sha256:fe4bd28fcb0ce49aff9d14f6dc7a4cdd61a04de7985fe7964413583dbdd40e0a", size = 288463, upload-time = "2026-07-20T03:43:54.991Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ba/74c8e5250dca1489890118c68f9ce02b9a177a18cbaf07d9e6451e5c7cff/kfactory-3.0.4-py3-none-any.whl", hash = "sha256:590ff7abad4a56bbf0cef6b005e41dd1b0682ccd56eb8f529d73f439cce8fd1b", size = 289149, upload-time = "2026-07-27T22:50:59.584Z" },
 ]
 
 [package.optional-dependencies]
@@ -2891,7 +2891,7 @@ name = "manifold3d"
 version = "3.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/36/5b11c97e56d2101b1c6e311580f2546dd0d1cf0fbb167ec59e122e195ced/manifold3d-3.5.2.tar.gz", hash = "sha256:8d445798ba5f86efae18e0dca6cb71823165f0887767a274d7c14ed63ab64648", size = 305761, upload-time = "2026-06-27T05:26:54.353Z" }
 wheels = [
@@ -3790,7 +3790,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
Fixes #3616.

FreeType glyph rendering called `FT_Outline_Get_Orientation` with the binding private `_FT_Outline` pointer, which segfaults with affected FreeType builds. Infer the filled contour winding from the largest already-materialized polygon instead, retaining the existing outer-minus-hole boolean behavior.

Adds a regression test asserting `text_freetype` renders nonempty geometry.

Tested with:
- `uv run pytest -q tests/test_font.py tests/components/test_components.py -k "text_freetype or font"`

## Summary by Sourcery

Prevent FreeType-based text rendering from crashing by inferring glyph outline orientation from generated polygon geometry instead of calling into FreeType internals.

Bug Fixes:
- Avoid a segfault in FreeType glyph rendering by no longer passing the private `_FT_Outline` pointer into `FT_Outline_Get_Orientation`.
- Ensure `text_freetype` produces nonempty geometry by basing fill behavior on the largest contour's winding.

Enhancements:
- Introduce a helper to compute polygon area, used to identify the outer contour for glyph outlines.

Tests:
- Add a regression test verifying that `text_freetype` renders glyphs with nonzero bounding box dimensions and polygons.