### PR TITLE
Add custom polygon font support to text

### DIFF
--- a/gdsfactory/components/texts/__init__.py
+++ b/gdsfactory/components/texts/__init__.py
@@ -4,6 +4,7 @@ from .text_rectangular import *
 from .text_rectangular_font import *
 
 __all__ = [
+    "TextFont",
     "character_a",
     "pixel_array",
     "rectangular_font",

--- a/gdsfactory/components/texts/text.py
+++ b/gdsfactory/components/texts/text.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-__all__ = ["text", "text_klayout", "text_lines"]
+__all__ = ["TextFont", "text", "text_klayout", "text_lines"]
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 
 import kfactory as kf
 import numpy as np
@@ -11,6 +14,30 @@ from gdsfactory.constants import _glyph, _indent, _width
 from gdsfactory.typings import Coordinate, LayerSpec, LayerSpecs
 
 
+@dataclass(frozen=True, eq=False)
+class TextFont:
+    """Polygon font data for :func:`text`.
+
+    Coordinates, widths, indents, and ``space_width`` use the same 1000-unit
+    em square as the built-in DEPLOF font. ``name`` identifies the font in
+    cell names and must uniquely identify its contents.
+    """
+
+    name: str
+    glyphs: Mapping[str, Sequence[Sequence[Coordinate]]]
+    widths: Mapping[str, float]
+    indents: Mapping[str, float]
+    space_width: float = 500
+
+    def __hash__(self) -> int:
+        """Hash fonts by their stable name."""
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare fonts by their stable name."""
+        return isinstance(other, TextFont) and self.name == other.name
+
+
 @gf.cell_with_module_name(tags=["texts"])
 def text(
     text: str = "abcd",
@@ -18,6 +45,7 @@ def text(
     position: Coordinate = (0, 0),
     justify: str = "left",
     layer: LayerSpec = "WG",
+    font: TextFont | None = None,
 ) -> Component:
     """Text shapes.
 
@@ -27,6 +55,7 @@ def text(
         position: x, y position.
         justify: left, right, center.
         layer: for the text.
+        font: optional named polygon font. Uses the built-in DEPLOF font by default.
     """
     scaling = size / 1000
     xoffset = position[0]
@@ -38,7 +67,25 @@ def text(
         for c in line:
             ascii_val = ord(c)
             if c == " ":
-                xoffset += 500 * scaling
+                xoffset += (font.space_width if font else 500) * scaling
+            elif font is not None:
+                if c not in font.glyphs:
+                    raise ValueError(
+                        f"No glyph for character {c!r} in font {font.name!r}"
+                    )
+                if c not in font.widths or c not in font.indents:
+                    raise ValueError(
+                        f"Missing width or indent for character {c!r} "
+                        f"in font {font.name!r}"
+                    )
+                for poly in font.glyphs[c]:
+                    xpts = np.array(poly)[:, 0] * scaling
+                    ypts = np.array(poly)[:, 1] * scaling
+                    label.add_polygon(
+                        list(zip(xpts + xoffset, ypts + yoffset, strict=False)),
+                        layer=layer,
+                    )
+                xoffset += (font.widths[c] + font.indents[c]) * scaling
             elif 33 <= ascii_val <= 126:
                 for poly in _glyph[ascii_val]:
                     xpts = np.array(poly)[:, 0] * scaling

--- a/tests/components/texts/test_text.py
+++ b/tests/components/texts/test_text.py
@@ -24,9 +24,7 @@ def test_text_custom_font() -> None:
         indents=font.indents,
         space_width=font.space_width,
     )
-    renamed_component = gf.c.text(
-        text="A B", size=10, font=renamed_font, layer=(1, 0)
-    )
+    renamed_component = gf.c.text(text="A B", size=10, font=renamed_font, layer=(1, 0))
 
     assert component.name.startswith("text_gdsfactorypcomponentsptextsptext_")
     assert component.name != renamed_component.name

--- a/tests/components/texts/test_text.py
+++ b/tests/components/texts/test_text.py
@@ -1,0 +1,45 @@
+import pytest
+
+import gdsfactory as gf
+from gdsfactory.components.texts.text import TextFont
+
+
+def test_text_custom_font() -> None:
+    font = TextFont(
+        name="test_blocks",
+        glyphs={
+            "A": [[(0, 0), (400, 0), (400, 1000), (0, 1000)]],
+            "B": [[(0, 0), (600, 0), (600, 1000), (0, 1000)]],
+        },
+        widths={"A": 400, "B": 600},
+        indents={"A": 100, "B": 200},
+        space_width=300,
+    )
+
+    component = gf.c.text(text="A B", size=10, font=font, layer=(1, 0))
+    renamed_font = TextFont(
+        name="test_blocks_v2",
+        glyphs=font.glyphs,
+        widths=font.widths,
+        indents=font.indents,
+        space_width=font.space_width,
+    )
+    renamed_component = gf.c.text(
+        text="A B", size=10, font=renamed_font, layer=(1, 0)
+    )
+
+    assert component.name.startswith("text_gdsfactorypcomponentsptextsptext_")
+    assert component.name != renamed_component.name
+    assert component.dxsize == pytest.approx(14)
+
+
+def test_text_custom_font_requires_metrics() -> None:
+    font = TextFont(
+        name="test_missing_metrics",
+        glyphs={"A": [[(0, 0), (400, 0), (400, 1000), (0, 1000)]]},
+        widths={},
+        indents={},
+    )
+
+    with pytest.raises(ValueError, match="Missing width or indent"):
+        gf.c.text(text="A", font=font)

--- a/tests/test-data-regression/test_netlists_die_.yml
+++ b/tests/test-data-regression/test_netlists_die_.yml
@@ -1,8 +1,9 @@
 instances:
-  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_0f73e94a_m4880000_m4850000:
+  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_4965e284_m4880000_m4850000:
     component: text
     info: {}
     settings:
+      font: null
       justify: left
       layer: WG
       position:
@@ -12,7 +13,7 @@ instances:
       text: chip99
 nets: []
 placements:
-  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_0f73e94a_m4880000_m4850000:
+  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_4965e284_m4880000_m4850000:
     mirror: false
     rotation: 0
     x: -4880

--- a/tests/test-data-regression/test_netlists_litho_steps_.yml
+++ b/tests/test-data-regression/test_netlists_litho_steps_.yml
@@ -164,10 +164,11 @@ instances:
       size:
       - 8
       - 50
-  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jcenter_LWG_m5000_0_A90:
+  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_daf81cfb_m5000_0_A90:
     component: text
     info: {}
     settings:
+      font: null
       justify: center
       layer: WG
       position:
@@ -232,7 +233,7 @@ placements:
     rotation: 0
     x: 36
     y: 0
-  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jcenter_LWG_m5000_0_A90:
+  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_daf81cfb_m5000_0_A90:
     mirror: false
     rotation: 90
     x: -5

--- a/tests/test-data-regression/test_settings_text_.yml
+++ b/tests/test-data-regression/test_settings_text_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: text_gdsfactorypcomponentsptextsptext_Tabcd_S10_P0_0_Jleft_LWG
+name: text_gdsfactorypcomponentsptextsptext_Tabcd_S10_P0_0_Jl_c890baee
 settings:
   justify: left
   layer: WG


### PR DESCRIPTION
## Summary
- add a public `TextFont` data object bundling glyph polygons, widths, indents, and space advance
- accept optional named custom fonts in `gf.c.text` while preserving the built-in default
- validate missing glyphs and metrics and cover custom geometry and stable font-specific cell identity

Closes #4110

## Validation
- `uv run pytest -q tests/components/texts/test_text.py`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Add support for supplying custom polygon fonts to the text component while preserving the existing default font behavior.

New Features:
- Introduce a public TextFont data object encapsulating glyph polygons and associated text metrics for custom polygon fonts.
- Allow the text component to render using an optional named custom TextFont, including configurable space width.

Tests:
- Add tests validating custom font rendering, name-based cell identity, and enforcement of required glyph metrics for custom fonts.