### PR TITLE
Return an interior representative point

### DIFF
--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -237,16 +237,27 @@ def get_polygons_points(
 def get_point_inside(
     component_or_instance: Component | ComponentReference, layer: LayerSpec
 ) -> npt.NDArray[np.floating[Any]]:
-    """Returns a point inside the component or instance.
+    """Returns a representative point strictly inside the requested layer.
 
     Args:
         component_or_instance: to find a point inside.
         layer: to find a point inside.
     """
-    layer = gf.get_layer(layer)
-    return np.array(
-        get_polygons_points(component_or_instance, layers=[layer])[layer][0][0]
-    )
+    from gdsfactory.boolean import get_ref_shapes
+
+    layer_index = gf.get_layer(layer)
+    if isinstance(component_or_instance, kf.DKCell):
+        region = kdb.Region(component_or_instance.begin_shapes_rec(layer_index))
+    else:
+        region = get_ref_shapes(component_or_instance, layer_index)
+
+    trapezoids = list(region.decompose_trapezoids_to_region())
+    if not trapezoids:
+        raise ValueError(f"No geometry found on layer {layer!r}")
+
+    trapezoid = max(trapezoids, key=lambda polygon: polygon.area())
+    points = np.array([(point.x, point.y) for point in trapezoid.each_point_hull()])
+    return points.mean(axis=0) * component_or_instance.kcl.dbu
 
 
 def sign_shape(pts: npt.NDArray[np.floating[Any]]) -> float:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER
 
@@ -17,6 +20,25 @@ def test_get_polygons() -> None:
     p = c.get_polygons(layers=("WG",), by="name")
     key = next(iter(p.keys()))
     assert key == "WG"
+
+
+def test_get_point_inside_returns_interior_point() -> None:
+    rectangle = gf.c.rectangle(size=(10, 4), layer=(1, 0))
+    np.testing.assert_allclose(
+        gf.functions.get_point_inside(rectangle, (1, 0)), (5, 2)
+    )
+
+    parent = gf.Component()
+    reference = parent.add_ref(rectangle)
+    reference.movex(10)
+    np.testing.assert_allclose(
+        gf.functions.get_point_inside(reference, (1, 0)), (15, 2)
+    )
+
+
+def test_get_point_inside_rejects_empty_layer() -> None:
+    with pytest.raises(ValueError, match="No geometry found"):
+        gf.functions.get_point_inside(gf.Component(), (1, 0))
 
 
 def test_trim() -> None:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -24,9 +24,7 @@ def test_get_polygons() -> None:
 
 def test_get_point_inside_returns_interior_point() -> None:
     rectangle = gf.c.rectangle(size=(10, 4), layer=(1, 0))
-    np.testing.assert_allclose(
-        gf.functions.get_point_inside(rectangle, (1, 0)), (5, 2)
-    )
+    np.testing.assert_allclose(gf.functions.get_point_inside(rectangle, (1, 0)), (5, 2))
 
     parent = gf.Component()
     reference = parent.add_ref(rectangle)


### PR DESCRIPTION
Fixes #3008.

`get_point_inside` previously returned the first polygon vertex, which lies on the boundary. Use KLayout native region trapezoid decomposition and return the centroid of the largest nonzero interior trapezoid instead. This supports recursive component geometry and transformed instances without a Shapely conversion.

Empty requested layers now raise a descriptive `ValueError`.

Tested with:
- `uv run pytest -q tests/test_functions.py`

## Summary by Sourcery

Return a strictly interior representative point for component geometry layers and enforce error handling for empty layers.

New Features:
- Compute a representative interior point using region trapezoid decomposition rather than returning a boundary vertex.

Bug Fixes:
- Raise a descriptive ValueError when requesting an interior point on layers with no geometry.

Tests:
- Add tests verifying that get_point_inside returns an interior point for components and references and rejects empty layers.