### PR TITLE
docs: add section on adding new layers to PDK tutorial

### DIFF
--- a/docs/notebooks/08_pdk.ipynb
+++ b/docs/notebooks/08_pdk.ipynb
@@ -141,6 +141,54 @@
   },
   {
    "cell_type": "markdown",
+   "id": "add-new-layers-md",
+   "metadata": {},
+   "source": [
+    "### Adding new layers\n",
+    "\n",
+    "You can also add new layers directly using `gf.kcl.layer(layer_number, datatype)`, which registers the layer in the KLayout database and returns its integer index.\n",
+    "\n",
+    "This is useful when you need to quickly define a custom layer for your PDK without modifying the full `LayerMap` class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add-new-layers-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "# Define a new layer with layer number 99 and datatype 0\n",
+    "PdkWG = gf.kcl.layer(99, 0)\n",
+    "PdkWG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add-new-layers-usage",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the new layer in a component\n",
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=(99, 0))\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "add-new-layers-tip",
+   "metadata": {},
+   "source": [
+    "For a full PDK, you should still define all your layers in a `LayerMap` class so they can be registered with the PDK and accessed by name.\n",
+    "However, `gf.kcl.layer` is handy for quick prototyping or when extending an existing PDK with additional layers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5",
    "metadata": {},
    "source": [

--- a/docs/notebooks/08_pdk.ipynb
+++ b/docs/notebooks/08_pdk.ipynb
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "add-new-layers-md",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Adding new layers\n",
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "add-new-layers-code",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "add-new-layers-usage",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "add-new-layers-tip",
+   "id": "8",
    "metadata": {},
    "source": [
     "For a full PDK, you should still define all your layers in a `LayerMap` class so they can be registered with the PDK and accessed by name.\n",
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Cross_Sections\n",
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "13",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -308,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Cells\n",
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "18",
    "metadata": {},
    "source": [
     "You can define a new PDK by creating a function that customizes partial parameters of the generic functions.\n",
@@ -373,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "20",
    "metadata": {},
    "source": [
     "## PDK\n",
@@ -400,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "24",
    "metadata": {},
    "source": [
     "### CrossSectionSpec\n",
@@ -451,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "28",
    "metadata": {},
    "source": [
     "### ComponentSpec\n",
@@ -495,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "31",
    "metadata": {},
    "source": [
     "## Layer Views\n",
@@ -536,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +548,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "33",
    "metadata": {},
    "source": [
     "LYP files are defined in XML and are only easy to edit in the KLayout Graphical User Interface (GUI).\n",
@@ -559,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "35",
    "metadata": {},
    "source": [
     "## PDK\n",
@@ -593,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Testing PDK cells\n",
@@ -677,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "39",
    "metadata": {},
    "source": [
     "## Compare gds files\n",
@@ -733,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary
- Adds a new "Adding new layers" subsection to the PDK docs (`08_pdk.ipynb`)
- Shows how to use `gf.kcl.layer(99, 0)` to register a custom layer and get its KLayout database index
- Includes example of using the new layer in a component
- Notes when to use `gf.kcl.layer` vs a full `LayerMap` class

Closes #4740

## Test plan
- [ ] Verify the notebook renders correctly in the docs
- [ ] Run the code cells to confirm `gf.kcl.layer(99, 0)` works as shown

⚠️ Reminder: AI-created PRs still require human review of the actual code changes before merge. I'll open the PR, but a human must review and approve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add an 'Adding new layers' section to the PDK tutorial notebook explaining gf.kcl.layer usage and when to prefer a LayerMap-based definition.