### PR TITLE
feat(electrical): add electric pins to start fixing SPICE export issues - ports logically connected by name are not being recognized as logically connected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ sample_reticle.csv
 
 
 # Packages
+uv.lock
 *.egg
 *.oas
 *.egg-info

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -446,6 +446,38 @@ add_pins_inside1nm = partial(add_pins, function=add_pin_inside1nm)
 add_pins_inside2um = partial(add_pins, function=add_pin_inside2um)
 
 
+def add_electric_pins(
+    component: Component,
+    layer_map: dict[tuple[int, int], tuple[int, int]] | None = None,
+    pin_function: AddPinFunction = add_pin_rectangle_inside,  # type: ignore[assignment]
+    pin_type: str = "DC",
+) -> None:
+    """Draw pin markers and register logical pins for all electrical ports.
+
+    Groups ports by name, draws a pin rectangle for each port on the
+    corresponding pin layer, and calls ``component.create_pin()`` to register
+    a logical pin for each group.
+
+    Args:
+        component: Component to add pins to.
+        layer_map: Optional mapping from port layer to pin layer. When None,
+            each port's own layer is used (for PDKs where ports are already
+            on pin layers).
+        pin_function: Function to draw each pin marker.
+        pin_type: Pin type string passed to create_pin().
+    """
+    by_name: dict[str, list] = {}
+    for port in component.ports:
+        if port.port_type == "electrical":
+            by_name.setdefault(port.name, []).append(port)
+    for name, ports in by_name.items():
+        for port in ports:
+            pin_layer = layer_map.get(port.layer) if layer_map else port.layer
+            if pin_layer:
+                pin_function(component, port, layer=pin_layer, layer_label=None)
+        component.create_pin(ports=ports, name=name, pin_type=pin_type)
+
+
 def add_settings_label(
     component: Component,
     reference: ComponentReference | None = None,

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -448,7 +448,7 @@ add_pins_inside2um = partial(add_pins, function=add_pin_inside2um)
 
 def add_electric_pins(
     component: Component,
-    layer_map: dict[tuple[int, int], tuple[int, int]] | None = None,
+    pin_layer_map: dict[tuple[int, int], tuple[int, int]] | None = None,
     pin_function: AddPinFunction = add_pin_rectangle_inside,  # type: ignore[assignment]
     pin_type: str = "DC",
 ) -> None:
@@ -460,7 +460,7 @@ def add_electric_pins(
 
     Args:
         component: Component to add pins to.
-        layer_map: Optional mapping from port layer to pin layer. When None,
+        pin_layer_map: Mapping from port layer to pin layer for PDK specific layer. When None,
             each port's own layer is used (for PDKs where ports are already
             on pin layers).
         pin_function: Function to draw each pin marker.
@@ -472,7 +472,7 @@ def add_electric_pins(
             by_name.setdefault(port.name, []).append(port)
     for name, ports in by_name.items():
         for port in ports:
-            pin_layer = layer_map.get(port.layer) if layer_map else port.layer
+            pin_layer = pin_layer_map.get(port.layer) if pin_layer_map else port.layer
             if pin_layer:
                 pin_function(component, port, layer=pin_layer, layer_label=None)
         component.create_pin(ports=ports, name=name, pin_type=pin_type)

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -1,7 +1,128 @@
 from __future__ import annotations
 
+import pytest
+
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER
+
+
+@pytest.fixture(autouse=True)
+def activate_generic_pdk():
+    gf.gpdk.PDK.activate()
+
+
+def test_add_electric_pins_without_layer_map() -> None:
+    """Pin rectangles are drawn on the port's own layer when no layer_map is given."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
+    component.add_port(
+        name="A",
+        center=(0, 2.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="B",
+        center=(10, 2.5),
+        width=5,
+        orientation=0,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    gf.add_pins.add_electric_pins(component)
+    polygons = component.get_polygons()
+    assert len(polygons[LAYER.M1]) == 3  # original polygon + 2 pin rectangles
+    assert len(component.pins) == 2
+
+
+def test_add_electric_pins_with_layer_map() -> None:
+    """Pin rectangles are drawn on the mapped pin layer, not the port layer."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
+    component.add_port(
+        name="A",
+        center=(0, 2.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="B",
+        center=(10, 2.5),
+        width=5,
+        orientation=0,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    gf.add_pins.add_electric_pins(
+        component, layer_map={LAYER.M1: LAYER.PORTE}
+    )
+    polygons = component.get_polygons()
+    assert len(polygons[LAYER.PORTE]) == 2
+    assert len(polygons[LAYER.M1]) == 1  # only the original polygon
+    assert len(component.pins) == 2
+
+
+def test_add_electric_pins_groups_ports_by_name() -> None:
+    """Ports with the same name are grouped into a single logical pin."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.M1)
+    component.add_port(
+        name="D",
+        center=(0, 2.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="D",
+        center=(0, 7.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="S",
+        center=(10, 5),
+        width=10,
+        orientation=0,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    gf.add_pins.add_electric_pins(component)
+    pin_names = {pin.name for pin in component.pins}
+    assert pin_names == {"D", "S"}
+    assert len(component.pins) == 2
+
+
+def test_add_electric_pins_skips_non_electrical_ports() -> None:
+    """Only electrical ports get pins; optical ports are ignored."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 0.5), (0, 0.5)], layer=LAYER.WG)
+    component.add_port(
+        name="o1",
+        center=(0, 0.25),
+        width=0.5,
+        orientation=180,
+        layer=LAYER.WG,
+        port_type="optical",
+    )
+    component.add_port(
+        name="e1",
+        center=(10, 0.25),
+        width=0.5,
+        orientation=0,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    gf.add_pins.add_electric_pins(component)
+    assert len(component.pins) == 1
+    assert component.pins[0].name == "e1"
 
 
 def test_add_pins() -> None:

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -7,7 +7,7 @@ from gdsfactory.gpdk import LAYER
 
 
 @pytest.fixture(autouse=True)
-def activate_generic_pdk():
+def activate_generic_pdk() -> None:
     gf.gpdk.PDK.activate()
 
 
@@ -57,9 +57,7 @@ def test_add_electric_pins_with_layer_map() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(
-        component, layer_map={LAYER.M1: LAYER.PORTE}
-    )
+    gf.add_pins.add_electric_pins(component, pin_layer_map={LAYER.M1: LAYER.PORTE})
     polygons = component.get_polygons()
     assert len(polygons[LAYER.PORTE]) == 2
     assert len(polygons[LAYER.M1]) == 1  # only the original polygon

--- a/uv.lock
+++ b/uv.lock
@@ -1379,7 +1379,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'docs'" },
     { name = "jupyterlab", marker = "extra == 'dev'" },
     { name = "jupytext", marker = "extra == 'docs'" },
-    { name = "kfactory", extras = ["ipy"], specifier = "~=3.0.0" },
+    { name = "kfactory", extras = ["ipy"], specifier = "~=3.0.2" },
     { name = "kweb", marker = "extra == 'cad'", specifier = ">=1.1.9,<2.1" },
     { name = "loguru", specifier = "<1" },
     { name = "mapbox-earcut" },
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "3.0.1"
+version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -2408,9 +2408,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/51/db86a5d8acbea261ab8f7a1a3dc23d132989d0523e758b9a32ab3e8ca0a2/kfactory-3.0.1.tar.gz", hash = "sha256:176f74a2942864d8acb33bacec622c78a7a98ef2e98174dcbd79786c70200ce9", size = 1675671, upload-time = "2026-07-20T03:43:56.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8c/de9a0d5d578e544e71d2da22ab3d0c238c762850c6cdebfb4205906d0e6b/kfactory-3.0.2.tar.gz", hash = "sha256:8246feaedfd9278df59c4301d3a8c6f6d9728c7cea0ed1a11bd05664ed7939a2", size = 1676892, upload-time = "2026-07-21T11:19:14.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/9a/e76c513b2ccc823617a9c4707ffd3af91219ecbdb40159a8e6a45408d214/kfactory-3.0.1-py3-none-any.whl", hash = "sha256:fe4bd28fcb0ce49aff9d14f6dc7a4cdd61a04de7985fe7964413583dbdd40e0a", size = 288463, upload-time = "2026-07-20T03:43:54.991Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/79/c3a38e30b848684f9ec0956a55d6ec47e68e1df29a2f3772a485e7118805/kfactory-3.0.2-py3-none-any.whl", hash = "sha256:87e47be3f0a20ac028a8fd3d8d170ef7b97153717097bbeb32e6cbf69107c507", size = 288666, upload-time = "2026-07-21T11:19:12.281Z" },
 ]
 
 [package.optional-dependencies]
@@ -2891,7 +2891,7 @@ name = "manifold3d"
 version = "3.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/36/5b11c97e56d2101b1c6e311580f2546dd0d1cf0fbb167ec59e122e195ced/manifold3d-3.5.2.tar.gz", hash = "sha256:8d445798ba5f86efae18e0dca6cb71823165f0887767a274d7c14ed63ab64648", size = 305761, upload-time = "2026-06-27T05:26:54.353Z" }
 wheels = [
@@ -3790,7 +3790,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
# Summary

## Upstream task:
- https://github.com/doplaydo/pdks/issues/45 (Add pins to all PDKs) 

- For SPICE export to work correctly, we need to identify which electrical ports in this PDK share a node with a gf.Pin object.


I am pushing this further upstream because this task can be aggregated in a single `gdsfactory` API function called in all PCell generators of each affected PDK (basically all PDKs with electrical routing).

## Task
Audit all cells in this PDK and identify every electrical port that shares a node with a gf.Pin object. This is a prerequisite for adding proper pin annotations to enable SPICE netlist export.

## Summary by Sourcery

Add support for generating logical electric pins for electrical ports and validate the behavior with new tests.

New Features:
- Introduce an add_electric_pins helper to create logical pins and pin markers for electrical ports, optionally using a PDK-specific pin layer map.

Enhancements:
- Group electrical ports by name into single logical pins to better reflect shared electrical nodes.

Tests:
- Add tests covering electric pin creation with and without a pin-layer map, grouping ports by name, and ignoring non-electrical ports during pin generation.