### PR TITLE
Add get_polygons_points to ComponentAllAngle

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1002,7 +1002,7 @@ class Component(ComponentBase, kf.DKCell):
 
         Args:
             merge: if True, merges the polygons.
-            scale: if True, scales the points.
+            scale: if not None, scales the points.
             by: the format of the resulting keys in the dictionary ('index', 'name', 'tuple')
             layers: list of layers to get polygons from. Defaults to all layers.
         """
@@ -1696,12 +1696,8 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):
         """
         scale = scale or 1
         return [
-            np.array(
-                [
-                    (point.x * scale, point.y * scale)
-                    for point in polygon.each_point_hull()
-                ]
-            )
+            scale
+            * np.array([(point.x, point.y) for point in polygon.each_point_hull()])
             for polygon in self.get_polygons(layer)
         ]
 

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1683,6 +1683,28 @@ class ComponentAllAngle(ComponentBase, kf.VKCell):
 
         return [x for x in self.shapes(get_layer(layer)) if isinstance(x, kdb.DPolygon)]
 
+    def get_polygons_points(
+        self, layer: LayerSpec, scale: float | None = None
+    ) -> list[npt.NDArray[np.floating[Any]]]:
+        """Returns a list of points per polygon in um.
+
+        Only the hull points are returned, holes are ignored.
+
+        Args:
+            layer: layer to get the polygons from.
+            scale: if not None, scales the points.
+        """
+        scale = scale or 1
+        return [
+            np.array(
+                [
+                    (point.x * scale, point.y * scale)
+                    for point in polygon.each_point_hull()
+                ]
+            )
+            for polygon in self.get_polygons(layer)
+        ]
+
 
 def container(
     component: ComponentSpec,

--- a/gdsfactory/functions.py
+++ b/gdsfactory/functions.py
@@ -198,40 +198,28 @@ def get_polygons_points(
     Args:
         component_or_instance: to extract the polygons.
         merge: if True, merges the polygons.
-        scale: if True, scales the points.
+        scale: if not None, scales the points.
         by: the format of the resulting keys in the dictionary ('index', 'name', 'tuple').
         layers: list of layer specs to extract the polygons from. If None, extracts all layers.
     """
     polygons_dict = get_polygons(
         component_or_instance=component_or_instance, merge=merge, by=by, layers=layers
     )
-    polygons_points: dict[
-        tuple[int, int] | str | int, list[npt.NDArray[np.floating[Any]]]
-    ] = {}
-    for layer, polygons in polygons_dict.items():
-        all_points: list[npt.NDArray[np.floating[Any]]] = []
-        for polygon in polygons:
-            if scale:
-                points = np.array(
-                    [
-                        (point.x * scale, point.y * scale)
-                        for point in polygon.to_simple_polygon()
-                        .to_dtype(component_or_instance.kcl.dbu)
-                        .each_point()
-                    ]
-                )
-            else:
-                points = np.array(
-                    [
-                        (point.x, point.y)
-                        for point in polygon.to_simple_polygon()
-                        .to_dtype(component_or_instance.kcl.dbu)
-                        .each_point()
-                    ]
-                )
-            all_points.append(points)
-        polygons_points[layer] = all_points
-    return polygons_points
+    dbu = component_or_instance.kcl.dbu
+    scale = scale or 1
+    return {
+        layer: [
+            scale
+            * np.array(
+                [
+                    (point.x, point.y)
+                    for point in polygon.to_simple_polygon().to_dtype(dbu).each_point()
+                ]
+            )
+            for polygon in polygons
+        ]
+        for layer, polygons in polygons_dict.items()
+    }
 
 
 def get_point_inside(

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -751,6 +751,20 @@ def test_component_all_angle_add_polygon_get_polygon() -> None:
     assert polygons[0].bbox() == kdb.DBox(5, 5, 15, 15)
 
 
+def test_component_all_angle_get_polygons_points() -> None:
+    c = gf.ComponentAllAngle()
+    c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))
+
+    points = c.get_polygons_points(layer=(1, 0))
+    assert len(points) == 1
+    np.testing.assert_allclose(points[0], [(0, 0), (0, 10), (10, 10), (10, 0)])
+
+    points = c.get_polygons_points(layer=(1, 0), scale=2)
+    np.testing.assert_allclose(points[0], [(0, 0), (0, 20), (20, 20), (20, 0)])
+
+    assert c.get_polygons_points(layer=(2, 0)) == []
+
+
 def test_component_add_ref_raises() -> None:
     c = gf.Component()
     c2 = gf.Component()


### PR DESCRIPTION
## Summary

Having a somewhat equivalent `get_polygons_points` for `ComponentAllAngle`. Only does hulls, but I think that's fine?

## Test Plan

Unit tests.

## Summary by Sourcery

Add polygon point extraction for ComponentAllAngle and align polygon point helper scaling semantics.

New Features:
- Introduce get_polygons_points on ComponentAllAngle to return hull points for polygons on a given layer in microns.

Enhancements:
- Simplify and clarify scaling behavior in the generic get_polygons_points helper, treating scale as an optional multiplier rather than a boolean flag.

Tests:
- Add unit tests covering ComponentAllAngle.get_polygons_points, including scaling behavior and empty-layer handling.