### PR TITLE
Add new method to insert a kdb.Region into a Component

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -981,6 +981,11 @@ class Component(ComponentBase, kf.DKCell):
             r.merge()
         return r
 
+    def insert_region(self, region: kdb.Region, layer: LayerSpec) -> None:
+        if self.locked:
+            raise LockedError(self)
+        self.shapes(layer).insert(region)
+
     def get_polygons_points(
         self,
         merge: bool = False,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -831,3 +831,16 @@ def test_fill() -> None:
     assert np.isclose(fill_area, expected_fill_area), (
         f"{fill_area} != {expected_fill_area}"
     )
+
+
+def test_insert_region() -> None:
+    """Verify that Component.insert_region correctly inserts a kdb.Region."""
+    c = gf.Component()
+
+    _ = c << gf.c.circle(layer=(1, 0), radius=10)
+    region = c.get_region(layer=(1, 0))
+
+    c.insert_region(region, layer=(2, 0))
+    polys1 = c.get_polygons(layers=[(1, 0)]).values()
+    polys2 = c.get_polygons(layers=[(2, 0)]).values()
+    assert list(polys1) == list(polys2)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -844,3 +844,12 @@ def test_insert_region() -> None:
     polys1 = c.get_polygons(layers=[(1, 0)]).values()
     polys2 = c.get_polygons(layers=[(2, 0)]).values()
     assert list(polys1) == list(polys2)
+
+
+def test_insert_region_locked() -> None:
+    """Verify that Component.insert_region fails for a locked Component."""
+    c = gf.c.circle(layer=(1, 0), radius=10)
+    region = c.get_region(layer=(1, 0))
+
+    with pytest.raises(LockedError):
+        c.insert_region(region, layer=(2, 0))

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.44.0"
+version = "9.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -2891,7 +2891,7 @@ name = "manifold3d"
 version = "3.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/36/5b11c97e56d2101b1c6e311580f2546dd0d1cf0fbb167ec59e122e195ced/manifold3d-3.5.2.tar.gz", hash = "sha256:8d445798ba5f86efae18e0dca6cb71823165f0887767a274d7c14ed63ab64648", size = 305761, upload-time = "2026-06-27T05:26:54.353Z" }
 wheels = [
@@ -3790,7 +3790,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary
Add method to insert a `kdb.Region` into a `gf.Component`

## Test Plan

Add `test_insert_region` test to `tests/test_component.py`

## Summary by Sourcery

Add support for inserting an existing kdb.Region into a Component on a specified layer.

New Features:
- Introduce Component.insert_region to insert a kdb.Region into a target layer of the component.

Tests:
- Add test_insert_region to verify that Component.insert_region correctly copies shapes from one layer to another via a kdb.Region.