### PR TITLE
feat: add RF inductors, transformers, and geometry helpers

### DIFF
--- a/gdsfactory/components/analog/__init__.py
+++ b/gdsfactory/components/analog/__init__.py
@@ -1,5 +1,13 @@
 from .inductors import *
 from .interdigital_capacitor import *
 from .interdigitated_electrodes import *
+from .transformers import *
 
-__all__ = ["inductor", "interdigital_capacitor", "interdigitated_electrodes"]
+__all__ = [
+    "get_extended_layer_stack",
+    "inductor",
+    "interdigital_capacitor",
+    "interdigitated_electrodes",
+    "stacked_transformer",
+    "symmetric_transformer",
+]

--- a/gdsfactory/components/analog/__init__.py
+++ b/gdsfactory/components/analog/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "interdigitated_electrodes",
     "stacked_transformer",
     "symmetric_transformer",
+    "via3",
 ]

--- a/gdsfactory/components/analog/_geometry.py
+++ b/gdsfactory/components/analog/_geometry.py
@@ -1,0 +1,150 @@
+"""Shared geometry primitives for analog inductor and transformer cells."""
+
+from __future__ import annotations
+
+import math
+from numpy import floor
+from typing import Callable
+from gdsfactory import Component
+
+Poly = list[tuple[float, float]]
+
+
+def _zip(xs: list[float], ys: list[float]) -> Poly:
+    return list(zip(xs, ys))
+
+
+def _map_y(p: Poly, f: Callable[[float], float]) -> Poly:
+    return [(x, f(y)) for (x, y) in p]
+
+
+def _mirror_x(p: Poly) -> Poly:
+    return [(-x, y) for (x, y) in p]
+
+
+def _sign(x: float) -> int:
+    return (x > 0) - (x < 0)
+
+
+def _make_aspect_shift_y(
+    Dout: float, aspect_ratio: float = 1.0
+) -> Callable[[float], float]:
+    """Stretch straight sides only (y=0 fixed). Identity when aspect_ratio == 1."""
+    if aspect_ratio == 1:
+        return lambda y: y
+    ext = Dout * (aspect_ratio - 1)
+    return lambda y: y + ext / 2 if y > 0 else (y - ext / 2 if y < 0 else y)
+
+
+def _routing_geometric_45(
+    w: float, s: float, x0: float, y0: float, extend: float = 0.0
+) -> Poly:
+    """45-degree crossing routing polygon."""
+    SQRT2 = math.sqrt(2)
+    g = (SQRT2 - 1) * s
+    d = (SQRT2 - 1) * w
+    h = w + s + (SQRT2 - 1) * (2 * s + w)
+    x_upper = [-h / 2, -h / 2 + g, h / 2 - g - d, h / 2]
+    y_upper = [-s / 2, -s / 2, s / 2 + w, s / 2 + w]
+    x_lower = [-h / 2, -h / 2 + g + d, h / 2 - g, h / 2]
+    y_lower = [-s / 2 - w, -s / 2 - w, s / 2, s / 2]
+    if extend > 0:
+        x_upper = [-h / 2 - extend] + x_upper + [h / 2 + extend]
+        y_upper = [-s / 2] + y_upper + [s / 2 + w]
+        x_lower = [-h / 2 - extend] + x_lower + [h / 2 + extend]
+        y_lower = [-s / 2 - w] + y_lower + [s / 2]
+    xs = [v + x0 for v in x_upper] + [v + x0 for v in reversed(x_lower)]
+    ys = [v + y0 for v in y_upper] + [v + y0 for v in reversed(y_lower)]
+    return list(zip(xs, ys))
+
+
+def _via_component_info(via_component: Component) -> tuple[float, float, float, float, float]:
+    """Validate and unpack the via geometry info gdsfactory via() cells carry.
+
+    Returns (xsize, ysize, enclosure, column_pitch, row_pitch).
+    """
+    for key in ("xsize", "ysize", "enclosure", "column_pitch", "row_pitch"):
+        if key not in via_component.info:
+            raise ValueError(f"via {via_component.name!r} is missing {key!r} info")
+    return (
+        via_component.info["xsize"],
+        via_component.info["ysize"],
+        via_component.info["enclosure"],
+        via_component.info["column_pitch"],
+        via_component.info["row_pitch"],
+    )
+
+
+def _add_via_array(
+    c: Component,
+    via_component: Component,
+    cx: float,
+    cy: float,
+    avail_x: float,
+    avail_y: float,
+):
+    """Place a via component array filling an avail_x x avail_y box centered
+    at (cx, cy). avail_x/avail_y are the enclosure-netted region —
+    same fill convention used across all four analog cells.
+    """
+    w, h, _enclosure, pitch_x, pitch_y = _via_component_info(via_component)
+
+    nb_vias_x = int(floor((avail_x - w) / pitch_x + 1)) or 1
+    nb_vias_y = int(floor((avail_y - h) / pitch_y + 1)) or 1
+    nb_vias_x = max(nb_vias_x, 1)
+    nb_vias_y = max(nb_vias_y, 1)
+
+    via_ref = c.add_ref(
+        via_component,
+        columns=nb_vias_x,
+        rows=nb_vias_y,
+        column_pitch=pitch_x,
+        row_pitch=pitch_y,
+    )
+    via_ref.move(
+        (
+            cx - via_ref.xsize / 2 + w / 2,
+            cy - via_ref.ysize / 2 + h / 2,
+        )
+    )
+    return via_ref
+
+
+def _via_array_at(
+    c: Component,
+    via_component: Component,
+    cx: float,
+    cy: float,
+    extend: float,
+    width: float,
+    enclosure: float,
+) -> None:
+    """Place a via array near (cx, cy), choosing the long axis (extend) to
+    align with whichever of x/y is farther from the origin. 
+    Used for the top/bottom/left-right crossing vias, which need to sit under crossings routed in
+    either the x or y direction depending on which quadrant they're in.
+    """
+    dx = _sign(cx) * (extend - width) / 2
+    dy = _sign(cy) * (extend - width) / 2
+    avail_extend = extend - 2 * enclosure
+    avail_width = width - 2 * enclosure
+ 
+    if abs(cy) > abs(cx):
+        _add_via_array(c, via_component, cx + dx, cy, avail_extend, avail_width)
+    else:
+        _add_via_array(c, via_component, cx, cy + dy, avail_width, avail_extend)
+ 
+
+
+def _pgs(D: float, w: float, s: float) -> list[Poly]:
+    """Manhattan fishbone patterned ground shield filling a DxD square."""
+    R = D / 2
+    pitch = w + s
+    sections: list[Poly] = []
+    sections.append([(-w / 2, -R), (-w / 2, R), (w / 2, R), (w / 2, -R)])
+    k_max = math.floor((R - w / 2) / pitch)
+    for k in range(-k_max, k_max + 1):
+        yc = k * pitch
+        yb, yt = yc - w / 2, yc + w / 2
+        sections.append([(-R, yb), (-R, yt), (R, yt), (R, yb)])
+    return sections

--- a/gdsfactory/components/analog/inductors.py
+++ b/gdsfactory/components/analog/inductors.py
@@ -1,14 +1,27 @@
 """Inductor components PDK."""
-
+ 
 import math
-
-__all__ = ["inductor"]
-
+ 
 import gdsfactory as gf
 from gdsfactory import Component
-from gdsfactory.typings import LayerSpec, LayerSpecs
-
+from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
+ 
 from .._schematic import inductor_schematic
+
+from ._geometry import (
+    Poly,
+    _zip,
+    _map_y,
+    _mirror_x,
+    _make_aspect_shift_y,
+    _routing_geometric_45,
+    _via_component_info,
+    _add_via_array,
+    _pgs,
+)
+ 
+__all__ = ["inductor", "spiral_inductor", "symmetric_inductor"]
+ 
 
 
 def inductor_min_diameter(width: float, space: float, turns: int, grid: float) -> float:
