### PR TITLE
docs: add electrical pins tutorial section and rename add_electric_pins -> add_electrical_pins

### DIFF
--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -1021,7 +1021,7 @@
    "source": [
     "### Electrical pins\n",
     "\n",
-    "For electrical ports, `add_electric_pins` draws pin markers and registers logical pins.\n",
+    "For electrical ports, `add_electrical_pins` draws pin markers and registers logical pins.\n",
     "It auto-groups electrical ports by name and lets you control which GDS layers the pin rectangles and labels are drawn on.\n",
     "\n",
     "The simplest usage passes a `default_pin_layer` so that every electrical port gets a pin rectangle on that layer:"
@@ -1042,7 +1042,7 @@
     "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
     "c.add_port(name=\"e2\", center=(10, 2.5), width=5, orientation=0, layer=LAYER.M1, port_type=\"electrical\")\n",
     "\n",
-    "gf.add_pins.add_electric_pins(c, default_pin_layer=LAYER.M1)\n",
+    "gf.add_pins.add_electrical_pins(c, default_pin_layer=LAYER.M1)\n",
     "print(f\"Pins registered: {len(c.pins)}\")\n",
     "c.plot()"
    ]
@@ -1066,7 +1066,7 @@
     "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",
     "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
     "\n",
-    "gf.add_pins.add_electric_pins(c, default_pin_layer=LAYER.M1, default_label_layer=LAYER.TEXT)\n",
+    "gf.add_pins.add_electrical_pins(c, default_pin_layer=LAYER.M1, default_label_layer=LAYER.TEXT)\n",
     "print(f\"Labels on TEXT layer: {len(c.get_labels(LAYER.TEXT))}\")\n",
     "c.plot()"
    ]
@@ -1091,7 +1091,7 @@
     "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
     "\n",
     "# Map M1 ports to specific pin and label layers\n",
-    "gf.add_pins.add_electric_pins(\n",
+    "gf.add_pins.add_electrical_pins(\n",
     "    c,\n",
     "    pin_layer_map={LAYER.M1: LAYER.M1},\n",
     "    pin_label_layer_map={LAYER.M1: LAYER.TEXT},\n",
@@ -1121,7 +1121,7 @@
     "c.add_port(name=\"C\", center=(20, 5), width=5, orientation=0, layer=LAYER.M1, port_type=\"electrical\")\n",
     "\n",
     "# Group ports A and B into \"VDD\", port C becomes \"GND\"\n",
-    "gf.add_pins.add_electric_pins(\n",
+    "gf.add_pins.add_electrical_pins(\n",
     "    c,\n",
     "    port_pin_mapping={\"VDD\": [\"A\", \"B\"], \"GND\": [\"C\"]},\n",
     "    default_pin_layer=LAYER.M1,\n",
@@ -1135,7 +1135,7 @@
    "id": "82",
    "metadata": {},
    "source": [
-    "If no pin or label layer can be resolved, `add_electric_pins` still registers the logical pins but skips drawing markers:"
+    "If no pin or label layer can be resolved, `add_electrical_pins` still registers the logical pins but skips drawing markers:"
    ]
   },
   {
@@ -1150,7 +1150,7 @@
     "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
     "\n",
     "# No layer info provided -- pins are registered but no markers are drawn\n",
-    "gf.add_pins.add_electric_pins(c)\n",
+    "gf.add_pins.add_electrical_pins(c)\n",
     "print(f\"Pins: {len(c.pins)}, Extra polygons on M1: {len(c.get_polygons()[LAYER.M1]) - 1}\")\n",
     "c.plot()"
    ]

