### PR TITLE
feat: add blackbox container to hide component geometry

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1038,6 +1038,9 @@ class Component(ComponentBase, kf.DKCell):
         and the original ports. No geometry, hierarchy or settings are copied,
         so proprietary layouts stay hidden when sharing a GDS file.
 
+        Note: port info dictionaries are copied to the result. If your ports
+        carry sensitive metadata, strip it before calling blackbox.
+
         Args:
             layer: layer to draw the bounding box rectangle on.
         """

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1028,6 +1028,23 @@ class Component(ComponentBase, kf.DKCell):
 
         return extract(self, layers=layers, recursive=recursive)
 
+    def to_blackbox(
+        self,
+        layer: LayerSpec = "FLOORPLAN",
+    ) -> Component:
+        """Returns a black box version of the Component.
+
+        The result contains only a bounding box rectangle on the given layer
+        and the original ports. No geometry, hierarchy or settings are copied,
+        so proprietary layouts stay hidden when sharing a GDS file.
+
+        Args:
+            layer: layer to draw the bounding box rectangle on.
+        """
+        from gdsfactory.components.containers.blackbox import blackbox
+
+        return blackbox(component=self, layer=layer)
+
     def copy_layers(
         self,
         layer_map: dict[LayerSpec, LayerSpec],

--- a/gdsfactory/components/containers/__init__.py
+++ b/gdsfactory/components/containers/__init__.py
@@ -5,6 +5,7 @@ from .add_trenches import *
 from .array_component import *
 from .array_hexagonal import *
 from .array_polar import *
+from .blackbox import *
 from .component_sequence import *
 from .copy_layers import *
 from .extend_ports_list import *
@@ -24,6 +25,7 @@ __all__ = [
     "array_component",
     "array_hexagonal",
     "array_polar",
+    "blackbox",
     "component_sequence",
     "copy_layers",
     "extend_ports",

--- a/gdsfactory/components/containers/blackbox.py
+++ b/gdsfactory/components/containers/blackbox.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+__all__ = ["blackbox"]
+
+import gdsfactory as gf
+from gdsfactory.component import Component
+from gdsfactory.components.shapes.bbox import bbox_to_points
+from gdsfactory.typings import ComponentSpec, LayerSpec
+
+
+@gf.cell_with_module_name(tags=["containers"])
+def blackbox(
+    component: ComponentSpec = "mmi1x2",
+    layer: LayerSpec = "FLOORPLAN",
+) -> Component:
+    """Returns a black box component with the same footprint and ports.
+
+    Replaces the component geometry with a single rectangle covering its
+    bounding box, keeping the original ports. Useful to hide proprietary
+    layouts before sharing a GDS file with third parties. The real component
+    can be swapped back in with Component.replace_instances.
+
+    Args:
+        component: component to hide.
+        layer: layer to draw the bounding box rectangle on.
+    """
+    original = gf.get_component(component)
+
+    c = Component()
+    c.add_polygon(bbox_to_points(original.dbbox()), layer=layer)
+
+    # Only ports are copied. The original component is never instantiated and
+    # its settings/info are not copied, so no geometry, hierarchy or
+    # parameters leak into the resulting cell.
+    c.add_ports(original.ports)
+    return c
+
+
+if __name__ == "__main__":
+    gf.gpdk.PDK.activate()
+    c = blackbox()
+    c.draw_ports()
+    c.show()

--- a/gdsfactory/components/containers/blackbox.py
+++ b/gdsfactory/components/containers/blackbox.py
@@ -25,9 +25,14 @@ def blackbox(
         layer: layer to draw the bounding box rectangle on.
     """
     original = gf.get_component(component)
+    bbox = original.dbbox()
+    if bbox.empty():
+        raise ValueError(
+            f"Cannot create a blackbox from {original.name!r}: it has no geometry."
+        )
 
     c = Component()
-    c.add_polygon(bbox_to_points(original.dbbox()), layer=layer)
+    c.add_polygon(bbox_to_points(bbox), layer=layer)
 
     # Only ports are copied. The original component is never instantiated and
     # its settings/info are not copied, so no geometry, hierarchy or

--- a/tests/components/containers/test_blackbox.py
+++ b/tests/components/containers/test_blackbox.py
@@ -1,3 +1,5 @@
+import pytest
+
 import gdsfactory as gf
 
 
@@ -10,9 +12,10 @@ def test_blackbox() -> None:
     assert c.dbbox() == original.dbbox()
     assert len(c.insts) == 0
 
-    assert len(c.ports) == len(original.ports)
-    for port, port_original in zip(c.ports, original.ports, strict=True):
-        assert port.name == port_original.name
+    ports_original = {p.name: p for p in original.ports}
+    assert {p.name for p in c.ports} == set(ports_original)
+    for port in c.ports:
+        port_original = ports_original[port.name]
         assert port.center == port_original.center
         assert port.width == port_original.width
         assert port.orientation == port_original.orientation
@@ -37,6 +40,11 @@ def test_blackbox_component_without_ports() -> None:
     c = gf.components.blackbox(component="text", layer=(2, 0))
     assert c.layers == [(2, 0)]
     assert len(c.ports) == 0
