### PR TITLE
Support shear angles on individual cross-section sections

### DIFF
--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -87,6 +87,8 @@ class Section(BaseModel):
                 polygon by more than the value listed here will be removed.
         skip_transition: if True, this section is excluded from cross-section \
                 transitions (will not be tapered between two CrossSections).
+        shear_angle_start: angle in degrees to shear this section's starting face.
+        shear_angle_end: angle in degrees to shear this section's ending face.
         width_function: parameterized function from 0 to 1.
         offset_function: parameterized function from 0 to 1.
 
@@ -116,6 +118,8 @@ class Section(BaseModel):
     hidden: bool = False
     simplify: float | None = None
     skip_transition: bool = False
+    shear_angle_start: float | None = None
+    shear_angle_end: float | None = None
 
     width_function: typings.WidthFunction | None = None
     offset_function: typings.OffsetFunction | None = None

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -118,13 +118,25 @@ class Section(BaseModel):
     hidden: bool = False
     simplify: float | None = None
     skip_transition: bool = False
-    shear_angle_start: float | None = None
-    shear_angle_end: float | None = None
+    shear_angle_start: float | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    shear_angle_end: float | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     width_function: typings.WidthFunction | None = None
     offset_function: typings.OffsetFunction | None = None
 
     model_config = ConfigDict(extra="forbid", frozen=True)
+
+    def __repr_args__(self) -> Any:
+        """Omit unset shear fields to preserve existing cross-section hashes."""
+        return [
+            (name, value)
+            for name, value in super().__repr_args__()
+            if not (name.startswith("shear_angle_") and value is None)
+        ]
 
     @model_validator(mode="before")
     @classmethod

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -1238,6 +1238,31 @@ def extrude(
             start_angle=start_angle,
             end_angle=end_angle,
         )
+        if section.shear_angle_start or section.shear_angle_end:
+            face_angle_start = (
+                start_angle + section.shear_angle_start - 90
+                if section.shear_angle_start
+                else None
+            )
+            face_angle_end = (
+                end_angle + section.shear_angle_end + 90
+                if section.shear_angle_end
+                else None
+            )
+            points1 = _cut_path_with_ray(
+                start_point=points[0],
+                start_angle=face_angle_start,
+                end_point=points[-1],
+                end_angle=face_angle_end,
+                path=points1,
+            )
+            points2 = _cut_path_with_ray(
+                start_point=points[0],
+                start_angle=face_angle_start,
+                end_point=points[-1],
+                end_angle=face_angle_end,
+                path=points2,
+            )
         if isinstance(simplify, bool):
             raise ValueError("simplify argument must be a number (e.g. 1e-3) or None")
 

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -285,3 +285,14 @@ def test_taper_cross_section_instance_matches_name() -> None:
             pdk.cross_sections.pop("_xs_4588", None)
         else:
             pdk.cross_sections["_xs_4588"] = previous
+
+
+def test_section_shear_serialization() -> None:
+    default_section = gf.Section(width=1, layer=(1, 0))
+    sheared_section = gf.Section(width=1, layer=(1, 0), shear_angle_start=15)
+
+    assert "shear_angle_start" not in default_section.model_dump()
+    assert "shear_angle_end" not in default_section.model_dump()
+    assert sheared_section.model_dump()["shear_angle_start"] == 15
+    assert "shear_angle" not in repr(default_section)
+    assert "shear_angle_start=15" in repr(sheared_section)

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -407,6 +407,34 @@ def test_path_extrude_transition() -> None:
     assert c.bbox() == kdb.DBox(0, -0.25, 1.25, 1)
 
 
+@pytest.mark.parametrize(
+    ("shear_angle_start", "shear_angle_end", "expected_bbox"),
+    [
+        (45, None, kdb.DBox(-1, -1, 10, 1)),
+        (None, 45, kdb.DBox(0, -1, 11, 1)),
+        (45, 45, kdb.DBox(-1, -1, 11, 1)),
+    ],
+)
+def test_extrude_section_shear_angles(
+    shear_angle_start: float | None,
+    shear_angle_end: float | None,
+    expected_bbox: kdb.DBox,
+) -> None:
+    core = gf.Section(
+        width=2,
+        layer=(1, 0),
+        shear_angle_start=shear_angle_start,
+        shear_angle_end=shear_angle_end,
+    )
+    cladding = gf.Section(width=4, layer=(2, 0))
+    cross_section = gf.CrossSection(sections=(core, cladding))
+
+    component = gf.path.extrude(gf.path.straight(length=10), cross_section)
+
+    assert component.bbox(gf.get_layer((1, 0))) == expected_bbox
+    assert component.bbox(gf.get_layer((2, 0))) == kdb.DBox(0, -2, 10, 2)
+
+
 def test_path_copy() -> None:
     path = gf.path.euler()
     path_copy = path.copy()


### PR DESCRIPTION
## Summary
- add `shear_angle_start` and `shear_angle_end` to `Section`
- cut only that section's boundary curves against the requested start/end face angles
- preserve square faces for other sections in the same cross-section
- cover start-only, end-only, and combined shear geometry

## Validation
- `uv run pytest tests/test_path.py -q` (62 passed)
- `uv run pre-commit run --all-files`

Fixes #2539

## Summary by Sourcery

Add support for per-section shear angles in cross-section extrusion while keeping other sections square.

New Features:
- Allow Section definitions to specify shear_angle_start and shear_angle_end to control the shear of that section’s start and end faces during path extrusion.

Enhancements:
- Update path extrusion to apply shear only to the targeted section’s boundary while preserving rectangular faces for other sections in the same CrossSection.

Tests:
- Add parametrized extrusion tests validating start-only, end-only, and combined shear angles and confirming unaffected cladding geometry.