### PR TITLE
Preserve multisection cross sections in extend_ports

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -316,6 +316,10 @@ class ComponentBase(ProtoKCell[float, BaseKCell], ABC):
 
         if xs_name:
             _port.info["cross_section"] = xs_name
+            if len(getattr(xs, "sections", ())) > 1:
+                _port.info["cross_section_settings"] = clean_value_json(
+                    xs, serialization_max_digits=15
+                )
             if register_cross_section:
                 from gdsfactory.pdk import get_active_pdk
 

--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -176,10 +176,16 @@ def extend_ports(
                     pdk = gf.get_active_pdk()
                     cross_section_names = list(pdk.cross_sections)
                     port_xs_name = port.info.get("cross_section", None)
+                    port_xs_settings = port.info.get("cross_section_settings", None)
 
                     if port_xs_name and port_xs_name in cross_section_names:
                         cross_section_extension = gf.get_cross_section(
                             port.info["cross_section"]
+                        )
+
+                    elif isinstance(port_xs_settings, dict):
+                        cross_section_extension = gf.CrossSection.model_validate(
+                            port_xs_settings
                         )
 
                     else:

--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -184,9 +184,18 @@ def extend_ports(
                         )
 
                     elif isinstance(port_xs_settings, dict):
-                        cross_section_extension = gf.CrossSection.model_validate(
-                            port_xs_settings
-                        )
+                        from pydantic import ValidationError
+
+                        try:
+                            cross_section_extension = gf.CrossSection.model_validate(
+                                port_xs_settings
+                            )
+                        except ValidationError:
+                            cross_section_extension = cross_section_function(
+                                layer=gf.get_layer_tuple(port.layer),
+                                width=port.width,
+                                port_types=(port_type, port_type),
+                            )
 
                     else:
                         cross_section_extension = cross_section_function(

--- a/tests/components/containers/test_extension.py
+++ b/tests/components/containers/test_extension.py
@@ -64,6 +64,23 @@ def test_extend_ports_with_custom_cross_section() -> None:
     assert len(extended_c.ports) > 0
 
 
+def test_extend_ports_preserves_unregistered_multisection_cross_section() -> None:
+    cross_section = gf.cross_section.cross_section(
+        width=1.2,
+        sections=(gf.Section(width=1.2, layer=(2, 0)),),
+    )
+    component = gf.c.straight(length=7, cross_section=cross_section)
+
+    extended = extend_ports(component=component, length=3)
+
+    for layer in ((1, 0), (2, 0)):
+        polygons = extended.get_polygons(by="tuple")[layer]
+        xmin = min(polygon.bbox().left for polygon in polygons) * extended.kcl.dbu
+        xmax = max(polygon.bbox().right for polygon in polygons) * extended.kcl.dbu
+        assert xmin == pytest.approx(-3)
+        assert xmax == pytest.approx(10)
+
+
 def test_line_function() -> None:
     p_start = gf.Port(name="o1", center=(0, 0), width=0.5, orientation=0, layer=1)
     p_end = gf.Port(name="o2", center=(10, 0), width=0.5, orientation=0, layer=1)


### PR DESCRIPTION
## Summary
- retain serializable multi-section cross-section definitions in port metadata
- reconstruct unregistered cross sections in `extend_ports` instead of falling back to the core layer
- cover both ends of a two-layer straight being extended on both material layers

Closes #4192

## Validation
- `uv run pytest -q tests/components/containers/test_extension.py`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Preserve and reconstruct multi-section cross-section metadata when extending component ports.

New Features:
- Store serializable multi-section cross-section settings on ports when adding them so they can be reconstructed later.

Enhancements:
- Update port extension logic to rebuild unregistered multi-section cross sections from stored settings instead of defaulting to core layers.

Tests:
- Add coverage ensuring extend_ports preserves geometry for components with unregistered multi-section cross sections across relevant layers.