@@ -131,6 +144,504 @@ def inductor(
     c.info["width"] = width
     c.info["space"] = space
     c.info["diameter"] = diameter
+    return c
+
+
+@gf.cell_with_module_name(tags=["analog"])
+def spiral_inductor(
+    Dout: float = 130.0,
+    N: int = 3,
+    sides: int = 8,
+    width: float = 10.0,
+    spacing: float = 4.0,
+    aspect_ratio: float = 1.0,
+    port_side: str = "same",
+    add_pgs: bool = False,
+    pgs_diameter: float = 150.0,
+    pgs_width: float = 2.0,
+    pgs_spacing: float = 1.0,
+    via: ComponentSpec = "via2",
+    resistance: float = 0.5777,
+    inductance: float = 33.303e-12,
+    layer_winding: LayerSpec = "M3",
+    layer_underpass: LayerSpec = "M2",
+    layers_pgs: LayerSpecs = ("M1",),
+) -> Component:
+    """Polygonal spiral inductor.
+
+    Args:
+        Dout: Outer diameter of the spiral in micrometers.
+        N: Number of complete turns.
+        sides: Number of polygon sides per full turn (8 = octagonal).
+        width: Metal trace width in micrometers.
+        spacing: Gap between adjacent turns in micrometers.
+        aspect_ratio: Y-axis scale factor for non-square spirals (1.0 = symmetric).
+        port_side: ``"same"`` keeps both ports on the same side;
+            ``"opposite"`` places them on opposite sides.
+        add_pgs: When True, add a patterned ground shield on layers_pgs.
+        pgs_diameter: Bounding size D of the ground shield square, in micrometers.
+        pgs_width: Strip width w of each ground shield finger, in micrometers.
+        pgs_spacing: Gap s between adjacent ground shield fingers, in micrometers.
+        via: via ComponentSpec connecting winding <-> underpass. 
+        resistance: Series resistance in ohms, stored as metadata only.
+        inductance: Inductance in henries, stored as metadata only.
+        layer_winding: Metal layer for the main spiral winding.
+        layer_underpass: Metal layer for the inner-terminal underpass bridge (one layer below layer_winding).
+        layers_pgs: Layers on which the patterned ground shield is drawn, 
+            kept separate from both layer_winding and layer_underpass 
+            since the underpass carries a live signal and shouldn't s
+            hare a layer with a grounded shield.
+
+    Returns:
+        Component with 2 RF ports:
+          P1  ->  entry terminal  (layer_winding)
+          P2  ->  exit terminal   (layer_underpass)
+    """
+    c = Component()
+    PI = math.pi
+    opposite = port_side == "opposite"
+
+    # Derived parameters (identical to build_spiral_inductor)
+    s = (spacing + width) / math.cos(PI / sides)
+    v = width / math.cos(PI / sides)
+    R1 = Dout / 2 / math.cos(PI / sides)
+    R2 = R1 - v
+
+    n_pts = sides // 2
+    angles = [
+        PI * (1 / (2 * n_pts) + i * (1 - 1 / n_pts) / (n_pts - 1)) for i in range(n_pts)
+    ]
+
+    x_shift = -s / 2 * math.cos(PI / sides)
+    y_shift = -s / 2 * math.sin(PI / sides)
+
+    n_sections = 2 * N - 1 if opposite else 2 * N
+
+    x_out: list[float] = []
+    y_out: list[float] = []
+    x_in: list[float] = []
+    y_in: list[float] = []
+    r1, r2 = R1, R2
+
+    for section in range(n_sections):
+        if section % 2 == 0:
+            for phi in angles:
+                x_out.append(r1 * math.cos(phi))
+                x_in.append(r2 * math.cos(phi))
+                y_out.append(r1 * math.sin(phi))
+                y_in.append(r2 * math.sin(phi))
+        else:
+            for phi in angles:
+                x_out.append(-r1 * math.cos(phi) + x_shift)
+                x_in.append(-r2 * math.cos(phi) + x_shift)
+                y_out.append(-r1 * math.sin(phi) + y_shift)
+                y_in.append(-r2 * math.sin(phi) + y_shift)
+        r1 -= s / 2
+        r2 -= s / 2
+
+    entry_yc = 0.0 if opposite else (width + spacing) / 2
+    exit_yc = 0.0 if opposite else -(width + spacing) / 2
+
+    x_out_start = [Dout / 2 + width, x_out[0]]
+    x_in_start = [Dout / 2 + width, x_in[0]]
+    y_out_start = [entry_yc + width / 2, entry_yc + width / 2]
+    y_in_start = [entry_yc - width / 2, entry_yc - width / 2]
+
+    x_out_end = [x_out[-1]]
+    x_in_end = [x_in[-1]]
+    y_end = [-width / 2 if opposite else -spacing / 2]
+
+    x_poly = (
+        x_out_start
+        + x_out
+        + x_out_end
+        + list(reversed(x_in_end))
+        + list(reversed(x_in))
+        + list(reversed(x_in_start))
+    )
+    y_poly = (
+        y_out_start
+        + y_out
+        + y_end
+        + list(reversed(y_end))
+        + list(reversed(y_in))
+        + list(reversed(y_in_start))
+    )
+    winding_polygon: Poly = list(zip(x_poly, y_poly))
+
+    last_x_in = x_in[-1]
+    last_x_out = x_out[-1]
+    underpass_end_x = -(Dout / 2 + width) if opposite else Dout / 2 + width
+
+    underpass_polygon: Poly = [
+        (last_x_in, exit_yc - width / 2),
+        (underpass_end_x, exit_yc - width / 2),
+        (underpass_end_x, exit_yc + width / 2),
+        (last_x_in, exit_yc + width / 2),
+    ]
+
+    shift_y = _make_aspect_shift_y(Dout, aspect_ratio)
+
+    # Winding + underpass polygons
+    c.add_polygon(_map_y(winding_polygon, shift_y), layer=layer_winding)
+    c.add_polygon(_map_y(underpass_polygon, shift_y), layer=layer_underpass)
+
+    # Via array: fill the overlap region between winding and underpass
+    via_cx = last_x_out + (last_x_in - last_x_out) / 2
+    via_cy = exit_yc
+
+    via_component = gf.get_component(via)
+    w, h, enclosure, pitch_x, pitch_y = _via_component_info(via_component)
+
+    via_spacing_y = pitch_y - h
+    extend = 2 * (h + enclosure) + via_spacing_y
+
+    avail_x = width - 2 * enclosure
+    if extend > width:
+        avail_y = extend - 2 * enclosure
+        via_center_y = via_cy + (extend - width) / 2
+    else:
+        avail_y = width - 2 * enclosure
+        via_center_y = via_cy
+
+    _add_via_array(
+        c, via_component, via_cx, shift_y(via_center_y), avail_x, avail_y
+    )
+
+    if add_pgs:
+        for layer in layers_pgs:
+            for strip in _pgs(pgs_diameter, pgs_width, pgs_spacing):
+                c.add_polygon(_map_y(strip, shift_y), layer=layer)
+
+    # Ports
+    c.add_port(
+        "P1",
+        center=(Dout / 2 + width, shift_y(entry_yc)),
+        width=width,
+        orientation=0.0,
+        layer=layer_winding,
+    )
+    c.add_port(
+        "P2",
+        center=(underpass_end_x, shift_y(exit_yc)),
+        width=width,
+        orientation=180.0,
+        layer=layer_underpass,
+    )
+
+    # Metadata
+    c.info["resistance"] = resistance
+    c.info["inductance"] = inductance
+    c.info["model"] = "spiral_inductor"
+    c.info["turns"] = N
+    c.info["width"] = width
+    c.info["spacing"] = spacing
+    c.info["diameter"] = Dout
+
+    return c
+
+
+# Symmetric (differential) inductor
+
+@gf.cell_with_module_name(tags=["analog"])
+def symmetric_inductor(
+    Dout: float = 150.0,
+    N: int = 3,
+    sides: int = 8,
+    width: float = 10.0,
+    spacing: float = 2.0,
+    center_tap: bool = False,
+    via_extent: float | None = None,
+    port_spacing: float | None = None,
+    aspect_ratio: float = 1.0,
+    via: ComponentSpec = "via2",
+    resistance: float = 0.5777,
+    inductance: float = 33.303e-12,
+    add_pgs: bool = False,
+    pgs_diameter: float = 180.0,
+    pgs_width: float = 4.0,
+    pgs_spacing: float = 2.0,
+    layer_winding: LayerSpec = "M3",
+    layer_underpass: LayerSpec = "M2",
+    layers_pgs: LayerSpecs = ("M1",),
+) -> Component:
+    """Symmetric (differential) spiral inductor.
+ 
+    Args:
+        Dout: Outer diameter of the two-lobe structure, in micrometers.
+        N: Number of complete windings per side.
+        sides: Number of polygon sides per full turn (8 = octagonal).
+        width: Metal trace width in micrometers.
+        spacing: Gap between adjacent turns in micrometers.
+        center_tap: When True, add a center-tap bridge (and CT port)
+            routed through layer_underpass with its own via connection
+            to the winding.
+        via_extent: Length the crossing route extends past the crossing
+            box on layer_underpass, and the box size used to size the
+            crossing/centertap via arrays. If None, it's derived from the
+            chosen via's own geometry.
+        port_spacing: Horizontal spacing of the differential ports P1/P2.
+        aspect_ratio: Y-axis scale factor for non-square windings
+        via: via ComponentSpec connecting winding <-> crossing/centertap.
+        resistance: Series resistance in ohms, stored as metadata only
+        inductance: Inductance in henries, stored as metadata only
+        add_pgs: When True, add a patterned ground shield on layers_pgs.
+        pgs_diameter: Bounding size D of the ground shield square, in micrometers.
+        pgs_width: Strip width w of each ground shield finger, in micrometers.
+        pgs_spacing: Gap s between adjacent ground shield fingers, in micrometers.
+        layer_winding: Metal layer for the main winding (top metal).
+        layer_underpass: Metal layer for crossings and the center-tap bridge (one layer below layer_winding).
+        layers_pgs: Layers on which the patterned ground shield is drawn.
+ 
+    Returns:
+        Component with 2 or 3 ports:
+          P1  ->  left differential terminal   (layer_winding)
+          P2  ->  right differential terminal  (layer_winding)
+          CT  ->  center tap (only if center_tap=True), on layer_winding
+                  if N <= 2, else on layer_underpass.
+    """
+    c = Component()
+    PI = math.pi
+    SQRT2 = math.sqrt(2)
+ 
+    via_component = gf.get_component(via)
+    via_w, via_h, via_enclosure, via_pitch_x, via_pitch_y = _via_component_info(
+        via_component
+    )
+ 
+    if via_extent is None:
+        via_spacing_y = via_pitch_y - via_h
+        extend = 2 * (via_h + via_enclosure) + via_spacing_y
+    else:
+        extend = via_extent
+ 
+    ps = spacing if port_spacing is None else port_spacing
+ 
+    v = width / math.cos(PI / sides)
+    s = (spacing + width) / math.cos(PI / sides)
+    R1 = Dout / 2 / math.cos(PI / sides)
+    R2 = R1 - v
+ 
+    n_half = sides // 2
+    left_angles = [PI * (0.5 + (i + 0.5) * 2 / sides) for i in range(n_half)]
+    right_angles = [PI * (-0.5 + (i + 0.5) * 2 / sides) for i in range(n_half)]
+    sep_total = width + spacing + (SQRT2 - 1) * (2 * spacing + width)
+ 
+    shift_y = _make_aspect_shift_y(Dout, aspect_ratio)
+ 
+    def add_winding(poly: Poly) -> None:
+        c.add_polygon(_map_y(poly, shift_y), layer=layer_winding)
+ 
+    def add_crossing(poly: Poly) -> None:
+        c.add_polygon(_map_y(poly, shift_y), layer=layer_underpass)
+ 
+    for winding in range(N):
+        # Left section
+        x_out = [R1 * math.cos(p) for p in left_angles]
+        y_out = [R1 * math.sin(p) for p in left_angles]
+        x_in = [R2 * math.cos(p) for p in left_angles]
+        y_in = [R2 * math.sin(p) for p in left_angles]
+        if winding == N - 1:
+            if N % 2 == 0:
+                x_out = [-sep_total / 2, *x_out, 0]
+                x_in = [-sep_total / 2, *x_in, 0]
+            else:
+                x_out = [0, *x_out, -sep_total / 2]
+                x_in = [0, *x_in, -sep_total / 2]
+        else:
+            x_out = [-sep_total / 2, *x_out, -sep_total / 2]
+            x_in = [-sep_total / 2, *x_in, -sep_total / 2]
+        y_out = [y_out[0], *y_out, y_out[-1]]
+        y_in = [y_in[0], *y_in, y_in[-1]]
+        add_winding(_zip([*x_out, *reversed(x_in)], [*y_out, *reversed(y_in)]))
+ 
+        # Right section
+        x_out = [R1 * math.cos(p) for p in right_angles]
+        y_out = [R1 * math.sin(p) for p in right_angles]
+        x_in = [R2 * math.cos(p) for p in right_angles]
+        y_in = [R2 * math.sin(p) for p in right_angles]
+        if winding == N - 1:
+            if N % 2 == 0:
+                x_out = [0, *x_out, sep_total / 2]
+                x_in = [0, *x_in, sep_total / 2]
+            else:
+                x_out = [sep_total / 2, *x_out, 0]
+                x_in = [sep_total / 2, *x_in, 0]
+        else:
+            x_out = [sep_total / 2, *x_out, sep_total / 2]
+            x_in = [sep_total / 2, *x_in, sep_total / 2]
+        y_out = [y_out[0], *y_out, y_out[-1]]
+        y_in = [y_in[0], *y_in, y_in[-1]]
+        add_winding(_zip([*x_out, *reversed(x_in)], [*y_out, *reversed(y_in)]))
+ 
+        # Crossings (skip on the innermost winding — nothing left to cross)
+        if winding != N - 1:
+            if winding % 2 == 0:
+                h = R1 * math.sin(PI * (0.5 - 1 / sides))
+            else:
+                h = (-R2 + s) * math.sin(PI * (0.5 - 1 / sides))
+ 
+            add_crossing(
+                _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, extend)
+            )
+            cross_top = _routing_geometric_45(
+                width, spacing, 0, h - width - spacing / 2, 0
+            )
+            add_winding(_mirror_x(cross_top))
+ 
+            for cx, cy in [
+                (-sep_total / 2 - width / 2, h - 3 * width / 2 - spacing),
+                (sep_total / 2 + width / 2, h - width / 2),
+            ]:
+                dx = math.copysign(1, cx) * (extend - width) / 2
+                _add_via_array(
+                    c,
+                    via_component,
+                    cx + dx,
+                    shift_y(cy),
+                    extend - 2 * via_enclosure,
+                    width - 2 * via_enclosure,
+                )
+ 
+        R1 -= s
+        R2 -= s
+ 
+    # Center tap
+    ct_port_layer = layer_winding
+    if center_tap:
+        x_ct = [-width / 2, -width / 2, width / 2, width / 2]
+        if N % 2 != 0:
+            if N <= 2:
+                y_ct = [
+                    -Dout / 2,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1),
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1),
+                    -Dout / 2,
+                ]
+            else:
+                y_ct = [
+                    -Dout / 2 + width - extend,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend,
+                    -Dout / 2 + width - extend,
+                ]
+        else:
+            if N <= 2:
+                y_ct = [
+                    -Dout / 2,
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2,
+                ]
+            else:
+                y_ct = [
+                    -Dout / 2 + width - extend,
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + width - extend,
+                ]
+ 
+        if N <= 2:
+            add_winding(_zip(x_ct, y_ct))
+        else:
+            ct_port_layer = layer_underpass
+            add_crossing(_zip(x_ct, y_ct))
+ 
+            if N % 2 != 0:
+                x_ct1, y_ct1 = 0, Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend / 2
+                x_ct2, y_ct2 = 0, -Dout / 2 + width / 2 + (width - extend) / 2
+            else:
+                x_ct1, y_ct1 = 0, -Dout / 2 + spacing * (N - 1) + width * N - width + extend / 2
+                x_ct2, y_ct2 = 0, -Dout / 2 + width - extend / 2
+ 
+            xvp1 = [x_ct1 - width / 2, x_ct1 - width / 2, x_ct1 + width / 2, x_ct1 + width / 2]
+            yvp1 = [y_ct1 - extend / 2, y_ct1 + extend / 2, y_ct1 + extend / 2, y_ct1 - extend / 2]
+            xvp2 = [x_ct2 - width / 2, x_ct2 - width / 2, x_ct2 + width / 2, x_ct2 + width / 2]
+            yvp2 = [y_ct2 - extend / 2, y_ct2 + extend / 2, y_ct2 + extend / 2, y_ct2 - extend / 2]
+ 
+            add_winding(_zip(xvp1, yvp1))
+            add_crossing(_zip(xvp1, yvp1))
+            add_crossing(_zip(xvp2, yvp2))
+ 
+            for cx, cy in [(x_ct1, y_ct1), (x_ct2, y_ct2)]:
+                _add_via_array(
+                    c,
+                    via_component,
+                    cx,
+                    shift_y(cy),
+                    width - 2 * via_enclosure,
+                    extend - 2 * via_enclosure,
+                )
+ 
+    # Ports
+    pxo = ps + width if center_tap else (ps + width) / 2
+    x_port = [
+        -sep_total / 2,
+        -pxo + width / 2,
+        -pxo + width / 2,
+        -pxo - width / 2,
+        -pxo - width / 2,
+        -sep_total / 2,
+    ]
+    y_port = [
+        -Dout / 2 + width,
+        -Dout / 2 + width,
+        -Dout / 2 - width,
+        -Dout / 2 - width,
+        -Dout / 2,
+        -Dout / 2,
+    ]
+    if center_tap:
+        add_winding(
+            _zip(
+                [-width / 2, -width / 2, width / 2, width / 2],
+                [-Dout / 2 - width, -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width],
+            )
+        )
+    add_winding(_zip(x_port, y_port))
+    add_winding(_zip([-x for x in x_port], y_port))
+ 
+    port_y = -Dout / 2 - width
+    port_x = ps + width if center_tap else (ps + width) / 2
+ 
+    c.add_port(
+        "P1",
+        center=(-port_x, shift_y(port_y)),
+        width=width,
+        orientation=270.0,
+        layer=layer_winding,
+    )
+    c.add_port(
+        "P2",
+        center=(port_x, shift_y(port_y)),
+        width=width,
+        orientation=270.0,
+        layer=layer_winding,
+    )
+    if center_tap:
+        c.add_port(
+            "CT",
+            center=(0, shift_y(port_y)),
+            width=width,
+            orientation=270.0,
+            layer=ct_port_layer,
+        )
+ 
+    if add_pgs:
+        for layer in layers_pgs:
+            for strip in _pgs(pgs_diameter, pgs_width, pgs_spacing):
+                c.add_polygon(_map_y(strip, shift_y), layer=layer)
+ 
+    # Metadata
+    c.info["resistance"] = resistance
+    c.info["inductance"] = inductance
+    c.info["model"] = "symmetric_inductor"
+    c.info["turns"] = N
+    c.info["width"] = width
+    c.info["spacing"] = spacing
+    c.info["diameter"] = Dout
+    c.info["center_tap"] = center_tap
+ 
     return c
 
 

