### PR TITLE
Preserve steps in route bundle error paths

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -624,6 +624,7 @@ def route_bundle(
             bboxes=bboxes,
             route_width=width,
             sort_ports=sort_ports,
+            waypoints=waypoints_,
             end_angles=end_angles,
             start_angles=start_angles,
             place_layer=layer_error_path,

--- a/tests/read/test_from_yaml_steps.py
+++ b/tests/read/test_from_yaml_steps.py
@@ -4,7 +4,6 @@ import pytest
 
 import gdsfactory as gf
 
-
 YAML_STEPS = """
 instances:
   cp1:

--- a/tests/read/test_from_yaml_steps.py
+++ b/tests/read/test_from_yaml_steps.py
@@ -1,0 +1,57 @@
+from itertools import pairwise
+
+import pytest
+
+import gdsfactory as gf
+
+
+YAML_STEPS = """
+instances:
+  cp1:
+    component: coupler
+  cp2:
+    component: coupler
+routes:
+  bundle1:
+    links:
+      cp1,o4: cp2,o1
+    routing_strategy: route_bundle
+    settings:
+      steps:
+        - dx: 10
+        - dy: -20
+        - dx: 10
+placements:
+  cp1:
+    x: 0
+    y: 0
+    dx: -5.041
+    dy: 31.798
+  cp2:
+    x: 0
+    y: 0
+    dx: 93.377
+    dy: -52.512
+"""
+
+
+def test_from_yaml_error_route_preserves_steps() -> None:
+    with pytest.warns(UserWarning, match="Routing failed"):
+        component = gf.read.from_yaml(YAML_STEPS)
+
+    route = next(iter(component.routes.values()))
+    start = route.backbone[0]
+    dbu10 = component.kcl.to_dbu(10)
+    dbu20 = component.kcl.to_dbu(20)
+    step_points = [
+        (start.x + dbu10, start.y),
+        (start.x + dbu10, start.y - dbu20),
+        (start.x + dbu20, start.y - dbu20),
+    ]
+
+    for x, y in step_points:
+        assert any(
+            min(p1.x, p2.x) <= x <= max(p1.x, p2.x)
+            and min(p1.y, p2.y) <= y <= max(p1.y, p2.y)
+            for p1, p2 in pairwise(route.backbone)
+        )


### PR DESCRIPTION
## Summary
- pass resolved waypoints to the electrical error-route fallback
- preserve user-supplied YAML step directives when optical routing reports a collision
- cover every requested step point from the issue reproduction

Closes #3948

## Validation
- `uv run pytest -q tests/read/test_from_yaml_steps.py tests/routing/test_routing_route_bundle.py`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Ensure route bundle error paths preserve user-specified step waypoints and cover them in YAML-based routing flows.

Bug Fixes:
- Preserve user-supplied step directives when routing falls back to the electrical error path for route bundles.

Tests:
- Add regression test verifying that YAML-defined routing steps remain present along the backbone of error-route bundles.