### PR TITLE
Handle plugin initialization errors in version report

### DIFF
--- a/gdsfactory/config.py
+++ b/gdsfactory/config.py
@@ -84,6 +84,12 @@ def print_version_plugins(packages: list[str] | None = None) -> None:
                 table.add_row(plugin, "", "")
         except ImportError:
             table.add_row(plugin, "not installed", "")
+        except Exception as error:
+            table.add_row(
+                plugin,
+                f"failed to import ({type(error).__name__})",
+                str(error),
+            )
 
     console = Console()
     console.print(table)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from gdsfactory import config
+
+
+def test_print_version_plugins_handles_plugin_initialization_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def import_plugin(name: str) -> None:
+        if name == "broken_plugin":
+            raise RuntimeError("native library initialization failed")
+        raise ImportError
+
+    monkeypatch.setattr(config.importlib, "import_module", import_plugin)
+
+    config.print_version_plugins(packages=["broken_plugin"])
+
+    output = capsys.readouterr().out
+    assert "broken_plugin" in output
+    assert "failed to import" in output
+    assert "(RuntimeError)" in output
+    assert "native library" in output
+    assert "initialization failed" in output


### PR DESCRIPTION
## Summary
- keep `print_version_plugins()` running when an installed plugin raises during native initialization
- report the exception type and message in the version table
- preserve the existing `not installed` handling for ordinary import failures
- cover the Windows-style DEVSIM `RuntimeError` path

## Validation
- `uv run pytest -q tests/test_config.py tests/test_cli.py --tb=short` (23 passed)
- `uv run pre-commit run --all-files`

Closes gdsfactory/gplugins#779

## Summary by Sourcery

Handle errors raised during plugin initialization in the version reporting logic and add coverage for this behavior.

Bug Fixes:
- Ensure plugin version reporting continues and surfaces error details when a plugin raises an exception during import or native initialization.

Tests:
- Add a test verifying that version reporting records plugin initialization RuntimeErrors without aborting execution.