### PR TITLE
Test headless layout diff output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestCLIHelp:
             "merge-gds",
             "watch",
             "show",
+            "diff",
             "gds-diff",
             "install-klayout-genericpdk",
             "install-git-diff",
@@ -91,6 +92,36 @@ class TestCLIHelp:
             result = runner.invoke(app, [command, "--help"])
             assert result.exit_code == 0, f"Help failed for command: {command}"
             assert "Usage:" in result.stdout
+
+
+class TestDiff:
+    """Test the headless layout diff command."""
+
+    def test_writes_xor_layout(
+        self, runner: CliRunner, sample_gds_file: Path, temp_dir: Path
+    ) -> None:
+        """Differences return code 2 and write the requested XOR layout."""
+        import gdsfactory as gf
+
+        changed_path = temp_dir / "changed.gds"
+        gf.components.rectangle(size=(2, 1)).write_gds(changed_path)
+        output_path = temp_dir / "difference.gds"
+
+        result = runner.invoke(
+            app,
+            [
+                "diff",
+                str(sample_gds_file),
+                str(changed_path),
+                "--xor",
+                "--output",
+                str(output_path),
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert output_path.is_file()
+        assert output_path.stat().st_size > 0
 
 
 class TestLayermapToDataclass:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -102,6 +102,17 @@ def test_diff_identical_files() -> None:
     assert result.layers == []
 
 
+def test_diff_identical_files_do_not_write_output(tmp_path: Path) -> None:
+    """An identical comparison does not create a misleading diff layout."""
+    ref_gds = _gds_dir / "big_rect.gds"
+    output = tmp_path / "identical_diff.gds"
+
+    result = diff(ref_gds, ref_gds, out_file=output)
+
+    assert not result
+    assert not output.exists()
+
+
 def test_diff_missing_layer(tmp_path: Path) -> None:
     """A layer present in only one file gets IoU=0 and correct present_in."""
     import gdsfactory as gf


### PR DESCRIPTION
## Summary
- cover the `gf diff` command in CLI help and execution tests
- verify differing layouts return exit code 2 and write a nonempty XOR GDS
- verify identical layouts do not create a misleading output artifact

## Validation
- `uv run pytest tests/test_cli.py tests/test_diff.py -q` (30 passed)
- `uv run pre-commit run --all-files`

Advances #2288.

## Summary by Sourcery

Extend CLI and diff tests to cover the headless layout diff command behavior for differing and identical GDS layouts.

New Features:
- Add coverage for the `diff` CLI command in individual command help tests.

Tests:
- Add tests verifying `diff` CLI returns exit code 2 and writes a nonempty XOR GDS output for differing layouts.
- Add tests ensuring identical layout comparisons do not produce an output GDS file.