### PR TITLE
Avoid hardcoded tolerance in _ensure_manhattan_waypoints

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -119,7 +119,7 @@ def _ensure_manhattan_waypoints(
     if len(waypoints) < 2:
         return list(waypoints)
 
-    tol = 1e-3
+    tol = 1.5 * gf.kcl.dbu
     go_horizontal_first = (
         int(start_port.orientation) % 360 in {0, 180}
         if start_port is not None and start_port.orientation is not None

--- a/tests/routing/test_routing_route_bundle_waypoints.py
+++ b/tests/routing/test_routing_route_bundle_waypoints.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
+import kfactory as kf
+import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 import gdsfactory as gf
-from gdsfactory.routing.route_bundle import route_bundle
+from gdsfactory.routing.route_bundle import _ensure_manhattan_waypoints, route_bundle
 
 
 def test_route_bundle_waypoints(data_regression: DataRegressionFixture) -> None:
@@ -34,6 +38,53 @@ def test_route_bundle_waypoints(data_regression: DataRegressionFixture) -> None:
 
     lengths = {i: route.length for i, route in enumerate(routes)}
     data_regression.check(lengths)
+
+
+@pytest.mark.parametrize("base_y", [99.999, 1234.0])
+def test_ensure_manhattan_waypoints_one_dbu_offset_is_position_independent(
+    base_y: float,
+) -> None:
+    """A one-dbu offset must classify the same wherever it sits in the layout.
+
+    `abs(1234.001 - 1234.0)` evaluates to slightly less than one dbu while
+    `abs(100.0 - 99.999)` evaluates to slightly more, so a tolerance sitting on
+    the exact dbu boundary classified identical geometry differently depending
+    on the absolute coordinates.
+    """
+    dbu = gf.kcl.dbu
+    result = _ensure_manhattan_waypoints(
+        [kf.kdb.DPoint(0, base_y), kf.kdb.DPoint(10, base_y + dbu)]
+    )
+
+    # Within tolerance: treated as horizontal, no corner inserted.
+    assert [(p.x, p.y) for p in result] == [(0.0, base_y), (10.0, base_y + dbu)]
+
+
+@pytest.fixture
+def fine_grid() -> Iterator[None]:
+    """Temporarily halve the layout database unit."""
+    from gdsfactory.gpdk import PDK
+
+    original_dbu = gf.kcl.dbu
+    gf.kcl.clear_kcells()
+    try:
+        gf.kcl.dbu = 0.0005
+        yield
+    finally:
+        gf.kcl.clear_kcells()
+        gf.kcl.dbu = original_dbu
+        PDK.activate(force=True)
+
+
+def test_ensure_manhattan_waypoints_tolerance_tracks_dbu(fine_grid: None) -> None:
+    """The tolerance follows the active grid, not a hardcoded 1 nm."""
+    # 0.001 um is one dbu on the default grid (collapsed, see the test above)
+    # but two dbu here, so it is a real diagonal and gets a corner.
+    result = _ensure_manhattan_waypoints(
+        [kf.kdb.DPoint(0, 0), kf.kdb.DPoint(10, 0.001)]
+    )
+
+    assert [(p.x, p.y) for p in result] == [(0.0, 0.0), (10.0, 0.0), (10.0, 0.001)]
 
 
 def test_route_bundle_waypoints_collinear_collapsed(


### PR DESCRIPTION
## Summary

The tolerance shouldn't be hardcoded.

## Test Plan

Clanker unit tests.

## Summary by Sourcery

Make Manhattan waypoint tolerance follow the active layout grid instead of a hardcoded value.

Bug Fixes:
- Align Manhattan waypoint tolerance with the active layout database unit to avoid coordinate-dependent classification and incorrect handling on non-default grids.

Tests:
- Add coverage for position-independent tolerance behavior and database-unit-dependent waypoint classification.