### PR TITLE
Keep layer source out of LYP names

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -617,11 +617,10 @@ class LayerView(BaseModel):
             "marked": str(self.marked).lower(),
             "xfill": str(self.xfill).lower(),
             "animation": self.animation,
-            "name": (
-                f"{name} {self.layer[0]}/{self.layer[1]}"
-                if self.layer_in_name and self.layer is not None
-                else name
-            ),
+            # KLayout can display ``source`` beside the logical name itself.
+            # Repeating layer/datatype here makes the UI show it twice when
+            # "Always show layer source in layer list" is enabled.
+            "name": name,
             "source": (
                 f"{self.layer[0]}/{self.layer[1]}@1"
                 if self.layer is not None

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -199,6 +199,21 @@ def test_nested_layerview_subclass_to_lyp(tmp_path: pathlib.Path) -> None:
     assert "<name>LAYER_B</name>" in content
 
 
+def test_to_lyp_keeps_layer_source_out_of_name(tmp_path: pathlib.Path) -> None:
+    layer_views = LayerViews(
+        layer_views={
+            "WG": LayerView(name="WG", layer=(1, 0), layer_in_name=True),
+        }
+    )
+
+    path = layer_views.to_lyp(tmp_path / "layers.lyp")
+    content = path.read_text()
+
+    assert "<name>WG</name>" in content
+    assert "<name>WG 1/0</name>" not in content
+    assert "<source>1/0@1</source>" in content
+
+
 def test_nested_layerview_explicit_group_members_preserved() -> None:
     """Explicit group_members are not overwritten by auto-population."""
 


### PR DESCRIPTION
Fixes #2984.

Write the logical layer name only in the LYP `<name>` field and keep layer/datatype exclusively in `<source>`. This prevents KLayout from displaying the identifier twice when “Always show layer source in layer list” is enabled. Legacy LYP parsing remains tolerant of names that already embed layer identifiers.

Verified before opening with:
- `uv run pytest -q tests/technology/test_layer_views.py`
- generic PDK LYP generation check across all top-level views
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Ensure KLayout LYP exports keep logical layer names separate from layer source identifiers to avoid duplicate display in the UI.

Bug Fixes:
- Prevent LYP exports from embedding layer/datatype identifiers in the <name> field when layer_in_name is enabled, relying on the <source> field instead.

Tests:
- Add a regression test to verify that LYP output keeps layer source out of the <name> field while still writing the correct <source> value.