### PR TITLE
Improving the state of cross sections

### DIFF
--- a/gdsfactory/components/bends/bend_circular_heater.py
+++ b/gdsfactory/components/bends/bend_circular_heater.py
@@ -49,9 +49,7 @@ def bend_circular_heater(
         offset=-offset,
         layer=layer_heater,
     )
-    sections = list(x.sections) + [s1, s2]
-
-    xs = x.copy(sections=tuple(sections))
+    xs = x.append_sections((s1, s2))
     p = arc(radius=radius, angle=angle, npoints=npoints)
 
     c = Component()

--- a/gdsfactory/components/tapers/taper_cross_section.py
+++ b/gdsfactory/components/tapers/taper_cross_section.py
@@ -65,14 +65,14 @@ def taper_cross_section(
 
         def _mark_skip(sections: tuple[gf.Section, ...]) -> tuple[gf.Section, ...]:
             return tuple(
-                s.model_copy(update={"skip_transition": True})
+                s._replace(skip_transition=True)
                 if gf.get_layer(s.layer) in excluded
                 else s
                 for s in sections
             )
 
-        x1 = x1.model_copy(update={"sections": _mark_skip(x1.sections)})
-        x2 = x2.model_copy(update={"sections": _mark_skip(x2.sections)})
+        x1 = x1.copy(sections=_mark_skip(x1.sections))
+        x2 = x2.copy(sections=_mark_skip(x2.sections))
 
     if x1 == x2 and not exclude_layers:
         return gf.components.straight(length=length, cross_section=x1)

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -30,6 +30,9 @@ from gdsfactory.config import CONF, ErrorType
 nm = 1e-3
 
 
+_UNSET = object()
+
+
 port_names_electrical: typings.IOPorts = ("e1", "e2")
 port_types_electrical: typings.IOPorts = ("electrical", "electrical")
 cladding_layers_optical: typings.Layers | None = None
@@ -290,26 +293,31 @@ class CrossSection(BaseModel):
 
     def copy(
         self,
-        width: float | None = None,
-        layer: typings.LayerSpec | None = None,
-        width_function: typings.WidthFunction | None = None,
-        offset_function: typings.OffsetFunction | None = None,
-        sections: Sections | None = None,
+        width: float = _UNSET,
+        offset: float = _UNSET,
+        layer: typings.LayerSpec = _UNSET,
+        width_function: typings.WidthFunction | None = _UNSET,
+        offset_function: typings.OffsetFunction | None = _UNSET,
+        sections: Sections = _UNSET,
         **kwargs: Any,
     ) -> CrossSection:
         """Returns copy of the cross_section with new parameters.
 
-        The overrides below apply to the first section, and only when they are not
-        None. There is no way to remove a `width_function` or an `offset_function`
-        with this method: pass `sections` with an explicitly built Section instead.
+        The overrides below apply to the first section, and an omitted one keeps the
+        current value. None is only accepted where the Section field accepts it, so it
+        removes a profile function instead of standing for an omission.
+
+        A profile function takes precedence during extrusion, so overriding `width` or
+        `offset` while one remains only sets a nominal value, and warns.
 
         Args:
             width: of the section (um). Defaults to current width.
+            offset: center offset of the section (um). Defaults to current offset.
             layer: layer spec. Defaults to current layer.
             width_function: parameterized function from 0 to 1. Defaults to the \
-                    current width_function.
+                    current width_function. None removes it.
             offset_function: parameterized function from 0 to 1. Defaults to the \
-                    current offset_function.
+                    current offset_function. None removes it.
             sections: a tuple of Sections, to replace the original sections. Used as \
                     given, except for the overrides above applied to the first one.
             kwargs: additional parameters to update.
@@ -319,7 +327,6 @@ class CrossSection(BaseModel):
             radius: route bend radius (um).
             bbox_layers: layer to add as bounding box.
             bbox_offsets: offset to add to the bounding box.
-            _name: name of the cross_section.
 
         """
         for kwarg in kwargs:
@@ -330,27 +337,44 @@ class CrossSection(BaseModel):
             key: value
             for key, value in (
                 ("width", width),
+                ("offset", offset),
                 ("layer", layer),
                 ("width_function", width_function),
                 ("offset_function", offset_function),
             )
-            if value is not None
+            if value is not _UNSET
         }
 
         update: dict[str, Any] = dict(kwargs)
 
-        if section_overrides or sections is not None:
+        if section_overrides or sections is not _UNSET:
             # Sections are frozen, so they can be shared with the copy
-            section_list = list(self.sections if sections is None else sections)
+            section_list = list(self.sections if sections is _UNSET else sections)
             if section_overrides:
                 if not section_list:
                     raise ValueError(
-                        "cannot override width, layer or the profile functions of a "
-                        "cross_section without sections"
+                        "no section to apply the width, offset or layer overrides to"
                     )
                 first = section_list[0]
                 # Rebuilt instead of copied so the overrides get validated
