### PR TITLE
Propagate cross section to route_single straights

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -138,7 +138,13 @@ def route_single(
         p2 = add_auto_tapers(component, [p2], xs, layer_transitions)[0]
 
     def straight_(width: float, length: float, **kwargs: Any) -> gf.Component:
-        return gf.get_component(straight, length=length, **kwargs)
+        return gf.get_component(
+            straight,
+            length=length,
+            cross_section=xs,
+            width=width,
+            **kwargs,
+        )
 
     def straight_dbu(width: int, length: int, **kwargs: Any) -> gf.Component:
         return straight_(c.kcl.to_um(width), c.kcl.to_um(length), **kwargs)

--- a/tests/routing/test_route_single.py
+++ b/tests/routing/test_route_single.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+
+
+def test_route_single_propagates_cross_section_to_straights() -> None:
+    component = gf.Component()
+    cross_section = gf.cross_section.cross_section(width=1, layer=(2, 0))
+    left = component.add_ref(gf.components.straight(cross_section=cross_section))
+    right = component.add_ref(gf.components.straight(cross_section=cross_section))
+    right.movex(30)
+
+    route = gf.routing.route_single(
+        component,
+        left.ports["o2"],
+        right.ports["o1"],
+        cross_section=cross_section,
+    )
+
+    assert route.length == 20_000

--- a/tests/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
+++ b/tests/test-data-regression/test_netlists_edge_coupler_array_with_loopback_.yml
@@ -112,7 +112,7 @@ instances:
       - 10
       text_rotation: 0
       x_reflection: false
-  straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_10000_A90:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_10000_A90:
     component: straight
     info:
       length: 107
@@ -125,8 +125,8 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: null
-  straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_879000_A270:
+      width: 0.5
+  straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_879000_A270:
     component: straight
     info:
       length: 107
@@ -139,22 +139,22 @@ instances:
       cross_section: strip
       length: 107
       npoints: 2
-      width: null
+      width: 0.5
 nets:
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_0_127000_A180,o1
   p2: edge_coupler_array_gdsfactorypcomponentspedge_couplersp_24e6908e_0_0,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_0_127000_A180,o2
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_10000_A90,o2
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_10000_A90,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_0_762000_A180_M,o1
   p2: edge_coupler_array_gdsfactorypcomponentspedge_couplersp_24e6908e_0_0,o7
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_0_762000_A180_M,o2
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_879000_A270,o2
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_879000_A270,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_m10000_10000_A270,o1
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_10000_A90,o1
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_10000_A90,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_m10000_10000_A270,o2
   p2: edge_coupler_array_gdsfactorypcomponentspedge_couplersp_24e6908e_0_0,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_m10000_879000_A90_M,o1
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_879000_A270,o1
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_879000_A270,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_R10_A_335c8724_m10000_879000_A90_M,o2
   p2: edge_coupler_array_gdsfactorypcomponentspedge_couplersp_24e6908e_0_0,o8
 placements:
@@ -183,12 +183,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_10000_A90:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_10000_A90:
     mirror: false
     rotation: 90
     x: -10
     y: 10
-  straight_gdsfactorypcomponentspwaveguidespstraight_L107_95448b36_m10000_879000_A270:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L107_0731327c_m10000_879000_A270:
     mirror: false
     rotation: 270
     x: -10

--- a/tests/test-data-regression/test_netlists_loop_mirror_.yml
+++ b/tests/test-data-regression/test_netlists_loop_mirror_.yml
@@ -112,7 +112,7 @@ instances:
       width: null
       width_mmi: 2.5
       width_taper: 1
-  straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_b215014a_45500_m10625_A90:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_1ce9e327_45500_m10625_A90:
     component: straight
     info:
       length: 1.25
@@ -125,8 +125,8 @@ instances:
       cross_section: strip
       length: 1.25
       npoints: 2
-      width: null
-  straight_gdsfactorypcomponentspwaveguidespstraight_L20__31a8c163_35500_625_A180:
+      width: 0.5
+  straight_gdsfactorypcomponentspwaveguidespstraight_L20__1d537c51_35500_625_A180:
     component: straight
     info:
       length: 20
@@ -139,22 +139,22 @@ instances:
       cross_section: strip
       length: 20
       npoints: 2
-      width: null
+      width: 0.5
 nets:
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_25500_m10625_A90,o1
   p2: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_35500_m20625_A180_M,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_25500_m10625_A90,o2
   p2: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_0_0,o3
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_35500_625_M,o1
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L20__31a8c163_35500_625_A180,o1
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L20__1d537c51_35500_625_A180,o1
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_35500_625_M,o2
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_b215014a_45500_m10625_A90,o2
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_1ce9e327_45500_m10625_A90,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_35500_m20625_A180_M,o1
   p2: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_45500_m10625_A270_M,o2
 - p1: bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_45500_m10625_A270_M,o1
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_b215014a_45500_m10625_A90,o1
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_1ce9e327_45500_m10625_A90,o1
 - p1: mmi1x2_gdsfactorypcomponentspmmispmmi1x2_WNone_WT1_LT10_1f097353_0_0,o2
-  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L20__31a8c163_35500_625_A180,o2
+  p2: straight_gdsfactorypcomponentspwaveguidespstraight_L20__1d537c51_35500_625_A180,o2
 placements:
   bend_euler_gdsfactorypcomponentspbendspbend_euler_RNone_387600b2_25500_m10625_A90:
     mirror: false
@@ -181,12 +181,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_b215014a_45500_m10625_A90:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L1p2_1ce9e327_45500_m10625_A90:
     mirror: false
     rotation: 90
     x: 45.5
     y: -10.625
-  straight_gdsfactorypcomponentspwaveguidespstraight_L20__31a8c163_35500_625_A180:
+  straight_gdsfactorypcomponentspwaveguidespstraight_L20__1d537c51_35500_625_A180:
     mirror: false
     rotation: 180
     x: 35.5


### PR DESCRIPTION
Fixes the remaining route construction bug in #2950.

`route_single` resolved the requested cross-section for bends but silently instantiated straight segments with the default strip cross-section. Nondefault widths/layers therefore fail strict port-width matching. Pass the resolved cross-section and route width into the straight factory as well.

Adds a regression using a 1 µm route on layer (2, 0); its 20 µm straight route now reports 20,000 DBU. The original issue reproduction now reports 248,477.08 DBU (248.47708 µm for the default 1 nm DBU).

Verified before opening with:
- `uv run pytest -q tests/routing/test_route_single.py tests/routing/test_route_single_from_steps.py`
- original #2950 reproduction
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Ensure route_single uses the resolved cross-section and width for straight segments so routed straights match bend geometry and port widths.

Bug Fixes:
- Fix incorrect default cross-section usage for straight segments in route_single that caused mismatched widths/layers and port-width validation failures.

Tests:
- Add a regression test verifying that route_single propagates the specified cross-section to straight segments and reports the correct routed length.