### PR TITLE
Preserve custom LYP patterns in YAML

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -318,7 +318,7 @@ class HatchPattern(BaseModel):
             for line in lines:
                 ET.SubElement(subel, "line").text = line
 
-        ET.SubElement(el, "order").text = str(self.order)
+        ET.SubElement(el, "order").text = str(self.order or 0)
         ET.SubElement(el, "name").text = self.name
         return el
 
@@ -363,10 +363,10 @@ class LineStyle(BaseModel):
                 f"Cannot write custom line style {self.name} to KLayout xml format because no pattern is present."
             )
 
-        el = ET.Element("custom-line-pattern")
+        el = ET.Element("custom-line-style")
 
         ET.SubElement(el, "pattern").text = str(self.custom_style)
-        ET.SubElement(el, "order").text = str(self.order)
+        ET.SubElement(el, "order").text = str(self.order or 0)
         ET.SubElement(el, "name").text = self.name
         return el
 
@@ -742,13 +742,10 @@ class LayerView(BaseModel):
             ]
 
         # Translate KLayout index to line style name
-        line_style = element.find("line-style")
-        if (
-            line_style is not None
-            and line_style.text is not None
-            and re.match(r"I\d+", line_style.text)
-        ):
-            line_style = list(_klayout_line_styles.keys())[int(line_style.text[1:])]  # type: ignore[assignment]
+        line_style_element = element.find("line-style")
+        line_style = line_style_element.text if line_style_element is not None else None
+        if line_style and re.match(r"I\d+", line_style):
+            line_style = list(_klayout_line_styles.keys())[int(line_style[1:])]
 
         lv = LayerView(
             name=name,
@@ -758,9 +755,7 @@ class LayerView(BaseModel):
             fill_brightness=element.find("fill-brightness").text or 0,  # type: ignore[union-attr]
             frame_brightness=element.find("frame-brightness").text or 0,  # type: ignore[union-attr]
             hatch_pattern=hatch_pattern or None,
-            line_style=line_style
-            if line_style is not None and len(line_style) > 0
-            else None,
+            line_style=line_style or None,
             valid=getattr(element.find("valid"), "text", True),
             visible=getattr(element.find("visible"), "text", True),
             transparent=getattr(element.find("transparent"), "text", False),
@@ -1134,8 +1129,14 @@ class LayerViews(BaseModel):
                 pattern_counter += 1
 
             assert name is not None  # Type assertion for mypy
-            pattern = "\n".join(
-                [line.text for line in dither_block.find("pattern").iter()]  # type: ignore[misc,union-attr]
+            pattern_element = dither_block.find("pattern")
+            if pattern_element is None:
+                continue
+            pattern_lines = pattern_element.findall("line")
+            pattern = (
+                "\n".join(line.text or "" for line in pattern_lines)
+                if pattern_lines
+                else pattern_element.text or ""
             )
 
             if name in dither_patterns:
@@ -1148,7 +1149,7 @@ class LayerViews(BaseModel):
             dither_patterns[name] = HatchPattern(
                 name=name,
                 order=int(order),
-                custom_pattern=pattern.lstrip(),
+                custom_pattern=pattern.strip(),
             )
         line_styles: dict[str, LineStyle] = {}
         style_counter = 0
@@ -1192,6 +1193,9 @@ class LayerViews(BaseModel):
                 hp = lv.hatch_pattern
                 if isinstance(hp, str) and re.match(r"C\d+", hp):
                     lv.hatch_pattern = list(dither_patterns.keys())[int(hp[1:])]
+                ls = lv.line_style
+                if isinstance(ls, str) and re.match(r"C\d+", ls):
+                    lv.line_style = list(line_styles.keys())[int(ls[1:])]
                 layer_views[lv.name] = lv
 
         return LayerViews.model_construct(

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -1,4 +1,5 @@
 import pathlib
+import xml.etree.ElementTree as ET
 
 import pytest
 from pydantic_extra_types.color import Color
@@ -113,6 +114,7 @@ def test_line_style_to_klayout_xml() -> None:
 
 def test_lyp_to_yaml_preserves_custom_patterns(tmp_path: pathlib.Path) -> None:
     hatch_pattern = HatchPattern(name="dots", custom_pattern=".*\n*.")
+    single_line_pattern = HatchPattern(name="single", custom_pattern="*")
     line_style = LineStyle(name="dash", custom_style="*.*.")
     layer_views = LayerViews(
         layer_views={
@@ -123,13 +125,21 @@ def test_lyp_to_yaml_preserves_custom_patterns(tmp_path: pathlib.Path) -> None:
                 line_style=line_style,
             )
         },
-        custom_dither_patterns={"dots": hatch_pattern},
+        custom_dither_patterns={
+            "dots": hatch_pattern,
+            "single": single_line_pattern,
+        },
         custom_line_styles={"dash": line_style},
     )
     lyp_path = tmp_path / "layers.lyp"
     yaml_path = tmp_path / "layers.yaml"
 
     layer_views.to_lyp(lyp_path)
+    tree = ET.parse(lyp_path)
+    pattern_without_geometry = ET.SubElement(tree.getroot(), "custom-dither-pattern")
+    ET.SubElement(pattern_without_geometry, "order").text = "2"
+    ET.SubElement(pattern_without_geometry, "name").text = "missing"
+    tree.write(lyp_path)
     loaded_from_lyp = LayerViews.from_lyp(lyp_path)
     loaded_from_lyp.to_yaml(yaml_path)
     roundtrip = LayerViews.from_yaml(yaml_path)
@@ -137,6 +147,8 @@ def test_lyp_to_yaml_preserves_custom_patterns(tmp_path: pathlib.Path) -> None:
     layer_view = roundtrip.layer_views["WG"]
     assert layer_view.hatch_pattern == "dots"
     assert roundtrip.custom_dither_patterns["dots"].custom_pattern == ".*\n*."
+    assert roundtrip.custom_dither_patterns["single"].custom_pattern == "*"
+    assert "missing" not in roundtrip.custom_dither_patterns
     assert layer_view.line_style == "dash"
     assert roundtrip.custom_line_styles["dash"].custom_style == "*.*."
 

--- a/tests/technology/test_layer_views.py
+++ b/tests/technology/test_layer_views.py
@@ -111,6 +111,36 @@ def test_line_style_to_klayout_xml() -> None:
         line_style.to_klayout_xml()
 
 
+def test_lyp_to_yaml_preserves_custom_patterns(tmp_path: pathlib.Path) -> None:
+    hatch_pattern = HatchPattern(name="dots", custom_pattern=".*\n*.")
+    line_style = LineStyle(name="dash", custom_style="*.*.")
+    layer_views = LayerViews(
+        layer_views={
+            "WG": LayerView(
+                name="WG",
+                layer=(1, 0),
+                hatch_pattern=hatch_pattern,
+                line_style=line_style,
+            )
+        },
+        custom_dither_patterns={"dots": hatch_pattern},
+        custom_line_styles={"dash": line_style},
+    )
+    lyp_path = tmp_path / "layers.lyp"
+    yaml_path = tmp_path / "layers.yaml"
+
+    layer_views.to_lyp(lyp_path)
+    loaded_from_lyp = LayerViews.from_lyp(lyp_path)
+    loaded_from_lyp.to_yaml(yaml_path)
+    roundtrip = LayerViews.from_yaml(yaml_path)
+
+    layer_view = roundtrip.layer_views["WG"]
+    assert layer_view.hatch_pattern == "dots"
+    assert roundtrip.custom_dither_patterns["dots"].custom_pattern == ".*\n*."
+    assert layer_view.line_style == "dash"
+    assert roundtrip.custom_line_styles["dash"].custom_style == "*.*."
+
+
 def test_layer_view_init() -> None:
     lv = LayerView(gds_layer=1, gds_datatype=0)
     assert lv.layer == (1, 0)


### PR DESCRIPTION
## Summary
- emit KLayout custom line styles with the documented `custom-line-style` XML tag
- serialize a valid default order instead of the string `None`
- parse multiline custom dither patterns without including the container node
- resolve custom `Cx` line-style references when importing LYP files
- add an end-to-end LYP → YAML regression for stipple and line styles

## Validation
- `uv run pytest -q tests/technology --tb=short` (30 passed, 1 skipped)
- `uv run pytest -q tests/technology/test_layer_views.py --tb=short` (12 passed)
- `uv run pre-commit run --all-files`

Closes #2569

## Summary by Sourcery

Preserve custom KLayout dither and line style patterns when converting between LYP, XML, and YAML layer view representations.

New Features:
- Add an end-to-end regression test ensuring custom hatch and line styles survive LYP → YAML → model roundtrips.

Bug Fixes:
- Emit custom KLayout line styles using the documented custom-line-style XML tag instead of custom-line-pattern.
- Ensure layer view order fields are serialized as a valid numeric default instead of the string None in KLayout XML.
- Correct parsing of multiline custom dither patterns to exclude the container node and trim surrounding whitespace.
- Resolve custom Cx-based dither and line-style references when importing LYP files, including index-based line-style mappings.
- Handle empty or missing line-style XML elements safely when constructing LayerView instances.

Enhancements:
- Simplify line-style handling in XML deserialization by treating empty values as None.