### PR TITLE
refactor(spice): allow for port to pin mapping in add_electric_pins

### DIFF
--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -448,6 +448,7 @@ add_pins_inside2um = partial(add_pins, function=add_pin_inside2um)
 
 def add_electric_pins(
     component: Component,
+    port_pin_mapping: dict[str, list[str]] | None = None,
     pin_layer_map: dict[tuple[int, int], tuple[int, int]] | None = None,
     pin_function: AddPinFunction = add_pin_rectangle_inside,  # type: ignore[assignment]
     pin_type: str = "DC",
@@ -460,16 +461,27 @@ def add_electric_pins(
 
     Args:
         component: Component to add pins to.
+        port_pin_mapping: Explicit mapping from pin name to port names.
+            When provided, each key becomes a logical pin whose ports are
+            looked up by name from the component. When None, electrical
+            ports are auto-grouped by their own name.
         pin_layer_map: Mapping from port layer to pin layer for PDK specific layer. When None,
             each port's own layer is used (for PDKs where ports are already
             on pin layers).
         pin_function: Function to draw each pin marker.
         pin_type: Pin type string passed to create_pin().
     """
-    by_name: dict[str, list] = {}
-    for port in component.ports:
-        if port.port_type == "electrical":
-            by_name.setdefault(port.name, []).append(port)
+    if port_pin_mapping is not None:
+        by_name: dict[str, list] = {
+            pin_name: [component.ports[pn] for pn in port_names]
+            for pin_name, port_names in port_pin_mapping.items()
+        }
+    else:
+        by_name = {}
+        for port in component.ports:
+            if port.port_type == "electrical":
+                by_name.setdefault(port.name, []).append(port)
+
     for name, ports in by_name.items():
         for port in ports:
             pin_layer = pin_layer_map.get(port.layer) if pin_layer_map else port.layer

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -98,6 +98,44 @@ def test_add_electric_pins_groups_ports_by_name() -> None:
     assert len(component.pins) == 2
 
 
+def test_add_electric_pins_with_port_pin_mapping() -> None:
+    """Explicit port_pin_mapping groups ports under custom pin names."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.M1)
+    component.add_port(
+        name="A",
+        center=(0, 2.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="B",
+        center=(0, 7.5),
+        width=5,
+        orientation=180,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    component.add_port(
+        name="C",
+        center=(10, 5),
+        width=10,
+        orientation=0,
+        layer=LAYER.M1,
+        port_type="electrical",
+    )
+    gf.add_pins.add_electric_pins(
+        component, port_pin_mapping={"VDD": ["A", "B"], "GND": ["C"]}
+    )
+    pin_names = {pin.name for pin in component.pins}
+    assert pin_names == {"VDD", "GND"}
+    assert len(component.pins) == 2
+    polygons = component.get_polygons()
+    assert len(polygons[LAYER.M1]) == 4  # original polygon + 3 pin rectangles
+
+
 def test_add_electric_pins_skips_non_electrical_ports() -> None:
     """Only electrical ports get pins; optical ports are ignored."""
     component = gf.Component()


### PR DESCRIPTION
## Summary

The add_electric_pins function now uses port_pin_mapping when provided — each key is a pin name and each value is a list of port name strings looked up from the component, ensuring backwards compatibility in all PDKs. When None, it falls back to the original auto-grouping of electrical ports by name.

## Test Plan

Test plan
- [x] Explicit mapping groups ports under custom pin names — three ports (A, B, C) mapped to two pins (VDD, GND) produce the correct logical pins and pin markers (test_add_electric_pins_with_port_pin_mapping)
 - [x] Fallback without mapping — when port_pin_mapping=None, electrical ports are auto-grouped by name as before (test_add_electric_pins_without_layer_map)
 - [x] Fallback with layer map — pin markers land on the mapped layer, not the port layer (test_add_electric_pins_with_layer_map)
 - [x] Auto-grouping by name — ports sharing a name collapse into a single logical pin (test_add_electric_pins_groups_ports_by_name)
 - [x] Non-electrical ports ignored — optical ports are skipped when no explicit mapping is provided (test_add_electric_pins_skips_non_electrical_ports)

## Summary by Sourcery

Allow explicit mapping from logical pin names to component ports when adding electrical pins while preserving previous auto-grouping behavior by port name.

New Features:
- Support explicit port-to-pin name mapping in add_electric_pins via an optional port_pin_mapping argument.

Tests:
- Add regression test verifying add_electric_pins groups multiple ports under custom pin names using port_pin_mapping.