### PR TITLE
Add register_layers method to Pdk

### DIFF
--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -141,6 +141,46 @@
    "id": "4",
    "metadata": {},
    "source": [
+    "### Register layers dynamically\n",
+    "\n",
+    "Instead of defining a full `LayerMap` class upfront, you can add layers to a PDK dynamically using `register_layers`.\n",
+    "This is useful when you want to quickly extend an existing PDK with custom layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "# Create a PDK and add layers dynamically\n",
+    "pdk = gf.Pdk(name=\"my_pdk\")\n",
+    "pdk.register_layers(WG=(1, 0), SLAB=(2, 0), HEATER=(47, 0))\n",
+    "\n",
+    "# Layers are immediately available\n",
+    "pdk.layers.WG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can also add layers to an existing PDK\n",
+    "pdk.register_layers(CUSTOM=(200, 0))\n",
+    "pdk.layers.CUSTOM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
     "### Extract layers\n",
     "\n",
     "You can also extract layers using the `extract` function. This function returns a new flattened component that contains the extracted layers.\n",
@@ -150,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Remove layers\n",
@@ -192,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Remap layers\n",
@@ -217,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "15",
    "metadata": {},
    "source": [
     "## LayerViews\n",
@@ -258,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "17",
    "metadata": {},
    "source": [
     "Once you modify the `YAML` file you can easily write it to klayout layer properties `lyp` or the other way around.\n",
@@ -283,7 +323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "18",
    "metadata": {},
    "source": [
     "### YAML -> LYP\n",
@@ -294,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "source": [
     "### LYP -> YAML\n",
@@ -322,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Preview layerset\n",
@@ -346,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +396,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "source": [
     "By default the generic PDK has some layers that are not visible and therefore are not shown."
@@ -365,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "28",
    "metadata": {},
    "source": [
     "You can make it visible"
@@ -409,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "32",
    "metadata": {},
    "source": [
     "## LayerStack\n",
@@ -463,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +710,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "43",
    "metadata": {},
    "source": [
     "### 3D rendering\n",
@@ -684,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "46",
    "metadata": {},
    "source": [
     "### Klayout 2.5D view\n",
@@ -716,7 +756,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +765,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "48",
    "metadata": {},
    "source": [
     "Then you go to Tools → 2.5d View -> New 2.5d Script\n",
@@ -740,7 +780,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Klayout cross-section\n",
@@ -755,7 +795,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "50",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -826,7 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "51",
    "metadata": {},
    "source": [
     "![xsection generic](images/layer_stack_xsection_generic.png)"
@@ -834,7 +874,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "52",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -855,7 +895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -956,7 +996,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "54",
    "metadata": {},
    "source": [
     "These process dataclasses can then be used in physical simulator plugins."

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -284,6 +284,51 @@ class Pdk(BaseModel):
                 warnings.warn(f"Overwriting cross_section {name!r}", stacklevel=3)
             self.cross_sections[name] = cross_section
 
+    def register_layers(self, **kwargs: tuple[int, int]) -> None:
+        """Register new layers into the PDK dynamically.
+
+        If the PDK has no layer map yet, one is created automatically.
+        When the PDK is currently active, kfactory's layer bookkeeping
+        is refreshed so the new layers are immediately usable.
+
+        Args:
+            kwargs: ``layer_name=(layer_number, datatype)`` pairs.
+
+        Example::
+
+            pdk.register_layers(WG=(1, 0), SLAB=(2, 0))
+
+        """
+        import aenum as _aenum
+
+        if self.layers is None:
+            self.layers = type(
+                "LAYER", (LayerEnum,), {"layout": _aenum.constant(kf.kcl.layout)}
+            )
+
+        for name, layer_tuple in kwargs.items():
+            if (
+                not isinstance(layer_tuple, tuple | list)
+                or len(layer_tuple) != 2
+                or not all(isinstance(v, int) for v in layer_tuple)
+            ):
+                raise ValueError(
+                    f"Layer {name!r} must be a (layer, datatype) tuple of ints, "
+                    f"got {layer_tuple!r}"
+                )
+            if hasattr(self.layers, name):
+                warnings.warn(f"Overwriting layer {name!r}", stacklevel=2)
+                old_member = getattr(self.layers, name)
+                old_val = int(old_member)
+                del self.layers._member_map_[name]  # type: ignore[union-attr]
+                self.layers._member_names_.remove(name)  # type: ignore[union-attr]
+                self.layers._value2member_map_.pop(old_val, None)  # type: ignore[union-attr]
+                type.__delattr__(self.layers, name)
+            _aenum.extend_enum(self.layers, name, *layer_tuple)
+
+        if _ACTIVE_PDK is not None and _ACTIVE_PDK.name == self.name:
+            _set_active_pdk(self)
+
     def register_cells_yaml(
         self,
         dirpath: PathType | None = None,

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -327,6 +327,74 @@ def test_get_cross_section_instance_applies_kwargs() -> None:
     assert gf.get_cross_section(xs) is xs
 
 
+def test_register_layers_from_scratch() -> None:
+    """register_layers creates a LayerEnum when pdk.layers is None."""
+    pdk = gf.Pdk(name="register_test")
+    assert pdk.layers is None
+
+    pdk.register_layers(WG=(1, 0), SLAB=(2, 0))
+
+    assert pdk.layers is not None
+    assert hasattr(pdk.layers, "WG")
+    assert hasattr(pdk.layers, "SLAB")
+    assert pdk.layers.WG.layer == 1
+    assert pdk.layers.WG.datatype == 0
+    assert pdk.layers.SLAB.layer == 2
+    assert pdk.layers.SLAB.datatype == 0
+
+
+def test_register_layers_adds_to_existing() -> None:
+    """register_layers extends an existing LayerEnum."""
+    pdk = gf.Pdk(name="register_test", layers=LAYER)
+    original_count = len(list(pdk.layers.__members__))
+
+    pdk.register_layers(CUSTOM_LAYER=(200, 0))
+
+    assert hasattr(pdk.layers, "CUSTOM_LAYER")
+    assert pdk.layers.CUSTOM_LAYER.layer == 200
+    assert pdk.layers.CUSTOM_LAYER.datatype == 0
+    assert len(list(pdk.layers.__members__)) == original_count + 1
+
+
+def test_register_layers_overwrite_warns() -> None:
+    """Overwriting an existing layer emits a warning."""
+    pdk = gf.Pdk(name="register_test")
+    pdk.register_layers(WG=(1, 0))
+
+    with pytest.warns(UserWarning, match="Overwriting layer 'WG'"):
+        pdk.register_layers(WG=(13, 14))
+
+    assert pdk.layers.WG.layer == 13
+    assert pdk.layers.WG.datatype == 14
+
+
+def test_register_layers_invalid_input() -> None:
+    """register_layers rejects non-tuple and wrong-length inputs."""
+    pdk = gf.Pdk(name="register_test")
+
+    with pytest.raises(ValueError, match="tuple of ints"):
+        pdk.register_layers(BAD="not a tuple")
+
+    with pytest.raises(ValueError, match="tuple of ints"):
+        pdk.register_layers(BAD=(1, 2, 3))
+
+    with pytest.raises(ValueError, match="tuple of ints"):
+        pdk.register_layers(BAD=(1.5, 0))
+
+
+def test_register_layers_get_layer(restore_kcl_state: None) -> None:
+    """Dynamically registered layers are accessible via get_layer."""
+    pdk = gf.Pdk(
+        name="register_get_test",
+        cross_sections={"strip": gf.cross_section.strip},
+    )
+    pdk.register_layers(WG=(1, 0), METAL1=(10, 0))
+    pdk.activate(force=True)
+
+    assert pdk.get_layer("WG") == pdk.layers.WG
+    assert pdk.get_layer("METAL1") == pdk.layers.METAL1
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 


### PR DESCRIPTION
## Summary

Adds a `register_layers(**kwargs)` method to the `Pdk` class, making it easy to add layers dynamically:

```python
pdk = gf.Pdk(name="my_pdk")
pdk.register_layers(WG=(1, 0), SLAB=(2, 0))
```

This follows the existing `register_cells()` / `register_cross_sections()` pattern.

### Behavior
- If `pdk.layers` is `None`, creates a new `LayerEnum` automatically
- Uses `aenum.extend_enum()` to add members to the `LayerEnum`
- Warns when overwriting an existing layer
- Refreshes kfactory bookkeeping when the PDK is currently active
- Validates input: rejects non-tuple, wrong length, non-int values

Closes #4734

## Test plan
- [x] `test_register_layers_from_scratch` — creates layers on a PDK with no layer map
- [x] `test_register_layers_adds_to_existing` — extends an existing LayerEnum
- [x] `test_register_layers_overwrite_warns` — warns and overwrites correctly
- [x] `test_register_layers_invalid_input` — rejects bad input types
- [x] `test_register_layers_get_layer` — registered layers work with `pdk.get_layer()`
- [x] All pre-commit hooks pass (ruff, pyright, codespell, etc.)

⚠️ Reminder: AI-created PRs still require human review of the actual code changes before merge. A human must review and approve it.

## Summary by Sourcery

Add a dynamic layer registration API to the Pdk class and cover it with tests.

New Features:
- Introduce Pdk.register_layers(...) to dynamically add or create layer enums and refresh active PDK state.

Enhancements:
- Validate layer registration input and emit warnings when overwriting existing layers.

Tests:
- Add tests for creating layers from scratch, extending existing layer enums, overwrite warnings, invalid inputs, and get_layer compatibility.