--- a/gdsfactory/components/analog/transformers.py
+++ b/gdsfactory/components/analog/transformers.py
@@ -1,0 +1,1198 @@
+"""Transformer components PDK."""
+
+import math
+
+import gdsfactory as gf
+from gdsfactory import Component
+from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
+
+from .inductors import inductor
+from ._geometry import (
+    Poly,
+    _zip,
+    _map_y,
+    _mirror_x,
+    _routing_geometric_45,
+    _via_component_info,
+    _add_via_array,
+    _via_array_at,
+    _pgs,
+)
+
+__all__ = [
+    "symmetric_transformer",
+    "stacked_transformer",
+    "get_extended_layer_stack",
+]
+
+
+# Symmetric transformer
+
+gf.cell_with_module_name(tags=["analog"])
+def symmetric_transformer(
+    Dout: float = 150.0,
+    N1: int = 2,
+    N2: int = 3,
+    sides: int = 8,
+    width: float = 7.0,
+    spacing: float = 2.0,
+    center_tap_primary: bool = False,
+    center_tap_secondary: bool = False,
+    via_extent: float | None = None,
+    port_spacing: float | None = None,
+    via: ComponentSpec = "via2",
+    resistance: float = 0.5777,
+    inductance: float = 33.303e-12,
+    add_pgs: bool = False,
+    pgs_diameter: float = 180.0,
+    pgs_width: float = 4.0,
+    pgs_spacing: float = 2.0,
+    layer_winding: LayerSpec = "M3",
+    layer_underpass: LayerSpec = "M2",
+    layers_pgs: LayerSpecs = ("M1",),
+) -> Component:
+    """Symmetric (interleaved) transformer.
+ 
+    Two interleaved windings (primary: N1 turns, secondary: N2 turns) share
+    the same octagonal spiral, alternating turn-by-turn. Crossings are
+    routed on layer_underpass wherever a turn boundary needs to jump
+    between quadrants; bridges wire together the top/bottom/left/right
+    quadrant segments directly on layer_winding.
+ 
+    Args:
+        Dout: Outer diameter of the winding structure, in micrometers.
+        N1: Number of turns in the primary winding.
+        N2: Number of turns in the secondary winding.
+        sides: Number of polygon sides per full turn (8 = octagonal).
+            Must be a multiple of 4 (quadrant angle lists use sides // 4).
+        width: Metal trace width in micrometers.
+        spacing: Gap between adjacent turns in micrometers.
+        center_tap_primary: When True, add a center-tap bridge (and CT1 or
+            CT2 port, depending on parity) for the primary winding.
+        center_tap_secondary: When True, add a center-tap bridge (and CT1
+            or CT2 port, depending on parity) for the secondary winding.
+        via_extent: Length crossing/bridge routes extend past their
+            crossing box on layer_underpass, and the box size used to size
+            the crossing/centertap via arrays. If None, it's derived from
+            the chosen via's own geometry the same way spiral_inductor and
+            symmetric_inductor derive their "extend" value.
+        port_spacing: Horizontal spacing of the differential port pairs.
+        via: via ComponentSpec connecting winding <-> crossing/centertap.
+        resistance: Series resistance in ohms, stored as metadata only.
+        inductance: Inductance in henries, stored as metadata only.
+        add_pgs: When True, add a patterned ground shield on layers_pgs.
+        pgs_diameter: Bounding size D of the ground shield square, in micrometers.
+        pgs_width: Strip width w of each ground shield finger, in micrometers.
+        pgs_spacing: Gap s between adjacent ground shield fingers, in micrometers.
+        layer_winding: Metal layer for the main winding (top metal).
+        layer_underpass: Metal layer for crossings and center-tap bridges (one layer below layer_winding).
+        layers_pgs: Layers on which the patterned ground shield is drawn, 
+            kept separate from both layer_winding and layer_underpass
+ 
+    Returns:
+        Component with 4-6 ports:
+          P1+ / P1-  ->  primary differential terminals   (bottom, layer_winding)
+          P2+ / P2-  ->  secondary differential terminals (top, layer_winding)
+          CT1        ->  present if a center tap lands on the bottom side
+          CT2        ->  present if a center tap lands on the top side
+    """
+    c = Component()
+    PI = math.pi
+    SQRT2 = math.sqrt(2)
+ 
+    via_component = gf.get_component(via)
+    via_w, via_h, via_enclosure, via_pitch_x, via_pitch_y = _via_component_info(
+        via_component
+    )
+    if via_extent is None:
+        via_spacing_y = via_pitch_y - via_h
+        extend = 2 * (via_h + via_enclosure) + via_spacing_y
+    else:
+        extend = via_extent
+ 
+    ps = spacing if port_spacing is None else port_spacing
+ 
+    N = N1 + N2
+    Nmin = min(N1, N2)
+    N1_end = N - 1 if N1 > N2 else N - abs(N1 - N2) - 1
+    N2_end = N - 1 if N1 < N2 else N - abs(N1 - N2) - 1
+    v = width / math.cos(PI / sides)
+    s = (spacing + width) / math.cos(PI / sides)
+    R1_init = Dout / 2 / math.cos(PI / sides)
+ 
+    ul: list[float] = []
+    ur: list[float] = []
+    ll: list[float] = []
+    lr: list[float] = []
+    for i in range(sides // 4):
+        t = (i + 0.5) * 2 / sides
+        ul.append(PI * (0.5 + t))
+        ur.append(PI * (0 + t))
+        ll.append(PI * (1 + t))
+        lr.append(PI * (1.5 + t))
+ 
+    sep_total = width + spacing + (SQRT2 - 1) * (2 * spacing + width)
+ 
+    def rng(a: int, b: int | None = None) -> list[int]:
+        return list(range(a)) if b is None else list(range(a, b))
+ 
+    top_bridge: list[int] = []
+    bot_bridge: list[int] = []
+    top_crossing: list[int] = []
+    bot_crossing: list[int] = []
+    if N2 % 2 == 0:
+        top_bridge.append(N2_end)
+        if N1 % 2 == 0:
+            bot_bridge.append(N1_end)
+            if N1 >= N2:
+                top_crossing += [w for w in rng(N) if w % 2 != 0 and 0 < w < Nmin * 2 - 1]
+                top_crossing += [w for w in rng(N) if w % 2 == 0 and N > w > Nmin * 2 - 1]
+                bot_crossing += [w for w in rng(N) if w % 2 != 0 and w < N - 1]
+            else:
+                bot_crossing += [w for w in rng(N) if w % 2 != 0 and 0 < w < Nmin * 2 - 1]
+                bot_crossing += [w for w in rng(N) if w % 2 == 0 and N > w > Nmin * 2 - 1]
+                top_crossing += [w for w in rng(N) if w % 2 != 0 and w < N - 1]
+        else:
+            top_bridge.append(N1_end)
+            top_crossing += [w for w in rng(N) if w % 2 != 0 and 0 < w < Nmin * 2 - 1]
+            top_crossing += [w for w in rng(N) if w % 2 == 0 and N - 1 > w > Nmin * 2 - 1]
+            bot_crossing += [w for w in rng(N) if w % 2 != 0 and w < N]
+    else:
+        bot_bridge.append(N2_end)
+        if N1 % 2 == 0:
+            bot_bridge.append(N1_end)
+            top_crossing += [w for w in rng(N) if w % 2 != 0 and 0 < w < N - 1]
+            bot_crossing += [w for w in rng(N) if w % 2 == 0 and N - 1 > w > Nmin * 2 - 1]
+            bot_crossing += [w for w in rng(N) if w % 2 != 0 and w < Nmin * 2 - 1]
+        else:
+            top_bridge.append(N1_end)
+            if N1 >= N2:
+                top_crossing += [w for w in rng(N) if w % 2 != 0 and w < N - 1]
+                bot_crossing += [w for w in rng(N) if w % 2 != 0 and w < Nmin * 2 - 1]
+                bot_crossing += [w for w in rng(N) if w % 2 == 0 and N - 1 > w > Nmin * 2 - 1]
+            else:
+                top_crossing += [w for w in rng(N) if w % 2 == 0 and N - 1 > w > Nmin * 2 - 1]
+                top_crossing += [w for w in rng(N) if w % 2 != 0 and w < Nmin * 2 - 1]
+                bot_crossing += [w for w in rng(N) if w % 2 != 0 and w < Nmin * 2]
+                bot_crossing += [w for w in rng(N) if w % 2 != 0 and N - 1 > w > Nmin * 2 - 1]
+    lr_bridge = [w - 1 for w in rng(1, N + 1) if w > 2 * Nmin]
+    lr_crossing = [w - 1 for w in rng(1, N + 1) if w % 2 != 0 and w < 2 * Nmin]
+ 
+    def add_winding(poly: Poly) -> None:
+        c.add_polygon(poly, layer=layer_winding)
+ 
+    def add_crossing(poly: Poly) -> None:
+        c.add_polygon(poly, layer=layer_underpass)
+ 
+    via_centers_tct: list[tuple[float, float]] = []
+ 
+    R1 = R1_init
+    R2 = R1 - v
+    for winding in range(N):
+        all_angles = [ul, ll, ur, lr]
+        for qi in range(4):
+            angs = all_angles[qi]
+            x_out = [R1 * math.cos(p) for p in angs]
+            y_out = [R1 * math.sin(p) for p in angs]
+            x_in = [R2 * math.cos(p) for p in angs]
+            y_in = [R2 * math.sin(p) for p in angs]
+            if qi == 0:
+                y_out = [y_out[0], *y_out, sep_total / 2]
+                y_in = [y_in[0], *y_in, sep_total / 2]
+                x_out = [-sep_total / 2, *x_out, x_out[-1]]
+                x_in = [-sep_total / 2, *x_in, x_in[-1]]
+            elif qi == 1:
+                y_out = [-sep_total / 2, *y_out, y_out[-1]]
+                y_in = [-sep_total / 2, *y_in, y_in[-1]]
+                x_out = [x_out[0], *x_out, -sep_total / 2]
+                x_in = [x_in[0], *x_in, -sep_total / 2]
+            elif qi == 2:
+                y_out = [sep_total / 2, *y_out, y_out[-1]]
+                y_in = [sep_total / 2, *y_in, y_in[-1]]
+                x_out = [x_out[0], *x_out, sep_total / 2]
+                x_in = [x_in[0], *x_in, sep_total / 2]
+            else:
+                y_out = [y_out[0], *y_out, -sep_total / 2]
+                y_in = [y_in[0], *y_in, -sep_total / 2]
+                x_out = [sep_total / 2, *x_out, x_out[-1]]
+                x_in = [sep_total / 2, *x_in, x_in[-1]]
+            add_winding(_zip([*x_out, *reversed(x_in)], [*y_out, *reversed(y_in)]))
+ 
+        if winding in bot_bridge:
+            h = -R2 * math.sin(PI * (0.5 - 1 / sides))
+            add_winding(
+                _zip(
+                    [-sep_total / 2, sep_total / 2, sep_total / 2, -sep_total / 2],
+                    [h, h, h - width, h - width],
+                )
+            )
+        if winding in top_bridge:
+            h = (R2 + v) * math.sin(PI * (0.5 - 1 / sides))
+            add_winding(
+                _zip(
+                    [-sep_total / 2, sep_total / 2, sep_total / 2, -sep_total / 2],
+                    [h, h, h - width, h - width],
+                )
+            )
+        if winding in lr_bridge:
+            hR = (R2 + v) * math.sin(PI * (0.5 - 1 / sides))
+            add_winding(
+                _zip(
+                    [hR, hR, hR - width, hR - width],
+                    [-sep_total / 2, sep_total / 2, sep_total / 2, -sep_total / 2],
+                )
+            )
+            hL = -R2 * math.sin(PI * (0.5 - 1 / sides))
+            add_winding(
+                _zip(
+                    [hL, hL, hL - width, hL - width],
+                    [-sep_total / 2, sep_total / 2, sep_total / 2, -sep_total / 2],
+                )
+            )
+ 
+        if winding in top_crossing:
+            h = R1 * math.sin(PI * (0.5 - 1 / sides))
+            add_crossing(
+                _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, extend)
+            )
+            ct = _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, 0)
+            add_winding(_mirror_x(ct))
+        if winding in bot_crossing:
+            h = (-R2 + s) * math.sin(PI * (0.5 - 1 / sides))
+            add_crossing(
+                _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, extend)
+            )
+            ct = _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, 0)
+            add_winding(_mirror_x(ct))
+        if winding in lr_crossing:
+            hR = R1 * math.sin(PI * (0.5 - 1 / sides))
+            cr = _routing_geometric_45(width, spacing, 0, hR - width - spacing / 2, extend)
+            add_crossing([(y, x) for (x, y) in cr])
+            cr = _routing_geometric_45(width, spacing, 0, hR - width - spacing / 2, 0)
+            add_winding([(-y, x) for (x, y) in cr])
+            hL = (-R2 + s) * math.sin(PI * (0.5 - 1 / sides))
+            cr = _routing_geometric_45(width, spacing, 0, hL - width - spacing / 2, extend)
+            add_crossing([(y, x) for (x, y) in cr])
+            cr = _routing_geometric_45(width, spacing, 0, hL - width - spacing / 2, 0)
+            add_winding([(-y, x) for (x, y) in cr])
+ 
+        # Crossing vias — recessed under the layer_underpass crossing strips above.
+        h_top = R1 * math.sin(PI * (0.5 - 1 / sides))
+        h_bot = (-R2 + s) * math.sin(PI * (0.5 - 1 / sides))
+        if winding in top_crossing:
+            _via_array_at(
+                c, via_component,
+                -sep_total / 2 - width / 2, h_top - 3 * width / 2 - spacing,
+                extend, width, via_enclosure,
+            )
+            _via_array_at(
+                c, via_component,
+                sep_total / 2 + width / 2, h_top - width / 2,
+                extend, width, via_enclosure,
+            )
+        if winding in bot_crossing:
+            _via_array_at(
+                c, via_component,
+                -sep_total / 2 - width / 2, h_bot - 3 * width / 2 - spacing,
+                extend, width, via_enclosure,
+            )
+            _via_array_at(
+                c, via_component,
+                sep_total / 2 + width / 2, h_bot - width / 2,
+                extend, width, via_enclosure,
+            )
+        if winding in lr_crossing:
+            _via_array_at(
+                c, via_component,
+                h_bot - 3 * width / 2 - spacing, -sep_total / 2 - width / 2,
+                extend, width, via_enclosure,
+            )
+            _via_array_at(
+                c, via_component,
+                h_bot - width / 2, sep_total / 2 + width / 2,
+                extend, width, via_enclosure,
+            )
+            _via_array_at(
+                c, via_component,
+                h_top - 3 * width / 2 - spacing, -sep_total / 2 - width / 2,
+                extend, width, via_enclosure,
+            )
+            _via_array_at(
+                c, via_component,
+                h_top - width / 2, sep_total / 2 + width / 2,
+                extend, width, via_enclosure,
+            )
+ 
+        R1 -= s
+        R2 -= s
+ 
+    # Center taps
+    def add_ct(n_end: int, ends_bottom: bool) -> None:
+        _ext = min(width, extend)
+        if ends_bottom:
+            x_ct = [-width / 2, -width / 2, width / 2, width / 2]
+            y_ct = [
+                -Dout / 2 + width - _ext,
+                -Dout / 2 + (spacing + width) * n_end,
+                -Dout / 2 + (spacing + width) * n_end,
+                -Dout / 2 + width - _ext,
+            ]
+            x_ct1, y_ct1 = 0, -Dout / 2 + spacing * n_end + width * (n_end + 1) - width + _ext / 2
+            x_ct2, y_ct2 = 0, -Dout / 2 + width / 2 + (width - _ext) / 2
+        else:
+            x_ct = [width / 2, width / 2, -width / 2, -width / 2]
+            y_ct = [
+                Dout / 2 - width + _ext,
+                Dout / 2 - (spacing + width) * n_end,
+                Dout / 2 - (spacing + width) * n_end,
+                Dout / 2 - width + _ext,
+            ]
+            x_ct1, y_ct1 = 0, Dout / 2 - spacing * n_end - width * (n_end + 1) + width - _ext / 2
+            x_ct2, y_ct2 = 0, Dout / 2 - width / 2 - (width - _ext) / 2
+ 
+        if n_end > 1:
+            via_centers_tct.append((x_ct1, y_ct1))
+            via_centers_tct.append((x_ct2, y_ct2))
+            xvp1 = [x_ct1 - width / 2, x_ct1 - width / 2, x_ct1 + width / 2, x_ct1 + width / 2]
+            yvp1 = [y_ct1 - _ext / 2, y_ct1 + _ext / 2, y_ct1 + _ext / 2, y_ct1 - _ext / 2]
+            xvp2 = [x_ct2 - width / 2, x_ct2 - width / 2, x_ct2 + width / 2, x_ct2 + width / 2]
+            yvp2 = [y_ct2 - _ext / 2, y_ct2 + _ext / 2, y_ct2 + _ext / 2, y_ct2 - _ext / 2]
+            add_winding(_zip(xvp1, yvp1))
+            add_crossing(_zip(xvp1, yvp1))
+            add_crossing(_zip(xvp2, yvp2))
+            if n_end > 2:
+                add_crossing(_zip(x_ct, y_ct))
+                add_crossing(_zip(xvp1, yvp1))
+                add_crossing(_zip(xvp2, yvp2))
+            else:
+                add_crossing(_zip(x_ct, y_ct))
+        else:
+            add_winding(_zip(x_ct, y_ct))
+ 
+    if center_tap_primary:
+        add_ct(N1_end, N1 % 2 == 0)
+    if center_tap_secondary:
+        add_ct(N2_end, N2 % 2 != 0)
+ 
+    # Ports
+    has_bottom_ct = (center_tap_primary and N1 % 2 == 0) or (
+        center_tap_secondary and N2 % 2 != 0
+    )
+    has_top_ct = (center_tap_primary and N1 % 2 != 0) or (
+        center_tap_secondary and N2 % 2 == 0
+    )
+    bpx = ps + width if has_bottom_ct else (ps + width) / 2
+    tpx = ps + width if has_top_ct else (ps + width) / 2
+ 
+    x_port_b = [
+        -sep_total / 2, -bpx + width / 2, -bpx + width / 2,
+        -bpx - width / 2, -bpx - width / 2, -sep_total / 2,
+    ]
+    y_port_b = [
+        -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width,
+        -Dout / 2 - width, -Dout / 2, -Dout / 2,
+    ]
+    if has_bottom_ct:
+        add_winding(
+            _zip(
+                [-width / 2, -width / 2, width / 2, width / 2],
+                [-Dout / 2 - width, -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width],
+            )
+        )
+    add_winding(_zip(x_port_b, y_port_b))
+    add_winding(_zip([-x for x in x_port_b], y_port_b))
+ 
+    x_port_t = [
+        -sep_total / 2, -tpx + width / 2, -tpx + width / 2,
+        -tpx - width / 2, -tpx - width / 2, -sep_total / 2,
+    ]
+    y_port_t = [
+        -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width,
+        -Dout / 2 - width, -Dout / 2, -Dout / 2,
+    ]
+    if has_top_ct:
+        add_winding(
+            _zip(
+                [-width / 2, -width / 2, width / 2, width / 2],
+                [Dout / 2 + width, Dout / 2 - width, Dout / 2 - width, Dout / 2 + width],
+            )
+        )
+    add_winding(_zip(x_port_t, [-y for y in y_port_t]))
+    add_winding(_zip([-x for x in x_port_t], [-y for y in y_port_t]))
+ 
+    # Center-tap vias
+    ext_ct = min(width, extend)
+    for cx, cy in via_centers_tct:
+        _add_via_array(
+            c, via_component, cx, cy,
+            width - 2 * via_enclosure, ext_ct - 2 * via_enclosure,
+        )
+ 
+    bot_y = -Dout / 2 - width
+    top_y = Dout / 2 + width
+ 
+    c.add_port("P1+", center=(-bpx, bot_y), width=width, orientation=270.0, layer=layer_winding)
+    c.add_port("P1-", center=(bpx, bot_y), width=width, orientation=270.0, layer=layer_winding)
+    c.add_port("P2+", center=(-tpx, top_y), width=width, orientation=90.0, layer=layer_winding)
+    c.add_port("P2-", center=(tpx, top_y), width=width, orientation=90.0, layer=layer_winding)
+    if has_bottom_ct:
+        c.add_port(
+            "CT1", center=(0, bot_y), width=width, orientation=270.0, layer=layer_winding
+        )
+    if has_top_ct:
+        c.add_port(
+            "CT2", center=(0, top_y), width=width, orientation=90.0, layer=layer_winding
+        )
+ 
+    if add_pgs:
+        for layer in layers_pgs:
+            for strip in _pgs(pgs_diameter, pgs_width, pgs_spacing):
+                c.add_polygon(strip, layer=layer)
+ 
+    # Metadata (mirrors inductor() / spiral_inductor() / symmetric_inductor())
+    c.info["resistance"] = resistance
+    c.info["inductance"] = inductance
+    c.info["model"] = "symmetric_transformer"
+    c.info["turns_primary"] = N1
+    c.info["turns_secondary"] = N2
+    c.info["width"] = width
+    c.info["spacing"] = spacing
+    c.info["diameter"] = Dout
+    c.info["center_tap_primary"] = center_tap_primary
+    c.info["center_tap_secondary"] = center_tap_secondary
+ 
+    return c
+
+
+# Stacked transformer 
+# ---------------------------------------------------------------------------
+# 4th metal (M4) + VIA3, used by stacked_transformer's DEFAULT full-isolation config. 
+# The gdsfactory generic PDK only has 3 real metals (M1/M2/M3). 
+# M4_LAYER/VIA3_LAYER are synthetic: valid GDS layers (KLayout accepts any registered layer number)
+# but NOT part of this PDK's real, fabricatable metal stack or its get_layer_stack() z-geometry.
+#
+# *** SIMULATION PIPELINE WARNING ***
+# If you're feeding a stacked_transformer() default-config component into
+# the gsim/Palace EM simulation pipeline, sim.set_stack(substrate_thickness=...) 
+# will NOT know M4 has any zmin/thickness/material, since get_layer_stack() has no metal4 entry.
+# You MUST instead call:
+#     sim.set_stack(stack=get_extended_layer_stack(), substrate_thickness=...)
+# using get_extended_layer_stack() so the mesher has real z-geometry for M4/VIA3. 
+# This only matters for simulation, plain GDS layout/export works fine with the defaults as-is.
+# ---------------------------------------------------------------------------
+ 
+_nm = 1e-3
+ 
+# Raw GDS layer registration. Picked layer/datatype numbers (53,0) and (48,0) as unused slots in this PDK's map;
+# change these if they collide with something in the layer map.
+M4_LAYER = gf.kcl.layer(53, 0)
+VIA3_LAYER = gf.kcl.layer(48, 0)
+ 
+ 
+@gf.cell
+def via3(
+    size: tuple[float, float] = (0.7, 0.7),
+    enclosure: float = 1.0,
+    pitch: float = 2.0,
+) -> Component:
+    """Via connecting M3 <-> M4, mirroring via1/via2/viac's shape
+    (0.7x0.7um squares, 1um enclosure, 2um pitch) but on VIA3_LAYER.
+ 
+    Only meaningful once M4 also has real z-geometry — see
+    get_extended_layer_stack() for the matching LayerStack entry.
+    """
+    c = Component()
+    w, h = size
+    c.add_polygon(
+        [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)],
+        layer=VIA3_LAYER,
+    )
+    c.info["xsize"] = w
+    c.info["ysize"] = h
+    c.info["enclosure"] = enclosure
+    c.info["column_pitch"] = pitch
+    c.info["row_pitch"] = pitch
+    return c
+
+ 
+ 
+def get_extended_layer_stack(
+    thickness_metal4: float = 700 * _nm,
+    thickness_via3: float | None = None,
+):
+    """Return the active generic PDK's LayerStack with metal4 + via3
+    appended, so Palace/gsim mesher knows M4's z-position, thickness, and material.
+ 
+    Since M4 doesn't exist in the generic PDK's real stack, there's no measured
+    metal3-to-metal4 dielectric gap to copy. 
+    thickness_via3 defaults to the PDK's actual via2 thickness (metal2<->metal3, ~0.2um) 
+    as the closest real analogue — via1 (metal1<->metal2, ~0.5um) is thicker,
+    consistent with vias generally thinning higher up the stack, so via2's
+    value is the more defensible guess for a via directly above it. 
+    This is an assumption, not a measured value — override thickness_via3 
+    if there is a better estimate for the actual process.
+ 
+    metal4 sits thickness_via3 above metal3's top, with via3 filling that
+    real dielectric gap (matching how via1/via2 physically work in this
+    stack — metal layers don't touch directly; a via plug bridges a
+    nonzero-thickness interlayer dielectric between them).
+ 
+    Must be called with the generic PDK active (gf.gpdk.get_generic_pdk()
+    .activate(), already done at import time in this module) so
+    get_layer_stack() resolves the base metal1/2/3 stack correctly.
+ 
+    Example:
+        >>> sim.set_stack(stack=get_extended_layer_stack(), substrate_thickness=180.0)
+    """
+    from gdsfactory.technology import LayerLevel, LogicalLayer
+ 
+    stack_mod = gf.gpdk.layer_stack
+    params = stack_mod.LayerStackParameters
+    base = stack_mod.get_layer_stack()
+ 
+    metal3_top = params.zmin_metal3 + params.thickness_metal3
+ 
+    if thickness_via3 is None:
+        # via2's real thickness in this PDK: metal3.zmin - metal2_top
+        metal2_top = params.zmin_metal2 + params.thickness_metal2
+        thickness_via3 = params.zmin_metal3 - metal2_top
+ 
+    zmin_metal4 = metal3_top + thickness_via3
+ 
+    base.layers["via3"] = LayerLevel(
+        layer=LogicalLayer(layer=VIA3_LAYER),
+        thickness=thickness_via3,
+        zmin=metal3_top,
+        material="Aluminum",
+        mesh_order=1,
+    )
+    base.layers["metal4"] = LayerLevel(
+        layer=LogicalLayer(layer=M4_LAYER),
+        thickness=thickness_metal4,
+        zmin=zmin_metal4,
+        material="Aluminum",
+        mesh_order=2,
+    )
+    return base
+
+ 
+
+def _stacked_half(
+    c: Component,
+    *,
+    N: int,
+    center_tap: bool,
+    Dout: float,
+    sides: int,
+    width: float,
+    spacing: float,
+    R1_start: float,
+    extend: float,
+    ps: float,
+    winding_layer: LayerSpec,
+    crossing_layer: LayerSpec,
+    via_component: Component,
+    via_enclosure: float,
+    sign: int,
+    port_prefix: str,
+) -> None:
+    """Build one winding half (primary or secondary) of a stacked
+    transformer directly onto Component c. sign=+1 places it at the
+    bottom as-is (port_side="bottom" in the TS source); sign=-1 flips
+    every y-coordinate, equivalent to the TS source's mirror_y() applied
+    to the whole polygon/via set for port_side="top" — since every shape
+    here is y-symmetric under negation, negating y per-point at draw time
+    is equivalent to mirroring the assembled set afterwards.
+    """
+    PI = math.pi
+    SQRT2 = math.sqrt(2)
+    v = width / math.cos(PI / sides)
+    s = (spacing + width) / math.cos(PI / sides)
+    sep_total = width + spacing + (SQRT2 - 1) * (2 * spacing + width)
+
+    n_half = sides // 2
+    left_angles = [
+        PI * (0.5 + (i + 0.5) * 2 / sides) for i in range(n_half)
+    ]
+    right_angles = [
+        PI * (-0.5 + (i + 0.5) * 2 / sides) for i in range(n_half)
+    ]
+
+    def add_w(poly: Poly) -> None:
+        c.add_polygon(_map_y(poly, lambda y: sign * y), layer=winding_layer)
+
+    def add_c(poly: Poly) -> None:
+        c.add_polygon(_map_y(poly, lambda y: sign * y), layer=crossing_layer)
+
+    R1 = R1_start
+    R2 = R1 - v
+    for winding in range(N):
+        for angles, left in ((left_angles, True), (right_angles, False)):
+            x_out = [R1 * math.cos(p) for p in angles]
+            y_out = [R1 * math.sin(p) for p in angles]
+            x_in = [R2 * math.cos(p) for p in angles]
+            y_in = [R2 * math.sin(p) for p in angles]
+            if winding == N - 1:
+                if left:
+                    if N % 2 == 0:
+                        x_out = [-sep_total / 2, *x_out, 0]
+                        x_in = [-sep_total / 2, *x_in, 0]
+                    else:
+                        x_out = [0, *x_out, -sep_total / 2]
+                        x_in = [0, *x_in, -sep_total / 2]
+                else:
+                    if N % 2 == 0:
+                        x_out = [0, *x_out, sep_total / 2]
+                        x_in = [0, *x_in, sep_total / 2]
+                    else:
+                        x_out = [sep_total / 2, *x_out, 0]
+                        x_in = [sep_total / 2, *x_in, 0]
+            else:
+                sgn = -1 if left else 1
+                x_out = [sgn * sep_total / 2, *x_out, sgn * sep_total / 2]
+                x_in = [sgn * sep_total / 2, *x_in, sgn * sep_total / 2]
+            y_out = [y_out[0], *y_out, y_out[-1]]
+            y_in = [y_in[0], *y_in, y_in[-1]]
+            add_w(_zip([*x_out, *reversed(x_in)], [*y_out, *reversed(y_in)]))
+
+        if winding != N - 1:
+            if winding % 2 == 0:
+                h = R1 * math.sin(PI * (0.5 - 1 / sides))
+            else:
+                h = (-R2 + s) * math.sin(PI * (0.5 - 1 / sides))
+
+            add_c(
+                _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, extend)
+            )
+            ct = _routing_geometric_45(width, spacing, 0, h - width - spacing / 2, 0)
+            add_w(_mirror_x(ct))
+
+            for cx, cy in [
+                (-sep_total / 2 - width / 2, h - 3 * width / 2 - spacing),
+                (sep_total / 2 + width / 2, h - width / 2),
+            ]:
+                dx = math.copysign(1, cx) * (extend - width) / 2
+                _add_via_array(
+                    c,
+                    via_component,
+                    cx + dx,
+                    sign * cy,
+                    extend - 2 * via_enclosure,
+                    width - 2 * via_enclosure,
+                )
+
+        R1 -= s
+        R2 -= s
+
+    ct_port_layer = winding_layer
+    if center_tap:
+        x_ct = [-width / 2, -width / 2, width / 2, width / 2]
+        if N % 2 != 0:
+            if N <= 2:
+                y_ct = [
+                    -Dout / 2,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1),
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1),
+                    -Dout / 2,
+                ]
+            else:
+                y_ct = [
+                    -Dout / 2 + width - extend,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend,
+                    Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend,
+                    -Dout / 2 + width - extend,
+                ]
+        else:
+            if N <= 2:
+                y_ct = [
+                    -Dout / 2,
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2,
+                ]
+            else:
+                y_ct = [
+                    -Dout / 2 + width - extend,
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + spacing * (N - 1) + width * (N - 1),
+                    -Dout / 2 + width - extend,
+                ]
+
+        if N <= 2:
+            add_w(_zip(x_ct, y_ct))
+        else:
+            ct_port_layer = crossing_layer
+            add_c(_zip(x_ct, y_ct))
+
+            if N % 2 != 0:
+                x_ct1, y_ct1 = 0, Dout / 2 - spacing * (N - 1) - width * (N - 1) - extend / 2
+                x_ct2, y_ct2 = 0, -Dout / 2 + width / 2 + (width - extend) / 2
+            else:
+                x_ct1, y_ct1 = 0, -Dout / 2 + spacing * (N - 1) + width * N - width + extend / 2
+                x_ct2, y_ct2 = 0, -Dout / 2 + width - extend / 2
+
+            xvp1 = [x_ct1 - width / 2, x_ct1 - width / 2, x_ct1 + width / 2, x_ct1 + width / 2]
+            yvp1 = [y_ct1 - extend / 2, y_ct1 + extend / 2, y_ct1 + extend / 2, y_ct1 - extend / 2]
+            xvp2 = [x_ct2 - width / 2, x_ct2 - width / 2, x_ct2 + width / 2, x_ct2 + width / 2]
+            yvp2 = [y_ct2 - extend / 2, y_ct2 + extend / 2, y_ct2 + extend / 2, y_ct2 - extend / 2]
+
+            add_w(_zip(xvp1, yvp1))
+            add_c(_zip(xvp1, yvp1))
+            add_c(_zip(xvp2, yvp2))
+
+            for cx, cy in [(x_ct1, y_ct1), (x_ct2, y_ct2)]:
+                _add_via_array(
+                    c,
+                    via_component,
+                    cx,
+                    sign * cy,
+                    width - 2 * via_enclosure,
+                    extend - 2 * via_enclosure,
+                )
+
+    # Ports (always built in "bottom" orientation, then sign-flipped above)
+    pxo = ps + width if center_tap else (ps + width) / 2
+    x_port = [
+        -sep_total / 2, -pxo + width / 2, -pxo + width / 2,
+        -pxo - width / 2, -pxo - width / 2, -sep_total / 2,
+    ]
+    y_port = [
+        -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width,
+        -Dout / 2 - width, -Dout / 2, -Dout / 2,
+    ]
+    if center_tap:
+        add_w(
+            _zip(
+                [-width / 2, -width / 2, width / 2, width / 2],
+                [-Dout / 2 - width, -Dout / 2 + width, -Dout / 2 + width, -Dout / 2 - width],
+            )
+        )
+    add_w(_zip(x_port, y_port))
+    add_w(_zip([-x for x in x_port], y_port))
+
+    port_marker_y = sign * (-Dout / 2 - width)
+    orientation = 270.0 if sign > 0 else 90.0
+
+    c.add_port(
+        f"{port_prefix}+",
+        center=(-pxo, port_marker_y),
+        width=width,
+        orientation=orientation,
+        layer=winding_layer,
+    )
+    c.add_port(
+        f"{port_prefix}-",
+        center=(pxo, port_marker_y),
+        width=width,
+        orientation=orientation,
+        layer=winding_layer,
+    )
+    if center_tap:
+        c.add_port(
+            f"CT_{port_prefix}",
+            center=(0, port_marker_y),
+            width=width,
+            orientation=orientation,
+            layer=ct_port_layer,
+        )
+
+
+@gf.cell_with_module_name(tags=["analog"])
+def stacked_transformer(
+    Dout: float = 150.0,
+    N1: int = 3,
+    N2: int = 3,
+    sides: int = 8,
+    width: float = 10.0,
+    spacing: float = 2.0,
+    center_tap_primary: bool = False,
+    center_tap_secondary: bool = False,
+    via_extent: float | None = None,
+    port_spacing: float | None = None,
+    via_primary: ComponentSpec = via3,
+    via_secondary: ComponentSpec = "via1",
+    resistance: float = 0.5777,
+    inductance: float = 33.303e-12,
+    add_pgs: bool = False,
+    pgs_diameter: float = 180.0,
+    pgs_width: float = 4.0,
+    pgs_spacing: float = 2.0,
+    # Defaults use the synthetic M4/VIA3 layers for full 4-metal isolation —
+    # see the module-level comment above M4_LAYER for the SIMULATION
+    # PIPELINE WARNING: use get_extended_layer_stack() with sim.set_stack(),
+    # not the PDK default, when meshing a component built with these.
+    layer_winding_primary: LayerSpec = M4_LAYER,
+    layer_crossing_primary: LayerSpec = "M3",
+    layer_winding_secondary: LayerSpec = "M2",
+    layer_crossing_secondary: LayerSpec = "M1",
+    layers_pgs: LayerSpecs = (),
+) -> Component:
+    """Stacked transformer. 
+    
+    The primary winding sits on layer_winding_primary with
+    its crossings on layer_crossing_primary (connected by via_primary);
+    the secondary winding sits on layer_winding_secondary with its
+    crossings on layer_crossing_secondary (connected by via_secondary),
+    mirrored to sit on the opposite side of Dout so the two windings
+    stack vertically over the same footprint.
+ 
+    LAYER STACK: this gdsfactory generic PDK only has 3 real metals
+    (M1/M2/M3). A fully isolated stacked transformer needs 4 independent
+    metals (primary winding, primary crossing, secondary winding,
+    secondary crossing), so the defaults here use an EXTRA, non-native
+    4th metal registered via gf.kcl.layer() at import time (M4_LAYER,
+    layer (53, 0)) with its own via (via3(), VIA3_LAYER, layer (48, 0))
+    connecting it to M3. This gives full primary/secondary isolation by
+    default:
+        layer_winding_primary=M4_LAYER, layer_crossing_primary="M3", via_primary=via3
+        layer_winding_secondary="M2",   layer_crossing_secondary="M1", via_secondary="via1"
+ 
+    M4_LAYER/VIA3_LAYER are valid GDS layers but are NOT part of this PDK's real,
+    fabricatable metal stack. If you need this component to be simulation-ready 
+    (Palace/gsim meshing) ortape-out-accurate, call get_extended_layer_stack()
+    instead of the PDK's default stack, e.g. sim.set_stack(stack=get_extended_layer_stack()).
+ 
+    If your ACTUAL target PDK has a genuine 4th metal, pass its real
+    layer name/via in place of M4_LAYER/via3 instead of relying on this
+    synthetic one.
+ 
+    layers_pgs defaults to an empty tuple: even with M4 in play, all of
+    M1/M2/M3/M4 are live signal layers in the default configuration, so
+    there's still no obviously-safe spare metal for a patterned ground
+    shield — pass an explicit LayerSpecs of your own (accepting whatever
+    coupling that implies) if you need one anyway.
+ 
+    Args:
+        Dout: Outer diameter of each winding, in micrometers.
+        N1: Number of turns in the primary winding.
+        N2: Number of turns in the secondary winding.
+        sides: Number of polygon sides per full turn (8 = octagonal).
+        width: Metal trace width in micrometers.
+        spacing: Gap between adjacent turns in micrometers.
+        center_tap_primary: When True, add a center-tap bridge and CT_P
+            port to the primary winding.
+        center_tap_secondary: When True, add a center-tap bridge and CT_S
+            port to the secondary winding.
+        via_extent: Length crossing routes extend past their crossing box,
+            and the box size used to size the crossing/centertap via
+            arrays, for both halves. If None, it's derived independently
+            for each half from that half's own via geometry (same
+            derivation spiral_inductor/symmetric_inductor use).
+        port_spacing: Horizontal spacing of both differential port pairs.
+            Defaults to spacing.
+        via_primary: via ComponentSpec connecting layer_winding_primary <-> layer_crossing_primary.
+        via_secondary: via ComponentSpec connecting layer_winding_secondary <-> layer_crossing_secondary.
+        resistance: Series resistance in ohms, stored as metadata only.
+        inductance: Inductance in henries, stored as metadata only.
+        add_pgs: When True, add a patterned ground shield on layers_pgs.
+            See the layer-stack caveat above before enabling this.
+        pgs_diameter: Bounding size D of the ground shield square, in micrometers.
+        pgs_width: Strip width w of each ground shield finger, in micrometers.
+        pgs_spacing: Gap s between adjacent ground shield fingers, in micrometers.
+        layer_winding_primary: Metal layer for the primary winding.
+        layer_crossing_primary: Metal layer for the primary crossings.
+        layer_winding_secondary: Metal layer for the secondary winding.
+        layer_crossing_secondary: Metal layer for the secondary crossings.
+        layers_pgs: Layers on which the patterned ground shield is drawn.
+ 
+    Returns:
+        Component with 4-6 ports:
+          P+ / P-    ->  primary differential terminals   (layer_winding_primary)
+          S+ / S-    ->  secondary differential terminals (layer_winding_secondary)
+          CT_P       ->  present if center_tap_primary=True
+          CT_S       ->  present if center_tap_secondary=True
+    """
+    c = Component()
+    PI = math.pi
+    R1_init = Dout / 2 / math.cos(PI / sides)
+    ps = spacing if port_spacing is None else port_spacing
+ 
+    via_primary_component = gf.get_component(via_primary)
+    _, via_p_h, via_p_enclosure, _, via_p_pitch_y = _via_component_info(
+        via_primary_component
+    )
+    if via_extent is None:
+        extend_primary = 2 * (via_p_h + via_p_enclosure) + (via_p_pitch_y - via_p_h)
+    else:
+        extend_primary = via_extent
+ 
+    via_secondary_component = gf.get_component(via_secondary)
+    _, via_s_h, via_s_enclosure, _, via_s_pitch_y = _via_component_info(
+        via_secondary_component
+    )
+    if via_extent is None:
+        extend_secondary = 2 * (via_s_h + via_s_enclosure) + (via_s_pitch_y - via_s_h)
+    else:
+        extend_secondary = via_extent
+ 
+    _stacked_half(
+        c,
+        N=N1,
+        center_tap=center_tap_primary,
+        Dout=Dout,
+        sides=sides,
+        width=width,
+        spacing=spacing,
+        R1_start=R1_init,
+        extend=extend_primary,
+        ps=ps,
+        winding_layer=layer_winding_primary,
+        crossing_layer=layer_crossing_primary,
+        via_component=via_primary_component,
+        via_enclosure=via_p_enclosure,
+        sign=1,
+        port_prefix="P",
+    )
+    _stacked_half(
+        c,
+        N=N2,
+        center_tap=center_tap_secondary,
+        Dout=Dout,
+        sides=sides,
+        width=width,
+        spacing=spacing,
+        R1_start=R1_init,
+        extend=extend_secondary,
+        ps=ps,
+        winding_layer=layer_winding_secondary,
+        crossing_layer=layer_crossing_secondary,
+        via_component=via_secondary_component,
+        via_enclosure=via_s_enclosure,
+        sign=-1,
+        port_prefix="S",
+    )
+ 
+    if add_pgs:
+        if not layers_pgs:
+            raise ValueError(
+                "add_pgs=True but layers_pgs is empty — this PDK's default "
+                "layer stack has no spare metal for a shield in "
+                "stacked_transformer (see docstring). Pass an explicit "
+                "layers_pgs if you want one anyway."
+            )
+        for layer in layers_pgs:
+            for strip in _pgs(pgs_diameter, pgs_width, pgs_spacing):
+                c.add_polygon(strip, layer=layer)
+ 
+    c.info["resistance"] = resistance
+    c.info["inductance"] = inductance
+    c.info["model"] = "stacked_transformer"
+    c.info["turns_primary"] = N1
+    c.info["turns_secondary"] = N2
+    c.info["width"] = width
+    c.info["spacing"] = spacing
+    c.info["diameter"] = Dout
+    c.info["center_tap_primary"] = center_tap_primary
+    c.info["center_tap_secondary"] = center_tap_secondary
+ 
+    return c
+
+
+# Concentric (single-turn, coplanar) 1:1 transformer
+
+@gf.cell
+def _secondary_inductor(
+    width: float = 3.0,
+    space: float = 3.1,
+    diameter: float = 50.0,
+    layer_metal: LayerSpec = "M2",
+    layer_jumper: LayerSpec = "M1",
+    via: ComponentSpec = "via1",
+    via_size: float = 3.0,
+) -> Component:
+    """Single-turn octagonal coil whose two leads jump to a lower metal
+    (layer_jumper) right where they meet the coil body, so the leads can
+    be routed straight out past an outer coil without shorting it —
+    internal helper defining the secondary of transformer_concentric only,
+    not a standalone component in its own right.
+ 
+    Args:
+        width: Metal trace width in micrometers.
+        space: Space between the coil and the leads/gap, in micrometers.
+        diameter: Coil diameter in micrometers.
+        layer_metal: Layer for the coil body.
+        layer_jumper: Layer for the two leads (must be via-connectable
+            to layer_metal).
+        via: via ComponentSpec connecting layer_jumper <-> layer_metal.
+        via_size: Side length of the square via_stack junction pad, in
+            micrometers. via_stack() requires this to be large enough to
+            enclose at least one via square with its enclosure margin —
+            too small raises a ValueError from via_stack() itself.
+ 
+    Returns:
+        Component with ports P1, P2 on layer_jumper.
+    """
+    w = width
+    s = space
+    d = diameter
+    r = d / 2 + s
+    octagon_center_y = 3 * r
+    pi_over_4 = math.radians(45)
+ 
+    path_points = [(+space / 2, octagon_center_y - r * math.cos(pi_over_4 / 2))]
+    for i in range(-2, 6):
+        angle = i * pi_over_4 + pi_over_4 / 2
+        r = d / 2 + s
+        x = r * math.cos(angle)
+        y = r * math.sin(angle) + octagon_center_y
+        path_points.append((x, y))
+    path_points.append((-space / 2, octagon_center_y - r * math.cos(pi_over_4 / 2)))
+    gap_y = octagon_center_y - r * math.cos(pi_over_4 / 2)
+ 
+    path = gf.Path(path_points)
+    c = gf.path.extrude(path, layer=layer_metal, width=w)
+ 
+    length = 2 * r + s
+ 
+    lead1 = c << gf.components.rectangle(size=(s, length), layer=layer_jumper)
+    lead1.move((-s - s / 2, 0))
+    c.add_port(name="P1", center=(-s, s), width=s, orientation=270, layer=layer_jumper)
+ 
+    lead2 = c << gf.components.rectangle(size=(s, length), layer=layer_jumper)
+    lead2.move((s - s / 2, 0))
+    c.add_port(name="P2", center=(s, s), width=s, orientation=270, layer=layer_jumper)
+ 
+    via_stack_component = gf.get_component(
+        "via_stack",
+        size=(via_size, via_size),
+        layers=(layer_jumper, layer_metal),
+        vias=(None, via),
+    )
+    junction1 = c.add_ref(via_stack_component)
+    junction1.move(junction1.center, (-space, gap_y))
+    junction2 = c.add_ref(via_stack_component)
+    junction2.move(junction2.center, (space, gap_y))
+ 
+    c.flatten()
+    return c
+
+
+@gf.cell_with_module_name(tags=["analog"])
+def transformer_concentric(
+    width_primary: float = 3.0,
+    width_secondary: float = 3.0,
+    space: float = 3.1,
+    coupling_gap: float = 4.0,
+    diameter_outer: float = 80.0,
+    layer_primary: LayerSpec = "M3",
+    layer_secondary: LayerSpec = "M2",
+    layer_secondary_jumper: LayerSpec = "M1",
+    via_secondary: ComponentSpec = "via1",
+    via_size: float | None = None,
+    layer_inductor: LayerSpec = "M1",
+    layers_no_fill: LayerSpecs = ("DEVREC", "NO_TILE_SI"),
+    add_pgs: bool = False,
+    pgs_diameter: float = 120.0,
+    pgs_width: float = 4.0,
+    pgs_spacing: float = 2.0,
+    layers_pgs: LayerSpecs = (),
+) -> Component:
+    """Concentric, coplanar 1:1 transformer (single-turn coils).
+ 
+    Primary: standard inductor(), outer ring, on layer_primary. 
+    Secondary: an internal single-turn coil helper (not
+    exposed as its own component), inner ring, whose leads are drawn on
+    layer_secondary_jumper instead of layer_secondary, so they pass
+    underneath the primary ring without colliding — a via_stack connects
+    each lead to the coil body right where they meet.
+
+ 
+    Args:
+        width_primary: Primary coil trace width, in micrometers.
+        width_secondary: Secondary coil trace width, in micrometers.
+        space: Space between adjacent turns/leads, in micrometers
+            (shared by both coils, matching the original).
+        coupling_gap: Radial gap between the primary's inner edge and
+            the secondary's outer edge, in micrometers.
+        diameter_outer: Primary coil's outer diameter, in micrometers.
+        layer_primary: Metal layer for the primary coil.
+        layer_secondary: Metal layer for the secondary coil body.
+        layer_secondary_jumper: Metal layer for the secondary's leads (via-connected to layer_secondary).
+        via_secondary: via ComponentSpec connecting layer_secondary_jumper <-> layer_secondary.
+        via_size: Side length of the secondary's via_stack junction pads,
+            in micrometers. Defaults to width_secondary if None — bump
+            this up if via_stack() raises an enclosure ValueError.
+        layer_inductor: Marker layer for the outer IND-style polygon
+            drawn around each coil (matches inductor()'s own
+            layer_inductor role).
+        layers_no_fill: Layers excluded from metal fill, drawn under
+            the same outer marker polygon.
+        add_pgs: When True, add a patterned ground shield on layers_pgs.
+        pgs_diameter: Bounding size D of the ground shield square, in micrometers.
+        pgs_width: Strip width w of each ground shield finger, in micrometers.
+        pgs_spacing: Gap s between adjacent ground shield fingers, in micrometers.
+        layers_pgs: Layers on which the patterned ground shield is drawn.
+            Empty by default: layer_primary/layer_secondary/
+            layer_secondary_jumper already consume all 3 of this PDK's
+            real metals in the default configuration, so there's no
+            obviously-safe spare layer — pass one explicitly (accepting
+            whatever coupling that implies) if you need a shield anyway.
+ 
+    Returns:
+        Component with ports P1, P2 (primary, on layer_primary) and
+        S1, S2 (secondary, on layer_secondary_jumper).
+    """
+    c = gf.Component()
+    via_size = via_size or width_secondary
+ 
+    # Primary coil (outer ring), standard inductor
+    primary = inductor(
+        width=width_primary,
+        space=space,
+        diameter=diameter_outer,
+        turns=1,
+        layer_metal=layer_primary,
+        layer_inductor=layer_inductor,
+        layer_metal_pin=layer_primary,
+        layers_no_fill=layers_no_fill,
+    )
+    prim_ref = c.add_ref(primary)
+    cx, cy = prim_ref.center
+    prim_ref.move((-cx, -cy))
+ 
+    # Inner diameter for secondary, leaving room for coupling_gap between
+    # the primary's inner edge and the secondary's outer edge.
+    diameter_secondary = (
+        diameter_outer - 2 * (width_primary + space) - 2 * coupling_gap
+    )
+ 
+    secondary = _secondary_inductor(
+        width=width_secondary,
+        space=space,
+        diameter=diameter_secondary,
+        layer_metal=layer_secondary,
+        layer_jumper=layer_secondary_jumper,
+        via=via_secondary,
+        via_size=via_size,
+    )
+    sec_ref = c.add_ref(secondary)
+    sec_ref.rotate(180)
+    cx, cy = sec_ref.center
+    sec_ref.move((-cx, -cy))
+ 
+    # Expose all 4 ports
+    c.add_port(name="P1", port=prim_ref.ports["P1"])
+    c.add_port(name="P2", port=prim_ref.ports["P2"])
+    c.add_port(name="S1", port=sec_ref.ports["P1"])
+    c.add_port(name="S2", port=sec_ref.ports["P2"])
+ 
+    if add_pgs:
+        if not layers_pgs:
+            raise ValueError(
+                "add_pgs=True but layers_pgs is empty — the default "
+                "layer_primary/layer_secondary/layer_secondary_jumper "
+                "already consume this PDK's 3 real metals, leaving no "
+                "obviously-safe spare layer for a shield (see docstring). "
+                "Pass an explicit layers_pgs if you want one anyway."
+            )
+        for layer in layers_pgs:
+            for strip in _pgs(pgs_diameter, pgs_width, pgs_spacing):
+                c.add_polygon(strip, layer=layer)
+ 
+    c.flatten()
+    return c
+
+
+if __name__ == "__main__":
+    c = symmetric_transformer()
+    c.show()

