### PR TITLE
feat: add layer stack background materials

### DIFF
--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -715,7 +715,7 @@
     "Two things to keep in mind:\n",
     "\n",
     "- Background levels are rendered in 3D even if their layer view is not visible (a substrate like `WAFER` is usually hidden in 2D). The material still takes its color from its layer view.\n",
-    "- Use `background_exclude_layers` to subtract other layers from the background volume (for example to carve full-depth trenches out of a substrate). Only source (logical) layers can be excluded; derived/boolean layers are not supported."
+    "- Use `background_exclude_layers` to subtract other layers from the background volume (for example to carve etches out of a substrate). Only source (logical) layers can be excluded; derived/boolean layers are not supported."
    ]
   },
   {
@@ -747,28 +747,38 @@
     "    }\n",
     ")\n",
     "\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "scene = c.to_3d(layer_stack=layer_stack_background)\n",
     "scene.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
-    "You can subtract layers from a background material with `background_exclude_layers`. Here a `SLAB90` shape carves a full-depth trench out of the bulk silicon."
+    "You can subtract layers from a background material with `background_exclude_layers`. Here a `DEEP_ETCH` shape carves a full-depth etch out of the bulk silicon."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
     "c = gf.Component()\n",
     "c.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.WG)\n",
-    "c.add_polygon([(4, 0), (6, 0), (6, 10), (4, 10)], layer=LAYER.SLAB90)\n",
+    "c.add_polygon([(4, 0), (6, 0), (6, 10), (4, 10)], layer=LAYER.DEEP_ETCH)\n",
     "\n",
     "layer_stack_exclude = LayerStack(\n",
     "    layers={\n",
@@ -778,18 +788,28 @@
     "            zmin=0,\n",
     "            material=\"si\",\n",
     "            background=True,\n",
-    "            background_exclude_layers=(LAYER.SLAB90,),  # subtract this layer\n",
+    "            background_exclude_layers=(LAYER.DEEP_ETCH,),  # subtract this etch layer\n",
     "        ),\n",
     "    }\n",
     ")\n",
     "\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "scene = c.to_3d(layer_stack=layer_stack_exclude)\n",
     "scene.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "source": [
     "### Klayout 2.5D view\n",
@@ -800,7 +820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "Then you go to Tools → 2.5d View -> New 2.5d Script\n",
@@ -824,7 +844,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Klayout cross-section\n",
@@ -839,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -910,7 +930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "54",
    "metadata": {},
    "source": [
     "![xsection generic](images/layer_stack_xsection_generic.png)"
@@ -918,7 +938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "55",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -939,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "56",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1040,7 +1060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "57",
    "metadata": {},
    "source": [
     "These process dataclasses can then be used in physical simulator plugins."

--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -714,7 +714,7 @@
     "\n",
     "Two things to keep in mind:\n",
     "\n",
-    "- The background material takes its color from its layer view, and it only renders if that layer view is **visible**. Invisible layers (like `WAFER` in the generic technology) are skipped, so make the view visible if you want it in the scene.\n",
+    "- Background levels are rendered in 3D even if their layer view is not visible (a substrate like `WAFER` is usually hidden in 2D). The material still takes its color from its layer view.\n",
     "- Use `background_exclude_layers` to subtract other layers from the background volume (for example to carve full-depth trenches out of a substrate). Only source (logical) layers can be excluded; derived/boolean layers are not supported."
    ]
   },
@@ -726,11 +726,6 @@
    "outputs": [],
    "source": [
     "from gdsfactory.technology import LogicalLayer\n",
-    "from gdsfactory.pdk import get_layer_views\n",
-    "\n",
-    "# WAFER is invisible by default, so make its view visible for the background to render\n",
-    "layer_views = get_layer_views()\n",
-    "layer_views.get_from_tuple(tuple(LAYER.WAFER)).visible = True\n",
     "\n",
     "c = gf.components.rectangle(size=(10, 5), layer=LAYER.WG)\n",
     "\n",
@@ -752,7 +747,7 @@
     "    }\n",
     ")\n",
     "\n",
-    "scene = c.to_3d(layer_stack=layer_stack_background, layer_views=layer_views)\n",
+    "scene = c.to_3d(layer_stack=layer_stack_background)\n",
     "scene.show()"
    ]
   },

