### PR TITLE
Add on_placer_error to route_single matching route_bundle

### DIFF
--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -68,7 +68,9 @@ def route_single(
     radius: float | None = None,
     route_width: float | None = None,
     auto_taper: bool = True,
+    on_collision: Literal["error", "show_error", "warning"] | None = None,
     on_placer_error: Literal["error", "show_error", "warning"] | None = None,
+    on_error: Literal["error"] | None = None,
     layer_transitions: LayerTransitions | None = None,
 ) -> ManhattanRoute:
     """Returns a Manhattan Route between 2 ports.
@@ -94,10 +96,13 @@ def route_single(
         radius: bend radius. If None, defaults to cross_section.radius.
         route_width: width of the route in um. If None, defaults to cross_section.width.
         auto_taper: add auto tapers.
-        on_placer_error: action to take on placer error. "error" raises an exception.
+        on_collision: action to take on route collision. "error" raises an exception.
             "show_error" shows the error in klayout's marker database.
             "warning" emits a warning and falls back to error markers.
-            None silently falls back to error markers. Defaults to CONF.on_placer_error.
+            None silently falls back to error markers. Defaults to CONF.on_collision.
+        on_placer_error: action to take on placer error. Same options as on_collision.
+            Defaults to CONF.on_placer_error.
+        on_error: deprecated, use on_placer_error instead. Maps to on_placer_error.
         layer_transitions: dictionary of layer transitions to use for the routing when auto_taper=True.
 
     Example:
@@ -112,6 +117,15 @@ def route_single(
         c.plot()
         ```
     """
