### PR TITLE
4641 open-access compliant via stack with ihp-style bottom layertop layer convenience args

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -25,6 +25,7 @@ parts:
           - file: notebooks/04_components_pack
           - file: notebooks/04_routing
           - file: notebooks/04_routing_electrical
+          - file: notebooks/04_via_array_region_raster
           - file: notebooks/07_mask
           - file: notebooks/11_best_practices
           - file: notebooks/12_grid_snapping

--- a/docs/notebooks/04_via_array_region_raster.ipynb
+++ b/docs/notebooks/04_via_array_region_raster.ipynb
@@ -1,0 +1,507 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Via Array Region Raster\n",
+    "\n",
+    "`via_array_region_raster` fills an arbitrary polygon region with a regular grid of via cuts, respecting DRC rules for cut size, enclosure, and spacing.\n",
+    "\n",
+    "A common use case is placing vias only where two metal shapes overlap. This notebook shows how to:\n",
+    "\n",
+    "1. Define two arbitrary polygon shapes (bottom and top metal).\n",
+    "2. Compute their intersection (logical AND) using Shapely.\n",
+    "3. Pass that intersection region to `via_array_region_raster` to place vias."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Define two overlapping metal shapes\n",
+    "\n",
+    "We define two arbitrary polygons representing the bottom and top metal layers. The via array will only be placed in their overlapping area."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from gdsfactory.gpdk import PDK\n",
+    "from shapely.geometry import Polygon as ShapelyPolygon\n",
+    "\n",
+    "gf.gpdk.PDK.activate()\n",
+    "\n",
+    "# Bottom metal: a wide rectangle\n",
+    "bottom_metal = ShapelyPolygon([(0, 0), (8, 0), (8, 5), (0, 5)])\n",
+    "\n",
+    "# Top metal: a rotated rectangle (diamond-like) that partially overlaps\n",
+    "top_metal = ShapelyPolygon([(2, -1), (10, 2), (8, 6), (0, 3)])\n",
+    "\n",
+    "# The via region is the intersection (logical AND) of both shapes\n",
+    "via_region = bottom_metal.intersection(top_metal)\n",
+    "\n",
+    "print(f\"Bottom metal area: {bottom_metal.area:.2f} um^2\")\n",
+    "print(f\"Top metal area:    {top_metal.area:.2f} um^2\")\n",
+    "print(f\"Intersection area: {via_region.area:.2f} um^2\")\n",
+    "print(f\"Intersection coords: {list(via_region.exterior.coords)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Visualize the overlap\n",
+    "\n",
+    "Let's plot the two metal shapes and their intersection to see where the vias will be placed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.patches import Polygon as MplPolygon\n",
+    "from matplotlib.collections import PatchCollection\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 1, figsize=(8, 6))\n",
+    "\n",
+    "bottom_patch = MplPolygon(list(bottom_metal.exterior.coords), closed=True, alpha=0.3, fc=\"blue\", ec=\"blue\", lw=2, label=\"Bottom metal (M1)\")\n",
+    "top_patch = MplPolygon(list(top_metal.exterior.coords), closed=True, alpha=0.3, fc=\"red\", ec=\"red\", lw=2, label=\"Top metal (M2)\")\n",
+    "intersection_patch = MplPolygon(list(via_region.exterior.coords), closed=True, alpha=0.5, fc=\"green\", ec=\"green\", lw=2, label=\"Intersection (via region)\")\n",
+    "\n",
+    "ax.add_patch(bottom_patch)\n",
+    "ax.add_patch(top_patch)\n",
+    "ax.add_patch(intersection_patch)\n",
+    "\n",
+    "ax.set_xlim(-1, 11)\n",
+    "ax.set_ylim(-2, 7)\n",
+    "ax.set_aspect(\"equal\")\n",
+    "ax.legend()\n",
+    "ax.set_xlabel(\"x (um)\")\n",
+    "ax.set_ylabel(\"y (um)\")\n",
+    "ax.set_title(\"Bottom & Top Metal Overlap\")\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Create the via array\n",
+    "\n",
+    "Pass the intersection polygon coordinates to `via_array_region_raster`. The function will:\n",
+    "\n",
+    "1. Erode the region inward by `enclosure + half_cut_size` to respect metal enclosure rules.\n",
+    "2. Build a meshgrid of via center candidates with pitch = `cut_size + spacing`.\n",
+    "3. Keep only the centers that fall inside the eroded region.\n",
+    "4. Place via cut polygons at each valid center, plus the full region on both metal layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.components.vias.via_stack import via_array_region_raster\n",
+    "\n",
+    "region_coords = list(via_region.exterior.coords)\n",
+    "\n",
+    "c = gf.Component(\"intersection_via_array\")\n",
+    "ref = c.add_ref(via_array_region_raster(\n",
+    "    region=region_coords,\n",
+    "    bottom_layer=\"M1\",\n",
+    "    via_layer=\"VIA1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    via_type=\"square\",\n",
+    "    via_x_minimum_cut_size=0.3,\n",
+    "    via_y_minimum_cut_size=0.3,\n",
+    "    via_x_minimum_enclosure=0.06,\n",
+    "    via_y_minimum_enclosure=0.06,\n",
+    "    via_x_minimum_spacing=0.3,\n",
+    "    via_y_minimum_spacing=0.3,\n",
+    "))\n",
+    "\n",
+    "print(f\"Cell name: {ref.cell.name}\")\n",
+    "print(f\"Number of vias placed: {ref.cell.info['num_vias']}\")\n",
+    "print(f\"Spacing (x, y): ({ref.cell.info['via_x_spacing']}, {ref.cell.info['via_y_spacing']}) um\")\n",
+    "print(f\"Cut size: {ref.cell.info['via_x_cut_size']} x {ref.cell.info['via_y_cut_size']} um\")\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Rectangular region example\n",
+    "\n",
+    "For comparison, here is the same function applied to a simple rectangular region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_rect = gf.Component(\"rectangular_via_array\")\n",
+    "ref_rect = c_rect.add_ref(via_array_region_raster(\n",
+    "    region=[(0, 0), (5, 0), (5, 3), (0, 3)],\n",
+    "    bottom_layer=\"M1\",\n",
+    "    via_layer=\"VIA1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    via_x_minimum_cut_size=0.3,\n",
+    "    via_y_minimum_cut_size=0.3,\n",
+    "    via_x_minimum_enclosure=0.06,\n",
+    "    via_y_minimum_enclosure=0.06,\n",
+    "    via_x_minimum_spacing=0.3,\n",
+    "    via_y_minimum_spacing=0.3,\n",
+    "))\n",
+    "\n",
+    "print(f\"Cell name: {ref_rect.cell.name}\")\n",
+    "print(f\"Number of vias: {ref_rect.cell.info['num_vias']}\")\n",
+    "c_rect.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## L-shaped region example\n",
+    "\n",
+    "Non-convex polygons work too. Vias are only placed where the grid centers fall inside the eroded polygon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_L = gf.Component(\"l_shaped_via_array\")\n",
+    "ref_L = c_L.add_ref(via_array_region_raster(\n",
+    "    region=[(0, 0), (5, 0), (5, 2), (3, 2), (3, 4), (0, 4)],\n",
+    "    bottom_layer=\"M1\",\n",
+    "    via_layer=\"VIA1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    via_x_minimum_cut_size=0.3,\n",
+    "    via_y_minimum_cut_size=0.3,\n",
+    "    via_x_minimum_enclosure=0.1,\n",
+    "    via_y_minimum_enclosure=0.1,\n",
+    "    via_x_minimum_spacing=0.3,\n",
+    "    via_y_minimum_spacing=0.3,\n",
+    "))\n",
+    "\n",
+    "print(f\"Number of vias: {ref_L.cell.info['num_vias']}\")\n",
+    "c_L.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Tighter DRC rules\n",
+    "\n",
+    "Increasing the enclosure requirement reduces the number of vias that fit inside the same region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_tight = gf.Component(\"tight_enclosure_via_array\")\n",
+    "ref_tight = c_tight.add_ref(via_array_region_raster(\n",
+    "    region=list(via_region.exterior.coords),\n",
+    "    bottom_layer=\"M1\",\n",
+    "    via_layer=\"VIA1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    via_type=\"square\",\n",
+    "    via_x_minimum_cut_size=0.3,\n",
+    "    via_y_minimum_cut_size=0.3,\n",
+    "    via_x_minimum_enclosure=0.3,\n",
+    "    via_y_minimum_enclosure=0.3,\n",
+    "    via_x_minimum_spacing=0.3,\n",
+    "    via_y_minimum_spacing=0.3,\n",
+    "))\n",
+    "\n",
+    "print(f\"Number of vias with tight enclosure (0.3 um): {ref_tight.cell.info['num_vias']}\")\n",
+    "print(f\"vs. loose enclosure (0.06 um): {ref.cell.info['num_vias']}\")\n",
+    "c_tight.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_tight = gf.Component(\"tight_enclosure_via_array_rectangle\")\n",
+    "ref_tight = c_tight.add_ref(via_array_region_raster(\n",
+    "    region=list(via_region.exterior.coords),\n",
+    "    bottom_layer=\"M1\",\n",
+    "    via_layer=\"VIA1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    via_type=\"rectangle\",\n",
+    "    via_x_minimum_cut_size=0.3,\n",
+    "    via_y_minimum_cut_size=0.3,\n",
+    "    via_x_minimum_enclosure=0.3,\n",
+    "    via_y_minimum_enclosure=0.3,\n",
+    "    via_x_minimum_spacing=0.3,\n",
+    "    via_y_minimum_spacing=0.3,\n",
+    "))\n",
+    "\n",
+    "print(f\"Number of vias with tight enclosure (0.3 um): {ref_tight.cell.info['num_vias']}\")\n",
+    "print(f\"vs. loose enclosure (0.06 um): {ref.cell.info['num_vias']}\")\n",
+    "c_tight.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Via stack (multi-layer)\n",
+    "\n",
+    "`via_array_stack_oa_compliant` builds a full via stack from `bottom_layer` to `top_layer` by iteratively calling `via_array_region_raster` for each via layer in the connectivity sequence.\n",
+    "\n",
+    "The `region`, `size`, and `grid_size` parameters are mutually exclusive (priority: region > size > grid_size). Per-via-layer DRC rules are provided as dictionaries keyed by via layer name."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "### Via stack from an arbitrary region (M1 to M3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.components.vias.via_stack import via_array_stack_oa_compliant\n",
+    "\n",
+    "c_stack_region = gf.Component(\"via_stack_region\")\n",
+    "ref_stack = c_stack_region.add_ref(via_array_stack_oa_compliant(\n",
+    "    bottom_layer=\"M1\",\n",
+    "    top_layer=\"M3\",\n",
+    "    region=list(via_region.exterior.coords),\n",
+    "    via_type=\"square\",\n",
+    "))\n",
+    "\n",
+    "info = ref_stack.cell.info\n",
+    "print(f\"Cell name: {ref_stack.cell.name}\")\n",
+    "print(f\"Stack: {info['bottom_layer']} -> {info['top_layer']}\")\n",
+    "for layer_info in info[\"per_layer_info\"]:\n",
+    "    print(f\"  {layer_info['via_layer']}: {layer_info['num_vias']} vias \"\n",
+    "          f\"(cut {layer_info['via_x_cut_size']}x{layer_info['via_y_cut_size']} um, \"\n",
+    "          f\"spacing {layer_info['via_x_spacing']}x{layer_info['via_y_spacing']} um)\")\n",
+    "c_stack_region.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "### OpenAccess-compliant metadata\n",
+    "\n",
+    "The via stack stores all metadata needed for OA interoperability: layer connectivity, per-layer via counts, cut sizes, spacings, and the enclosing region coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "info = ref_stack.cell.info\n",
+    "\n",
+    "print(\"=== OpenAccess Via Stack Metadata ===\\n\")\n",
+    "print(f\"  cell_name:                   {ref_stack.cell.name}\")\n",
+    "print(f\"  bottom_layer:                {info['bottom_layer']}\")\n",
+    "print(f\"  top_layer:                   {info['top_layer']}\")\n",
+    "print(f\"  via_type:                    {info['via_type']}\")\n",
+    "print(f\"  total_num_vias:              {info['total_num_vias']}\")\n",
+    "print(f\"  num_via_layers:              {info['num_via_layers']}\")\n",
+    "print(f\"  layer_connectivity_sequence: {info['layer_connectivity_sequence']}\")\n",
+    "print(f\"  enclosing_region:            {info['enclosing_region']}\")\n",
+    "\n",
+    "print(\"\\n--- Per-layer info ---\")\n",
+    "for i, layer_info in enumerate(info[\"per_layer_info\"]):\n",
+    "    print(f\"\\n  Via layer {i}: {layer_info['via_layer']} \"\n",
+    "          f\"({layer_info['bottom_layer']} -> {layer_info['top_layer']})\")\n",
+    "    print(f\"    num_vias:       {layer_info['num_vias']}\")\n",
+    "    print(f\"    via_x_cut_size: {layer_info['via_x_cut_size']} um\")\n",
+    "    print(f\"    via_y_cut_size: {layer_info['via_y_cut_size']} um\")\n",
+    "    print(f\"    via_x_spacing:  {layer_info['via_x_spacing']} um\")\n",
+    "    print(f\"    via_y_spacing:  {layer_info['via_y_spacing']} um\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "### Via stack with custom per-layer DRC rules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_stack_custom = gf.Component(\"via_stack_custom_rules\")\n",
+    "ref_stack_custom = c_stack_custom.add_ref(via_array_stack_oa_compliant(\n",
+    "    bottom_layer=\"M1\",\n",
+    "    top_layer=\"M3\",\n",
+    "    size=(5, 5),\n",
+    "    via_type=\"square\",\n",
+    "    via_x_minimum_cut_size_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_y_minimum_cut_size_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_x_minimum_enclosure_rules={\"VIA\": 0.05, \"VIA1\": 0.06, \"VIA2\": 0.08},\n",
+    "    via_y_minimum_enclosure_rules={\"VIA\": 0.05, \"VIA1\": 0.06, \"VIA2\": 0.08},\n",
+    "    via_x_minimum_spacing_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_y_minimum_spacing_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "))\n",
+    "\n",
+    "info = ref_stack_custom.cell.info\n",
+    "print(f\"Stack: {info['bottom_layer']} -> {info['top_layer']}\")\n",
+    "for layer_info in info[\"per_layer_info\"]:\n",
+    "    print(f\"  {layer_info['via_layer']}: {layer_info['num_vias']} vias \"\n",
+    "          f\"(cut {layer_info['via_x_cut_size']}x{layer_info['via_y_cut_size']} um)\")\n",
+    "c_stack_custom.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_stack_custom = gf.Component(\"via_stack_custom_rules_rectangle\")\n",
+    "ref_stack_custom = c_stack_custom.add_ref(via_array_stack_oa_compliant(\n",
+    "    bottom_layer=\"M1\",\n",
+    "    top_layer=\"M3\",\n",
+    "    size=(5, 5),\n",
+    "    via_type=\"rectangle\",\n",
+    "    via_x_minimum_cut_size_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_y_minimum_cut_size_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_x_minimum_enclosure_rules={\"VIA\": 0.05, \"VIA1\": 0.06, \"VIA2\": 0.08},\n",
+    "    via_y_minimum_enclosure_rules={\"VIA\": 0.05, \"VIA1\": 0.06, \"VIA2\": 0.08},\n",
+    "    via_x_minimum_spacing_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "    via_y_minimum_spacing_rules={\"VIA\": 0.2, \"VIA1\": 0.25, \"VIA2\": 0.3},\n",
+    "))\n",
+    "\n",
+    "info = ref_stack_custom.cell.info\n",
+    "print(f\"Stack: {info['bottom_layer']} -> {info['top_layer']}\")\n",
+    "for layer_info in info[\"per_layer_info\"]:\n",
+    "    print(f\"  {layer_info['via_layer']}: {layer_info['num_vias']} vias \"\n",
+    "          f\"(cut {layer_info['via_x_cut_size']}x{layer_info['via_y_cut_size']} um)\")\n",
+    "c_stack_custom.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_stack_region = gf.Component(\"via_stack_region_rectangle\")\n",
+    "ref_stack = c_stack_region.add_ref(via_array_stack_oa_compliant(\n",
+    "    bottom_layer=\"M1\",\n",
+    "    top_layer=\"M3\",\n",
+    "    region=list(via_region.exterior.coords),\n",
+    "    via_type=\"rectangle\",\n",
+    "))\n",
+    "\n",
+    "info = ref_stack.cell.info\n",
+    "print(f\"Stack: {info['bottom_layer']} -> {info['top_layer']}\")\n",
+    "for layer_info in info[\"per_layer_info\"]:\n",
+    "    print(f\"  {layer_info['via_layer']}: {layer_info['num_vias']} vias \"\n",
+    "          f\"(cut {layer_info['via_x_cut_size']}x{layer_info['via_y_cut_size']} um, \"\n",
+    "          f\"spacing {layer_info['via_x_spacing']}x{layer_info['via_y_spacing']} um)\")\n",
+    "c_stack_region.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c_stack_region = gf.Component(\"m1_m2_via_stack_region_rectangle\")\n",
+    "ref_stack = c_stack_region.add_ref(via_array_stack_oa_compliant(\n",
+    "    bottom_layer=\"M1\",\n",
+    "    top_layer=\"M2\",\n",
+    "    region=list(via_region.exterior.coords),\n",
+    "    via_type=\"rectangle\",\n",
+    "))\n",
+    "\n",
+    "info = ref_stack.cell.info\n",
+    "print(f\"Cell name: {ref_stack.cell.name}\")\n",
+    "print(f\"Stack: {info['bottom_layer']} -> {info['top_layer']}\")\n",
+    "for layer_info in info[\"per_layer_info\"]:\n",
+    "    print(f\"  {layer_info['via_layer']}: {layer_info['num_vias']} vias \"\n",
+    "          f\"(cut {layer_info['via_x_cut_size']}x{layer_info['via_y_cut_size']} um, \"\n",
+    "          f\"spacing {layer_info['via_x_spacing']}x{layer_info['via_y_spacing']} um)\")\n",
+    "c_stack_region.plot()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gdsfactory (3.12.13.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/04_via_array_region_raster.ipynb
+++ b/docs/notebooks/04_via_array_region_raster.ipynb
@@ -481,11 +481,19 @@
     "          f\"spacing {layer_info['via_x_spacing']}x{layer_info['via_y_spacing']} um)\")\n",
     "c_stack_region.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gdsfactory (3.12.13.final.0)",
+   "display_name": "gdsfactory (3.12.x)",
    "language": "python",
    "name": "python3"
   },

