### PR TITLE
Make built-in text glyph spacing monospace

### DIFF
--- a/gdsfactory/components/texts/text.py
+++ b/gdsfactory/components/texts/text.py
@@ -46,6 +46,7 @@ def text(
     justify: str = "left",
     layer: LayerSpec = "WG",
     font: TextFont | None = None,
+    monospace: bool = True,
 ) -> Component:
     """Text shapes.
 
@@ -56,6 +57,7 @@ def text(
         justify: left, right, center.
         layer: for the text.
         font: optional named polygon font. Uses the built-in DEPLOF font by default.
+        monospace: use a fixed advance for built-in ASCII letters and digits.
     """
     scaling = size / 1000
     xoffset = position[0]
@@ -94,7 +96,12 @@ def text(
                         list(zip(xpts + xoffset, ypts + yoffset, strict=False)),
                         layer=layer,
                     )
-                xoffset += (_width[ascii_val] + _indent[ascii_val]) * scaling
+                advance = (
+                    1100
+                    if monospace and c.isascii() and c.isalnum()
+                    else _width[ascii_val] + _indent[ascii_val]
+                )
+                xoffset += advance * scaling
             else:
                 raise ValueError(f"No character with ascii value {ascii_val!r}")
         t.add_ref(label)

--- a/tests/components/texts/test_text.py
+++ b/tests/components/texts/test_text.py
@@ -41,3 +41,18 @@ def test_text_custom_font_requires_metrics() -> None:
 
     with pytest.raises(ValueError, match="Missing width or indent"):
         gf.c.text(text="A", font=font)
+
+
+@pytest.mark.parametrize("character", ["0", "1", "A", "m"])
+def test_text_builtin_font_is_monospace(character: str) -> None:
+    single = gf.c.text(text=character, size=10)
+    double = gf.c.text(text=character * 2, size=10)
+
+    assert double.dxsize - single.dxsize == pytest.approx(11)
+
+
+def test_text_builtin_font_can_use_proportional_spacing() -> None:
+    single = gf.c.text(text="1", size=10, monospace=False)
+    double = gf.c.text(text="11", size=10, monospace=False)
+
+    assert double.dxsize - single.dxsize == pytest.approx(5)

--- a/tests/test-data-regression/test_netlists_die_.yml
+++ b/tests/test-data-regression/test_netlists_die_.yml
@@ -1,11 +1,12 @@
 instances:
-  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_4965e284_m4880000_m4850000:
+  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_b2b715c8_m4880000_m4850000:
     component: text
     info: {}
     settings:
       font: null
       justify: left
       layer: WG
+      monospace: true
       position:
       - 0
       - 0
@@ -13,7 +14,7 @@ instances:
       text: chip99
 nets: []
 placements:
-  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_4965e284_m4880000_m4850000:
+  text_gdsfactorypcomponentsptextsptext_Tchip99_S100_P0_0_b2b715c8_m4880000_m4850000:
     mirror: false
     rotation: 0
     x: -4880

--- a/tests/test-data-regression/test_netlists_litho_steps_.yml
+++ b/tests/test-data-regression/test_netlists_litho_steps_.yml
@@ -164,13 +164,14 @@ instances:
       size:
       - 8
       - 50
-  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_daf81cfb_m5000_0_A90:
+  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_9805ca98_m5000_0_A90:
     component: text
     info: {}
     settings:
       font: null
       justify: center
       layer: WG
+      monospace: true
       position:
       - 0
       - 0
@@ -233,7 +234,7 @@ placements:
     rotation: 0
     x: 36
     y: 0
-  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_daf81cfb_m5000_0_A90:
+  text_gdsfactorypcomponentsptextsptext_T16p0_S50_P0_0_Jc_9805ca98_m5000_0_A90:
     mirror: false
     rotation: 90
     x: -5

--- a/tests/test-data-regression/test_settings_text_.yml
+++ b/tests/test-data-regression/test_settings_text_.yml
@@ -1,8 +1,9 @@
 info: {}
-name: text_gdsfactorypcomponentsptextsptext_Tabcd_S10_P0_0_Jl_c890baee
+name: text_gdsfactorypcomponentsptextsptext_Tabcd_S10_P0_0_Jl_17905dd9
 settings:
   justify: left
   layer: WG
+  monospace: true
   position:
   - 0
   - 0


### PR DESCRIPTION
## Summary
- make built-in ASCII letters and digits use a fixed 1100-unit advance by default
- retain proportional spacing through `monospace=False`
- add regression tests for narrow, regular, and wide glyphs
- update affected settings and netlist snapshots

## Validation
- `uv run pytest -q tests/components/texts/test_text.py` (7 passed)
- focused component/settings/netlist checks pass apart from the 11 expected GDS reference changes
- `uv run pre-commit run --all-files`

Stacked on #4714 because it extends the text API introduced there. A coordinated gdsfactory-test-data PR will carry the expected GDS references and must merge with this change.

Closes #4111

## Summary by Sourcery

Make built-in text glyphs use monospace spacing by default while preserving an option for proportional spacing, and update tests and snapshots accordingly.

New Features:
- Add a monospace parameter to the text component API to control glyph spacing for built-in ASCII letters and digits.

Enhancements:
- Change built-in ASCII letters and digits to use a fixed advance by default when monospace is enabled.

Tests:
- Add regression tests verifying monospace behavior and optional proportional spacing for built-in text glyphs.
- Update text-related settings and netlist regression snapshots to reflect the new monospace default behavior.