### PR TITLE
Stabilize path offsets across the angle branch cut

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1578,7 +1578,7 @@ def _compute_offset_directions(
     """
     dx = np.diff(points[:, 0])
     dy = np.diff(points[:, 1])
-    theta = np.arctan2(dy, dx)
+    theta = np.unwrap(np.arctan2(dy, dx))
     theta = np.concatenate([theta[:1], theta, theta[-1:]])
     theta_mid = (np.pi + theta[1:] + theta[:-1]) / 2
     dtheta_int = np.pi + theta[:-1] - theta[1:]

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -386,6 +386,17 @@ def test_centerpoint_offset_curve() -> None:
     np.testing.assert_array_almost_equal(new_points, expected_points)
 
 
+def test_centerpoint_offset_curve_across_angle_branch_cut() -> None:
+    """Nearly collinear segments stay stable when their angles cross +/- pi."""
+    points = np.array([(1, 0), (0, 1e-6), (-1, 0)], dtype=np.float64)
+    path = Path(points)
+
+    new_points = path.centerpoint_offset_curve(points, offset_distance=0.5)
+
+    assert np.all(np.isfinite(new_points))
+    assert np.max(np.linalg.norm(new_points - points, axis=1)) < 0.501
+
+
 def test_path_hash() -> None:
     assert hash(Path([(0, 0), (1, 1), (2, 0)])) == hash(Path([(0, 0), (1, 1), (2, 0)]))
 


### PR DESCRIPTION
## Summary
- unwrap segment angles before computing centerpoint offset directions
- prevent nearly collinear paths crossing +/- pi from producing enormous offset miters
- add a regression test covering the branch-cut geometry

## Validation
- `uv run pytest tests/test_path.py -q` (60 passed)
- `uv run pre-commit run --all-files`

Fixes #3689

## Summary by Sourcery

Stabilize centerpoint offset curve computation for nearly collinear paths whose segment angles cross the ±π branch cut.

Bug Fixes:
- Prevent centerpoint offset calculations from producing extreme or invalid miters when path segment angles cross the ±π branch cut.

Tests:
- Add a regression test ensuring centerpoint_offset_curve remains finite and bounded for nearly collinear paths that span the angle branch cut.