### PR TITLE
Facilitate path inversion

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -669,7 +669,10 @@ class Path(UMGeometricObject):
         The shape of the path is unchanged, but its start becomes its end and vice versa.
         """
         self.points = self.points[::-1]
-        self.start_angle, self.end_angle = self.end_angle + 180, self.start_angle + 180
+        self.start_angle, self.end_angle = (
+            mod(self.end_angle + 180, 360),
+            mod(self.start_angle + 180, 360),
+        )
         return self
 
 

--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -663,6 +663,15 @@ class Path(UMGeometricObject):
             self.end_angle = mod(2 * angle - self.end_angle, 360)
         return self
 
+    def invert(self) -> Path:
+        """Inverts the Path by reversing the order of its points.
+
+        The shape of the path is unchanged, but its start becomes its end and vice versa.
+        """
+        self.points = self.points[::-1]
+        self.start_angle, self.end_angle = self.end_angle + 180, self.start_angle + 180
+        return self
+
 
 PathFactory = Callable[..., Path]
 T = TypeVar("T", float, npt.NDArray[np.floating[Any]])

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -358,6 +358,18 @@ def test_mirror() -> None:
     )
 
 
+def test_invert() -> None:
+    path = Path([(0, 0), (1, 0), (1, 1)])
+    assert path.start_angle == 0
+    assert path.end_angle == 90
+    path.invert()
+    np.testing.assert_array_equal(
+        path.points, np.array([(1, 1), (1, 0), (0, 0)], dtype=np.float64)
+    )
+    assert path.start_angle == 270
+    assert path.end_angle == 180
+
+
 def test_centerpoint_offset_curve() -> None:
     path = Path([(0, 0), (1, 0), (2, 0)])
     offset_distance = [0.5]

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -369,6 +369,11 @@ def test_invert() -> None:
     assert path.start_angle == 270
     assert path.end_angle == 180
 
+    path = Path([(0, 0), (1, 0)], start_angle=200, end_angle=270)
+    path.invert()
+    assert path.start_angle == 90
+    assert path.end_angle == 20
+
 
 def test_centerpoint_offset_curve() -> None:
     path = Path([(0, 0), (1, 0), (2, 0)])


### PR DESCRIPTION
## Summary

Closes #4773.

It's a pretty simple method, all in all. The only point I'm a bit unsure about is if you care about clipping `start_angle` and `end_angle` to the interval [-180, 180] (which is the interval it lies in when detected using `arctan2`). I didn't bother with this for now.

## Test Plan
I added a test. Let me know if you want to cover more cases.

## Summary by Sourcery

Add path inversion to reverse traversal while preserving the path geometry.

New Features:
- Add support for inverting paths by swapping their start and end points and directions.

Tests:
- Add coverage for path inversion, including point ordering and angle updates.