--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -1019,6 +1019,147 @@
    "id": "74",
    "metadata": {},
    "source": [
+    "### Electrical pins\n",
+    "\n",
+    "For electrical ports, `add_electric_pins` draws pin markers and registers logical pins.\n",
+    "It auto-groups electrical ports by name and lets you control which GDS layers the pin rectangles and labels are drawn on.\n",
+    "\n",
+    "The simplest usage passes a `default_pin_layer` so that every electrical port gets a pin rectangle on that layer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from gdsfactory.generic_tech import LAYER\n",
+    "\n",
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",
+    "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "c.add_port(name=\"e2\", center=(10, 2.5), width=5, orientation=0, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "\n",
+    "gf.add_pins.add_electric_pins(c, default_pin_layer=LAYER.M1)\n",
+    "print(f\"Pins registered: {len(c.pins)}\")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76",
+   "metadata": {},
+   "source": [
+    "You can also place labels on a separate layer using `default_label_layer`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",
+    "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "\n",
+    "gf.add_pins.add_electric_pins(c, default_pin_layer=LAYER.M1, default_label_layer=LAYER.TEXT)\n",
+    "print(f\"Labels on TEXT layer: {len(c.get_labels(LAYER.TEXT))}\")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78",
+   "metadata": {},
+   "source": [
+    "For PDKs where different port layers need different pin or label layers, use `pin_layer_map` and `pin_label_layer_map`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",
+    "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "\n",
+    "# Map M1 ports to specific pin and label layers\n",
+    "gf.add_pins.add_electric_pins(\n",
+    "    c,\n",
+    "    pin_layer_map={LAYER.M1: LAYER.M1},\n",
+    "    pin_label_layer_map={LAYER.M1: LAYER.TEXT},\n",
+    ")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80",
+   "metadata": {},
+   "source": [
+    "You can group multiple ports into a single logical pin using `port_pin_mapping`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (20, 0), (20, 10), (0, 10)], layer=LAYER.M1)\n",
+    "c.add_port(name=\"A\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "c.add_port(name=\"B\", center=(0, 7.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "c.add_port(name=\"C\", center=(20, 5), width=5, orientation=0, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "\n",
+    "# Group ports A and B into \"VDD\", port C becomes \"GND\"\n",
+    "gf.add_pins.add_electric_pins(\n",
+    "    c,\n",
+    "    port_pin_mapping={\"VDD\": [\"A\", \"B\"], \"GND\": [\"C\"]},\n",
+    "    default_pin_layer=LAYER.M1,\n",
+    ")\n",
+    "print(f\"Pin names: {[pin.name for pin in c.pins]}\")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82",
+   "metadata": {},
+   "source": [
+    "If no pin or label layer can be resolved, `add_electric_pins` still registers the logical pins but skips drawing markers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",
+    "c.add_port(name=\"e1\", center=(0, 2.5), width=5, orientation=180, layer=LAYER.M1, port_type=\"electrical\")\n",
+    "\n",
+    "# No layer info provided -- pins are registered but no markers are drawn\n",
+    "gf.add_pins.add_electric_pins(c)\n",
+    "print(f\"Pins: {len(c.pins)}, Extra polygons on M1: {len(c.get_polygons()[LAYER.M1]) - 1}\")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84",
+   "metadata": {},
+   "source": [
     "## Component_sequence\n",
     "\n",
     "When you have repetitive connections you can describe the connectivity as an ASCII map."
@@ -1027,7 +1168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,7 +1208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "86",
    "metadata": {},
    "source": [
     "As the sequence is defined as a string you can use the string operations to easily build complex sequences"
@@ -1075,7 +1216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "87",
    "metadata": {},
    "source": [
     "## Movement\n",
@@ -1086,7 +1227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1112,7 +1253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "89",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1128,7 +1269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "90",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1146,7 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "91",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1164,7 +1305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "92",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1181,7 +1322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,7 +1339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "94",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1216,7 +1357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "96",
    "metadata": {},
    "source": [
     "Each Component and Instance object has several properties which can be used\n",
@@ -1250,7 +1391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "98",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1290,7 +1431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "99",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1318,7 +1459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1328,7 +1469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "101",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1345,7 +1486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "102",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1365,7 +1506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1381,7 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "104",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1396,7 +1537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "105",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1413,7 +1554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -1035,7 +1035,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
-    "from gdsfactory.generic_tech import LAYER\n",
+    "from gdsfactory.gpdk import LAYER\n",
     "\n",
     "c = gf.Component()\n",
     "c.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)\n",

--- a/gdsfactory/add_pins.py
+++ b/gdsfactory/add_pins.py
@@ -447,7 +447,7 @@ add_pins_inside1nm = partial(add_pins, function=add_pin_inside1nm)
 add_pins_inside2um = partial(add_pins, function=add_pin_inside2um)
 
 
-def add_electric_pins(
+def add_electrical_pins(
     component: Component,
     port_pin_mapping: dict[str, list[str]] | None = None,
     pin_layer_map: dict[typings.LayerSpec, typings.LayerSpec] | None = None,

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -11,7 +11,7 @@ def activate_generic_pdk() -> None:
     gf.gpdk.PDK.activate()
 
 
-def test_add_electric_pins_without_layer_map() -> None:
+def test_add_electrical_pins_without_layer_map() -> None:
     """Pin rectangles are drawn via default_pin_layer when no layer_map is given."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
@@ -31,13 +31,13 @@ def test_add_electric_pins_without_layer_map() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component, default_pin_layer=LAYER.M1)
+    gf.add_pins.add_electrical_pins(component, default_pin_layer=LAYER.M1)
     polygons = component.get_polygons()
     assert len(polygons[LAYER.M1]) == 3  # original polygon + 2 pin rectangles
     assert len(component.pins) == 2
 
 
-def test_add_electric_pins_with_layer_map() -> None:
+def test_add_electrical_pins_with_layer_map() -> None:
     """Pin rectangles are drawn on the mapped pin layer, not the port layer."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
@@ -57,14 +57,14 @@ def test_add_electric_pins_with_layer_map() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component, pin_layer_map={LAYER.M1: LAYER.PORTE})
+    gf.add_pins.add_electrical_pins(component, pin_layer_map={LAYER.M1: LAYER.PORTE})
     polygons = component.get_polygons()
     assert len(polygons[LAYER.PORTE]) == 2
     assert len(polygons[LAYER.M1]) == 1  # only the original polygon
     assert len(component.pins) == 2
 
 
-def test_add_electric_pins_groups_ports_by_name() -> None:
+def test_add_electrical_pins_groups_ports_by_name() -> None:
     """Ports with the same name are grouped into a single logical pin."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.M1)
@@ -92,13 +92,13 @@ def test_add_electric_pins_groups_ports_by_name() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component)
+    gf.add_pins.add_electrical_pins(component)
     pin_names = {pin.name for pin in component.pins}
     assert pin_names == {"D", "S"}
     assert len(component.pins) == 2
 
 
-def test_add_electric_pins_with_port_pin_mapping() -> None:
+def test_add_electrical_pins_with_port_pin_mapping() -> None:
     """Explicit port_pin_mapping groups ports under custom pin names."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.M1)
@@ -126,7 +126,7 @@ def test_add_electric_pins_with_port_pin_mapping() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(
+    gf.add_pins.add_electrical_pins(
         component,
         port_pin_mapping={"VDD": ["A", "B"], "GND": ["C"]},
         default_pin_layer=LAYER.M1,
@@ -138,7 +138,7 @@ def test_add_electric_pins_with_port_pin_mapping() -> None:
     assert len(polygons[LAYER.M1]) == 4  # original polygon + 3 pin rectangles
 
 
-def test_add_electric_pins_skips_non_electrical_ports() -> None:
+def test_add_electrical_pins_skips_non_electrical_ports() -> None:
     """Only electrical ports get pins; optical ports are ignored."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 0.5), (0, 0.5)], layer=LAYER.WG)
@@ -158,12 +158,12 @@ def test_add_electric_pins_skips_non_electrical_ports() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component)
+    gf.add_pins.add_electrical_pins(component)
     assert len(component.pins) == 1
     assert component.pins[0].name == "e1"
 
 
-def test_add_electric_pins_with_pin_label_layer_map() -> None:
+def test_add_electrical_pins_with_pin_label_layer_map() -> None:
     """Labels are routed to the mapped layer via pin_label_layer_map."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
@@ -175,13 +175,13 @@ def test_add_electric_pins_with_pin_label_layer_map() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component, pin_label_layer_map={LAYER.M1: LAYER.TEXT})
+    gf.add_pins.add_electrical_pins(component, pin_label_layer_map={LAYER.M1: LAYER.TEXT})
     labels = component.get_labels(LAYER.TEXT)
     assert len(labels) == 1
     assert len(component.pins) == 1
 
 
-def test_add_electric_pins_with_default_label_layer() -> None:
+def test_add_electrical_pins_with_default_label_layer() -> None:
     """Labels use default_label_layer as fallback when no label map is given."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
@@ -193,13 +193,13 @@ def test_add_electric_pins_with_default_label_layer() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component, default_label_layer=LAYER.TEXT)
+    gf.add_pins.add_electrical_pins(component, default_label_layer=LAYER.TEXT)
     labels = component.get_labels(LAYER.TEXT)
     assert len(labels) == 1
     assert len(component.pins) == 1
 
 
-def test_add_electric_pins_no_drawing_without_layers() -> None:
+def test_add_electrical_pins_no_drawing_without_layers() -> None:
     """No pin markers are drawn when no layer info is given, but pins are still registered."""
     component = gf.Component()
     component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER.M1)
@@ -211,7 +211,7 @@ def test_add_electric_pins_no_drawing_without_layers() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electric_pins(component)
+    gf.add_pins.add_electrical_pins(component)
     polygons = component.get_polygons()
     assert len(polygons[LAYER.M1]) == 1  # only the original polygon, no pin rectangles
     assert len(component.pins) == 1

--- a/tests/test_add_pins.py
+++ b/tests/test_add_pins.py
@@ -175,7 +175,9 @@ def test_add_electrical_pins_with_pin_label_layer_map() -> None:
         layer=LAYER.M1,
         port_type="electrical",
     )
-    gf.add_pins.add_electrical_pins(component, pin_label_layer_map={LAYER.M1: LAYER.TEXT})
+    gf.add_pins.add_electrical_pins(
+        component, pin_label_layer_map={LAYER.M1: LAYER.TEXT}
+    )
     labels = component.get_labels(LAYER.TEXT)
     assert len(labels) == 1
     assert len(component.pins) == 1


### PR DESCRIPTION
## Summary

- Adds an "Electrical pins" subsection under "Port markers (Pins)" in the `01_references.ipynb` layout tutorial
- Documents `add_electric_pins` with examples covering:
  - Basic usage with `default_pin_layer`
  - Labels on a separate layer via `default_label_layer`
  - PDK-specific layer routing with `pin_layer_map` and `pin_label_layer_map`
  - Grouping ports into logical pins with `port_pin_mapping`
  - Behavior when no layer info is provided (pins registered, no markers drawn)

Closes #4761
Ref: #4749

## Test plan

- [ ] Run notebook cells to verify examples execute without error
- [ ] Visually inspect rendered pin markers in plots

Reminder: AI-created PRs still require human review of the actual code changes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add an "Electrical pins" subsection to the layout tutorial explaining `add_electric_pins` behavior and configuration options, including layer selection, PDK-specific mappings, port grouping, and no-layer behavior.