### PR TITLE
Match generated transition section names by layer

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -959,7 +959,17 @@ def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
     for section in sections:
         if section.skip_transition:
             continue
-        name = section.name or get_layer_name(section.layer)
+        name = section.name
+        is_generated_name = bool(
+            name
+            and len(name) == 10
+            and name.startswith("s_")
+            and all(character in "0123456789abcdef" for character in name[2:])
+        )
+        if name == "_default" or is_generated_name:
+            name = get_layer_name(section.layer)
+        else:
+            name = name or get_layer_name(section.layer)
         if name in named_sections:
             raise ValueError(
                 f"Duplicate name or layer '{name}' of section used for cross-section in transition. Cross-sections with multiple Sections for a single layer must have unique names for each section"

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -966,10 +966,9 @@ def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
             and name.startswith("s_")
             and all(character in "0123456789abcdef" for character in name[2:])
         )
-        if name == "_default" or is_generated_name:
-            name = get_layer_name(section.layer)
-        else:
-            name = name or get_layer_name(section.layer)
+        if is_generated_name:
+            name = "_default"
+        name = name or get_layer_name(section.layer)
         if name in named_sections:
             raise ValueError(
                 f"Duplicate name or layer '{name}' of section used for cross-section in transition. Cross-sections with multiple Sections for a single layer must have unique names for each section"

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -959,22 +959,22 @@ def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
     for section in sections:
         if section.skip_transition:
             continue
-        name = section.name
-        is_generated_name = bool(
-            name
-            and len(name) == 10
-            and name.startswith("s_")
-            and all(character in "0123456789abcdef" for character in name[2:])
-        )
-        if is_generated_name:
-            name = "_default"
-        name = name or get_layer_name(section.layer)
+        name = section.name or get_layer_name(section.layer)
         if name in named_sections:
             raise ValueError(
                 f"Duplicate name or layer '{name}' of section used for cross-section in transition. Cross-sections with multiple Sections for a single layer must have unique names for each section"
             )
         named_sections[name] = section
     return named_sections
+
+
+def _is_implicit_section_name(name: str) -> bool:
+    """Return whether a section name was assigned by gdsfactory."""
+    return name == "_default" or (
+        len(name) == 10
+        and name.startswith("s_")
+        and all(character in "0123456789abcdef" for character in name[2:])
+    )
 
 
 @overload
@@ -1396,6 +1396,17 @@ def extrude_transition(
     names2 = list(named_sections2.keys())
 
     common_sections = set(names1).intersection(names2)
+    if not common_sections and len(names1) == len(names2) == 1:
+        name1, name2 = names1[0], names2[0]
+        section1 = named_sections1[name1]
+        section2 = named_sections2[name2]
+        if (
+            _is_implicit_section_name(name1)
+            and _is_implicit_section_name(name2)
+            and get_layer(section1.layer) == get_layer(section2.layer)
+        ):
+            named_sections2[name1] = named_sections2.pop(name2)
+            common_sections = {name1}
     if not common_sections:
         raise ValueError(
             f"transition() found no common section names X1 {names1} and X2 {names2}"

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -407,6 +407,16 @@ def test_path_extrude_transition() -> None:
     assert c.bbox() == kdb.DBox(0, -0.25, 1.25, 1)
 
 
+def test_path_extrude_transition_matches_generated_names_by_layer() -> None:
+    cross_section1 = gf.cross_section.cross_section(width=1, layer=(1, 0))
+    cross_section2 = gf.CrossSection(sections=(gf.Section(width=2, layer=(1, 0)),))
+    transition = gf.path.transition(cross_section1, cross_section2)
+
+    component = gf.path.extrude_transition(gf.path.straight(length=10), transition)
+
+    assert component.area((1, 0)) == pytest.approx(15)
+
+
 def test_path_copy() -> None:
     path = gf.path.euler()
     path_copy = path.copy()


### PR DESCRIPTION
## Summary
- treat `_default` and generated `s_<hash>` section names as unnamed during transition matching
- match those sections by layer while preserving explicit user-defined names
- add regression coverage for factory-created to directly constructed cross-sections

## Validation
- `uv run pytest tests/test_path.py -q` (60 passed)
- `uv run pre-commit run --all-files` (clean second pass)

Fixes #2383

## Summary by Sourcery

Adjust transition section matching to treat default and generated section names as unnamed and align them by layer, and add regression coverage for the new matching behavior.

Bug Fixes:
- Ensure cross-section transitions correctly match sections with default or generated names by their layer instead of by the generated name.

Tests:
- Add regression test verifying extruded transitions match sections with generated names by layer when transitioning between factory-created and directly constructed cross-sections.