--- a/gdsfactory/components/analog/transformers.py
+++ b/gdsfactory/components/analog/transformers.py
@@ -24,6 +24,7 @@ __all__ = [
     "get_extended_layer_stack",
     "stacked_transformer",
     "symmetric_transformer",
+    "via3",
 ]
 
 
@@ -613,8 +614,12 @@ _nm = 1e-3
 
 # Raw GDS layer registration. Picked layer/datatype numbers (53,0) and (48,0) as unused slots in this PDK's map;
 # change these if they collide with something in the layer map.
-M4_LAYER = gf.kcl.layer(53, 0)
-VIA3_LAYER = gf.kcl.layer(48, 0)
+def _m4_layer() -> int:
+    return gf.kcl.layer(53, 0)
+
+
+def _via3_layer() -> int:
+    return gf.kcl.layer(48, 0)
 
 
 @gf.cell
@@ -632,7 +637,7 @@ def via3(
     w, h = size
     c.add_polygon(
         [(-w / 2, -h / 2), (w / 2, -h / 2), (w / 2, h / 2), (-w / 2, h / 2)],
-        layer=VIA3_LAYER,
+        layer=_via3_layer(),
     )
     c.info["xsize"] = w
     c.info["ysize"] = h
@@ -685,14 +690,14 @@ def get_extended_layer_stack(
     zmin_metal4 = metal3_top + thickness_via3
 
     base.layers["via3"] = LayerLevel(
-        layer=LogicalLayer(layer=VIA3_LAYER),
+        layer=LogicalLayer(layer=_via3_layer()),
         thickness=thickness_via3,
         zmin=metal3_top,
         material="Aluminum",
         mesh_order=1,
     )
     base.layers["metal4"] = LayerLevel(
-        layer=LogicalLayer(layer=M4_LAYER),
+        layer=LogicalLayer(layer=_m4_layer()),
         thickness=thickness_metal4,
         zmin=zmin_metal4,
         material="Aluminum",
@@ -981,7 +986,7 @@ def stacked_transformer(
     # see the module-level comment above M4_LAYER for the SIMULATION
     # PIPELINE WARNING: use get_extended_layer_stack() with sim.set_stack(),
     # not the PDK default, when meshing a component built with these.
-    layer_winding_primary: LayerSpec = M4_LAYER,
+    layer_winding_primary: LayerSpec | None = None,
     layer_crossing_primary: LayerSpec = "M3",
     layer_winding_secondary: LayerSpec = "M2",
     layer_crossing_secondary: LayerSpec = "M1",
@@ -1062,6 +1067,9 @@ def stacked_transformer(
           CT_P       ->  present if center_tap_primary=True
           CT_S       ->  present if center_tap_secondary=True
     """
+    if layer_winding_primary is None:
+        layer_winding_primary = _m4_layer()
+
     c = Component()
     PI = math.pi
     R1_init = d_out / 2 / math.cos(PI / sides)

--- a/gdsfactory/components/analog/transformers.py
+++ b/gdsfactory/components/analog/transformers.py
@@ -612,6 +612,7 @@ def symmetric_transformer(
 
 _nm = 1e-3
 
+
 # Raw GDS layer registration. Picked layer/datatype numbers (53,0) and (48,0) as unused slots in this PDK's map;
 # change these if they collide with something in the layer map.
 def _m4_layer() -> int:

--- a/tests/test-data-regression/test_netlists_stacked_transformer_.yml
+++ b/tests/test-data-regression/test_netlists_stacked_transformer_.yml
@@ -1,0 +1,220 @@
+instances:
+  via3_S0p7_0p7_E1_P2_10249_67000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via3
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      enclosure: 1
+      pitch: 2
+      size:
+      - 0.7
+      - 0.7
+  via3_S0p7_0p7_E1_P2_10249_m49000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via3
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      enclosure: 1
+      pitch: 2
+      size:
+      - 0.7
+      - 0.7
+  via3_S0p7_0p7_E1_P2_m12249_55000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via3
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      enclosure: 1
+      pitch: 2
+      size:
+      - 0.7
+      - 0.7
+  via3_S0p7_0p7_E1_P2_m12249_m61000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via3
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      enclosure: 1
+      pitch: 2
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_10249_43000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA1
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_10249_m73000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA1
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_m12249_55000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA1
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_m12249_m61000:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 4
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA1
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+nets: []
+placements:
+  via3_S0p7_0p7_E1_P2_10249_67000:
+    mirror: false
+    rotation: 0
+    x: 10.249
+    y: 67
+  via3_S0p7_0p7_E1_P2_10249_m49000:
+    mirror: false
+    rotation: 0
+    x: 10.249
+    y: -49
+  via3_S0p7_0p7_E1_P2_m12249_55000:
+    mirror: false
+    rotation: 0
+    x: -12.249
+    y: 55
+  via3_S0p7_0p7_E1_P2_m12249_m61000:
+    mirror: false
+    rotation: 0
+    x: -12.249
+    y: -61
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_10249_43000:
+    mirror: false
+    rotation: 0
+    x: 10.249
+    y: 43
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_10249_m73000:
+    mirror: false
+    rotation: 0
+    x: 10.249
+    y: -73
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_m12249_55000:
+    mirror: false
+    rotation: 0
+    x: -12.249
+    y: 55
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA1_BL_0068d91e_m12249_m61000:
+    mirror: false
+    rotation: 0
+    x: -12.249
+    y: -61
+ports: {}

--- a/tests/test-data-regression/test_netlists_symmetric_transformer_.yml
+++ b/tests/test-data-regression/test_netlists_symmetric_transformer_.yml
@@ -1,0 +1,424 @@
+instances:
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_42500_m10128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_51500_8128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_60500_m10128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_69500_8128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_42500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_60500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_m55500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_33500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_51500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_m64500:
+    array:
+      column_pitch: 2
+      columns: 2
+      row_pitch: 2
+      rows: 3
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m46500_8128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m55500_m10128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m64500_8128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m73500_m10128:
+    array:
+      column_pitch: 2
+      columns: 3
+      row_pitch: 2
+      rows: 2
+    component: via
+    info:
+      column_pitch: 2
+      enclosure: 1
+      row_pitch: 2
+      xsize: 0.7
+      ysize: 0.7
+    settings:
+      bbox_layers: null
+      bbox_offset: 0
+      bbox_offsets: null
+      column_pitch: null
+      enclosure: 1
+      layer: VIA2
+      pitch: 2
+      row_pitch: null
+      size:
+      - 0.7
+      - 0.7
+nets: []
+placements:
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_42500_m10128:
+    mirror: false
+    rotation: 0
+    x: 42.5
+    y: -10.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_51500_8128:
+    mirror: false
+    rotation: 0
+    x: 51.5
+    y: 8.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_60500_m10128:
+    mirror: false
+    rotation: 0
+    x: 60.5
+    y: -10.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_69500_8128:
+    mirror: false
+    rotation: 0
+    x: 69.5
+    y: 8.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_42500:
+    mirror: false
+    rotation: 0
+    x: 8.128
+    y: 42.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_60500:
+    mirror: false
+    rotation: 0
+    x: 8.128
+    y: 60.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_8128_m55500:
+    mirror: false
+    rotation: 0
+    x: 8.128
+    y: -55.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_33500:
+    mirror: false
+    rotation: 0
+    x: -10.128
+    y: 33.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_51500:
+    mirror: false
+    rotation: 0
+    x: -10.128
+    y: 51.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m10128_m64500:
+    mirror: false
+    rotation: 0
+    x: -10.128
+    y: -64.5
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m46500_8128:
+    mirror: false
+    rotation: 0
+    x: -46.5
+    y: 8.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m55500_m10128:
+    mirror: false
+    rotation: 0
+    x: -55.5
+    y: -10.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m64500_8128:
+    mirror: false
+    rotation: 0
+    x: -64.5
+    y: 8.128
+  via_gdsfactorypcomponentspviaspvia_S0p7_0p7_E1_LVIA2_BL_c51b5ebb_m73500_m10128:
+    mirror: false
+    rotation: 0
+    x: -73.5
+    y: -10.128
+ports: {}

--- a/tests/test-data-regression/test_netlists_via3_.yml
+++ b/tests/test-data-regression/test_netlists_via3_.yml
@@ -1,0 +1,4 @@
+instances: {}
+nets: []
+placements: {}
+ports: {}

--- a/tests/test-data-regression/test_settings_stacked_transformer_.yml
+++ b/tests/test-data-regression/test_settings_stacked_transformer_.yml
@@ -1,0 +1,33 @@
+info:
+  center_tap_primary: false
+  center_tap_secondary: false
+  diameter: 150
+  inductance: 0
+  model: stacked_transformer
+  resistance: 0.578
+  spacing: 2
+  turns_primary: 3
+  turns_secondary: 3
+  width: 10
+name: stacked_transformer_gdsfactorypcomponentspanalogptransf_5c77bf46
+settings:
+  N1: 3
+  N2: 3
+  add_pgs: false
+  center_tap_primary: false
+  center_tap_secondary: false
+  d_out: 150
+  inductance: 0
+  layer_crossing_primary: M3
+  layer_crossing_secondary: M1
+  layer_winding_secondary: M2
+  layers_pgs: []
+  pgs_diameter: 180
+  pgs_spacing: 2
+  pgs_width: 4
+  resistance: 0.578
+  sides: 8
+  spacing: 2
+  via_primary: via3
+  via_secondary: via1
+  width: 10

--- a/tests/test-data-regression/test_settings_symmetric_transformer_.yml
+++ b/tests/test-data-regression/test_settings_symmetric_transformer_.yml
@@ -1,0 +1,32 @@
+info:
+  center_tap_primary: false
+  center_tap_secondary: false
+  diameter: 150
+  inductance: 0
+  model: symmetric_transformer
+  resistance: 0.578
+  spacing: 2
+  turns_primary: 2
+  turns_secondary: 3
+  width: 7
+name: symmetric_transformer_gdsfactorypcomponentspanalogptran_55361279
+settings:
+  N1: 2
+  N2: 3
+  add_pgs: false
+  center_tap_primary: false
+  center_tap_secondary: false
+  d_out: 150
+  inductance: 0
+  layer_underpass: M2
+  layer_winding: M3
+  layers_pgs:
+  - M1
+  pgs_diameter: 180
+  pgs_spacing: 2
+  pgs_width: 4
+  resistance: 0.578
+  sides: 8
+  spacing: 2
+  via: via2
+  width: 7

--- a/tests/test-data-regression/test_settings_via3_.yml
+++ b/tests/test-data-regression/test_settings_via3_.yml
@@ -1,0 +1,13 @@
+info:
+  column_pitch: 2
+  enclosure: 1
+  row_pitch: 2
+  xsize: 0.7
+  ysize: 0.7
+name: via3_S0p7_0p7_E1_P2
+settings:
+  enclosure: 1
+  pitch: 2
+  size:
+  - 0.7
+  - 0.7


### PR DESCRIPTION
## Summary
This PR introduces four new RF components to the `gdsfactory` analog library, along with shared geometry helpers. These components are designed to facilitate RF circuit design, electromagnetic simulations, and S-parameter extraction.

## Changes Introduced
*   **Inductors (`gdsfactory/components/analog/inductors.py`):** Added a standard Spiral Inductor and a Symmetric Inductor.
*   **Transformers (`gdsfactory/components/analog/transformers.py`):** Added a Symmetric Transformer and a Stacked Transformer.
*   **Geometry Helpers (`gdsfactory/components/analog/_geometry.py`):** Added foundational helper functions used to construct the routing and geometry of these four components.

## Important Note: Stacked Transformer & Generic Layer Stack
A fully isolated stacked transformer inherently requires 4 independent metal layers (primary winding, primary crossing, secondary winding, and secondary crossing). Because the `gdsfactory` generic PDK only provides 3 native metals (M1, M2, M3), this PR implements a necessary workaround for the default behavior:

*   **Synthetic 4th Metal:** We register an extra, non-native 4th metal (`M4_LAYER`, layer `(53, 0)`) and via (`VIA3_LAYER`, layer `(48, 0)`) via `gf.kcl.layer()` at import time to ensure the component can generate cleanly by default.
*   **Simulation & Meshing:** While `M4_LAYER` is a valid GDS layer, it is not in the default PDK stack. For users running tape-out checks or electromagnetic meshing (e.g., Palace or gsim), they will need to call `get_extended_layer_stack()` (e.g., `sim.set_stack(stack=get_extended_layer_stack())`). 
*   **Targeting Real PDKs:** If a user is targeting an actual foundry technology that possesses a genuine 4th metal (for example, the IHP open PDK), they can simply pass their real layer and via names in place of the synthetic M4 instead of relying on this default workaround.

## Patterned Ground Shields (PGS)
All new components accept arguments to generate a Patterned Ground Shield (PGS), which is highly beneficial for S-parameter simulations. 

*   *Stacked Transformer PGS Exception:* For the stacked transformer, `layers_pgs` defaults to an empty tuple. Because the default configuration utilizes M1 through M4 as live signal layers, there is no safely isolated spare metal for a default ground shield. Users needing a PGS on this component must pass an explicit `LayerSpecs` and manage the implied coupling.

## Summary by Sourcery

Expand the analog component library with RF inductors and transformers supported by reusable geometry helpers and simulation-aware layer-stack configuration.

New Features:
- Add spiral and symmetric inductors with configurable windings, ports, center taps, metadata, and patterned ground shields.
- Add symmetric, stacked, and concentric transformer components with configurable windings, layer assignments, ports, center taps, and patterned ground shields.
- Provide synthetic fourth-metal support, VIA3, and an extended layer stack for stacked-transformer layout and electromagnetic simulation workflows.

Enhancements:
- Introduce shared analog geometry utilities for routing, via-array placement, aspect-ratio adjustment, mirroring, and patterned ground-shield generation.

Documentation:
- Document the stacked transformer's fourth-metal layer-stack requirements and simulation guidance.

Tests:
- Add regression data covering symmetric and stacked transformers and the VIA3 component.