### PR TITLE
Fix to_np

### DIFF
--- a/gdsfactory/export/to_np.py
+++ b/gdsfactory/export/to_np.py
@@ -31,11 +31,11 @@ def to_np(
 
     dbbox = component.kdb_cell.dbbox()
 
-    xmin, ymin, xmax, ymax = dbbox.bottom, dbbox.left, dbbox.top, dbbox.right
+    xmin, ymin, xmax, ymax = dbbox.left, dbbox.bottom, dbbox.right, dbbox.top
 
     shape = (
-        int(np.ceil(xmax - xmin) * pixels_per_um),
-        int(np.ceil(ymax - ymin) * pixels_per_um),
+        int(np.ceil((xmax - xmin) * pixels_per_um)),
+        int(np.ceil((ymax - ymin) * pixels_per_um)),
     )
     img = np.zeros(shape, dtype=float)
     if layers is None:

--- a/tests/export/test_to_np.py
+++ b/tests/export/test_to_np.py
@@ -77,6 +77,14 @@ def test_to_np_with_pad_width() -> None:
     assert img.shape[0] > 0 and img.shape[1] > 0
 
 
+def test_to_np_shape_follows_component() -> None:
+    c = gf.components.rectangle(size=(10, 1), layer=(1, 0))
+    img = to_np(c, nm_per_pixel=100, layers=((1, 0),), pad_width=0)
+
+    assert img.shape == (100, 10)
+    assert int((img > 0).sum()) == img.size
+
+
 def test_to_np_with_bend_circular() -> None:
     c = bend_circular()
     img = to_np(c, nm_per_pixel=20)


### PR DESCRIPTION
## Summary

bbox is wrong, `np.ceil` on the wrong thing

## Test Plan

Unit test

## Summary by Sourcery

Correct bounding box handling in to_np export and add coverage for component-aligned output shapes.

Bug Fixes:
- Fix computation of bounding box coordinates and pixel dimensions in to_np to use the correct extent and scaling.

Tests:
- Add regression test ensuring to_np output shape follows the component geometry and is fully populated.