--- a/gdsfactory/components/vias/__init__.py
+++ b/gdsfactory/components/vias/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "via",
     "via1",
     "via2",
+    "via_array_region_raster",
+    "via_array_stack_oa_compliant",
     "via_chain",
     "via_circular",
     "via_corner",

--- a/gdsfactory/components/vias/via.py
+++ b/gdsfactory/components/vias/via.py
@@ -38,8 +38,6 @@ def via(
         column_pitch: Optional pitch between columns of vias. Default is pitch.
         row_pitch: Optional pitch between rows of vias. Default is pitch.
 
-    .. code::
-
         enclosure
         _________________________________________
         |<--->                                  |

--- a/gdsfactory/components/vias/via_stack.py
+++ b/gdsfactory/components/vias/via_stack.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 __all__ = [
+    "via_array_region_raster",
+    "via_array_stack_oa_compliant",
     "via_stack",
     "via_stack_corner45",
     "via_stack_corner45_extended",
@@ -22,12 +24,15 @@ __all__ = [
 import warnings
 from collections.abc import Iterable, Sequence
 from functools import partial
+from typing import Literal
 
 import numpy as np
+from shapely.geometry import MultiPoint, Point
+from shapely.geometry import Polygon as ShapelyPolygon
 
 import gdsfactory as gf
 from gdsfactory._deprecation import deprecate
-from gdsfactory.component import Component, ComponentReference
+from gdsfactory.component import Component, ComponentReference, _PolygonPoints
 from gdsfactory.typings import ComponentSpec, Floats, Ints, LayerSpec, LayerSpecs, Size
 
 
@@ -527,6 +532,326 @@ via_stack_heater_mtop_mini = partial(via_stack_heater_mtop, size=(4, 4))
 via_stack_heater_m2 = partial(via_stack, layers=("HEATER", "M2"), vias=(None, "via1"))
 
 via_stack_slab_m1_horizontal = partial(via_stack_slab_m1, slot_horizontal=True)
+
+
+def _region_to_shapely(region: _PolygonPoints) -> ShapelyPolygon:
+    """Convert a _PolygonPoints region to a Shapely Polygon."""
+    from kfactory import kdb
+
+    if isinstance(region, np.ndarray):
+        coords = region.tolist()
+    elif isinstance(region, (kdb.DPolygon, kdb.DSimplePolygon)):
+        coords = [(p.x, p.y) for p in region.each_point()]
+    elif isinstance(region, kdb.Polygon):
+        coords = [(p.x * 1e-3, p.y * 1e-3) for p in region.each_point()]
+    elif isinstance(region, kdb.Region):
+        merged = region.merged()
+        poly = next(merged.each())
+        coords = [(p.x * 1e-3, p.y * 1e-3) for p in poly.each_point()]
+    else:
+        coords = [(float(x), float(y)) for x, y in region]
+    return ShapelyPolygon(coords)
+
+
+@gf.cell_with_module_name(tags=["vias"])
+def via_array_region_raster(
+    region: _PolygonPoints,
+    bottom_layer: LayerSpec = "M1",
+    via_layer: LayerSpec = "VIA1",
+    top_layer: LayerSpec = "M2",
+    via_type: Literal["square", "rectangle"] = "square",
+    via_x_spacing: float = 0.3,
+    via_y_spacing: float = 0.3,
+    via_x_minimum_cut_size: float = 0.3,
+    via_y_minimum_cut_size: float = 0.3,
+    via_x_minimum_enclosure: float = 0.06,
+    via_y_minimum_enclosure: float = 0.06,
+    via_x_minimum_spacing: float = 0.3,
+    via_y_minimum_spacing: float = 0.3,
+) -> Component:
+    """Via array that fills an arbitrary polygon region with vias on a regular grid.
+
+    Builds a meshgrid of via center positions, filters to those inside the
+    region (eroded by enclosure), and places via cuts plus top/bottom metal.
+
+    Args:
+        region: polygon defining the area to fill with vias.
+        bottom_layer: metal layer below the vias.
+        via_layer: via cut layer.
+        top_layer: metal layer above the vias.
+        via_type: "square" uses via_x_minimum_cut_size for both axes.
+        via_x_spacing: via spacing in x (um), must be >= via_x_minimum_spacing.
+        via_y_spacing: via spacing in y (um), must be >= via_y_minimum_spacing.
+        via_x_minimum_cut_size: via cut width in x (um).
+        via_y_minimum_cut_size: via cut height in y (um).
+        via_x_minimum_enclosure: min enclosure of via by metal in x (um).
+        via_y_minimum_enclosure: min enclosure of via by metal in y (um).
+        via_x_minimum_spacing: min spacing between via cuts in x (um).
+        via_y_minimum_spacing: min spacing between via cuts in y (um).
+    """
+    assert via_x_spacing >= via_x_minimum_spacing, (
+        "Bound to fail spacing DRC on x direction"
+    )
+    assert via_y_spacing >= via_y_minimum_spacing, (
+        "Bound to fail spacing DRC on y direction"
+    )
+    c = Component()
+
+    cut_w = via_x_minimum_cut_size
+    cut_h = via_y_minimum_cut_size
+    if via_type == "rectangle":
+        minx, miny, maxx, maxy = _region_to_shapely(region).bounds
+        dx = maxx - minx
+        dy = maxy - miny
+        if dy >= dx:
+            cut_h = 2 * via_y_minimum_cut_size
+        else:
+            cut_w = 2 * via_x_minimum_cut_size
+
+    enc_x = via_x_minimum_enclosure
+    enc_y = via_y_minimum_enclosure
+
+    pitch_x = cut_w + via_x_spacing
+    pitch_y = cut_h + via_y_spacing
+
+    poly = _region_to_shapely(region)
+
+    erosion = max(enc_x + pitch_x / 2, enc_y + pitch_y / 2)
+    via_region = poly.buffer(-erosion, join_style="mitre")
+
+    if via_region.is_empty:
+        c.add_polygon(list(poly.exterior.coords), layer=bottom_layer)
+        c.add_polygon(list(poly.exterior.coords), layer=top_layer)
+        return c
+
+    minx, miny, maxx, maxy = via_region.bounds
+
+    xs = np.arange(minx, maxx + pitch_x, pitch_x)
+    ys = np.arange(miny, maxy + pitch_y, pitch_y)
+    # xs = np.arange(minx, maxx, pitch_x)
+    # ys = np.arange(miny, maxy, pitch_y)
+    gx, gy = np.meshgrid(xs, ys)
+    centers = np.column_stack([gx.ravel(), gy.ravel()])
+
+    points = MultiPoint([Point(x, y) for x, y in centers])
+    valid_points = points.intersection(via_region)
+
+    if valid_points.is_empty:
+        c.add_polygon(list(poly.exterior.coords), layer=bottom_layer)
+        c.add_polygon(list(poly.exterior.coords), layer=top_layer)
+        return c
+
+    valid_centers = (
+        np.array([[p.x, p.y] for p in valid_points.geoms])
+        if hasattr(valid_points, "geoms")
+        else np.array([[valid_points.x, valid_points.y]])
+    )
+
+    hw = cut_w / 2
+    hh = cut_h / 2
+    for cx, cy in valid_centers:
+        c.add_polygon(
+            [
+                (cx - hw, cy - hh),
+                (cx + hw, cy - hh),
+                (cx + hw, cy + hh),
+                (cx - hw, cy + hh),
+            ],
+            layer=via_layer,
+        )
+
+    c.add_polygon(list(poly.exterior.coords), layer=bottom_layer)
+    c.add_polygon(list(poly.exterior.coords), layer=top_layer)
+
+    # Open Access metadata
+    c.info["num_vias"] = len(valid_centers)
+    c.info["via_x_spacing"] = via_x_spacing
+    c.info["via_y_spacing"] = via_y_spacing
+    c.info["via_x_cut_size"] = cut_w
+    c.info["via_y_cut_size"] = cut_h
+    c.info["via_x_enclosure"] = via_x_minimum_enclosure
+    c.info["via_y_enclosure"] = via_y_minimum_enclosure
+    c.info["enclosing_region"] = list(poly.exterior.coords)
+    c.info["top_layer"] = top_layer
+    c.info["bottom_layer"] = bottom_layer
+
+    return c
+
+
+@gf.cell_with_module_name(tags=["vias"])
+def via_array_stack_oa_compliant(
+    bottom_layer: LayerSpec = "M1",
+    top_layer: LayerSpec = "M5",
+    region: _PolygonPoints | None = None,
+    size: tuple[float, float] | None = None,
+    grid_size: tuple[int, int] | None = None,
+    via_type: Literal["square", "rectangle"] = "square",
+    via_x_minimum_cut_size_rules: dict[LayerSpec, float] | None = None,
+    via_y_minimum_cut_size_rules: dict[LayerSpec, float] | None = None,
+    via_x_minimum_enclosure_rules: dict[LayerSpec, float] | None = None,
+    via_y_minimum_enclosure_rules: dict[LayerSpec, float] | None = None,
+    via_x_minimum_spacing_rules: dict[LayerSpec, float] | None = None,
+    via_y_minimum_spacing_rules: dict[LayerSpec, float] | None = None,
+    layer_connectivity_sequence: LayerSpecs = (
+        "M1",
+        "VIA1",
+        "M2",
+        "VIA2",
+        "M3",
+        "VIA3",
+        "M4",
+        "VIA4",
+        "M5",
+    ),
+) -> Component:
+    """OpenAccess-compliant via stack between bottom_layer and top_layer.
+
+    Iterates through the layer_connectivity_sequence, placing a
+    via_array_region_raster for each via layer between bottom_layer and
+    top_layer. Each via layer uses its own DRC rules from the per-layer
+    rule dictionaries.
+
+    The region, size, and grid_size parameters are mutually exclusive.
+    Priority order: region > size > grid_size. If multiple are provided,
+    only the highest-priority one is used.
+
+    - region: arbitrary polygon coordinates defining the via area.
+    - size: (width, height) in um, centered at origin.
+    - grid_size: (columns, rows) of vias. The region is computed from
+      the grid dimensions using the DRC rules of the first via layer.
+
+    Args:
+        bottom_layer: lowest metal layer in the stack.
+        top_layer: highest metal layer in the stack.
+        region: arbitrary polygon region for via placement.
+        size: (width, height) rectangle centered at origin (um).
+        grid_size: (columns, rows) number of vias per axis.
+        via_type: "square" or "rectangle" via cuts.
+        via_x_minimum_cut_size_rules: per-via-layer minimum cut width in x.
+        via_y_minimum_cut_size_rules: per-via-layer minimum cut height in y.
+        via_x_minimum_enclosure_rules: per-via-layer minimum metal enclosure in x.
+        via_y_minimum_enclosure_rules: per-via-layer minimum metal enclosure in y.
+        via_x_minimum_spacing_rules: per-via-layer minimum spacing in x.
+        via_y_minimum_spacing_rules: per-via-layer minimum spacing in y.
+        layer_connectivity_sequence: ordered tuple of alternating
+            drawing and via layers (e.g. M1, VIA, M2, VIA1, M3, ...).
+    """
+    _default_cut = {"VIA": 0.3, "VIA1": 0.3, "VIA2": 0.4, "VIA3": 0.5}
+    _default_enc = {"VIA": 0.06, "VIA1": 0.06, "VIA2": 0.06, "VIA3": 0.06}
+    _default_spc = {"VIA": 0.3, "VIA1": 0.3, "VIA2": 0.4, "VIA3": 0.5}
+
+    cut_x_rules = via_x_minimum_cut_size_rules or _default_cut
+    cut_y_rules = via_y_minimum_cut_size_rules or _default_cut
+    enc_x_rules = via_x_minimum_enclosure_rules or _default_enc
+    enc_y_rules = via_y_minimum_enclosure_rules or _default_enc
+    spc_x_rules = via_x_minimum_spacing_rules or _default_spc
+    spc_y_rules = via_y_minimum_spacing_rules or _default_spc
+
+    seq = list(layer_connectivity_sequence)
+    drawing_layers: list[LayerSpec] = seq[0::2]
+    via_layers: list[LayerSpec] = seq[1::2]
+
+    if bottom_layer not in drawing_layers:
+        raise ValueError(
+            f"{bottom_layer=} not found in drawing layers {drawing_layers}"
+        )
+    if top_layer not in drawing_layers:
+        raise ValueError(f"{top_layer=} not found in drawing layers {drawing_layers}")
+
+    bot_idx = drawing_layers.index(bottom_layer)
+    top_idx = drawing_layers.index(top_layer)
+    if top_idx <= bot_idx:
+        raise ValueError(
+            f"top_layer {top_layer} must be above bottom_layer {bottom_layer} "
+            f"in the connectivity sequence."
+        )
+
+    # Resolve mutually exclusive inputs: region > size > grid_size
+    if region is not None:
+        resolved_region = region
+    elif size is not None:
+        w, h = size
+        resolved_region = [
+            (-w / 2, -h / 2),
+            (w / 2, -h / 2),
+            (w / 2, h / 2),
+            (-w / 2, h / 2),
+        ]
+    elif grid_size is not None:
+        cols, rows = grid_size
+        first_via = via_layers[bot_idx]
+        cut_x = cut_x_rules.get(first_via, 0.3)
+        cut_y = cut_y_rules.get(first_via, 0.3)
+        enc_x = enc_x_rules.get(first_via, 0.06)
+        enc_y = enc_y_rules.get(first_via, 0.06)
+        spc_x = spc_x_rules.get(first_via, 0.3)
+        spc_y = spc_y_rules.get(first_via, 0.3)
+        w = cols * cut_x + (cols - 1) * spc_x + 2 * enc_x
+        h = rows * cut_y + (rows - 1) * spc_y + 2 * enc_y
+        resolved_region = [
+            (-w / 2, -h / 2),
+            (w / 2, -h / 2),
+            (w / 2, h / 2),
+            (-w / 2, h / 2),
+        ]
+    else:
+        raise ValueError("One of region, size, or grid_size must be provided.")
+
+    c = Component()
+    total_vias = 0
+    layer_info: list[dict] = []
+
+    for i in range(bot_idx, top_idx):
+        metal_below = drawing_layers[i]
+        via_lyr = via_layers[i]
+        metal_above = drawing_layers[i + 1]
+
+        via_comp = via_array_region_raster(
+            region=resolved_region,
+            bottom_layer=metal_below,
+            via_layer=via_lyr,
+            top_layer=metal_above,
+            via_type=via_type,
+            via_x_spacing=spc_x_rules.get(via_lyr, 0.3),
+            via_y_spacing=spc_y_rules.get(via_lyr, 0.3),
+            via_x_minimum_cut_size=cut_x_rules.get(via_lyr, 0.3),
+            via_y_minimum_cut_size=cut_y_rules.get(via_lyr, 0.3),
+            via_x_minimum_enclosure=enc_x_rules.get(via_lyr, 0.06),
+            via_y_minimum_enclosure=enc_y_rules.get(via_lyr, 0.06),
+            via_x_minimum_spacing=spc_x_rules.get(via_lyr, 0.3),
+            via_y_minimum_spacing=spc_y_rules.get(via_lyr, 0.3),
+        )
+        c.add_ref(via_comp)
+
+        num = via_comp.info.get("num_vias", 0)
+        total_vias += num
+        layer_info.append(
+            {
+                "via_layer": via_lyr,
+                "bottom_layer": metal_below,
+                "top_layer": metal_above,
+                "num_vias": num,
+                "via_x_cut_size": via_comp.info.get("via_x_cut_size", 0),
+                "via_y_cut_size": via_comp.info.get("via_y_cut_size", 0),
+                "via_x_spacing": via_comp.info.get("via_x_spacing", 0),
+                "via_y_spacing": via_comp.info.get("via_y_spacing", 0),
+                "via_x_enclosure": via_comp.info.get("via_x_enclosure", 0),
+                "via_y_enclosure": via_comp.info.get("via_y_enclosure", 0),
+            }
+        )
+
+    # OpenAccess-compliant metadata
+    c.info["bottom_layer"] = bottom_layer
+    c.info["top_layer"] = top_layer
+    c.info["total_num_vias"] = total_vias
+    c.info["num_via_layers"] = top_idx - bot_idx
+    c.info["via_type"] = via_type
+    c.info["layer_connectivity_sequence"] = list(layer_connectivity_sequence)
+    c.info["per_layer_info"] = layer_info
+    resolved_shapely = _region_to_shapely(resolved_region)
+    c.info["enclosing_region"] = list(resolved_shapely.exterior.coords)
+
+    return c
 
 
 if __name__ == "__main__":

--- a/tests/components/vias/test_via_array_region_raster.py
+++ b/tests/components/vias/test_via_array_region_raster.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.components.vias.via_stack import (
+    via_array_region_raster,
+    via_array_stack_oa_compliant,
+)
+
+
+def test_via_array_region_raster_rectangular_region() -> None:
+    gf.gpdk.PDK.activate()
+    c = via_array_region_raster(
+        region=[(0, 0), (5, 0), (5, 3), (0, 3)],
+        bottom_layer="M1",
+        via_layer="VIA1",
+        top_layer="M2",
+        via_x_minimum_cut_size=0.3,
+        via_y_minimum_cut_size=0.3,
+        via_x_minimum_enclosure=0.06,
+        via_y_minimum_enclosure=0.06,
+        via_x_minimum_spacing=0.3,
+        via_y_minimum_spacing=0.3,
+    )
+    assert c.info["num_vias"] > 0
+    assert c.info["bottom_layer"] == "M1"
+    assert c.info["top_layer"] == "M2"
+    assert c.info["via_x_cut_size"] == 0.3
+    assert c.info["via_y_cut_size"] == 0.3
+
+
+def test_via_array_region_raster_rectangle_via_type() -> None:
+    gf.gpdk.PDK.activate()
+    c = via_array_region_raster(
+        region=[(0, 0), (5, 0), (5, 3), (0, 3)],
+        bottom_layer="M1",
+        via_layer="VIA1",
+        top_layer="M2",
+        via_type="rectangle",
+        via_x_minimum_cut_size=0.3,
+        via_y_minimum_cut_size=0.3,
+        via_x_minimum_enclosure=0.06,
+        via_y_minimum_enclosure=0.06,
+        via_x_minimum_spacing=0.3,
+        via_y_minimum_spacing=0.3,
+    )
+    assert c.info["num_vias"] > 0
+    cut_w = c.info["via_x_cut_size"]
+    cut_h = c.info["via_y_cut_size"]
+    assert cut_w != cut_h, "Rectangle via type should double one dimension"
+
+
+def test_via_array_stack_oa_compliant_size_input() -> None:
+    gf.gpdk.PDK.activate()
+    c = via_array_stack_oa_compliant(
+        bottom_layer="M1",
+        top_layer="M3",
+        size=(5, 5),
+        via_type="square",
+    )
+    assert c.info["bottom_layer"] == "M1"
+    assert c.info["top_layer"] == "M3"
+    assert c.info["num_via_layers"] == 2
+    assert c.info["total_num_vias"] > 0
+    assert len(c.info["per_layer_info"]) == 2
+
+
+def test_via_array_stack_oa_compliant_region_input() -> None:
+    gf.gpdk.PDK.activate()
+    from shapely.geometry import Polygon as ShapelyPolygon
+
+    bottom = ShapelyPolygon([(0, 0), (8, 0), (8, 5), (0, 5)])
+    top = ShapelyPolygon([(2, -1), (10, 2), (8, 6), (0, 3)])
+    region = list(bottom.intersection(top).exterior.coords)
+
+    c = via_array_stack_oa_compliant(
+        bottom_layer="M1",
+        top_layer="M3",
+        region=region,
+        via_type="square",
+    )
+    assert c.info["total_num_vias"] > 0
+    assert c.info["num_via_layers"] == 2
+    for layer_info in c.info["per_layer_info"]:
+        assert layer_info["num_vias"] > 0
+        assert layer_info["via_x_cut_size"] > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.44.0"
+version = "9.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -1880,7 +1880,7 @@ name = "jinxed"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/e9/96633f12b6829eb1e91e70e5846704c0b1293ec47bd65a7b681e19c8eeff/jinxed-1.4.0.tar.gz", hash = "sha256:8f7801a10799de39e509eb5abc6d131ee169c1ce4fd5d568aa85b5f56ed58068", size = 37169, upload-time = "2026-03-26T01:49:38.337Z" }
 wheels = [
@@ -3442,7 +3442,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5429,7 +5429,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -5449,7 +5449,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/3e/695c7ab56be57814e369c1f38bc3f64b9dea0a83e867d00c0c9d613a9929/tifffile-2026.5.2.tar.gz", hash = "sha256:21b10227ede8493814a34676774797f721f487e36cb0530e7c3bd882caa87f5a", size = 429140, upload-time = "2026-05-02T20:19:31.497Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Added an Open-Access-compatible factory signature for the via_stack PCell generator, following: 

### Open Access via stack / array definition

A pseudo code definition of the Open-Access-compatible PCell signature can be simplified to:

```python
def standard_via_array_def(
    # --- Identity & Layers ---
    viaDefName,       # string  : unique name for this via def, e.g. "VIA1_M1_M2"
    layer1,           # string  : lower metal layer name, e.g. "Metal1"
    layer2,           # string  : upper metal layer name, e.g. "Metal2"

    # --- Cut Layer ---
    cutLayer,         # string  : cut/contact layer name, e.g. "Via1"
    cutWidth,         # float   : width  of one cut shape, e.g. 0.06 (um)
    cutHeight,        # float   : height of one cut shape, e.g. 0.06 (um)
    resistancePerCut, # float   : (optional) resistance of a single cut, e.g. 5.0 (ohms)

    # --- Array Configuration ---
    cutRows,          # int     : number of cut rows,    e.g. 2
    cutCols,          # int     : number of cut columns, e.g. 2
    cutSpace,         # [float, float] : (x_space, y_space) between cuts, e.g. [0.07, 0.07]

    # --- Enclosures ---
    layer1Enc,        # [float, float] : (side_enc, end_enc) of layer1 around cuts, e.g. [0.03, 0.03]
    layer2Enc,        # [float, float] : (side_enc, end_enc) of layer2 around cuts, e.g. [0.03, 0.03]

    # --- Offsets --- # Offsets are not implemented by default / convention - may violate enclosure DRC, defaulted to 0
    layer1Offset,     # [float, float] : (dx, dy) shift of layer1 rect from cut center, e.g. [0.0, 0.0]
    layer2Offset,     # [float, float] : (dx, dy) shift of layer2 rect from cut center, e.g. [0.0, 0.0]
    origOffset,       # [float, float] : (dx, dy) shift of via origin from bbox center, e.g. [0.0, 0.0]

    # --- Optional Implant Layers --- # NOT covered automatically when creating a via to diffusion layer. A dedicated via stack between metal 1 and doped implant layers should be created using this helper function.
    implant1     = None,  # string         : first implant layer name,  e.g. "NPlus"
    implant1Enc  = None,  # [float, float] : enclosure of implant1 around cut array
    implant2     = None,  # string         : second implant layer name, e.g. "PPlus"
    implant2Enc  = None,  # [float, float] : enclosure of implant2 around cut array
):
```

### 1. Helper Python PCell implementation and function signature and raster-based via array definition

The implementation was performed  in two steps. The first defines a helper function 
```python
@gf.cell_with_module_name(tags=["vias"])
def via_array_region_raster(
    region: _PolygonPoints,
   # --- Identity & Layers ---
    bottom_layer: LayerSpec = "M1",
    top_layer: LayerSpec = "M2",
    
    # The following parameters should be obtained from PDK-specific DRC rule set at runtime
    # --- Cut Layer ---
    via_layer: LayerSpec = "VIA1",
    via_type: Literal["square", "rectangle"] = "square", # Typically used to divide the via resistance by 2 by selecting rectangle 
    via_x_minimum_cut_size: float = 0.3,
    via_y_minimum_cut_size: float = 0.3,

    # --- Cut Space ---
    via_x_spacing: float = 0.3,
    via_y_spacing: float = 0.3,
  
   # --- Enclosures --- 
    via_x_minimum_enclosure: float = 0.06,
    via_y_minimum_enclosure: float = 0.06,
    via_x_minimum_spacing: float = 0.3,
    via_y_minimum_spacing: float = 0.3

) -> Component:
```

This helper function allows for creating a via-array by clicking on top of a region that has an overlap between consecutive layers, speeding up via array creation.

From overlapping region between consecutive metals that we want to route between:
<img width="676" height="531" alt="image" src="https://github.com/user-attachments/assets/19814eab-27db-450d-91d4-3694bbc8e76d" />

Into a region rastered with a via array complying with the DRC rule set parsed as input, following the open access standard for via array definition:
<img width="828" height="582" alt="image" src="https://github.com/user-attachments/assets/63503cf7-a142-45c7-a355-67b344743414" />


### 2. Standard via stack array python PCell implementation and function signature, raster-based, open-access compliant definition

```python
@gf.cell_with_module_name(tags=["vias"])
def via_array_stack_oa_compliant(
    bottom_layer: LayerSpec = "M1",
    top_layer: LayerSpec = "M5",
    region: _PolygonPoints | None = None,
    size: tuple[float, float] | None = None,
    grid_size: tuple[int, int] | None = None,
    via_type: Literal["square", "rectangle"] = "square",
    via_x_minimum_cut_size_rules: dict[LayerSpec, float] | None = None,
    via_y_minimum_cut_size_rules: dict[LayerSpec, float] | None = None,
    via_x_minimum_enclosure_rules: dict[LayerSpec, float] | None = None,
    via_y_minimum_enclosure_rules: dict[LayerSpec, float] | None = None,
    via_x_minimum_spacing_rules: dict[LayerSpec, float] | None = None,
    via_y_minimum_spacing_rules: dict[LayerSpec, float] | None = None,
    layer_connectivity_sequence: LayerSpecs = ( # Defines the cut layers by order of bot-top layer enclosure
        "M1",
        "VIA1",
        "M2",
        "VIA2",
        "M3",
        "VIA3",
        "M4",
        "VIA4",
        "M5",
    ),
) -> Component:
```

Uses the raster-based via definition of the via array stack throughout multiple consecutive layers. 

<img width="838" height="628" alt="image" src="https://github.com/user-attachments/assets/2bc2a32e-64d9-4eff-9150-e660a0715fe8" />


The region, size, and grid_size parameters are mutually exclusive. Priority order: region > size > grid_size. If multiple are provided, only the highest-priority one is used:

    - region: arbitrary polygon coordinates defining the via area.
    - size: (width, height) in um, centered at origin.
    - grid_size: (columns, rows) of vias.  Open-access-compliant through (cutRows, cutCols) tuple. The region is computed from the grid dimensions using the DRC rules of the first via layer.

## Test Plan 

- [x] Creation of several examples and stress testing with violating parameters
- [x] Documentation-ready examples on jupyter notebook

## Deprecation Plan 

- Change the current to via_stack_deprecated, and update the oa_compliant one to via_stack, only.

## Summary by Sourcery

Add OpenAccess-compliant via array and via stack generators that rasterize vias over arbitrary regions and expose metadata for interoperability.

New Features:
- Introduce via_array_region_raster to fill arbitrary polygon regions with via arrays respecting per-layer DRC-style spacing and enclosure rules.
- Introduce via_array_stack_oa_compliant to build multi-layer via stacks between selected metal layers using per-layer rule dictionaries and OpenAccess-style metadata.
- Expose the new via array utilities through the vias package API and add a demonstration Jupyter notebook for interactive usage.

Documentation:
- Document via_array_region_raster and via_array_stack_oa_compliant usage in a new notebook linked from the main documentation TOC.

Tests:
- Add unit tests covering via_array_region_raster behavior (including rectangular via type) and via_array_stack_oa_compliant with both size- and region-based inputs.

## Summary by Sourcery

Add OpenAccess-compliant via array and via stack generators for rasterized via placement over arbitrary regions and expose them through the vias API.

New Features:
- Introduce via_array_region_raster to fill arbitrary polygon regions with via arrays respecting DRC-style spacing and enclosure constraints.
- Introduce via_array_stack_oa_compliant to build multi-layer via stacks between selected metal layers using per-layer rule dictionaries and OpenAccess-style metadata.

Documentation:
- Add a Jupyter notebook demonstrating via_array_region_raster and link it from the main documentation table of contents.

Tests:
- Add tests covering via_array_region_raster (including rectangular via type) and via_array_stack_oa_compliant for size- and region-based inputs.