### PR TITLE
Fast path for ndarray in points_to_polygon

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -126,6 +126,8 @@ def points_to_polygon(
 ) -> kdb.Polygon | kdb.DPolygon | kdb.DSimplePolygon | kdb.Region:
     if isinstance(points, kdb.Polygon | kdb.DPolygon | kdb.DSimplePolygon | kdb.Region):
         return points
+    if isinstance(points, np.ndarray):
+        return kdb.DPolygon(points.tolist())
     points = ensure_tuple_of_tuples(points)
     return kdb.DPolygon(to_kdb_dpoints(points))
 


### PR DESCRIPTION
## Summary

Avoids a bunch of conversions in `ensure_tuple_of_tuples` for ndarray

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Enhancements:
- Optimize `points_to_polygon` for NumPy arrays by converting them directly into KLayout polygons.