### PR TITLE
Preserve component partial docstrings

### DIFF
--- a/gdsfactory/components/__init__.py
+++ b/gdsfactory/components/__init__.py
@@ -1,3 +1,5 @@
+from functools import partial as _partial
+
 from . import (
     bends,
     containers,
@@ -423,3 +425,18 @@ __all__ = [
     "wire_straight",
     "ytron_round",
 ]
+
+
+def _copy_partial_docstrings() -> None:
+    for name in __all__:
+        component = globals().get(name)
+        if not isinstance(component, _partial):
+            continue
+        wrapped = component.func
+        while isinstance(wrapped, _partial):
+            wrapped = wrapped.func
+        component.__doc__ = wrapped.__doc__
+
+
+_copy_partial_docstrings()
+del _copy_partial_docstrings

--- a/tests/components/test_partial_docstrings.py
+++ b/tests/components/test_partial_docstrings.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from functools import partial
+
+import gdsfactory.components as components
+
+
+def test_exported_component_partials_preserve_docstrings() -> None:
+    partials = {
+        name: component
+        for name in components.__all__
+        if isinstance(component := getattr(components, name, None), partial)
+    }
+
+    assert partials
+    for name, component in partials.items():
+        wrapped = component.func
+        while isinstance(wrapped, partial):
+            wrapped = wrapped.func
+        assert component.__doc__ == wrapped.__doc__, name


### PR DESCRIPTION
## Summary
- copy underlying component documentation onto exported `functools.partial` factories
- recursively unwrap nested partials
- avoid `functools.update_wrapper`, preserving partial signatures and caching behavior
- cover every exported component partial

## Validation
- `uv run pytest -q tests/components/test_partial_docstrings.py tests/test_get_factories.py --tb=short` (4 passed)
- `uv run pre-commit run --all-files`

Closes #2754

## Summary by Sourcery

Preserve and propagate docstrings from underlying component functions to all exported functools.partial component factories.

New Features:
- Ensure exported component partial factories inherit the docstrings of their wrapped component functions, including nested partials.

Tests:
- Add tests verifying that all exported component partials maintain the same docstring as their underlying wrapped component implementations.