-                section_list[0] = first.model_validate(dict(first) | section_overrides)
+                new_first = first.model_validate(dict(first) | section_overrides)
+                for name, passed, function in (
+                    ("width", width_function, new_first.width_function),
+                    ("offset", offset_function, new_first.offset_function),
+                ):
+                    # an explicitly passed function may be deliberate
+                    if (
+                        name in section_overrides
+                        and passed is _UNSET
+                        and function is not None
+                    ):
+                        warnings.warn(
+                            f"{name}={section_overrides[name]} is only nominal for "
+                            f"section {new_first.name!r}: its {name}_function drives "
+                            f"the extrusion. Pass {name}_function=None to remove it.",
+                            stacklevel=2,
+                        )
+                section_list[0] = new_first
             update["sections"] = tuple(section_list)
 
         return self._copy(update)

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -125,10 +125,10 @@ class Section(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def generate_default_name(cls, data: Any) -> Any:
-        if not data.get("name"):
-            h = hashlib.md5(str(data).encode()).hexdigest()[:8]
-            data["name"] = f"s_{h}"
-        return data
+        if data.get("name"):
+            return data
+        h = hashlib.md5(str(data).encode()).hexdigest()[:8]
+        return {**data, "name": f"s_{h}"}
 
     @model_validator(mode="after")
     def _require_width_value_or_function(self) -> Self:

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -311,7 +311,13 @@ class CrossSection(BaseModel):
 
         xs_original = self
 
-        if width_function or offset_function or width or layer or sections:
+        if (
+            width_function
+            or offset_function
+            or width is not None
+            or layer is not None
+            or sections
+        ):
             if sections is None:
                 section_list = list(self.sections)
             else:
@@ -322,8 +328,8 @@ class CrossSection(BaseModel):
                 update={
                     "width_function": width_function,
                     "offset_function": offset_function,
-                    "width": width or self.width,
-                    "layer": layer or self.layer,
+                    "width": width if width is not None else self.width,
+                    "layer": layer if layer is not None else self.layer,
                 }
             )
             xs = self.model_copy(update={"sections": tuple(section_list), **kwargs})

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -288,16 +288,22 @@ class CrossSection(BaseModel):
     ) -> CrossSection:
         """Returns copy of the cross_section with new parameters.
 
+        The overrides below apply to the first section, and only when they are not
+        None. There is no way to remove a `width_function` or an `offset_function`
+        with this method: pass `sections` with an explicitly built Section instead.
+
         Args:
             width: of the section (um). Defaults to current width.
             layer: layer spec. Defaults to current layer.
-            width_function: parameterized function from 0 to 1.
-            offset_function: parameterized function from 0 to 1.
-            sections: a tuple of Sections, to replace the original sections
+            width_function: parameterized function from 0 to 1. Defaults to the \
+                    current width_function.
+            offset_function: parameterized function from 0 to 1. Defaults to the \
+                    current offset_function.
+            sections: a tuple of Sections, to replace the original sections. Used as \
+                    given, except for the overrides above applied to the first one.
             kwargs: additional parameters to update.
 
         Keyword Args:
-            sections: tuple of Sections(width, offset, layer, ports).
             components_along_path: tuple of ComponentAlongPaths.
             radius: route bend radius (um).
             bbox_layers: layer to add as bounding box.
@@ -309,36 +315,35 @@ class CrossSection(BaseModel):
             if kwarg not in dict(self):
                 raise ValueError(f"{kwarg!r} not in CrossSection")
 
-        xs_original = self
-
-        if (
-            width_function
-            or offset_function
-            or width is not None
-            or layer is not None
-            or sections
-        ):
-            if sections is None:
-                section_list = list(self.sections)
-            else:
-                section_list = list(sections)
-
-            section_list = [s.model_copy() for s in section_list]
-            section_list[0] = section_list[0].model_copy(
-                update={
-                    "width_function": width_function,
-                    "offset_function": offset_function,
-                    "width": width if width is not None else self.width,
-                    "layer": layer if layer is not None else self.layer,
-                }
+        section_overrides: dict[str, Any] = {
+            key: value
+            for key, value in (
+                ("width", width),
+                ("layer", layer),
+                ("width_function", width_function),
+                ("offset_function", offset_function),
             )
-            xs = self.model_copy(update={"sections": tuple(section_list), **kwargs})
-            if xs != xs_original:
-                xs._name = f"xs_{xs.hash}"
-            return xs
+            if value is not None
+        }
 
-        xs = self.model_copy(update=kwargs)
-        if xs != xs_original:
+        update: dict[str, Any] = dict(kwargs)
+
+        if section_overrides or sections is not None:
+            # Sections are frozen, so they can be shared with the copy
+            section_list = list(self.sections if sections is None else sections)
+            if section_overrides:
+                if not section_list:
+                    raise ValueError(
+                        "cannot override width, layer or the profile functions of a "
+                        "cross_section without sections"
+                    )
+                first = section_list[0]
+                # Rebuilt instead of copied so the overrides get validated
+                section_list[0] = first.model_validate(dict(first) | section_overrides)
+            update["sections"] = tuple(section_list)
+
+        xs = self.model_copy(update=update)
+        if xs != self:
             xs._name = f"xs_{xs.hash}"
         return xs
 

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -13,6 +13,7 @@ from typing import Any, Self
 
 import numpy as np
 from kfactory import DCrossSection, SymmetricalCrossSection
+from kfactory.layer import LayerEnum
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -30,7 +31,7 @@ from gdsfactory.config import CONF, ErrorType
 nm = 1e-3
 
 
-_UNSET = object()
+_UNSET: Any = object()
 
 
 port_names_electrical: typings.IOPorts = ("e1", "e2")
@@ -125,19 +126,44 @@ class Section(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    @model_validator(mode="before")
-    @classmethod
-    def generate_default_name(cls, data: Any) -> Any:
-        if data.get("name"):
-            return data
-        h = hashlib.md5(str(data).encode()).hexdigest()[:8]
-        return {**data, "name": f"s_{h}"}
+    @model_validator(mode="after")
+    def generate_default_name(self) -> Self:
+        """Fill an omitted name with one derived from the validated content."""
+        if not self.name:
+            object.__setattr__(self, "name", self._derived_name)
+            self.__pydantic_fields_set__.add("name")
+        return self
+
+    @property
+    def _derived_name(self) -> str:
+        """The name a section with this content gets when it is given none.
+
+        Two profile functions sampling the same profile give the same name, since
+        the hash covers the sampled values rather than the function object.
+        """
+        h = hashlib.md5(self.model_dump_json(exclude={"name"}).encode())
+        return f"s_{h.hexdigest()[:8]}"
+
+    def _replace(self, **overrides: Any) -> Self:
+        """Copy with validated overrides, keeping only a name that was given.
+
+        A derived name describes the content it was derived from, so it has to
+        be derived again rather than follow the overrides.
+        """
+        data = dict(self) | overrides
+        if "name" not in overrides and self.name == self._derived_name:
+            del data["name"]
+        return self.model_validate(data)
 
     @model_validator(mode="after")
     def _require_width_value_or_function(self) -> Self:
         if self.width == 0 and self.width_function is None:
             raise ValueError("Section requires `width > 0` or a `width_function`.")
         return self
+
+    @field_serializer("layer", when_used="json")
+    def serialize_layer(self, layer: typings.LayerSpec) -> Any:
+        return layer.name if isinstance(layer, LayerEnum) else layer
 
     @field_serializer("width_function")
     def serialize_width_function(
@@ -175,6 +201,11 @@ class ComponentAlongPath(BaseModel):
     offset: float = 0.0
 
     model_config = ConfigDict(extra="forbid", frozen=True, arbitrary_types_allowed=True)
+
+    @field_serializer("component")
+    def serialize_component(self, component: Component) -> str:
+        # pydantic serializes an arbitrary type as {}
+        return component.name
 
 
 Sections = tuple[Section, ...]
@@ -228,7 +259,6 @@ class CrossSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
     _name: str = PrivateAttr("")
-    _dcross_section: DCrossSection | None = PrivateAttr()
 
     def validate_radius(
         self, radius: float, error_type: ErrorType | None = None
@@ -250,10 +280,8 @@ class CrossSection(BaseModel):
 
     @property
     def name(self) -> str:
-        if self._name:
-            return self._name
-        h = hashlib.md5(str(self).encode()).hexdigest()[:8]
-        return f"xs_{h}"
+        """Explicit name, or one derived from the content."""
+        return self._name or f"xs_{self.hash[:8]}"
 
     @property
     def width(self) -> float:
@@ -274,9 +302,8 @@ class CrossSection(BaseModel):
         Rebuilt rather than using `model_copy` so the update gets validated.
         """
         xs = type(self).model_validate(dict(self) | update)
