### PR TITLE
Support custom uPDK parameter formatting

### DIFF
--- a/gdsfactory/read/from_updk.py
+++ b/gdsfactory/read/from_updk.py
@@ -39,6 +39,7 @@ def from_updk(
     suffix: str = "",
     add_plot_to_docstring: bool = True,
     pdk_name: str = "pdk",
+    parameter_format: str = "{name}={value}",
 ) -> str:
     """Read uPDK YAML file and returns a gdsfactory script.
 
@@ -63,6 +64,8 @@ def from_updk(
         suffix: optional suffix to add to the script.
         add_plot_to_docstring: if True, add a plot to the docstring.
         pdk_name: name of the pdk.
+        parameter_format: format for each parameter in generated black-box names.
+            Supports ``{name}``, ``{value}``, and ``{block_name}`` placeholders.
     """
     optical_xsections = optical_xsections or []
     electrical_xsections = electrical_xsections or []
@@ -147,14 +150,22 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
             if parameters
             else []
         )
-        parameters_equal = (
-            [
-                f"{clean_value_name(p_name)}={{{clean_value_name(p_name)}}}"
-                for p_name in parameters
-            ]
-            if parameters
-            else []
-        )
+        parameters_formatted = []
+        for p_name in parameters:
+            name = clean_value_name(p_name)
+            try:
+                parameters_formatted.append(
+                    parameter_format.format(
+                        name=name,
+                        value=f"{{{name}}}",
+                        block_name=block_name,
+                    )
+                )
+            except KeyError as error:
+                raise ValueError(
+                    "parameter_format supports only {name}, {value}, and "
+                    "{block_name} placeholders"
+                ) from error
 
         parameters_labels = (
             "\n".join(
@@ -166,7 +177,7 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
             if layer_label and parameters_colon
             else ""
         )
-        list_parameters = "\\n".join(f"{p_name}" for p_name in parameters_equal)
+        list_parameters = "\\n".join(parameters_formatted)
         parameters_labels = f"    c.add_label(text=f'Parameters:\\n{list_parameters}', position=(0,0), layer=layer_label)\n"
 
         docstring = block.get("doc", "")
@@ -192,8 +203,8 @@ add_pins = partial(add_pins_inside2um, layer_label=layer_label, layer=layer_pin_
             doc = f'"""{docstring}    {plot_docstring}"""'
 
         cell_name = (
-            f"{block_name}:{','.join(parameters_equal)}"
-            if parameters_equal
+            f"{block_name}:{','.join(parameters_formatted)}"
+            if parameters_formatted
             else block_name
         )
 

--- a/tests/read/test_updk.py
+++ b/tests/read/test_updk.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from gdsfactory.config import GDSDIR_TEMP
 from gdsfactory.gpdk import get_generic_pdk
 from gdsfactory.read.from_updk import from_updk
@@ -24,3 +28,46 @@ def test_updk_generic() -> None:
     filepath.write_text(yaml_pdk_description)
     gdsfactory_script = from_updk(filepath)
     assert gdsfactory_script
+
+
+def test_updk_custom_parameter_format(tmp_path: Path) -> None:
+    filepath = tmp_path / "pdk.yaml"
+    filepath.write_text(
+        """
+blocks:
+  phase_shifter:
+    parameters:
+      length:
+        type: float
+        value: 10
+        doc: Length
+    bbox:
+      - [0, 0]
+      - [10, 0]
+      - [10, 1]
+      - [0, 1]
+"""
+    )
+
+    script = from_updk(filepath, parameter_format="{name}:{value}")
+
+    assert "name = f'phase_shifter:length:{length}'" in script
+
+
+def test_updk_rejects_unknown_parameter_format_placeholder(tmp_path: Path) -> None:
+    filepath = tmp_path / "pdk.yaml"
+    filepath.write_text(
+        """
+blocks:
+  straight:
+    parameters:
+      length:
+        type: float
+        value: 10
+        doc: Length
+    bbox: [[0, 0], [10, 0], [10, 1], [0, 1]]
+"""
+    )
+
+    with pytest.raises(ValueError, match="supports only"):
+        from_updk(filepath, parameter_format="{unknown}")


### PR DESCRIPTION
## Summary
- add a `parameter_format` hook for generated uPDK black-box names
- support `{name}`, `{value}`, and `{block_name}` placeholders
- preserve `name=value` as the default format
- reject unknown placeholders with an actionable error
- cover colon-style parameter naming

## Validation
- `uv run pytest -q tests/read/test_updk.py --tb=short` (3 passed)
- `uv run pre-commit run --all-files`

Closes #2749

## Summary by Sourcery

Add support for customizable parameter formatting in uPDK-generated black-box names while preserving the existing default behavior.

New Features:
- Allow callers of from_updk to specify a parameter_format string to control how parameters appear in generated black-box names, supporting {name}, {value}, and {block_name} placeholders.

Enhancements:
- Validate parameter_format placeholders and raise a clear ValueError when unsupported placeholders are used.
- Improve uPDK reading tests to cover custom colon-style parameter formatting and error handling for unknown placeholders.

Documentation:
- Document the new parameter_format option in from_updk, including supported placeholders.

Tests:
- Extend uPDK tests to verify custom parameter formatting and rejection of unknown placeholders.