### PR TITLE
Fix issues with `extend_ports`

### DIFF
--- a/gdsfactory/components/containers/extension.py
+++ b/gdsfactory/components/containers/extension.py
@@ -108,7 +108,8 @@ def extend_ports(
     Args:
         component: component to extend ports.
         port_names: list of ports names to extend, if None it extends all ports.
-        length: extension length.
+        length: extension length, added after any automatic taper, so the total
+            extension is taper_length + length when a taper is inserted.
         extension: function to extend ports (defaults to a straight).
         port1: extension input port name.
         port2: extension output port name.
@@ -139,34 +140,37 @@ def extend_ports(
         cref.y = 0
 
     ports_all = cref.ports
-    port_names_all = [p.name for p in ports_all if p.name is not None]
+    ports_all_names = [p.name for p in ports_all if p.name is not None]
 
-    ports_to_extend = list(
-        gf.port.get_ports_list(cref.ports, port_type=port_type, **kwargs)
-    )
+    ports_to_extend = gf.port.get_ports_list(ports_all, port_type=port_type, **kwargs)
     ports_to_extend_names = [p.name for p in ports_to_extend if p.name is not None]
     ports_to_extend_names = cast("list[str]", port_names or ports_to_extend_names)
 
-    if auto_taper and cross_section:
-        from gdsfactory.routing.auto_taper import add_auto_tapers
-
-        _ = add_auto_tapers(
-            component=c, ports=ports_to_extend, cross_section=cross_section
-        )
-
+    ports_to_connect: dict[str, Port] = {}
     for port_name_to_extend in ports_to_extend_names:
-        if port_name_to_extend not in port_names_all:
+        if port_name_to_extend in ports_all_names:
+            ports_to_connect[port_name_to_extend] = ports_all[port_name_to_extend]
+        else:
             warnings.warn(
-                f"Port Name {port_name_to_extend!r} not in {port_names_all}",
+                f"Port Name {port_name_to_extend!r} not in {ports_all_names}",
                 stacklevel=3,
                 category=UserWarning,
             )
 
+    if auto_taper and cross_section:
+        from gdsfactory.routing.auto_taper import add_auto_tapers
+
+        tapered = add_auto_tapers(
+            component=c,
+            ports=list(ports_to_connect.values()),
+            cross_section=cross_section,
+        )
+        ports_to_connect = dict(zip(ports_to_connect, tapered, strict=True))
+
     for port in ports_all:
         port_name = port.name
-        port = cref.ports[port_name]
 
-        if port_name in ports_to_extend_names:
+        if port_name in ports_to_connect:
             if extension:
                 extension_component = gf.get_component(extension)
             else:
@@ -181,7 +185,6 @@ def extend_ports(
                         cross_section_extension = gf.get_cross_section(
                             port.info["cross_section"]
                         )
-
                     else:
                         cross_section_extension = cross_section_function(
                             layer=gf.get_layer_tuple(port.layer),
@@ -201,7 +204,9 @@ def extend_ports(
 
             extension_ref = c << extension_component
             extension_ref.connect(
-                port1, port, allow_width_mismatch=allow_width_mismatch
+                port1,
+                ports_to_connect[port_name],
+                allow_width_mismatch=allow_width_mismatch,
             )
             c.add_port(port_name, port=extension_ref.ports[port2])
             extension_port_names = extension_port_names or []
@@ -210,7 +215,7 @@ def extend_ports(
                 for name in extension_port_names
             ]
         else:
-            c.add_port(port_name, port=component.ports[port_name])
+            c.add_port(port_name, port=port)
 
     c.copy_child_info(component)
     return c

--- a/tests/components/containers/test_extension.py
+++ b/tests/components/containers/test_extension.py
@@ -22,9 +22,11 @@ def test_extend_ports_with_extension() -> None:
 
 
 def test_extend_ports_with_auto_taper() -> None:
-    c0 = gf.c.straight(width=0.5)
+    c0 = gf.c.straight(width=2.0)
     extended_c = extend_ports(component=c0, auto_taper=True, cross_section="strip")
     assert len(extended_c.ports) > 0
+    tapers = [i for i in extended_c.insts if i.cell.name.startswith("taper")]
+    assert len(tapers) == 2, [i.cell.name for i in extended_c.insts]
 
 
 def test_extend_ports_with_custom_port_names() -> None:
@@ -62,6 +64,47 @@ def test_extend_ports_with_custom_cross_section() -> None:
     c0 = gf.c.straight(width=0.5)
     extended_c = extend_ports(component=c0, cross_section="strip")
     assert len(extended_c.ports) > 0
+
+
+def test_extend_ports_auto_taper_port_locations() -> None:
+    """Ports land past the auto taper, at the end of the extension."""
+    c0 = gf.c.straight(width=2.0, length=10)
+    # no allow_width_mismatch: the extension now meets the taper's narrow end
+    c = extend_ports(component=c0, cross_section="strip", length=5)
+
+    taper = gf.get_component(
+        gf.get_active_pdk().layer_transitions[gf.get_layer("WG")],
+        width1=2.0,
+        width2=0.5,
+    )
+    extension = (taper.dxmax - taper.dxmin) + 5
+
+    assert c["o1"].center == pytest.approx((-extension, 0))
+    assert c["o2"].center == pytest.approx((10 + extension, 0))
+    assert c["o1"].width == 0.5
+    # ports sit on the component edge, not buried inside the taper
+    assert c.dxmin == pytest.approx(-extension)
+    assert c.dxmax == pytest.approx(10 + extension)
+
+
+def test_extend_ports_auto_taper_respects_port_names() -> None:
+    """No taper is planted on a port that was not requested."""
+    c0 = gf.c.straight(width=2.0, length=10)
+    c = extend_ports(component=c0, cross_section="strip", length=5, port_names=("o1",))
+
+    assert len(c.insts) == 3  # component + one taper + one extension
+    assert c["o2"].center == pytest.approx((10, 0))
+    assert c["o2"].width == 2.0
+
+
+def test_extend_ports_centered_keeps_non_extended_ports_on_instance() -> None:
+    """Non-extended ports follow the centered instance, not the original cell."""
+    c0 = gf.c.mmi1x2()
+    c = extend_ports(component=c0, port_names=("o1",), length=5, centered=True)
+
+    inst = next(i for i in c.insts if i.cell.name.startswith("mmi1x2"))
+    for name in ("o2", "o3"):
+        assert c[name].center == pytest.approx(inst.ports[name].center)
 
 
 def test_line_function() -> None:


### PR DESCRIPTION
## Summary

- ports follow the ref when it's been centered
- place ports at the end of the extension
- place tapers only if the ports are named in `port_names`

## Test Plan

Clanker tests

## Summary by Sourcery

Correct port extension geometry and selective automatic taper behavior in `extend_ports`.

Bug Fixes:
- Fix port placement so extended ports remain at the end of the extension, including when automatic tapers are added.
- Ensure centered extensions preserve the positions of ports that are not extended.
- Restrict automatic taper insertion to the requested port names.

Enhancements:
- Clarify that the requested extension length is added after any automatic taper.

Tests:
- Add coverage for automatic taper count and placement, selective tapering, and centered non-extended ports.