-        xs._name = self._name  # Restoring for the comparison
-        if xs != self:
-            xs._name = ""  # Deriving name from the new content
+        if dict(xs) == dict(self):
+            xs._name = self._name  # the content still is what the name describes
         return xs
 
     def __getitem__(self, key: str) -> Section:
@@ -289,7 +316,7 @@ class CrossSection(BaseModel):
     @property
     def hash(self) -> str:
         """Returns a hash of the cross_section."""
-        return hashlib.md5(str(self).encode()).hexdigest()
+        return hashlib.md5(self.model_dump_json().encode()).hexdigest()
 
     def copy(
         self,
@@ -300,7 +327,7 @@ class CrossSection(BaseModel):
         offset_function: typings.OffsetFunction | None = _UNSET,
         sections: Sections = _UNSET,
         **kwargs: Any,
-    ) -> CrossSection:
+    ) -> Self:
         """Returns copy of the cross_section with new parameters.
 
         The overrides below apply to the first section, and an omitted one keeps the
@@ -325,12 +352,13 @@ class CrossSection(BaseModel):
         Keyword Args:
             components_along_path: tuple of ComponentAlongPaths.
             radius: route bend radius (um).
+            radius_min: minimum acceptable bend radius (um).
             bbox_layers: layer to add as bounding box.
             bbox_offsets: offset to add to the bounding box.
 
         """
         for kwarg in kwargs:
-            if kwarg not in dict(self):
+            if kwarg not in type(self).model_fields:
                 raise ValueError(f"{kwarg!r} not in CrossSection")
 
         section_overrides: dict[str, Any] = {
@@ -356,22 +384,24 @@ class CrossSection(BaseModel):
                         "no section to apply the width, offset or layer overrides to"
                     )
                 first = section_list[0]
+                if not isinstance(first, Section):  # sections may be given as mappings
+                    first = Section.model_validate(first)
                 # Rebuilt instead of copied so the overrides get validated
