### PR TITLE
Avoid resistance meander cell name collisions

### DIFF
--- a/gdsfactory/components/pcms/resistance_meander.py
+++ b/gdsfactory/components/pcms/resistance_meander.py
@@ -70,7 +70,9 @@ def resistance_meander(
     col.move((length_row - width, -width))
 
     # Creating entire straight net
-    N = Component(name=name)
+    # This cell is flattened before returning, so a fixed name only creates
+    # collisions when different meanders coexist in the same layout.
+    N = Component()
     n = 1
     for i in range(num_rows):
         d = N.add_ref(T) if i != num_rows - 1 else N.add_ref(Row)

--- a/tests/components/test_resistance_meander.py
+++ b/tests/components/test_resistance_meander.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+
+
+def test_resistance_meander_multiple_parameter_sets() -> None:
+    component = gf.Component()
+
+    first = component.add_ref(
+        gf.components.resistance_meander(
+            pad_size=(50, 50),
+            num_squares=1_000,
+            width=1,
+            res_layer="MTOP",
+            pad_layer="MTOP",
+        )
+    )
+    second = component.add_ref(
+        gf.components.resistance_meander(
+            pad_size=(50, 50),
+            num_squares=1_500,
+            width=1,
+            res_layer="MTOP",
+            pad_layer="MTOP",
+        )
+    )
+
+    assert first.cell.name != second.cell.name
+    assert len(component.insts) == 2


### PR DESCRIPTION
Fixes #3042.

Use an anonymous temporary cell for the internal meander net. That cell is flattened before the component returns, so its fixed `net` name had no external value and prevented different parameter sets from being created in one layout.

The public `name` argument remains accepted for compatibility. A regression test creates the two parameter sets from the issue in one parent component.

Verified before opening with:
- `uv run pytest -q tests/components/test_resistance_meander.py tests/components/test_components.py -k "resistance_meander"`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Avoid resistance meander internal cell name collisions when multiple parameter sets are instantiated in the same layout.

Bug Fixes:
- Ensure resistance_meander internal net component uses an anonymous temporary cell to prevent name collisions across different parameter sets.

Tests:
- Add a regression test that instantiates resistance_meander with two different parameter sets in one parent component and asserts distinct cell names and correct instance count.