+
+
+def test_blackbox_empty_component_raises() -> None:
+    with pytest.raises(ValueError, match="no geometry"):
+        gf.components.blackbox(component=gf.Component(), layer=(2, 0))
 
 
 def test_to_blackbox_method() -> None:

--- a/tests/components/containers/test_blackbox.py
+++ b/tests/components/containers/test_blackbox.py
@@ -1,0 +1,43 @@
+import gdsfactory as gf
+
+
+def test_blackbox() -> None:
+    """Blackbox keeps footprint and ports, hides everything else."""
+    original = gf.components.mmi1x2()
+    c = gf.components.blackbox(component="mmi1x2", layer=(2, 0))
+
+    assert c.layers == [(2, 0)]
+    assert c.dbbox() == original.dbbox()
+    assert len(c.insts) == 0
+
+    assert len(c.ports) == len(original.ports)
+    for port, port_original in zip(c.ports, original.ports, strict=True):
+        assert port.name == port_original.name
+        assert port.center == port_original.center
+        assert port.width == port_original.width
+        assert port.orientation == port_original.orientation
+
+
+def test_blackbox_does_not_modify_original() -> None:
+    original = gf.components.mmi1x2()
+    area_before = original.area((1, 0))
+    original.to_blackbox(layer=(2, 0))
+    assert original.area((1, 0)) == area_before
+    assert (1, 0) in original.layers
+
+
+def test_blackbox_settings_not_copied() -> None:
+    """Settings of the original component must not leak into the blackbox."""
+    c = gf.components.blackbox(component="mmi1x2")
+    assert "length_mmi" not in c.settings
+
+
+def test_to_blackbox_method() -> None:
+    """Component.to_blackbox returns same result as the container."""
+    original = gf.components.mmi1x2()
+    c = original.to_blackbox(layer=(2, 0))
+
+    assert c.layers == [(2, 0)]
+    assert c.dbbox() == original.dbbox()
+    assert len(c.insts) == 0
+    assert [p.name for p in c.ports] == [p.name for p in original.ports]

--- a/tests/components/containers/test_blackbox.py
+++ b/tests/components/containers/test_blackbox.py
@@ -30,6 +30,13 @@ def test_blackbox_settings_not_copied() -> None:
     """Settings of the original component must not leak into the blackbox."""
     c = gf.components.blackbox(component="mmi1x2")
     assert "length_mmi" not in c.settings
+    assert set(dict(c.settings)) <= {"component", "layer"}
+
+
+def test_blackbox_component_without_ports() -> None:
+    c = gf.components.blackbox(component="text", layer=(2, 0))
+    assert c.layers == [(2, 0)]
+    assert len(c.ports) == 0
 
 
 def test_to_blackbox_method() -> None:

--- a/tests/test-data-regression/test_settings_blackbox_.yml
+++ b/tests/test-data-regression/test_settings_blackbox_.yml
@@ -1,0 +1,5 @@
+info: {}
+name: blackbox_gdsfactorypcomponentspcontainerspblackbox_Cmmi_6f7e1aa1
+settings:
+  component: mmi1x2
+  layer: FLOORPLAN

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.48.0"
+version = "9.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.47.0"
+version = "9.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## What does this PR do?

 Adds a blackbox container and a Component.to_blackbox() convenience method that replace a component's geometry with a single rectangle covering its bounding box, while keeping the original ports.

```
import gdsfactory as gf

c = gf.components.blackbox(component="mmi1x2", layer="FLOORPLAN")
# or
c = gf.components.mmi1x2().to_blackbox(layer="FLOORPLAN")
```
Resulting GDS in Klayout (with c.draw_ports()):
<img width="948" height="150" alt="image" src="https://github.com/user-attachments/assets/e484b41a-8c5c-43a2-aef1-c630ceece615" />

## Why?

When sharing GDS files with customers or partners, design houses often need to hide the internals of proprietary components while keeping them routable. We currently do this by hand with a loop that removes layers and draws a rectangle. 

 The result is a flat cell: no original geometry, no child cell names, no labels, and no settings/info metadata (which could reveal design parameters). 

## Notes for reviewers

-  copy_child_info is deliberately not called, to avoid leaking the original component's settings.
-   Port info dictionaries are copied to the result (documented in the docstring), since they usually only carry cross_section information needed for routing.
-   Known limitation: the generated cell name embeds a truncated form of the original component name. Users who need to hide that too can rename with c.dup("new_name"). Happy to address differently if preferred.
- The GDS regression test test_gds[blackbox] needs a new reference file (blackbox.gds) in the gdsfactory-test-data repository, so it will fail in CI here. I generated the file locally with pytest --force-regen, but I'm not sure of the preferred process for contributing. Happy to open a PR against gdsfactory-test-data or send the file however you prefer.

This is my first open-source pull request, so any feedback on the code or the process is very welcome.

## Summary by Sourcery

Add support for generating blackbox versions of components that preserve footprint and ports while hiding internal geometry and metadata.

New Features:
- Introduce a blackbox container component that replaces a component’s geometry with a single bounding-box rectangle on a specified layer while keeping its ports.
- Add a Component.to_blackbox() convenience method to create blackbox instances directly from existing components.

Tests:
- Add regression and unit tests covering blackbox behavior, including footprint and port preservation, non-modification of the original component, and omission of sensitive settings in the blackbox output.