--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -708,9 +708,14 @@
    "id": "43",
    "metadata": {},
    "source": [
-    "### Klayout 2.5D view\n",
+    "### Background materials\n",
     "\n",
-    "From the `LayerStack` you can generate the KLayout 2.5D view script."
+    "By default `to_3d` only extrudes the polygons that exist on each layer. Set `background=True` on a `LayerLevel` to extrude that material across the whole component **bounding box**, even where there are no polygons on its layer. This is handy for substrates, buried-oxide/cladding fill, or any bulk material that should surround the device.\n",
+    "\n",
+    "Two things to keep in mind:\n",
+    "\n",
+    "- The background material takes its color from its layer view, and it only renders if that layer view is **visible**. Invisible layers (like `WAFER` in the generic technology) are skipped, so make the view visible if you want it in the scene.\n",
+    "- Use `background_exclude_layers` to subtract other layers from the background volume (for example to carve full-depth trenches out of a substrate). Only source (logical) layers can be excluded; derived/boolean layers are not supported."
    ]
   },
   {
@@ -720,12 +725,96 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(LAYER_STACK.get_klayout_3d_script())"
+    "from gdsfactory.technology import LogicalLayer\n",
+    "from gdsfactory.pdk import get_layer_views\n",
+    "\n",
+    "# WAFER is invisible by default, so make its view visible for the background to render\n",
+    "layer_views = get_layer_views()\n",
+    "layer_views.get_from_tuple(tuple(LAYER.WAFER)).visible = True\n",
+    "\n",
+    "c = gf.components.rectangle(size=(10, 5), layer=LAYER.WG)\n",
+    "\n",
+    "layer_stack_background = LayerStack(\n",
+    "    layers={\n",
+    "        \"substrate\": LayerLevel(\n",
+    "            layer=LogicalLayer(layer=LAYER.WAFER),\n",
+    "            thickness=2,\n",
+    "            zmin=-2,\n",
+    "            material=\"si\",\n",
+    "            background=True,  # fill the whole component bounding box\n",
+    "        ),\n",
+    "        \"core\": LayerLevel(\n",
+    "            layer=LogicalLayer(layer=LAYER.WG),\n",
+    "            thickness=0.22,\n",
+    "            zmin=0,\n",
+    "            material=\"si\",\n",
+    "        ),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "scene = c.to_3d(layer_stack=layer_stack_background, layer_views=layer_views)\n",
+    "scene.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "45",
+   "metadata": {},
+   "source": [
+    "You can subtract layers from a background material with `background_exclude_layers`. Here a `SLAB90` shape carves a full-depth trench out of the bulk silicon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = gf.Component()\n",
+    "c.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=LAYER.WG)\n",
+    "c.add_polygon([(4, 0), (6, 0), (6, 10), (4, 10)], layer=LAYER.SLAB90)\n",
+    "\n",
+    "layer_stack_exclude = LayerStack(\n",
+    "    layers={\n",
+    "        \"bulk\": LayerLevel(\n",
+    "            layer=LogicalLayer(layer=LAYER.WG),\n",
+    "            thickness=1,\n",
+    "            zmin=0,\n",
+    "            material=\"si\",\n",
+    "            background=True,\n",
+    "            background_exclude_layers=(LAYER.SLAB90,),  # subtract this layer\n",
+    "        ),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "scene = c.to_3d(layer_stack=layer_stack_exclude)\n",
+    "scene.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47",
+   "metadata": {},
+   "source": [
+    "### Klayout 2.5D view\n",
+    "\n",
+    "From the `LayerStack` you can generate the KLayout 2.5D view script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(LAYER_STACK.get_klayout_3d_script())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49",
    "metadata": {},
    "source": [
     "Then you go to Tools → 2.5d View -> New 2.5d Script\n",
@@ -740,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "50",
    "metadata": {},
    "source": [
     "### Klayout cross-section\n",
@@ -755,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "51",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -826,7 +915,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "52",
    "metadata": {},
    "source": [
     "![xsection generic](images/layer_stack_xsection_generic.png)"
@@ -834,7 +923,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "53",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -855,7 +944,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "54",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -956,7 +1045,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "55",
    "metadata": {},
    "source": [
     "These process dataclasses can then be used in physical simulator plugins."

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -54,7 +54,12 @@ def to_3d(
     polygons_per_layer = component_with_booleans.get_polygons_points(
         merge=True,
     )
-    polygons_per_source_layer = component.get_polygons_points(merge=False)
+    # Source-layer polygons are only needed for background exclusions, which are
+    # rare, so skip the extra extraction unless a background level uses them.
+    has_background = any(level.background for level in layer_stack.layers.values())
+    polygons_per_source_layer = (
+        component.get_polygons_points(merge=False) if has_background else {}
+    )
     has_polygons = False
 
     for level_name, level in layer_stack.layers.items():

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -54,6 +54,7 @@ def to_3d(
     polygons_per_layer = component_with_booleans.get_polygons_points(
         merge=True,
     )
+    polygons_per_source_layer = component.get_polygons_points(merge=False)
     has_polygons = False
 
     for level_name, level in layer_stack.layers.items():
@@ -75,7 +76,7 @@ def to_3d(
         if layer_index in exclude_layers:
             continue
 
-        if layer_index not in polygons_per_layer:
+        if not level.background and layer_index not in polygons_per_layer:
             continue
 
         zmin = level.zmin
@@ -86,10 +87,34 @@ def to_3d(
         color_rgb = [c / 255 for c in layer_view.fill_color.as_rgb_tuple(alpha=False)]
         if zmin is not None and layer_view.visible:
             has_polygons = True
-            polygons = polygons_per_layer[layer_index]
+            if level.background:
+                bbox = component.dbbox()
+                background = shapely.geometry.box(
+                    bbox.left, bbox.bottom, bbox.right, bbox.top
+                )
+                exclusions = [
+                    shapely.geometry.Polygon(polygon)
+                    for excluded_layer in level.background_exclude_layers
+                    for polygon in polygons_per_source_layer.get(
+                        int(get_layer(excluded_layer)), ()
+                    )
+                ]
+                if exclusions:
+                    background = background.difference(
+                        shapely.ops.unary_union(exclusions)
+                    )
+                polygons = list(shapely.get_parts(background))
+            else:
+                polygons = polygons_per_layer[layer_index]
             height = level.thickness
             for i, polygon in enumerate(polygons):
-                p = shapely.geometry.Polygon(polygon)
+                p = (
+                    polygon
+                    if isinstance(polygon, shapely.geometry.Polygon)
+                    else shapely.geometry.Polygon(polygon)
+                )
+                if p.is_empty:
+                    continue
                 mesh = extrude_polygon(p, height=height)
                 mesh.apply_translation((0, 0, zmin))
                 if isinstance(mesh.visual, ColorVisuals):

--- a/gdsfactory/export/to_3d.py
+++ b/gdsfactory/export/to_3d.py
@@ -90,7 +90,7 @@ def to_3d(
         layer_view = layer_views.get_from_tuple(layer_tuple)
         assert layer_view.fill_color is not None
         color_rgb = [c / 255 for c in layer_view.fill_color.as_rgb_tuple(alpha=False)]
-        if zmin is not None and layer_view.visible:
+        if zmin is not None and (level.background or layer_view.visible):
             has_polygons = True
             if level.background:
                 bbox = component.dbbox()

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from gdsfactory.config import __next_major_version__
 from gdsfactory.technology.layer_views import LayerViews
 from gdsfactory.technology.variation import Variation
-from gdsfactory.typings import LayerSpec
+from gdsfactory.typings import LayerSpec, LayerSpecs
 
 if TYPE_CHECKING:
     from gdsfactory.component import Component
@@ -347,6 +347,9 @@ class LayerLevel(BaseModel):
                     NOTE: A dict might be more expressive.
         mesh_order: lower mesh order (e.g. 1) will have priority over higher mesh order (e.g. 2) in the regions where materials overlap.
         material: used in the klayout script
+        background: extrude this material across the component bounding box,
+            including regions with no polygons on ``layer``.
+        background_exclude_layers: layers to remove from a background material.
         info: all other rendering and simulation metadata should go here.
     """
 
@@ -384,6 +387,8 @@ class LayerLevel(BaseModel):
     # Rendering
     mesh_order: int = 3
     material: str | None = None
+    background: bool = False
+    background_exclude_layers: LayerSpecs = ()
 
     # Other
     info: dict[str, Any] = Field(default_factory=dict)

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -349,7 +349,8 @@ class LayerLevel(BaseModel):
         material: used in the klayout script
         background: extrude this material across the component bounding box,
             including regions with no polygons on ``layer``.
-        background_exclude_layers: layers to remove from a background material.
+        background_exclude_layers: source (logical) layers to subtract from a
+            background material. Derived/boolean layers are not supported here.
         info: all other rendering and simulation metadata should go here.
     """
 

--- a/gdsfactory/technology/layer_stack.py
+++ b/gdsfactory/technology/layer_stack.py
@@ -348,7 +348,8 @@ class LayerLevel(BaseModel):
         mesh_order: lower mesh order (e.g. 1) will have priority over higher mesh order (e.g. 2) in the regions where materials overlap.
         material: used in the klayout script
         background: extrude this material across the component bounding box,
-            including regions with no polygons on ``layer``.
+            including regions with no polygons on ``layer``. Background levels
+            are rendered in 3D even if their layer view is not visible.
         background_exclude_layers: source (logical) layers to subtract from a
             background material. Derived/boolean layers are not supported here.
         info: all other rendering and simulation metadata should go here.

--- a/tests/export/test_to_3d.py
+++ b/tests/export/test_to_3d.py
@@ -80,6 +80,29 @@ def test_background_layer() -> None:
     assert scene.bounds.tolist() == [[0.0, 0.0, 0.0], [2.0, 3.0, 1.0]]
 
 
+def test_background_layer_invisible_view() -> None:
+    """A background level renders even if its layer view is not visible."""
+    layer_views = gf.get_active_pdk().get_layer_views()
+    assert not layer_views.get_from_tuple(tuple(LAYER.WAFER)).visible
+
+    c = gf.components.rectangle(size=(2, 3), layer=LAYER.SLAB90)
+    layer_stack = LayerStack(
+        layers={
+            "substrate": LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WAFER),
+                thickness=1,
+                zmin=0,
+                material="si",
+                background=True,
+            )
+        }
+    )
+
+    scene = to_3d(c, layer_stack=layer_stack)
+
+    assert scene.bounds.tolist() == [[0.0, 0.0, 0.0], [2.0, 3.0, 1.0]]
+
+
 def test_background_layer_exclusions() -> None:
     """Background exclusions form full-depth etches."""
     c = gf.Component()

--- a/tests/export/test_to_3d.py
+++ b/tests/export/test_to_3d.py
@@ -58,3 +58,46 @@ def test_missing_zmin_or_thickness() -> None:
     layer_stack = get_layer_stack()
     with pytest.raises(ValueError):
         to_3d(c, layer_stack=layer_stack)
+
+
+def test_background_layer() -> None:
+    """A background level fills the component bounding box."""
+    c = gf.components.rectangle(size=(2, 3), layer=LAYER.SLAB90)
+    layer_stack = LayerStack(
+        layers={
+            "background": LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WG),
+                thickness=1,
+                zmin=0,
+                material="si",
+                background=True,
+            )
+        }
+    )
+
+    scene = to_3d(c, layer_stack=layer_stack)
+
+    assert scene.bounds.tolist() == [[0.0, 0.0, 0.0], [2.0, 3.0, 1.0]]
+
+
+def test_background_layer_exclusions() -> None:
+    """Background exclusions form full-depth etches."""
+    c = gf.Component()
+    c.add_polygon([(0, 0), (3, 0), (3, 3), (0, 3)], layer=LAYER.WG)
+    c.add_polygon([(1, 0), (2, 0), (2, 3), (1, 3)], layer=LAYER.SLAB90)
+    layer_stack = LayerStack(
+        layers={
+            "background": LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WG),
+                thickness=1,
+                zmin=0,
+                material="si",
+                background=True,
+                background_exclude_layers=(LAYER.SLAB90,),
+            )
+        }
+    )
+
+    scene = to_3d(c, layer_stack=layer_stack)
+
+    assert sum(mesh.volume for mesh in scene.geometry.values()) == 6.0


### PR DESCRIPTION
## Summary

- add opt-in bounding-box backgrounds to `LayerLevel` for 3D export
- support subtracting mask layers from background materials
- cover background extrusion and exclusions with 3D export tests

## Validation

- `pre-commit run --all-files`
- `uv run pytest tests/export/test_to_3d.py -q`

## Summary by Sourcery

Add support for defining layer stack backgrounds that fill a component’s bounding box and participate in 3D export.

New Features:
- Allow LayerLevel entries to be marked as background materials that are extruded across the component bounding box, even where no polygons exist on the layer.
- Support excluding specific source layers from background materials so their geometry is subtracted from the background volume in 3D exports.

Enhancements:
- Extend 3D export logic to generate meshes from background bounding boxes and handle empty polygons safely.
- Add tests covering background layer extrusion and exclusion behavior in 3D export scenes.