### PR TITLE
Preserve nested islands in from_np

### DIFF
--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -48,7 +48,6 @@ def from_np(
     """
     from skimage import measure
 
-    c = Component()
     d = Component()
     ndarray = np.pad(ndarray, 2)
     contours = measure.find_contours(ndarray, threshold)
@@ -57,15 +56,31 @@ def from_np(
         " threshold"
     )
 
+    polygons: list[tuple[float, Component]] = []
     for contour in contours:
         area = compute_area_signed(contour)
         points = contour * 1e-3 * nm_per_pixel
-        if area < 0:
-            c.add_polygon(points, layer=layer)
-        else:
-            d.add_polygon(points, layer=layer)
+        polygon = Component()
+        polygon.add_polygon(points, layer=layer)
+        polygons.append((area, polygon))
+        if area >= 0:
+            d.add_ref(polygon)
 
-    return boolean(c, d, operation="not", layer=layer) if invert else d
+    if not invert:
+        return d
+
+    # Apply contours from the outside in so that islands nested inside holes are
+    # restored after their enclosing hole is subtracted. Combining all positive
+    # and negative contours separately loses this even-odd nesting information.
+    result = Component()
+    for area, polygon in sorted(polygons, key=lambda item: abs(item[0]), reverse=True):
+        result = boolean(
+            result,
+            polygon,
+            operation="or" if area < 0 else "not",
+            layer=layer,
+        )
+    return result
 
 
 @gf.cell

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -48,7 +48,6 @@ def from_np(
     """
     from skimage import measure
 
-    d = Component()
     ndarray = np.pad(ndarray, 2)
     contours = measure.find_contours(ndarray, threshold)
     assert len(contours) > 0, (
@@ -56,6 +55,16 @@ def from_np(
         " threshold"
     )
 
+    if not invert:
+        d = Component()
+        for contour in contours:
+            if compute_area_signed(contour) >= 0:
+                d.add_polygon(contour * 1e-3 * nm_per_pixel, layer=layer)
+        return d
+
+    # Apply contours from the outside in so that islands nested inside holes are
+    # restored after their enclosing hole is subtracted. Combining all positive
+    # and negative contours separately loses this even-odd nesting information.
     polygons: list[tuple[float, Component]] = []
     for contour in contours:
         area = compute_area_signed(contour)
@@ -63,15 +72,7 @@ def from_np(
         polygon = Component()
         polygon.add_polygon(points, layer=layer)
         polygons.append((area, polygon))
-        if area >= 0:
-            d.add_ref(polygon)
 
-    if not invert:
-        return d
-
-    # Apply contours from the outside in so that islands nested inside holes are
-    # restored after their enclosing hole is subtracted. Combining all positive
-    # and negative contours separately loses this even-odd nesting information.
     result = Component()
     for area, polygon in sorted(polygons, key=lambda item: abs(item[0]), reverse=True):
         result = boolean(

--- a/gdsfactory/read/from_np.py
+++ b/gdsfactory/read/from_np.py
@@ -8,8 +8,12 @@ import numpy as np
 import numpy.typing as npt
 
 import gdsfactory as gf
-from gdsfactory.boolean import boolean
-from gdsfactory.component import Component
+from gdsfactory.component import (
+    Component,
+    boolean_not,
+    boolean_or,
+    points_to_polygon,
+)
 from gdsfactory.typings import PathType
 
 
@@ -65,23 +69,24 @@ def from_np(
     # Apply contours from the outside in so that islands nested inside holes are
     # restored after their enclosing hole is subtracted. Combining all positive
     # and negative contours separately loses this even-odd nesting information.
-    polygons: list[tuple[float, Component]] = []
-    for contour in contours:
-        area = compute_area_signed(contour)
-        points = contour * 1e-3 * nm_per_pixel
-        polygon = Component()
-        polygon.add_polygon(points, layer=layer)
-        polygons.append((area, polygon))
-
-    result = Component()
-    for area, polygon in sorted(polygons, key=lambda item: abs(item[0]), reverse=True):
-        result = boolean(
-            result,
-            polygon,
-            operation="or" if area < 0 else "not",
-            layer=layer,
+    c = Component()
+    layer_index = gf.get_layer(layer)
+    dbu = c.kcl.dbu
+    region = gf.kdb.Region()
+    for area, contour in sorted(
+        ((compute_area_signed(contour), contour) for contour in contours),
+        key=lambda item: abs(item[0]),
+        reverse=True,
+    ):
+        poly = cast("gf.kdb.DPolygon", points_to_polygon(contour * 1e-3 * nm_per_pixel))
+        contour_region = gf.kdb.Region(poly.to_itype(dbu))
+        region = (
+            boolean_or(region, contour_region)
+            if area < 0
+            else boolean_not(region, contour_region)
         )
-    return result
+    c.shapes(layer_index).insert(region)
+    return c
 
 
 @gf.cell

--- a/tests/read/test_from_np.py
+++ b/tests/read/test_from_np.py
@@ -27,6 +27,19 @@ def test_from_np_returns_component_with_polygons() -> None:
     assert sum(len(v) for v in polys.values()) >= 1
 
 
+def test_from_np_preserves_island_inside_hole() -> None:
+    array = np.zeros((15, 15))
+    array[1:14, 1:14] = 1
+    array[4:11, 4:11] = 0
+    array[6:9, 6:9] = 1
+
+    component = from_np(array, nm_per_pixel=1_000, threshold=0.5)
+
+    # Marching squares places the contours halfway between pixels: the expected
+    # area is outer contour - hole + the nested island.
+    assert component.area((1, 0)) == pytest.approx(168.5 - 48.5 + 8.5)
+
+
 def test_from_np_no_contours_raises() -> None:
     # all zeros below threshold -> no contours found
     arr = np.zeros((10, 10))

--- a/tests/read/test_from_np.py
+++ b/tests/read/test_from_np.py
@@ -36,8 +36,9 @@ def test_from_np_preserves_island_inside_hole() -> None:
     component = from_np(array, nm_per_pixel=1_000, threshold=0.5)
 
     # Marching squares places the contours halfway between pixels: the expected
-    # area is outer contour - hole + the nested island.
-    assert component.area((1, 0)) == pytest.approx(168.5 - 48.5 + 8.5)
+    # area is outer contour - hole + the nested island. Absolute tolerance so
+    # small geometry differences across skimage/KLayout versions don't flake.
+    assert component.area((1, 0)) == pytest.approx(168.5 - 48.5 + 8.5, abs=1e-3)
 
 
 def test_from_np_no_contours_raises() -> None:

--- a/tests/read/test_from_np.py
+++ b/tests/read/test_from_np.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
 
 from gdsfactory.read.from_np import compute_area_signed, from_np
 
@@ -46,3 +48,83 @@ def test_from_np_no_contours_raises() -> None:
     arr = np.zeros((10, 10))
     with pytest.raises(AssertionError, match="no contours found"):
         from_np(arr, threshold=0.5)
+
+
+def _concentric_array(widths: list[int]) -> np.ndarray:
+    n = widths[0] + 2
+    array = np.zeros((n, n))
+    for depth, width in enumerate(widths):
+        start = (n - width) // 2
+        array[start : start + width, start : start + width] = (
+            1.0 if depth % 2 == 0 else 0.0
+        )
+    return array
+
+
+def _even_odd_area(widths: list[int]) -> float:
+    # expected area in um^2 at 1 um per pixel: each contour of a width-wide
+    # block encloses width^2 - 0.5 pixels, alternating solid/hole by depth
+    return sum(
+        (width * width - 0.5) if depth % 2 == 0 else -(width * width - 0.5)
+        for depth, width in enumerate(widths)
+    )
+
+
+@pytest.mark.parametrize(
+    "widths",
+    [[19], [19, 13], [19, 13, 9], [19, 13, 9, 5], [19, 13, 9, 5, 3]],
+    ids=["solid", "hole", "island", "island-with-hole", "double-island"],
+)
+def test_from_np_even_odd_nesting_preserved(widths: list[int]) -> None:
+    component = from_np(_concentric_array(widths), nm_per_pixel=1_000, threshold=0.5)
+
+    assert component.area((1, 0)) == pytest.approx(_even_odd_area(widths), abs=1e-3)
+    assert len(component.insts) == 0
+
+
+def test_from_np_no_invert_keeps_only_holes() -> None:
+    widths = [19, 13, 9, 5, 3]
+    component = from_np(
+        _concentric_array(widths), nm_per_pixel=1_000, threshold=0.5, invert=False
+    )
+
+    # invert=False keeps only the hole contours, and each hole contour encloses
+    # all deeper nesting, so the result is just the outermost hole's enclosure
+    assert component.area((1, 0)) == pytest.approx(widths[1] ** 2 - 0.5, abs=1e-3)
+    assert len(component.insts) == 0
+
+
+def test_from_np_multiple_disjoint_blobs() -> None:
+    array = np.zeros((150, 150))
+    for row in range(3):
+        for col in range(3):
+            y0, x0 = row * 50, col * 50
+            array[y0 + 5 : y0 + 45, x0 + 5 : x0 + 45] = 1
+            array[y0 + 15 : y0 + 35, x0 + 15 : x0 + 35] = 0
+            array[y0 + 22 : y0 + 28, x0 + 22 : x0 + 28] = 1
+
+    component = from_np(array, threshold=0.5)
+
+    blob_area = (40**2 - 0.5) - (20**2 - 0.5) + (6**2 - 0.5)
+    assert component.area((1, 0)) == pytest.approx(
+        9 * blob_area * (20 * 1e-3) ** 2, abs=1e-3
+    )
+    assert len(component.insts) == 0
+
+
+@settings(deadline=None)
+@given(
+    outer=st.integers(min_value=8, max_value=60),
+    gaps=st.lists(st.integers(min_value=4, max_value=12), max_size=4),
+)
+def test_from_np_random_nesting_matches_even_odd_area(
+    outer: int, gaps: list[int]
+) -> None:
+    widths = [outer]
+    for gap in gaps:
+        widths.append(widths[-1] - gap)
+    assume(widths[-1] >= 3)
+
+    component = from_np(_concentric_array(widths), nm_per_pixel=1_000, threshold=0.5)
+
+    assert component.area((1, 0)) == pytest.approx(_even_odd_area(widths), abs=1e-3)


### PR DESCRIPTION
Fixes #3692.

Apply extracted contours from largest to smallest according to winding when `invert=True`. This preserves even-odd topology, restoring solid islands nested inside subtracted holes instead of erasing them when all solids are unioned first.

The outside-in combination is done directly on a `kdb.Region`, so the output stays flat and no per-contour `Component` is created. The existing `invert=False` behavior is retained. A regression test covers an outer solid, enclosed hole, and inner solid island.

Tested with:
- `uv run pytest -q tests/read/`