### PR TITLE
feat: add layer stack variation fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,6 +162,12 @@ Classes and functions for construction and manipulation of geometric objects.
 
 ::: gdsfactory.technology.LogicalLayer
 
+::: gdsfactory.technology.NormalVariation
+
+::: gdsfactory.technology.UniformVariation
+
+::: gdsfactory.technology.AsymmetricVariation
+
 ::: gdsfactory.technology.lyp_to_dataclass
 
 ## Pack

--- a/gdsfactory/technology/__init__.py
+++ b/gdsfactory/technology/__init__.py
@@ -7,9 +7,16 @@ from gdsfactory.technology.layer_stack import (
     LogicalLayer,
 )
 from gdsfactory.technology.layer_views import LayerView, LayerViews
+from gdsfactory.technology.variation import (
+    AsymmetricVariation,
+    NormalVariation,
+    UniformVariation,
+    Variation,
+)
 
 __all__ = [
     "AbstractLayer",
+    "AsymmetricVariation",
     "DerivedLayer",
     "LayerLevel",
     "LayerMap",
@@ -17,5 +24,8 @@ __all__ = [
     "LayerView",
     "LayerViews",
     "LogicalLayer",
+    "NormalVariation",
+    "UniformVariation",
+    "Variation",
     "lyp_to_dataclass",
 ]

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
@@ -10,7 +11,9 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from rich.console import Console
 from rich.table import Table
 
+from gdsfactory.config import __next_major_version__
 from gdsfactory.technology.layer_views import LayerViews
+from gdsfactory.technology.variation import Variation
 from gdsfactory.typings import LayerSpec
 
 if TYPE_CHECKING:
@@ -327,12 +330,14 @@ class LayerLevel(BaseModel):
         layer: LogicalLayer or DerivedLayer. DerivedLayers can be composed of operations consisting of multiple other GDSLayers or other DerivedLayers.
         derived_layer: if the layer is derived, LogicalLayer to assign to the derived layer.
         thickness: layer thickness in um.
-        thickness_tolerance: layer thickness tolerance in um.
-        width_tolerance: layer width tolerance in um.
+        thickness_variation: statistical variation of layer thickness.
+        thickness_tolerance: deprecated layer thickness tolerance in um.
+        width_tolerance: deprecated layer width tolerance in um.
         zmin: height position where material starts in um.
-        zmin_tolerance: layer height tolerance in um.
+        zmin_tolerance: deprecated layer height tolerance in um.
         sidewall_angle: in degrees with respect to normal.
-        sidewall_angle_tolerance: in degrees.
+        sidewall_angle_variation: statistical variation of sidewall angle.
+        sidewall_angle_tolerance: deprecated sidewall-angle tolerance in degrees.
         width_to_z: if sidewall_angle, reference z-position (0 --> zmin, 1 --> zmin + thickness, 0.5 in the middle).
         bias: shrink/grow of the level compared to the mask
         z_to_bias: most generic way to specify an extrusion.\
@@ -352,12 +357,26 @@ class LayerLevel(BaseModel):
 
     # Extrusion rules
     thickness: float
-    thickness_tolerance: float | None = None
-    width_tolerance: float | None = None
+    thickness_variation: Variation | None = None
+    thickness_tolerance: float | None = Field(
+        default=None,
+        deprecated=f"Use thickness_variation instead. This field will be removed in {__next_major_version__}.",
+    )
+    width_tolerance: float | None = Field(
+        default=None,
+        deprecated=f"Width belongs to cross-sections; model width variation there. This field will be removed in {__next_major_version__}.",
+    )
     zmin: float
-    zmin_tolerance: float | None = None
+    zmin_tolerance: float | None = Field(
+        default=None,
+        deprecated=f"Derive zmin variation from thickness variations. This field will be removed in {__next_major_version__}.",
+    )
     sidewall_angle: float = 0.0
-    sidewall_angle_tolerance: float | None = None
+    sidewall_angle_variation: Variation | None = None
+    sidewall_angle_tolerance: float | None = Field(
+        default=None,
+        deprecated=f"Use sidewall_angle_variation instead. This field will be removed in {__next_major_version__}.",
+    )
     width_to_z: float = 0.0
     z_to_bias: tuple[list[float], list[float]] | None = None
     bias: tuple[float, float] | float | None = None
@@ -375,6 +394,29 @@ class LayerLevel(BaseModel):
         if isinstance(layer, LogicalLayer | DerivedLayer):
             return layer
         return LogicalLayer(layer=layer)
+
+    @model_validator(mode="before")
+    @classmethod
+    def warn_deprecated_tolerances(cls, data: Any) -> Any:
+        """Warn when deprecated tolerance fields receive values."""
+        if not isinstance(data, Mapping):
+            return data
+
+        guidance = {
+            "thickness_tolerance": "Use thickness_variation instead.",
+            "width_tolerance": "Width belongs to cross-sections; model width variation there.",
+            "zmin_tolerance": "Derive zmin variation from thickness variations.",
+            "sidewall_angle_tolerance": "Use sidewall_angle_variation instead.",
+        }
+        for field_name, replacement in guidance.items():
+            if data.get(field_name) is not None:
+                warnings.warn(
+                    f"LayerLevel.{field_name} is deprecated. {replacement} "
+                    f"It will be removed in {__next_major_version__}.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+        return data
 
     @model_validator(mode="after")
     def check_derived_layer(self) -> LayerLevel:

--- a/gdsfactory/technology/variation.py
+++ b/gdsfactory/technology/variation.py
@@ -1,0 +1,50 @@
+"""Statistical process variation declarations."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _VariationBase(BaseModel):
+    """Fields shared by every variation distribution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sigma_basis: Literal["one_sigma", "three_sigma_norm"]
+    lower_spec_limit: float | None = None
+    upper_spec_limit: float | None = None
+    scope: Literal["process", "mismatch"]
+    random_var: str | None = None
+
+
+class NormalVariation(_VariationBase):
+    """Gaussian spread around an attached nominal value."""
+
+    distribution: Literal["normal"] = "normal"
+    sigma: float = Field(ge=0)
+    percent: bool
+    truncate_sigma: float | None = Field(default=None, ge=0)
+
+
+class UniformVariation(_VariationBase):
+    """Bounded uniform spread around an attached nominal value."""
+
+    distribution: Literal["uniform"] = "uniform"
+    half_range: float = Field(gt=0)
+
+
+class AsymmetricVariation(_VariationBase):
+    """Two-sided spread with explicit best, nominal, and worst values."""
+
+    distribution: Literal["asymmetric"] = "asymmetric"
+    best: float
+    nominal: float
+    worst: float
+
+
+type Variation = Annotated[
+    NormalVariation | UniformVariation | AsymmetricVariation,
+    Field(discriminator="distribution"),
+]

--- a/tests/technology/test_layerstack.py
+++ b/tests/technology/test_layerstack.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER, LAYER_STACK
@@ -104,6 +105,11 @@ def test_layer_level_deprecated_tolerances() -> None:
     assert properties["width_tolerance"]["deprecated"] is True
     assert properties["zmin_tolerance"]["deprecated"] is True
     assert properties["sidewall_angle_tolerance"]["deprecated"] is True
+
+
+def test_layer_level_rejects_non_mapping_input() -> None:
+    with pytest.raises(ValidationError):
+        LayerLevel.model_validate(None)
 
 
 def test_get_layer_to_mesh_order() -> None:

--- a/tests/technology/test_layerstack.py
+++ b/tests/technology/test_layerstack.py
@@ -2,7 +2,7 @@ import pytest
 
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER, LAYER_STACK
-from gdsfactory.technology import LayerLevel, LayerStack
+from gdsfactory.technology import LayerLevel, LayerStack, NormalVariation
 from gdsfactory.technology.layer_stack import LogicalLayer
 
 nm = 1e-3
@@ -30,23 +30,80 @@ def test_layerstack_copy() -> None:
 
 def test_layer_level() -> None:
     layers = ["WG", (1, 0), LAYER.WG]
+    thickness_variation = NormalVariation(
+        sigma_basis="three_sigma_norm",
+        scope="process",
+        random_var="wg_thickness",
+        sigma=5 * nm,
+        percent=False,
+        truncate_sigma=3,
+    )
+    sidewall_angle_variation = NormalVariation(
+        sigma_basis="three_sigma_norm",
+        scope="process",
+        random_var="wg_sidewall_angle",
+        sigma=2,
+        percent=False,
+        truncate_sigma=3,
+    )
 
     for layer in layers:
         level = LayerLevel(
             layer=layer,
             thickness=220 * nm,
-            thickness_tolerance=5 * nm,
+            thickness_variation=thickness_variation,
             material="Si",
             mesh_order=2,
             zmin=0,
             sidewall_angle=10,
-            sidewall_angle_tolerance=2,
+            sidewall_angle_variation=sidewall_angle_variation,
         )
+        assert level.thickness_variation == thickness_variation
+        assert level.sidewall_angle_variation == sidewall_angle_variation
         level_layer = level.layer
         assert isinstance(level_layer, LogicalLayer)
         layer_ = gf.get_layer(level_layer.layer)
         assert isinstance(layer_, int)
         assert int(layer_) == 1, int(layer_)
+
+
+def test_layer_level_deprecated_tolerances() -> None:
+    with pytest.warns(
+        DeprecationWarning, match="will be removed in 10.0.0"
+    ) as captured_warnings:
+        level = LayerLevel(
+            layer=LAYER.WG,
+            thickness=220 * nm,
+            thickness_tolerance=5 * nm,
+            width_tolerance=5 * nm,
+            zmin=0,
+            zmin_tolerance=5 * nm,
+            sidewall_angle_tolerance=2,
+        )
+
+    warning_messages = [str(warning.message) for warning in captured_warnings]
+    for field_name in (
+        "thickness_tolerance",
+        "width_tolerance",
+        "zmin_tolerance",
+        "sidewall_angle_tolerance",
+    ):
+        assert any(
+            f"LayerLevel.{field_name} is deprecated." in message
+            for message in warning_messages
+        )
+
+    level_data = level.model_dump()
+    assert level_data["thickness_tolerance"] == 5 * nm
+    assert level_data["width_tolerance"] == 5 * nm
+    assert level_data["zmin_tolerance"] == 5 * nm
+    assert level_data["sidewall_angle_tolerance"] == 2
+
+    properties = LayerLevel.model_json_schema()["properties"]
+    assert properties["thickness_tolerance"]["deprecated"] is True
+    assert properties["width_tolerance"]["deprecated"] is True
+    assert properties["zmin_tolerance"]["deprecated"] is True
+    assert properties["sidewall_angle_tolerance"]["deprecated"] is True
 
 
 def test_get_layer_to_mesh_order() -> None:


### PR DESCRIPTION
Adds typed process-variation models and LayerLevel variation fields. Keeps the existing tolerance fields with deprecation warnings through gdsfactory 10.0.0, and adds public exports, API docs, and compatibility tests.

## Summary by Sourcery

Introduce typed process-variation models and integrate them into layer stack definitions while deprecating legacy tolerance fields.

New Features:
- Add NormalVariation, UniformVariation, AsymmetricVariation, and a discriminated Variation type for modeling statistical process variations.
- Expose variation types through the gdsfactory.technology public API and document them in the API reference.

Enhancements:
- Extend LayerLevel to support thickness and sidewall-angle variation fields using the new Variation types and emit deprecation metadata for legacy tolerance fields.

Documentation:
- Document new variation types in the technology API docs.

Tests:
- Add tests covering LayerLevel variation fields, deprecation warnings for tolerance fields, JSON schema deprecation metadata, and validation of non-mapping inputs to LayerLevel.