+    if on_error is not None:
+        warnings.warn(
+            "on_error is deprecated, use on_placer_error instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        on_placer_error = on_placer_error or (on_error if on_error == "error" else None)
+
+    on_collision = on_collision or CONF.on_collision
     on_placer_error = on_placer_error or CONF.on_placer_error
 
     if cross_section is None and (layer is None or route_width is None):
@@ -287,6 +301,7 @@ def route_single(
             )
 
     else:
+        kf_on_collision = "error" if on_collision == "warning" else on_collision
         kf_on_placer_error = (
             "error" if on_placer_error == "warning" else on_placer_error
         )
@@ -303,16 +318,17 @@ def route_single(
                 place_port_type=port_type,
                 allow_width_mismatch=allow_width_mismatch,
                 route_width=route_width,
+                on_collision=kf_on_collision,
                 on_placer_error=kf_on_placer_error,
             )[0]
         except Exception as e:
-            if on_placer_error == "error":
+            if on_placer_error == "error" or on_collision == "error":
                 raise
 
-            if on_placer_error == "show_error":
+            if on_placer_error == "show_error" or on_collision == "show_error":
                 raise
 
-            if on_placer_error == "warning":
+            if on_placer_error == "warning" or on_collision == "warning":
                 gf.logger.error(f"Error in route_single: {e}")
                 warnings.warn(f"Routing failed: {e}", stacklevel=2)
 

--- a/gdsfactory/routing/route_single.py
+++ b/gdsfactory/routing/route_single.py
@@ -27,6 +27,7 @@ To generate a route:
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
@@ -36,6 +37,7 @@ from kfactory.routing.optical import place_manhattan
 
 import gdsfactory as gf
 from gdsfactory.component import Component
+from gdsfactory.config import CONF
 from gdsfactory.routing.auto_taper import add_auto_tapers
 from gdsfactory.typings import (
     STEP_DIRECTIVES,
@@ -66,7 +68,7 @@ def route_single(
     radius: float | None = None,
     route_width: float | None = None,
     auto_taper: bool = True,
-    on_error: Literal["error"] | None = "error",
+    on_placer_error: Literal["error", "show_error", "warning"] | None = None,
     layer_transitions: LayerTransitions | None = None,
 ) -> ManhattanRoute:
     """Returns a Manhattan Route between 2 ports.
@@ -92,7 +94,10 @@ def route_single(
         radius: bend radius. If None, defaults to cross_section.radius.
         route_width: width of the route in um. If None, defaults to cross_section.width.
         auto_taper: add auto tapers.
-        on_error: what to do on error. If error, raises an error. If None ignores the error.
+        on_placer_error: action to take on placer error. "error" raises an exception.
+            "show_error" shows the error in klayout's marker database.
+            "warning" emits a warning and falls back to error markers.
+            None silently falls back to error markers. Defaults to CONF.on_placer_error.
         layer_transitions: dictionary of layer transitions to use for the routing when auto_taper=True.
 
     Example:
@@ -107,6 +112,8 @@ def route_single(
         c.plot()
         ```
     """
+    on_placer_error = on_placer_error or CONF.on_placer_error
+
     if cross_section is None and (layer is None or route_width is None):
         raise ValueError(
             f"Either {cross_section=} or {layer=} and route_width must be provided"
@@ -203,6 +210,9 @@ def route_single(
                 for p in cast("Sequence[gf.kdb.DPoint]", waypoints_list)
             ]
 
+        kf_on_placer_error = (
+            "error" if on_placer_error == "warning" else on_placer_error
+        )
         try:
             return place_manhattan(
                 component.to_itype(),
@@ -216,34 +226,38 @@ def route_single(
                 route_width=c.kcl.to_dbu(width),
             )
         except Exception as e:
-            # error_route((ps, pe, router.start.pts, router.width))
-            ps = p1
-            pe = p2
-            c = component
-            pts = w
-            db = kf.rdb.ReportDatabase("Route Placing Errors")
-            cell = db.create_cell(
-                (
-                    c.kcl._future_cell_name or c.name
-                    if c.name is not None and c.name.startswith("Unnamed_")
-                    else c.name
-                )
-                or ""
-            )
-            cat = db.create_category(f"{ps.name} - {pe.name}")
-            it = db.create_item(cell=cell, category=cat)
-            it.add_value(
-                f"Error while trying to place route from {ps.name} to {pe.name} at"
-                f" points (dbu): {pts}"
-            )
-            it.add_value(f"Exception: {e}")
-            if route_width is not None:
-                path = kf.kdb.Path(pts, c.kcl.to_dbu(route_width))
-            else:
-                path = kf.kdb.Path(pts, c.kcl.to_dbu(ps.width))
+            if on_placer_error == "error":
+                raise kf.routing.generic.PlacerError(
+                    f"Error while trying to place route from {p1.name} to {p2.name} at"
+                    f" points (dbu): {w}"
+                ) from e
 
-            it.add_value(c.kcl.to_um(path.polygon()))
-            if on_error == "error":
+            if on_placer_error == "show_error":
+                ps = p1
+                pe = p2
+                c = component
+                pts = w
+                db = kf.rdb.ReportDatabase("Route Placing Errors")
+                cell = db.create_cell(
+                    (
+                        c.kcl._future_cell_name or c.name
+                        if c.name is not None and c.name.startswith("Unnamed_")
+                        else c.name
+                    )
+                    or ""
+                )
+                cat = db.create_category(f"{ps.name} - {pe.name}")
+                it = db.create_item(cell=cell, category=cat)
+                it.add_value(
+                    f"Error while trying to place route from {ps.name} to {pe.name} at"
+                    f" points (dbu): {pts}"
+                )
+                it.add_value(f"Exception: {e}")
+                if route_width is not None:
+                    path = kf.kdb.Path(pts, c.kcl.to_dbu(route_width))
+                else:
+                    path = kf.kdb.Path(pts, c.kcl.to_dbu(ps.width))
+                it.add_value(c.kcl.to_um(path.polygon()))
                 c.name = (
                     c.kcl._future_cell_name or c.name
                     if c.name is not None and c.name.startswith("Unnamed_")
@@ -254,29 +268,68 @@ def route_single(
                     f"Error while trying to place route from {ps.name} to {pe.name} at"
                     f" points (dbu): {pts}"
                 ) from e
+
+            if on_placer_error == "warning":
+                gf.logger.error(f"Error in route_single: {e}")
+                warnings.warn(f"Routing failed: {e}", stacklevel=2)
+
             layer_error = gf.CONF.layer_error_path
             layer_index = c.kcl.layer(*layer_error)
+            if route_width is not None:
+                path = kf.kdb.Path(w, c.kcl.to_dbu(route_width))
+            else:
+                path = kf.kdb.Path(w, c.kcl.to_dbu(p1.width))
             c.shapes(layer_index).insert(path)
             return ManhattanRoute(
-                backbone=pts,
+                backbone=w,
                 start_port=p1.to_itype(),
                 end_port=p2.to_itype(),
             )
 
     else:
-        return kf.routing.optical.route_bundle(
-            c=component,
-            start_ports=[p1],
-            end_ports=[p2],
-            straight_factory=straight_,
-            bend90_cell=bend90,
-            starts=start_straight_length,
-            ends=end_straight_length,
-            separation=0,
-            place_port_type=port_type,
-            allow_width_mismatch=allow_width_mismatch,
-            route_width=route_width,
-        )[0]
+        kf_on_placer_error = (
+            "error" if on_placer_error == "warning" else on_placer_error
+        )
+        try:
+            return kf.routing.optical.route_bundle(
+                c=component,
+                start_ports=[p1],
+                end_ports=[p2],
+                straight_factory=straight_,
+                bend90_cell=bend90,
+                starts=start_straight_length,
+                ends=end_straight_length,
+                separation=0,
+                place_port_type=port_type,
+                allow_width_mismatch=allow_width_mismatch,
+                route_width=route_width,
+                on_placer_error=kf_on_placer_error,
+            )[0]
+        except Exception as e:
+            if on_placer_error == "error":
+                raise
+
+            if on_placer_error == "show_error":
+                raise
+
+            if on_placer_error == "warning":
+                gf.logger.error(f"Error in route_single: {e}")
+                warnings.warn(f"Routing failed: {e}", stacklevel=2)
+
+            layer_error_path = gf.get_layer_info(gf.CONF.layer_error_path)
+            route = kf.routing.electrical.route_bundle(
+                component,
+                [p1],
+                [p2],
+                separation=0,
+                starts=start_straight_length,
+                ends=end_straight_length,
+                on_collision=None,
+                on_placer_error=None,
+                route_width=width,
+                place_layer=layer_error_path,
+            )
+            return route[0]
 
 
 def route_single_electrical(

--- a/tests/routing/test_route_single_on_placer_error.py
+++ b/tests/routing/test_route_single_on_placer_error.py
@@ -8,28 +8,34 @@ from kfactory.routing.generic import PlacerError
 import gdsfactory as gf
 
 
-def _make_failing_route_args() -> tuple[gf.Component, gf.Port, gf.Port]:
-    """Return (component, port1, port2) that will fail to route.
+def _make_failing_route_args() -> tuple[gf.Component, gf.Port, gf.Port, list[dict]]:
+    """Return (component, port1, port2, steps) that will fail to route.
 
-    Two straights placed with the same orientation but only 2um apart
-    vertically. Both o2 ports face right so the router needs U-turns
-    that require far more space than 2um (default radius ~10um).
+    Uses steps with corners separated by only 1um, which is far too tight
+    for the default bend radius (~10um). The placer will fail trying to
+    fit bend cells into these corners.
     """
     c = gf.Component()
     s1 = c << gf.components.straight(length=5, cross_section="strip")
     s2 = c << gf.components.straight(length=5, cross_section="strip")
-    s2.dmove((0, 2))
-    return c, s1.ports["o2"], s2.ports["o2"]
+    s2.dmove((100, 80))
+    steps = [
+        {"dx": 1},
+        {"dy": 1},
+        {"dx": 1},
+    ]
+    return c, s1.ports["o2"], s2.ports["o1"], steps
 
 
 def test_route_single_on_placer_error_none() -> None:
     """on_placer_error=None silently falls back to error markers."""
-    c, p1, p2 = _make_failing_route_args()
+    c, p1, p2, steps = _make_failing_route_args()
     route = gf.routing.route_single(
         c,
         p1,
         p2,
         cross_section="strip",
+        steps=steps,
         on_placer_error=None,
     )
     assert route is not None
@@ -37,20 +43,21 @@ def test_route_single_on_placer_error_none() -> None:
 
 def test_route_single_on_placer_error_error() -> None:
     """on_placer_error='error' raises an exception."""
-    c, p1, p2 = _make_failing_route_args()
+    c, p1, p2, steps = _make_failing_route_args()
     with pytest.raises((PlacerError, ValueError)):
         gf.routing.route_single(
             c,
             p1,
             p2,
             cross_section="strip",
+            steps=steps,
             on_placer_error="error",
         )
 
 
 def test_route_single_on_placer_error_warning() -> None:
     """on_placer_error='warning' emits a warning and falls back to error markers."""
-    c, p1, p2 = _make_failing_route_args()
+    c, p1, p2, steps = _make_failing_route_args()
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         route = gf.routing.route_single(
@@ -58,6 +65,7 @@ def test_route_single_on_placer_error_warning() -> None:
             p1,
             p2,
             cross_section="strip",
+            steps=steps,
             on_placer_error="warning",
         )
         routing_warnings = [x for x in w if "Routing failed" in str(x.message)]
@@ -67,12 +75,13 @@ def test_route_single_on_placer_error_warning() -> None:
 
 def test_route_single_on_placer_error_show_error() -> None:
     """on_placer_error='show_error' raises and sends error to klayout marker database."""
-    c, p1, p2 = _make_failing_route_args()
+    c, p1, p2, steps = _make_failing_route_args()
     with pytest.raises((PlacerError, ValueError)):
         gf.routing.route_single(
             c,
             p1,
             p2,
             cross_section="strip",
+            steps=steps,
             on_placer_error="show_error",
         )

--- a/tests/routing/test_route_single_on_placer_error.py
+++ b/tests/routing/test_route_single_on_placer_error.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from kfactory.routing.generic import PlacerError
+
+import gdsfactory as gf
+
+
+def _make_failing_route_args() -> tuple[gf.Component, gf.Port, gf.Port]:
+    """Return (component, port1, port2) that will fail to route.
+
+    Both ports face the same direction with a tiny offset, making it
+    impossible to fit the default bend radius.
+    """
+    c = gf.Component()
+    p1 = gf.Port(name="o1", center=(0, 0), width=0.5, orientation=0, layer=(1, 0))
+    p2 = gf.Port(name="o2", center=(3, 3), width=0.5, orientation=0, layer=(1, 0))
+    return c, p1, p2
+
+
+def test_route_single_on_placer_error_none() -> None:
+    """on_placer_error=None silently falls back to error markers."""
+    c, p1, p2 = _make_failing_route_args()
+    route = gf.routing.route_single(
+        c,
+        p1,
+        p2,
+        cross_section="strip",
+        on_placer_error=None,
+    )
+    assert route is not None
+
+
+def test_route_single_on_placer_error_error() -> None:
+    """on_placer_error='error' raises an exception."""
+    c, p1, p2 = _make_failing_route_args()
+    with pytest.raises((PlacerError, ValueError)):
+        gf.routing.route_single(
+            c,
+            p1,
+            p2,
+            cross_section="strip",
+            on_placer_error="error",
+        )
+
+
+def test_route_single_on_placer_error_warning() -> None:
+    """on_placer_error='warning' emits a warning and falls back to error markers."""
+    c, p1, p2 = _make_failing_route_args()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        route = gf.routing.route_single(
+            c,
+            p1,
+            p2,
+            cross_section="strip",
+            on_placer_error="warning",
+        )
+        routing_warnings = [x for x in w if "Routing failed" in str(x.message)]
+        assert len(routing_warnings) >= 1
+    assert route is not None
+
+
+def test_route_single_on_placer_error_show_error() -> None:
+    """on_placer_error='show_error' raises and sends error to klayout marker database."""
+    c, p1, p2 = _make_failing_route_args()
+    with pytest.raises((PlacerError, ValueError)):
+        gf.routing.route_single(
+            c,
+            p1,
+            p2,
+            cross_section="strip",
+            on_placer_error="show_error",
+        )

--- a/tests/routing/test_route_single_on_placer_error.py
+++ b/tests/routing/test_route_single_on_placer_error.py
@@ -11,13 +11,15 @@ import gdsfactory as gf
 def _make_failing_route_args() -> tuple[gf.Component, gf.Port, gf.Port]:
     """Return (component, port1, port2) that will fail to route.
 
-    Both ports face the same direction with a tiny offset, making it
-    impossible to fit the default bend radius.
+    Two straights placed with the same orientation but only 2um apart
+    vertically. Both o2 ports face right so the router needs U-turns
+    that require far more space than 2um (default radius ~10um).
     """
     c = gf.Component()
-    p1 = gf.Port(name="o1", center=(0, 0), width=0.5, orientation=0, layer=(1, 0))
-    p2 = gf.Port(name="o2", center=(3, 3), width=0.5, orientation=0, layer=(1, 0))
-    return c, p1, p2
+    s1 = c << gf.components.straight(length=5, cross_section="strip")
+    s2 = c << gf.components.straight(length=5, cross_section="strip")
+    s2.dmove((0, 2))
+    return c, s1.ports["o2"], s2.ports["o2"]
 
 
 def test_route_single_on_placer_error_none() -> None:


### PR DESCRIPTION
## Summary

Closes #4745

`route_single` uses kfactory's `route_bundle` internally but lacked the error-handling fallover logic that gdsfactory's `route_bundle` provides.

- Replace `on_error` parameter with `on_placer_error` supporting all four modes: `"error"` (raise), `"show_error"` (klayout marker DB + raise), `"warning"` (warn + error markers), `None` (silent error markers)
- Default to `CONF.on_placer_error` matching `route_bundle` behavior
- Add fallover to `kf.routing.electrical.route_bundle` on the error layer in the non-waypoints code path (previously had no error handling at all)
- Add tests for all four `on_placer_error` modes

## Test plan

- [ ] `test_route_single_on_placer_error_none` — verifies silent fallback returns a route
- [ ] `test_route_single_on_placer_error_error` — verifies exception is raised
- [ ] `test_route_single_on_placer_error_warning` — verifies warning is emitted and route returned
- [ ] `test_route_single_on_placer_error_show_error` — verifies klayout marker DB path raises

⚠️ Reminder: AI-created PRs still require human review of the actual code changes before merge. A human must review and approve it.

## Summary by Sourcery

Align route_single error handling with route_bundle by introducing configurable placer error behavior and consistent fallback routing on failures.

New Features:
- Add on_placer_error parameter to route_single supporting error, show_error, warning, and silent fallback modes, defaulting to CONF.on_placer_error.

Enhancements:
- Unify placer error handling in route_single by raising PlacerError, logging, and generating error-marker routes depending on the configured mode, including in the non-waypoints routing path.
- Introduce fallback to kfactory.routing.electrical.route_bundle on the error layer when route_bundle placement fails without waypoints.

Tests:
- Add tests covering all on_placer_error modes for route_single, including silent fallback, exception raising, warning emission, and klayout marker database behavior.