### PR TITLE
Add instance cell replacement API

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -662,6 +662,33 @@ class Component(ComponentBase, kf.DKCell):
     """
 
     routes: dict[str, Route] = Field(default_factory=dict)
+
+    def replace_instances(self, replacements: Mapping[str, AnyComponent]) -> Self:
+        """Replace directly referenced cells while preserving instance transforms.
+
+        Args:
+            replacements: mapping from referenced cell names to replacement
+                component specifications.
+
+        Returns:
+            This component.
+        """
+        if self.locked:
+            raise LockedError(self)
+
+        from gdsfactory.pdk import get_component
+
+        resolved = {
+            name: get_component(component) for name, component in replacements.items()
+        }
+        for instance in self.insts:
+            replacement = resolved.get(instance.cell.name)
+            if replacement is None:
+                continue
+            cell_inst = instance.instance.cell_inst.dup()
+            cell_inst.cell_index = replacement.cell_index()
+            instance.instance.cell_inst = cell_inst
+        return self
 
     def dup(self, new_name: str | None = None) -> Self:
         """Copy the full cell.

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -831,3 +831,39 @@ def test_fill() -> None:
     assert np.isclose(fill_area, expected_fill_area), (
         f"{fill_area} != {expected_fill_area}"
     )
+
+
+def test_replace_instances_preserves_placements_and_arrays() -> None:
+    real = gf.c.mmi1x2()
+    black_box = gf.Component("test_mmi_black_box")
+    bbox = real.dbbox()
+    black_box.add_polygon(
+        [
+            (bbox.left, bbox.bottom),
+            (bbox.right, bbox.bottom),
+            (bbox.right, bbox.top),
+            (bbox.left, bbox.top),
+        ],
+        layer=(11, 0),
+    )
+    black_box.add_ports(real.ports)
+
+    circuit = gf.Component()
+    first = circuit.add_ref(black_box)
+    second = circuit.add_ref(black_box)
+    second.connect("o1", first.ports["o2"])
+    array = circuit.add_ref(black_box, columns=2, rows=3, column_pitch=20, row_pitch=30)
+    array.rotate(30)
+    placements = [instance.instance.cell_inst.dup() for instance in circuit.insts]
+
+    returned = circuit.replace_instances({black_box.name: real})
+
+    assert returned is circuit
+    assert all(instance.cell.name == real.name for instance in circuit.insts)
+    for instance, placement in zip(circuit.insts, placements, strict=True):
+        replacement = instance.instance.cell_inst
+        assert replacement.cplx_trans == placement.cplx_trans
+        assert replacement.a == placement.a
+        assert replacement.b == placement.b
+        assert replacement.na == placement.na
+        assert replacement.nb == placement.nb

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -867,3 +867,22 @@ def test_replace_instances_preserves_placements_and_arrays() -> None:
         assert replacement.b == placement.b
         assert replacement.na == placement.na
         assert replacement.nb == placement.nb
+
+
+def test_replace_instances_ignores_unmatched_instances() -> None:
+    child = gf.Component("test_replace_instances_unmatched_child")
+    circuit = gf.Component()
+    instance = circuit.add_ref(child)
+    placement = instance.instance.cell_inst.dup()
+
+    circuit.replace_instances({"another_cell": gf.c.straight})
+
+    assert instance.cell.name == child.name
+    assert instance.instance.cell_inst == placement
+
+
+def test_replace_instances_rejects_locked_component() -> None:
+    circuit = gf.c.mzi()
+
+    with pytest.raises(LockedError):
+        circuit.replace_instances({})


### PR DESCRIPTION
Fixes #2944.

Add `Component.replace_instances()`, accepting a mapping from referenced cell names to replacement component specifications. It duplicates each existing KLayout `CellInstArray` and changes only the target cell index, preserving displacement, rotation, mirror state, magnification, and arbitrary array vectors exactly.

A regression test replaces connected MMI black boxes and a rotated array with the real MMI cell while verifying all placement data remains unchanged.

Verified before opening with:
- `uv run pytest -q tests/test_component.py -k "replace_instances"`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Add an API on Component to replace referenced instances with other components while preserving all placement and array transforms.

New Features:
- Introduce Component.replace_instances() to swap referenced cells based on a name-to-component mapping without altering instance transforms.

Tests:
- Add a regression test ensuring replace_instances preserves placements, rotations, mirroring, magnification, and array parameters for replaced instances.