-                new_first = first.model_validate(dict(first) | section_overrides)
-                for name, passed, function in (
+                new_first = first._replace(**section_overrides)
+                for field, passed, function in (
                     ("width", width_function, new_first.width_function),
                     ("offset", offset_function, new_first.offset_function),
                 ):
                     # an explicitly passed function may be deliberate
                     if (
-                        name in section_overrides
+                        field in section_overrides
                         and passed is _UNSET
                         and function is not None
                     ):
                         warnings.warn(
-                            f"{name}={section_overrides[name]} is only nominal for "
-                            f"section {new_first.name!r}: its {name}_function drives "
-                            f"the extrusion. Pass {name}_function=None to remove it.",
+                            f"{field}={section_overrides[field]} is only nominal for "
+                            f"section {new_first.name!r}: its {field}_function drives "
+                            f"the extrusion. Pass {field}_function=None to remove it.",
                             stacklevel=2,
                         )
                 section_list[0] = new_first
@@ -379,9 +409,9 @@ class CrossSection(BaseModel):
 
         return self._copy(update)
 
-    def mirror(self) -> CrossSection:
+    def mirror(self) -> Self:
         """Returns a mirrored copy of the cross_section."""
-        sections = [s.model_copy(update=dict(offset=-s.offset)) for s in self.sections]
+        sections = [s._replace(offset=-s.offset) for s in self.sections]
         return self._copy({"sections": tuple(sections)})
 
     def add_bbox(

--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -263,7 +263,18 @@ class CrossSection(BaseModel):
     def append_sections(self, sections: Sections) -> Self:
         """Append sections to the cross_section."""
         new_sections = list(self.sections) + list(sections)
-        return self.model_copy(update={"sections": tuple(new_sections)})
+        return self._copy({"sections": tuple(new_sections)})
+
+    def _copy(self, update: dict[str, Any]) -> Self:
+        """Copy that does not carry a name if the content has changed.
+
+        Rebuilt rather than using `model_copy` so the update gets validated.
+        """
+        xs = type(self).model_validate(dict(self) | update)
+        xs._name = self._name  # Restoring for the comparison
+        if xs != self:
+            xs._name = ""  # Deriving name from the new content
+        return xs
 
     def __getitem__(self, key: str) -> Section:
         """Returns the section with the given name."""
@@ -342,15 +353,12 @@ class CrossSection(BaseModel):
                 section_list[0] = first.model_validate(dict(first) | section_overrides)
             update["sections"] = tuple(section_list)
 
-        xs = self.model_copy(update=update)
-        if xs != self:
-            xs._name = f"xs_{xs.hash}"
-        return xs
+        return self._copy(update)
 
     def mirror(self) -> CrossSection:
         """Returns a mirrored copy of the cross_section."""
         sections = [s.model_copy(update=dict(offset=-s.offset)) for s in self.sections]
-        return self.model_copy(update={"sections": tuple(sections)})
+        return self._copy({"sections": tuple(sections)})
 
     def add_bbox(
         self,

--- a/gdsfactory/cross_section/utils.py
+++ b/gdsfactory/cross_section/utils.py
@@ -199,8 +199,9 @@ def cross_section(
         def _cladding_width_kwargs(offset: float) -> dict[str, Any]:
             if callable(width):
                 return {
-                    "width_function": lambda t: cast(Callable[..., Any], width)(t)
-                    + 2 * offset
+                    "width_function": lambda t: (
+                        cast(Callable[..., Any], width)(t) + 2 * offset
+                    )
                 }
             return {"width": cast(Any, width) + 2 * offset}
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -954,11 +954,20 @@ def along_path(
     return c
 
 
-def _get_named_sections(sections: tuple[Section, ...]) -> dict[str, Section]:
-    named_sections: dict[str, Section] = {}
-    for section in sections:
-        if section.skip_transition:
-            continue
+def _get_named_sections(sections: tuple[Section, ...]) -> dict[str | int, Section]:
+    """Keys to pair the sections of two cross_sections by, in transition order.
+
+    A name a caller gave says which section on the other side to pair with. A name
+    derived from the content says nothing: it moves with every edit, so a
+    cross_section and its own `copy` would have nothing in common. Those pair by
+    position instead.
+    """
+    kept = [section for section in sections if not section.skip_transition]
+    if kept and all(section.name == section._derived_name for section in kept):
+        return dict(enumerate(kept))
+
+    named_sections: dict[str | int, Section] = {}
+    for section in kept:
         name = section.name or get_layer_name(section.layer)
         if name in named_sections:
             raise ValueError(
@@ -1386,7 +1395,7 @@ def extrude_transition(
     names1 = list(named_sections1.keys())
     names2 = list(named_sections2.keys())
 
-    common_sections = set(names1).intersection(names2)
+    common_sections = sorted(set(names1).intersection(names2), key=str)
     if not common_sections:
         raise ValueError(
             f"transition() found no common section names X1 {names1} and X2 {names2}"

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -362,7 +362,7 @@ class Pdk(BaseModel):
                     )
             cell_dict = cast("dict[str, Any]", cell)  # type: ignore[redundant-cast]
             settings = dict(cell_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
 
             cell_name = cell_dict.get("function")
             if not isinstance(cell_name, str) or cell_name not in cells_and_containers:
@@ -480,7 +480,7 @@ class Pdk(BaseModel):
                     )
             component_dict = cast("dict[str, Any]", component)  # type: ignore[redundant-cast]
             settings = dict(component_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
 
             cell_name = component_dict.get("component", None)
             cell_name = cell_name or component_dict.get("function")
@@ -523,7 +523,7 @@ class Pdk(BaseModel):
             if xs_name is None:
                 raise ValueError("cross_section name is required")
             settings = dict(xs_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
             return self.get_cross_section(xs_name, **settings)
         if isinstance(cross_section, CrossSection):
             if kwargs:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -503,7 +503,7 @@ class Pdk(BaseModel):
         """Returns cross_section from a cross_section spec.
 
         Args:
-            cross_section: CrossSection, CrossSectionFactory, Transition, string or dict.
+            cross_section: CrossSection, CrossSectionFactory, string or dict.
             kwargs: settings to override.
         """
         if callable(cross_section):
@@ -559,7 +559,7 @@ class Pdk(BaseModel):
             return xs_
         raise ValueError(
             "get_cross_section expects a CrossSectionSpec (CrossSection, "
-            f"CrossSectionFactory, Transition, string or dict), got {type(cross_section)}"
+            f"CrossSectionFactory, string or dict), got {type(cross_section)}"
         )
 
     def get_layer(self, layer: LayerSpec | kf.kdb.LayerInfo) -> LayerEnum | int:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -522,7 +522,8 @@ class Pdk(BaseModel):
             xs_name = xs_dict.get("cross_section", None)
             if xs_name is None:
                 raise ValueError("cross_section name is required")
-            settings = xs_dict.get("settings", {})
+            settings = dict(xs_dict.get("settings", {}))
+            settings.update(**kwargs)
             return self.get_cross_section(xs_name, **settings)
         if isinstance(cross_section, CrossSection):
             if kwargs:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -556,7 +556,7 @@ class Pdk(BaseModel):
                 radius_min=kf.kcl.to_um(cross_section_.radius_min),
             )
             xs_._name = cross_section_.name
-            return xs_
+            return xs_.copy(**kwargs) if kwargs else xs_
         raise ValueError(
             "get_cross_section expects a CrossSectionSpec (CrossSection, "
             f"CrossSectionFactory, string or dict), got {type(cross_section)}"

--- a/tests/test-data-regression/test_netlists_cdsem_straight_.yml
+++ b/tests/test-data-regression/test_netlists_cdsem_straight_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_c284ebda
+      route_info_type: xs_393c62f4
       route_info_weight: 420
-      route_info_xs_c284ebda_length: 420
+      route_info_xs_393c62f4_length: 420
       width: 0.45
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_dd2e6447
+      route_info_type: xs_8ef1aa83
       route_info_weight: 420
-      route_info_xs_dd2e6447_length: 420
+      route_info_xs_8ef1aa83_length: 420
       width: 0.6
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_a1e27c19
+      route_info_type: xs_393b79f9
       route_info_weight: 420
-      route_info_xs_a1e27c19_length: 420
+      route_info_xs_393b79f9_length: 420
       width: 1
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_caa9c64e
+      route_info_type: xs_a136854a
       route_info_weight: 420
-      route_info_xs_caa9c64e_length: 420
+      route_info_xs_a136854a_length: 420
       width: 0.4
     settings:
       cross_section: strip_no_ports
@@ -60,9 +60,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_9b17039c
+      route_info_type: xs_a8c7c3f1
       route_info_weight: 420
-      route_info_xs_9b17039c_length: 420
+      route_info_xs_a8c7c3f1_length: 420
       width: 0.8
     settings:
       cross_section: strip_no_ports

--- a/tests/test-data-regression/test_netlists_cdsem_straight_density_.yml
+++ b/tests/test-data-regression/test_netlists_cdsem_straight_density_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -60,9 +60,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -74,9 +74,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -88,9 +88,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -102,9 +102,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -116,9 +116,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -130,9 +130,9 @@ instances:
     info:
       length: 420
       route_info_length: 420
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 420
-      route_info_xs_28f5a27d_length: 420
+      route_info_xs_8c8e414f_length: 420
       width: 0.3
     settings:
       cross_section: strip_no_ports

--- a/tests/test-data-regression/test_netlists_dbr_tapered_.yml
+++ b/tests/test-data-regression/test_netlists_dbr_tapered_.yml
@@ -18,9 +18,9 @@ instances:
     info:
       length: 10
       route_info_length: 10
-      route_info_type: xs_ff979da3
+      route_info_type: xs_373b5a6b
       route_info_weight: 10
-      route_info_xs_ff979da3_length: 10
+      route_info_xs_373b5a6b_length: 10
       width: 0.4
     settings:
       cross_section: strip

--- a/tests/test-data-regression/test_netlists_mzit_.yml
+++ b/tests/test-data-regression/test_netlists_mzit_.yml
@@ -9,9 +9,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_6701e932
+      route_info_type: xs_3704aac9
       route_info_weight: 16.637
-      route_info_xs_6701e932_length: 16.637
+      route_info_xs_3704aac9_length: 16.637
       width: 0.45
     settings:
       allow_min_radius_violation: false
@@ -34,9 +34,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_6701e932
+      route_info_type: xs_3704aac9
       route_info_weight: 16.637
-      route_info_xs_6701e932_length: 16.637
+      route_info_xs_3704aac9_length: 16.637
       width: 0.45
     settings:
       allow_min_radius_violation: false
@@ -59,9 +59,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 16.637
-      route_info_xs_38085465_length: 16.637
+      route_info_xs_21e1adaf_length: 16.637
       width: 0.55
     settings:
       allow_min_radius_violation: false
@@ -84,9 +84,9 @@ instances:
       route_info_length: 16.637
       route_info_min_bend_radius: 7.061
       route_info_n_bend_90: 1
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 16.637
-      route_info_xs_38085465_length: 16.637
+      route_info_xs_21e1adaf_length: 16.637
       width: 0.55
     settings:
       allow_min_radius_violation: false
@@ -130,9 +130,9 @@ instances:
     info:
       length: 1
       route_info_length: 1
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 1
-      route_info_xs_38085465_length: 1
+      route_info_xs_21e1adaf_length: 1
       width: 0.55
     settings:
       cross_section: strip
@@ -144,9 +144,9 @@ instances:
     info:
       length: 1
       route_info_length: 1
-      route_info_type: xs_6701e932
+      route_info_type: xs_3704aac9
       route_info_weight: 1
-      route_info_xs_6701e932_length: 1
+      route_info_xs_3704aac9_length: 1
       width: 0.45
     settings:
       cross_section: strip
@@ -158,9 +158,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 3
-      route_info_xs_38085465_length: 3
+      route_info_xs_21e1adaf_length: 3
       width: 0.55
     settings:
       cross_section: strip
@@ -172,9 +172,9 @@ instances:
     info:
       length: 3
       route_info_length: 3
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 3
-      route_info_xs_38085465_length: 3
+      route_info_xs_21e1adaf_length: 3
       width: 0.55
     settings:
       cross_section: strip
@@ -186,9 +186,9 @@ instances:
     info:
       length: 4
       route_info_length: 4
-      route_info_type: xs_38085465
+      route_info_type: xs_21e1adaf
       route_info_weight: 4
-      route_info_xs_38085465_length: 4
+      route_info_xs_21e1adaf_length: 4
       width: 0.55
     settings:
       cross_section: strip

--- a/tests/test-data-regression/test_netlists_resonator_lumped_.yml
+++ b/tests/test-data-regression/test_netlists_resonator_lumped_.yml
@@ -78,13 +78,13 @@ instances:
       size:
       - 5
       - 5
-  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__6ca19ef0_52000_0:
+  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__327e88d2_52000_0:
     component: spiral
     info:
       length: 977.644
     settings:
       bend: bend_euler
-      cross_section: xs_4a304818
+      cross_section: xs_fbd45a80
       length: 100
       n_loops: 3
       spacing: 3
@@ -118,7 +118,7 @@ placements:
     rotation: 0
     x: -10
     y: 10
-  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__6ca19ef0_52000_0:
+  spiral_gdsfactorypcomponentspspiralspspiral_L100_Bbend__327e88d2_52000_0:
     mirror: false
     rotation: 0
     x: 52

--- a/tests/test-data-regression/test_netlists_terminator_.yml
+++ b/tests/test-data-regression/test_netlists_terminator_.yml
@@ -1,5 +1,5 @@
 instances:
-  taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0:
+  taper_cross_section_gdsfactorypcomponentsptapersptaper__c9857549_0_0:
     component: taper_cross_section
     info:
       route_info_length: 50
@@ -9,7 +9,7 @@ instances:
       route_info_weight: 50
     settings:
       cross_section1: strip
-      cross_section2: xs_91a65ea3
+      cross_section2: xs_320e8cbc
       exclude_layers: null
       length: 50
       linear: false
@@ -17,10 +17,10 @@ instances:
       width_type: sine
 nets: []
 placements:
-  taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0:
+  taper_cross_section_gdsfactorypcomponentsptapersptaper__c9857549_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
 ports:
-  o1: taper_cross_section_gdsfactorypcomponentsptapersptaper__dbf9663d_0_0,o1
+  o1: taper_cross_section_gdsfactorypcomponentsptapersptaper__c9857549_0_0,o1

--- a/tests/test-data-regression/test_netlists_verniers_.yml
+++ b/tests/test-data-regression/test_netlists_verniers_.yml
@@ -4,9 +4,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_28f5a27d
+      route_info_type: xs_8c8e414f
       route_info_weight: 100
-      route_info_xs_28f5a27d_length: 100
+      route_info_xs_8c8e414f_length: 100
       width: 0.3
     settings:
       cross_section: strip_no_ports
@@ -18,9 +18,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_1f5bd993
+      route_info_type: xs_c9096c22
       route_info_weight: 100
-      route_info_xs_1f5bd993_length: 100
+      route_info_xs_c9096c22_length: 100
       width: 0.2
     settings:
       cross_section: strip_no_ports
@@ -32,9 +32,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_6f4217dd
+      route_info_type: xs_7401cd45
       route_info_weight: 100
-      route_info_xs_6f4217dd_length: 100
+      route_info_xs_7401cd45_length: 100
       width: 0.1
     settings:
       cross_section: strip_no_ports
@@ -46,9 +46,9 @@ instances:
     info:
       length: 100
       route_info_length: 100
-      route_info_type: xs_caa9c64e
+      route_info_type: xs_a136854a
       route_info_weight: 100
-      route_info_xs_caa9c64e_length: 100
+      route_info_xs_a136854a_length: 100
       width: 0.4
     settings:
       cross_section: strip_no_ports

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -90,6 +90,31 @@ def test_copy() -> None:
     assert xs2.name == xs1.name, f"{xs2.name} != {xs1.name}"
 
 
+def test_copy_keeps_falsy_overrides() -> None:
+    """A nominal width of 0 and the layer with index 0 are overrides, not omissions."""
+
+    def width_function(
+        t: npt.NDArray[np.floating[Any]],
+    ) -> npt.NDArray[np.floating[Any]]:
+        return 0.5 + 2 * t
+
+    xs = gf.get_cross_section("strip")
+
+    # width_function drives the extrusion, so width is only a nominal value
+    taper = xs.copy(width=0.0, width_function=width_function)
+    assert taper.width == 0.0
+    assert taper.sections[0].width_function is width_function
+    c = gf.path.extrude(gf.path.straight(length=10), cross_section=taper)
+    assert np.isclose(c.ysize, width_function(1.0))
+
+    # first entry of a layer enum has index 0, which is falsy
+    assert xs.copy(layer=LAYER.WAFER).layer == LAYER.WAFER
+
+    # None still means "keep the current value"
+    assert xs.copy(width=None).width == xs.width
+    assert xs.copy(layer=None).layer == xs.layer
+
+
 def test_name() -> None:
     s = gf.cross_section.strip()
     assert s.name == "strip"

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -90,22 +90,34 @@ def test_copy() -> None:
     assert xs2.name == xs1.name, f"{xs2.name} != {xs1.name}"
 
 
+def _width_function(t: float) -> float:
+    return 0.5 + 2 * t
+
+
+def _offset_function(t: float) -> float:
+    return 0.0
+
+
+def _other_offset_function(t: float) -> float:
+    return 2.0 * t
+
+
+def _profile_cross_section() -> gf.CrossSection:
+    return gf.cross_section.cross_section(
+        width=_width_function, offset=_offset_function
+    )
+
+
 def test_copy_keeps_falsy_overrides() -> None:
     """A nominal width of 0 and the layer with index 0 are overrides, not omissions."""
-
-    def width_function(
-        t: npt.NDArray[np.floating[Any]],
-    ) -> npt.NDArray[np.floating[Any]]:
-        return 0.5 + 2 * t
-
     xs = gf.get_cross_section("strip")
 
     # width_function drives the extrusion, so width is only a nominal value
-    taper = xs.copy(width=0.0, width_function=width_function)
+    taper = xs.copy(width=0.0, width_function=_width_function)
     assert taper.width == 0.0
-    assert taper.sections[0].width_function is width_function
+    assert taper.sections[0].width_function is _width_function
     c = gf.path.extrude(gf.path.straight(length=10), cross_section=taper)
-    assert np.isclose(c.ysize, width_function(1.0))
+    assert np.isclose(c.ysize, _width_function(1.0))
 
     # first entry of a layer enum has index 0, which is falsy
     assert xs.copy(layer=LAYER.WAFER).layer == LAYER.WAFER
@@ -113,6 +125,63 @@ def test_copy_keeps_falsy_overrides() -> None:
     # None still means "keep the current value"
     assert xs.copy(width=None).width == xs.width
     assert xs.copy(layer=None).layer == xs.layer
+
+
+def test_copy_keeps_profile_functions() -> None:
+    """A copy that does not pass the profile functions has to keep them."""
+    xs = _profile_cross_section()
+
+    nominal_wider = xs.copy(width=3.0)
+    assert nominal_wider.sections[0].width_function is _width_function
+    assert nominal_wider.sections[0].offset_function is _offset_function
+    assert nominal_wider.width == 3.0
+
+    # width_function survived, so it still drives the extrusion over the new width
+    c = gf.path.extrude(gf.path.straight(length=10), cross_section=nominal_wider)
+    assert np.isclose(c.ysize, _width_function(1.0))
+
+
+def test_copy_replaces_only_the_profile_function_it_is_given() -> None:
+    """Passing one profile function must not clear the other one."""
+    xs = _profile_cross_section()
+
+    other_width_function = gf.path.transition_exponential(1.0, 5.0)
+    new_width = xs.copy(width_function=other_width_function).sections[0]
+    assert new_width.width_function is other_width_function
+    assert new_width.offset_function is _offset_function
+
+    new_offset = xs.copy(offset_function=_other_offset_function).sections[0]
+    assert new_offset.width_function is _width_function
+    assert new_offset.offset_function is _other_offset_function
+
+
+def test_copy_keeps_replacement_sections_verbatim() -> None:
+    """Replacement sections used to get the original width and layer written over them."""
+    xs = _profile_cross_section()
+    other = gf.Section(width=4.0, layer="SLAB90", name="other")
+
+    assert xs.copy(sections=(other,)).sections == (other,)
+
+    # an explicit empty tuple is an override, not an omission
+    assert xs.copy(sections=()).sections == ()
+
+
+def test_copy_validates_overrides() -> None:
+    """Overrides go through Section validation instead of around it."""
+    xs = gf.get_cross_section("strip")
+
+    # width of 0 needs a width_function to give the section a width
+    with pytest.raises(ValidationError):
+        xs.copy(width=0.0)
+
+    with pytest.raises(ValidationError):
+        xs.copy(width=-1.0)
+
+
+def test_copy_without_sections_rejects_overrides() -> None:
+    """There is no first section to apply the overrides to."""
+    with pytest.raises(ValueError, match="without sections"):
+        gf.CrossSection().copy(width=1.0)
 
 
 def test_name() -> None:

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -247,6 +247,13 @@ def test_copy_validates_replacement_sections() -> None:
     assert isinstance(built, gf.Section)
     assert built.width == 4.0
 
+    # a mapping has to take the overrides meant for the first section too
+    overridden = xs.copy(
+        width=2.0, sections=({"width": 4.0, "layer": "SLAB90"},)
+    ).sections[0]
+    assert overridden.width == 2.0
+    assert overridden.layer == "SLAB90"
+
     with pytest.raises(ValidationError):
         xs.copy(sections=({"width": -1.0, "layer": "SLAB90"},))
 
@@ -264,6 +271,183 @@ def test_copy_without_sections_rejects_overrides() -> None:
 def test_name() -> None:
     s = gf.cross_section.strip()
     assert s.name == "strip"
+
+
+def _unnamed(width: float, **kwargs: Any) -> gf.CrossSection:
+    """A cross_section whose section name is derived rather than given."""
+    return gf.CrossSection(
+        sections=(gf.Section(width=width, layer="WG", **kwargs),), radius=10
+    )
+
+
+def test_derived_name_does_not_depend_on_provenance() -> None:
+    """The same cross_section has the same name however it was built.
+
+    Cross_section names reach cell names, Component.info and netlists, so a name
+    that depends on the code path churns golden data.
+    """
+    fresh = _unnamed(2.0)
+    copied = _unnamed(1.0).copy(width=2.0)
+
+    assert copied.name == fresh.name, f"{copied.name} != {fresh.name}"
+    assert copied.sections[0].name == fresh.sections[0].name
+
+    # the name is a private attribute, which pydantic compares, so a name that
+    # depends on the code path makes equal cross_sections compare unequal too
+    assert copied == fresh
+
+
+def test_derived_name_is_a_prefix_of_the_hash() -> None:
+    """One derivation, so the short name cannot drift from the full digest."""
+    xs = _unnamed(2.0)
+
+    assert len(xs.hash) == 32
+    assert xs.name == f"xs_{xs.hash[:8]}"
+
+
+def test_derived_name_tracks_content_through_mirror_and_append() -> None:
+    """A transformed cross_section must not keep the name of the old content."""
+    asymmetric = gf.CrossSection(
+        sections=(
+            gf.Section(width=0.5, layer="WG", name="core"),
+            gf.Section(width=0.2, layer="SLAB90", offset=1.0, name="rib"),
+        ),
+        radius=10,
+    )
+    derived = asymmetric.copy(width=1.0)
+
+    def rebuild(xs: gf.CrossSection) -> gf.CrossSection:
+        return gf.CrossSection(
+            sections=xs.sections, radius=xs.radius, radius_min=xs.radius_min
+        )
+
+    mirrored = derived.mirror()
+    assert mirrored.name == rebuild(mirrored).name, f"{mirrored.name} is stale"
+    assert mirrored.name != derived.name
+
+    appended = derived.append_sections(
+        (gf.Section(width=0.3, layer="M1", name="metal"),)
+    )
+    assert appended.name == rebuild(appended).name, f"{appended.name} is stale"
+    assert appended.name != derived.name
+
+    # a transformation that leaves the content alone keeps the given name
+    assert gf.get_cross_section("strip").mirror().name == "strip"
+
+
+def test_copy_re_derives_a_derived_section_name() -> None:
+    """A derived section name describes content, so an edit has to derive it again."""
+    xs = _unnamed(0.5)
+    wide = xs.copy(width=3.0).sections[0]
+
+    assert wide.name != xs.sections[0].name
+    # the name a section built with the new content from the start would get
+    assert wide.name == _unnamed(3.0).sections[0].name
+
+    # a given name belongs to the caller, so the copy keeps it
+    named = gf.CrossSection(sections=(gf.Section(width=0.5, layer="WG", name="core"),))
+    assert named.copy(width=3.0).sections[0].name == "core"
+
+
+def test_mirror_re_derives_section_names() -> None:
+    """A mirrored section holds new content, so it gets the name that content gets."""
+    off_center = _unnamed(0.5, offset=1.0)
+    assert (
+        off_center.mirror().sections[0].name
+        == _unnamed(0.5, offset=-1.0).sections[0].name
+    )
+    assert off_center.mirror().mirror() == off_center
+
+
+def test_derived_names_do_not_depend_on_the_function_object() -> None:
+    """Two profile functions that do the same thing have to give the same name.
+
+    A name taken from a function's repr holds its id(), so it moves between
+    processes, and cell names, Component.info and netlists move with it.
+    """
+
+    def equivalent_width_function(t: float) -> float:
+        return 0.5 + 2 * t
+
+    one = gf.Section(width=1.0, layer="WG", width_function=_width_function)
+    two = gf.Section(width=1.0, layer="WG", width_function=equivalent_width_function)
+
+    assert one.width_function is not two.width_function
+    assert one.name == two.name, f"{one.name} != {two.name}"
+    assert (
+        gf.CrossSection(sections=(one,)).name == gf.CrossSection(sections=(two,)).name
+    )
+
+
+def test_derived_name_covers_components_along_path() -> None:
+    """Pydantic serializes an arbitrary type as {}, which would hide the component."""
+    sections = (gf.Section(width=1.0, layer="WG"),)
+
+    def along(component: gf.Component) -> gf.CrossSection:
+        return gf.CrossSection(
+            sections=sections,
+            components_along_path=(
+                gf.cross_section.ComponentAlongPath(component=component, spacing=5),
+            ),
+        )
+
+    rectangle = along(gf.components.rectangle(size=(1, 1)))
+    circle = along(gf.components.circle(radius=3))
+
+    assert rectangle != circle
+    assert rectangle.name != circle.name, f"{rectangle.name} collides"
+
+
+def test_hash_stays_out_of_the_fields() -> None:
+    """`hash` is derived from the fields, so it must not become one of them.
+
+    A cache in __dict__ would: pydantic iterates __dict__, so the hash would reach
+    dict(), the round-trip through it, and every model_copy.
+    """
+    xs = _unnamed(0.5)
+    assert xs.hash == xs.hash
+
+    read = _unnamed(0.5)
+    assert read.name  # anything that reads the name would have filled a cache
+
+    assert set(dict(read)) == set(type(read).model_fields)
+    assert gf.CrossSection(**dict(read)) == read
+    assert read.model_dump() == _unnamed(0.5).model_dump()
+    assert read.copy(width=4.0) == _unnamed(4.0)
+
+
+def test_name_tracks_content_through_model_copy() -> None:
+    """A name read before the copy must not follow the old content into it."""
+    xs = _unnamed(0.5)
+    assert xs.name  # a cached hash would be filled here and copied below
+
+    wider = xs.model_copy(update={"sections": _unnamed(3.0).sections})
+
+    assert wider.name == _unnamed(3.0).name, f"{wider.name} is stale"
+
+
+def test_derived_name_does_not_depend_on_the_layer_spelling() -> None:
+    """A layer named twice over is one layer, so it gives one name."""
+    by_name = gf.Section(width=1.0, layer="WG")
+    by_enum = gf.Section(width=1.0, layer=LAYER.WG)
+
+    assert by_name.layer != by_enum.layer  # the spelling is kept as given
+    assert by_name.name == by_enum.name, f"{by_name.name} != {by_enum.name}"
+
+
+def test_transition_pairs_derived_sections_with_their_copy() -> None:
+    """A derived name moves with every edit, so it cannot be the pairing key.
+
+    Pairing on it left a cross_section with nothing in common with its own copy.
+    """
+    xs = _unnamed(0.5)
+
+    gf.path.extrude_transition(
+        gf.path.straight(10), gf.path.transition(xs, xs.copy(width=2.0))
+    )
+    gf.components.taper_cross_section(
+        cross_section1=xs, cross_section2=xs.copy(width=2.0)
+    )
 
 
 xc_sin = partial(

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -122,16 +122,39 @@ def test_copy_keeps_falsy_overrides() -> None:
     # first entry of a layer enum has index 0, which is falsy
     assert xs.copy(layer=LAYER.WAFER).layer == LAYER.WAFER
 
-    # None still means "keep the current value"
-    assert xs.copy(width=None).width == xs.width
-    assert xs.copy(layer=None).layer == xs.layer
+    # an offset back to the center is an override, not an omission
+    assert (
+        gf.cross_section.cross_section(offset=1.0).copy(offset=0.0).sections[0].offset
+        == 0.0
+    )
+
+
+def test_copy_rejects_none_for_fields_that_take_no_none() -> None:
+    """Omitting an override is the default, so None is left to mean what the field says."""
+    xs = gf.get_cross_section("strip")
+
+    overrides: list[dict[str, Any]] = [
+        {"width": None},
+        {"offset": None},
+        {"layer": None},
+    ]
+    for override in overrides:
+        with pytest.raises(ValidationError):
+            xs.copy(**override)
 
 
 def test_copy_keeps_profile_functions() -> None:
     """A copy that does not pass the profile functions has to keep them."""
     xs = _profile_cross_section()
 
-    nominal_wider = xs.copy(width=3.0)
+    # an override that leaves the profile alone keeps it silently
+    unrelated = xs.copy(radius=20)
+    assert unrelated.sections[0].width_function is _width_function
+    assert unrelated.sections[0].offset_function is _offset_function
+
+    # a width override cannot win against the width_function it inherits, so it warns
+    with pytest.warns(UserWarning, match="only nominal"):
+        nominal_wider = xs.copy(width=3.0)
     assert nominal_wider.sections[0].width_function is _width_function
     assert nominal_wider.sections[0].offset_function is _offset_function
     assert nominal_wider.width == 3.0
@@ -139,6 +162,44 @@ def test_copy_keeps_profile_functions() -> None:
     # width_function survived, so it still drives the extrusion over the new width
     c = gf.path.extrude(gf.path.straight(length=10), cross_section=nominal_wider)
     assert np.isclose(c.ysize, _width_function(1.0))
+
+
+def test_copy_removes_profile_function_given_none() -> None:
+    """None is an override that removes the function, unlike omitting it."""
+    xs = _profile_cross_section()
+
+    # the width now has nothing competing with it, so no warning and no taper
+    literal = xs.copy(width=1.0, width_function=None)
+    assert literal.sections[0].width_function is None
+    assert literal.sections[0].offset_function is _offset_function
+    c = gf.path.extrude(gf.path.straight(length=10), cross_section=literal)
+    assert np.isclose(c.ysize, 1.0)
+
+    # removing one profile function leaves the other one alone
+    assert xs.copy(offset_function=None).sections[0].width_function is _width_function
+    assert xs.copy(offset_function=None).sections[0].offset_function is None
+
+    # a callable width leaves a nominal width of 0 behind, so the section needs one
+    with pytest.raises(ValidationError):
+        xs.copy(width_function=None)
+
+
+def test_copy_overrides_offset() -> None:
+    """`offset` is an override of its own, next to the function that can outrank it."""
+    assert gf.get_cross_section("strip").copy(offset=1.0).sections[0].offset == 1.0
+
+    xs = _profile_cross_section()
+
+    # the offset_function drives the extrusion, so the offset is only nominal, and warns
+    with pytest.warns(UserWarning, match="only nominal"):
+        nominal = xs.copy(offset=1.0)
+    assert nominal.sections[0].offset == 1.0
+    assert nominal.sections[0].offset_function is _offset_function
+
+    # removing the function leaves the offset alone to drive it, so nothing warns
+    literal = xs.copy(offset=1.0, offset_function=None)
+    assert literal.sections[0].offset == 1.0
+    assert literal.sections[0].offset_function is None
 
 
 def test_copy_replaces_only_the_profile_function_it_is_given() -> None:
@@ -178,9 +239,25 @@ def test_copy_validates_overrides() -> None:
         xs.copy(width=-1.0)
 
 
+def test_copy_validates_replacement_sections() -> None:
+    """The whole update is validated, not just the overrides applied to it."""
+    xs = gf.get_cross_section("strip")
+
+    built = xs.copy(sections=({"width": 4.0, "layer": "SLAB90"},)).sections[0]
+    assert isinstance(built, gf.Section)
+    assert built.width == 4.0
+
+    with pytest.raises(ValidationError):
+        xs.copy(sections=({"width": -1.0, "layer": "SLAB90"},))
+
+    # kwargs are validated too, instead of being written in as given
+    with pytest.raises(ValidationError):
+        xs.copy(radius="wide")
+
+
 def test_copy_without_sections_rejects_overrides() -> None:
     """There is no first section to apply the overrides to."""
-    with pytest.raises(ValueError, match="without sections"):
+    with pytest.raises(ValueError, match="no section to apply"):
         gf.CrossSection().copy(width=1.0)
 
 

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -238,6 +238,41 @@ def test_is_cross_section_private() -> None:
     assert not gf.cross_section.is_cross_section("_private_xs", _private_xs)
 
 
+def test_section_default_name_does_not_mutate_input() -> None:
+    from gdsfactory.cross_section import CrossSection, Section
+
+    section = {"width": 2.0, "layer": "SLAB90"}
+    expected = dict(section)
+
+    assert Section.model_validate(section).name
+    assert section == expected
+
+    assert CrossSection(sections=[section]).sections[0].name
+    assert section == expected
+
+    # the derived name is unchanged by the copy: keywords and spec agree
+    assert Section(**expected).name == Section.model_validate(expected).name
+
+
+def test_section_default_name_tracks_edits() -> None:
+    from gdsfactory.cross_section import CrossSection
+
+    section = {"width": 2.0, "layer": "SLAB90"}
+    narrow = CrossSection(sections=[section]).sections[0]
+
+    section["width"] = 5.0
+    wide = CrossSection(sections=[section]).sections[0]
+
+    assert wide.width == 5.0
+    assert wide.name != narrow.name
+
+    # two different sections must not collide on an inherited name,
+    # which extrude_transition rejects
+    xs = gf.CrossSection(sections=(narrow, wide), radius=10)
+    assert len({s.name for s in xs.sections}) == 2
+    gf.path.extrude_transition(gf.path.straight(10), gf.path.transition(xs, xs))
+
+
 def test_taper_cross_section_instance_matches_name() -> None:
     """Taper must honor width overrides when cross_section is a CrossSection.
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -337,6 +337,19 @@ def test_get_cross_section_dict_applies_kwargs() -> None:
     assert spec == {"cross_section": "strip", "settings": {"width": 1}}
 
 
+def test_get_cross_section_kfactory_applies_kwargs() -> None:
+    """A kfactory cross_section takes overrides like every other spec does."""
+    kf_xs = gf.components.straight().ports[0].cross_section
+    registered = gf.get_cross_section(kf_xs)
+
+    # the kfactory name describes the original, so an override cannot keep it
+    assert gf.get_cross_section(kf_xs, width=2.0).width == 2.0
+    assert gf.get_cross_section(kf_xs, width=2.0).name != registered.name
+
+    # an override that changes nothing leaves the name alone
+    assert gf.get_cross_section(kf_xs, radius=registered.radius).name == registered.name
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -327,6 +327,16 @@ def test_get_cross_section_instance_applies_kwargs() -> None:
     assert gf.get_cross_section(xs) is xs
 
 
+def test_get_cross_section_dict_applies_kwargs() -> None:
+    """Overrides win over the dict spec's own settings."""
+    spec = {"cross_section": "strip", "settings": {"width": 1}}
+    assert gf.get_cross_section(spec).width == 1
+    assert gf.get_cross_section(spec, width=3.0).width == 3.0
+    assert gf.get_cross_section(spec, radius=20).radius == 20
+    # the override does not write back into spec["settings"]
+    assert spec == {"cross_section": "strip", "settings": {"width": 1}}
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 


### PR DESCRIPTION
## Summary

There are many issues with cross-sections as we are both aware.

Still waiting on https://github.com/gdsfactory/gdsfactory/issues/4597, but in the meantime we can still improve on the current state.

- kwarg overrides not being applied on `get_cross_section`
- copy didn't handle width/width_function properly
- lack of validation on copy letting bad state happen
- naming and hashing was inconsistent
- naming based on json and not `str(self)` to avoid callable fields with a per-process `id()` and therefore name
and the list goes on

## Test Plan

Unit tests, mostly made by clankers.

## Summary by Sourcery

Improve cross-section copying, naming, and hashing semantics so overrides are validated, profile functions behave predictably, and derived names/hash values consistently reflect content changes.

Bug Fixes:
- Ensure kwargs passed to get_cross_section for dict and CrossSection specs are applied without mutating the original settings.
- Fix CrossSection.copy so width/offset/layer/profile-function overrides are honored, validated, and rejected when invalid, including handling falsy values and None correctly.
- Prevent mirrored or modified cross-sections and sections from keeping stale derived names that no longer match their content.
- Avoid cached hash values leaking into model fields or affecting equality/copy semantics.
- Ensure Section default-name generation does not mutate input mappings and tracks content edits correctly.
- Make derived names independent of function object identities and ensure components along path participate in naming to avoid collisions.

Enhancements:
- Introduce content-derived, stable naming and hashing for Section and CrossSection that are consistent across rebuilds and transformations and are cached efficiently.
- Refine CrossSection.copy, mirror, and append_sections to rebuild via validation, re-derive names when content changes, and warn when nominal width/offset overrides conflict with profile functions.
- Add JSON field serialization for ComponentAlongPath.component so netlist names capture component identity rather than an empty object.
- Adjust cladding width broadcasting to preserve clarity in width_function behavior.

Tests:
- Add extensive tests covering CrossSection.copy behavior with width/offset/layer/profile-function overrides, replacement sections, validation errors, and empty-section cases.
- Add tests to verify derived naming and hashing semantics across copies, mirrors, appends, profile-function equivalence, components_along_path, and hash caching.
- Update golden netlist regression data to reflect the new cross-section hashes and names.
- Add tests ensuring Section default-name generation is non-mutating, tracks edits, and avoids name collisions in transitions.