### PR TITLE
Preserve curved path tangents with section insets

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1193,10 +1193,20 @@ def extrude(
             new_stop_point = v_stop_inset + p_pts[stop_diff_idx, :]
 
             _path_points = [new_start_point]
-            _path_points.extend(p_pts[start_diff_idx + 1 : stop_diff_idx])
+            _path_points.extend(p_pts[start_diff_idx + 1 : stop_diff_idx + 1])
             _path_points.append(new_stop_point)
+            trimmed_points = np.array(_path_points, dtype=np.float64)
+            trimmed_points = trimmed_points[
+                np.concatenate(
+                    ([True], np.any(np.diff(trimmed_points, axis=0) != 0, axis=1))
+                )
+            ]
 
-            p_sec = Path(np.array(_path_points, dtype=np.float64))
+            p_sec = Path(
+                trimmed_points,
+                start_angle=p.start_angle if section.insets[0] == 0 else None,
+                end_angle=p.end_angle if section.insets[1] == 0 else None,
+            )
 
         if callable(offset_function):
             p_sec.offset(offset_function)

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -24,6 +24,35 @@ def test_path_zero_length() -> None:
     assert c.area((1, 0)) == 0
 
 
+@pytest.mark.parametrize("insets", [(2, 0), (0, 1)])
+def test_curved_path_insets_preserve_endpoint_tangents(
+    insets: tuple[float, float],
+) -> None:
+    path = gf.path.straight(length=10) + gf.path.euler(
+        radius=100, angle=15, p=0.5, use_eff=False
+    )
+    section = gf.Section(
+        width=6,
+        insets=insets,
+        layer=(2, 0),
+        port_names=("o1", "o2"),
+    )
+
+    component = gf.path.extrude(path, gf.CrossSection(sections=[section]))
+
+    if insets[1] == 0:
+        expected_end_angle = path.end_angle
+    else:
+        segments = np.diff(path.points, axis=0)
+        reverse_lengths = np.cumsum(np.linalg.norm(segments, axis=1)[::-1])
+        reverse_index = np.flatnonzero(reverse_lengths >= insets[1])[0]
+        segment = segments[len(segments) - 1 - reverse_index]
+        expected_end_angle = np.degrees(np.arctan2(segment[1], segment[0]))
+
+    assert component.ports["o1"].orientation == pytest.approx(180)
+    assert component.ports["o2"].orientation == pytest.approx(expected_end_angle)
+
+
 @pytest.mark.parametrize("npoints", [17, 100])
 def test_spiral_archimedean_matches_reference(npoints: int) -> None:
     min_bend_radius = 5.0


### PR DESCRIPTION
## Summary
- retain the path vertex immediately before a trimmed stop point
- remove duplicate consecutive trim points safely
- preserve exact original endpoint angles when that side has no inset
- verify curved-path inset ports follow the actual local tangent

## Validation
- `uv run pytest -q tests/test_path.py --tb=short` (61 passed)
- full component GDS sweep produced no new inset-related reference changes
- `uv run pre-commit run --all-files`

Closes #2537

## Summary by Sourcery

Preserve path endpoint tangents when extruding curved paths with section insets and ensure inset trimming produces stable geometry.

Enhancements:
- Adjust path extrusion trimming to retain the vertex before the stop point and drop duplicate consecutive points when applying insets.
- Preserve original path start and end angles for extruded sections when the corresponding side has no inset, improving tangent accuracy for ports.

Tests:
- Add a parametrized test verifying that curved paths with asymmetric insets preserve the expected endpoint tangents on both ports.