### PR TITLE
Use deterministic colors for unconfigured plot layers

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1371,11 +1371,29 @@ class Component(ComponentBase, kf.DKCell):
         import matplotlib.pyplot as plt
 
         from gdsfactory.pdk import get_layer_views
+        from gdsfactory.technology.layer_views import LayerView, LayerViews
 
         self.insert_vinsts()
 
         lyp_path = GDSDIR_TEMP / "layer_properties.lyp"
-        layer_views = get_layer_views()
+        pdk_layer_views = get_layer_views()
+        layer_views = LayerViews(
+            layer_views=dict(pdk_layer_views.layer_views),
+            custom_dither_patterns=dict(pdk_layer_views.custom_dither_patterns),
+            custom_line_styles=dict(pdk_layer_views.custom_line_styles),
+            layers=pdk_layer_views.layers,
+        )
+        configured_layers = {
+            layer_view.layer
+            for layer_view in layer_views.get_layer_views().values()
+            if layer_view.layer is not None
+        }
+        for layer in self.layers:
+            if layer not in configured_layers:
+                layer_views.add_layer_view(
+                    name=f"UNNAMED_{layer[0]}_{layer[1]}",
+                    layer_view=LayerView(layer=layer),
+                )
         layer_views.to_lyp(filepath=lyp_path)
 
         layout_view = lay.LayoutView()

--- a/tests/test_component_plot.py
+++ b/tests/test_component_plot.py
@@ -4,6 +4,8 @@ import pytest
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+from gdsfactory.config import GDSDIR_TEMP
+from gdsfactory.technology.layer_views import LayerViews
 from gdsfactory.typings import PixelBufferOptions
 
 
@@ -89,3 +91,15 @@ class TestComponentPlot:
         assert tuple(default_size) != tuple(high_size)
         assert tuple(default_size) != tuple(low_size)
         assert tuple(high_size) != tuple(low_size)
+
+
+def test_plot_adds_deterministic_views_for_unconfigured_layers() -> None:
+    component = Component()
+    component.add_polygon([(0, 0), (1, 0), (1, 1)], layer=(101, 10))
+    component.add_polygon([(2, 0), (3, 0), (3, 1)], layer=(101, 11))
+
+    component.plot()
+
+    layer_views = LayerViews(filepath=GDSDIR_TEMP / "layer_properties.lyp")
+    views = {view.layer: view for view in layer_views.get_layer_views().values()}
+    assert views[(101, 10)].get_color_dict() == views[(101, 11)].get_color_dict()


### PR DESCRIPTION
Fixes #3672.

Before rendering, extend the temporary plotting LYP with any component layers absent from the active PDK layer views. This avoids KLayout assigning its own irregular fallback styles and uses gdsfactory deterministic layer-based color fallback, keeping datatypes of the same layer consistent.

The active PDK layer views are not mutated. A regression test checks two unconfigured datatypes receive the same deterministic color.

Tested with:
- `uv run pytest -q tests/test_component_plot.py`

## Summary by Sourcery

Ensure plots use deterministic colors for layers lacking configured views while preserving existing PDK layer view configuration.

New Features:
- Automatically add temporary layer views for unconfigured component layers before plotting to enforce deterministic layer-based color fallback.

Tests:
- Add regression test verifying that multiple unconfigured datatypes on the same layer receive identical deterministic colors in generated layer properties.