### PR TITLE
Avoid evaluating section functions during serialization

### DIFF
--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -135,6 +135,7 @@ class Section(BaseModel):
             raise ValueError("Section requires `width > 0` or a `width_function`.")
         return self
 
+
 class ComponentAlongPath(BaseModel):
     """A ComponentAlongPath object to place along an extruded path.
 

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -11,7 +11,6 @@ import warnings
 from collections.abc import Callable
 from typing import Any, Self
 
-import numpy as np
 from kfactory import DCrossSection, SymmetricalCrossSection
 from pydantic import (
     BaseModel,
@@ -135,25 +134,6 @@ class Section(BaseModel):
         if self.width == 0 and self.width_function is None:
             raise ValueError("Section requires `width > 0` or a `width_function`.")
         return self
-
-    @field_serializer("width_function")
-    def serialize_width_function(
-        self, func: typings.WidthFunction | None
-    ) -> str | None:
-        if func is None:
-            return None
-        t_values = np.linspace(0, 1, 11)
-        return ",".join([str(round(width, 3)) for width in func(t_values)])
-
-    @field_serializer("offset_function")
-    def serialize_offset_function(
-        self, func: typings.OffsetFunction | None
-    ) -> str | None:
-        if func is None:
-            return None
-        t_values = np.linspace(0, 1, 11)
-        return ",".join([str(round(func(offset), 3)) for offset in t_values])
-
 
 class ComponentAlongPath(BaseModel):
     """A ComponentAlongPath object to place along an extruded path.

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -231,6 +231,24 @@ def test_cross_section_callable_width_offset(
     )
 
 
+def test_section_serialization_does_not_evaluate_functions() -> None:
+    calls = 0
+
+    def width_function(
+        t: npt.NDArray[np.floating[Any]],
+    ) -> npt.NDArray[np.floating[Any]]:
+        nonlocal calls
+        calls += 1
+        return 0.5 + t
+
+    section = gf.Section(width=0, layer=(1, 0), width_function=width_function)
+
+    dumped = section.model_dump()
+
+    assert dumped["width_function"] is width_function
+    assert calls == 0
+
+
 def test_is_cross_section_private() -> None:
     def _private_xs() -> gf.CrossSection:
         return gf.cross_section.cross_section(width=1.0, layer=(1, 0))


### PR DESCRIPTION
Fixes #3033.

Remove the `Section` field serializers that eagerly sampled width and offset functions. Python-mode model dumps now retain the callable, which gdsfactory existing serialization layer converts to a callable descriptor without invoking user code. Extrusion remains the only operation that evaluates the function.

Adds a regression test proving `model_dump()` does not call `width_function`.

Tested with:
- `uv run pytest -q tests/test_cross_section.py tests/test_serialization.py`

## Summary by Sourcery

Avoid evaluating cross-section width and offset callables during serialization so model dumps retain the original functions without invoking user code.

Bug Fixes:
- Prevent Section model_dump() from calling width_function and offset_function during serialization, avoiding unintended user code execution.

Tests:
- Add a regression test ensuring Section.model_dump() preserves width_function without calling it.