### PR TITLE
Fix use of on_collision/on_placer_error in route_bundle

### DIFF
--- a/gdsfactory/routing/route_bundle.py
+++ b/gdsfactory/routing/route_bundle.py
@@ -179,8 +179,8 @@ def route_bundle(
     taper: ComponentSpec | None = None,
     port_type: str | None = None,
     collision_check_layers: LayerSpecs | None = None,
-    on_collision: Literal["error", "show_error", "warning"] | None = None,
-    on_placer_error: Literal["error", "show_error", "warning"] | None = None,
+    on_collision: Literal["error", "show_error", "warning", "ignore"] | None = None,
+    on_placer_error: Literal["error", "show_error", "warning", "ignore"] | None = None,
     bboxes: Sequence[kf.kdb.DBox] | None = None,
     allow_width_mismatch: bool | None = None,
     allow_layer_mismatch: bool | None = None,
@@ -212,25 +212,31 @@ def route_bundle(
     Routes connect a bundle of ports with a river router.
     Chooses the correct routing function depending on port angles.
 
-    Can also be used with single ports instead of lists, replacing route_bundle.
+    Can also be used with single ports instead of lists, replacing route_single.
 
     Args:
         component: component to add the routes to.
         ports1: starting port or list of starting ports.
         ports2: end port or list of end ports.
         cross_section: CrossSection or function that returns a cross_section.
-        layer: layer to use for the route.
-        separation: bundle separation (center to center). Defaults to cross_section.width + cross_section.gap
+            Required unless both layer and route_width are given. Mutually exclusive with layer.
+        layer: layer to use for the route. Requires route_width. Mutually exclusive with cross_section.
+        separation: bundle separation (center to center) in um.
         bend: function for the bend. Defaults to euler.
         sort_ports: sort port coordinates.
-        start_straight_length: straight length at the beginning of the route. If None, uses default value for the routing CrossSection.
-        end_straight_length: end length at the beginning of the route. If None, uses default value for the routing CrossSection.
-        min_straight_taper: minimum length for tapering the straight sections.
+        start_straight_length: minimum straight length in um after the start ports.
+        end_straight_length: minimum straight length in um before the end ports.
+        min_straight_taper: minimum straight length in um before attempting to place tapers.
         taper: function for tapering long straight waveguides beyond min_straight_taper. Defaults to None.
-        port_type: type of port to place. Defaults to optical.
+        port_type: port type to route. If None, uses the port_type of the first port in ports1.
         collision_check_layers: list of layers to check for collisions.
-        on_collision: action to take on collision. Defaults to None (ignore).
-        on_placer_error: action to take on placer error. Defaults to None (ignore).
+        on_collision: action to take on route collision. "error" raises an exception.
+            "show_error" records the error in klayout's marker database.
+            "warning" emits a warning and falls back to error markers.
+            "ignore" places the route without checking for collisions.
+            If None, uses CONF.on_collision ("warning" by default). See also raise_on_error.
+        on_placer_error: action to take on placer error. Same options as on_collision.
+            If None, uses CONF.on_placer_error ("warning" by default).
         bboxes: list of bounding boxes to avoid collisions.
         allow_width_mismatch: allow different port widths.
         allow_layer_mismatch: allow different port layers to connect.
@@ -238,21 +244,26 @@ def route_bundle(
         radius: bend radius. If None, defaults to cross_section.radius.
         route_width: width of the route. If None, defaults to cross_section.width.
         straight: function for the straight. Defaults to straight.
-        sbend: function for the s-bend. If None, uses the same function as bend.
+        sbend: function for the s-bend. If None, s-bends are not used in the routing.
         auto_taper: if True, auto-tapers ports to the cross-section of the route.
-        auto_taper_taper: taper to use for auto-tapering. If None, uses the default taper for the cross-section.
+        auto_taper_taper: deprecated, use layer_transitions instead. When set together with
+            auto_taper=True this taper is used and layer_transitions is ignored.
         waypoints: list of waypoints to add to the route.
         steps: list of steps to add to the route.
             Each step is a dict with keys: x (absolute), y (absolute), dx (relative), dy (relative).
             Use x/y to set an absolute coordinate and dx/dy to shift relative to the current position.
-        start_angles: list of start angles for the routes. Only used for electrical ports.
-        end_angles: list of end angles for the routes. Only used for electrical ports.
-        router: Set the type of router to use, either the optical one or the electrical one.
-            If None, the router is optical unless the port_type is "electrical".
+        start_angles: overrides the orientation of the start ports. Pass a single value to apply
+            it to every port, or one value per port.
+        end_angles: overrides the orientation of the end ports. Pass a single value to apply it
+            to every port, or one value per port. Without waypoints all end angles must match.
+        router: deprecated and ignored. Passing any value emits a warning.
         layer_transitions: dictionary of layer transitions to use for the routing when auto_taper=True.
-        show_waypoints: if True, places markers at each waypoint using CONF.layer_marker.
-        layer_marker: layer to place markers on the route. Overrides CONF.layer_marker when show_waypoints=True.
+        show_waypoints: if True, places markers at each waypoint or step. No effect when neither
+            waypoints nor steps are given.
+        layer_marker: layer for the waypoint and step markers. Setting it places markers even when
+            show_waypoints=False. If None and show_waypoints=True, uses CONF.layer_marker.
         raise_on_error: if True, raises an exception on routing error instead of adding error markers.
+            If None, uses CONF.raise_on_error (False by default).
         path_length_matching_config: path length matching configuration. Convenience \
             shortcut that is converted into a single ``kf.schematic.PathLengthMatch`` \
             constraint. Mutually exclusive with ``constraints``.
@@ -260,8 +271,8 @@ def route_bundle(
             instances, e.g. ``kf.schematic.PathLengthMatch``) passed through to \
             kfactory. Mutually exclusive with ``path_length_matching_config``.
         layer_label: layer to place length labels on the route.
-        port1: single start port (alternative to ports1 for single-port routing).
-        port2: single end port (alternative to ports2 for single-port routing).
+        port1: deprecated, use ports1. Single start port for single-port routing.
+        port2: deprecated, use ports2. Single end port for single-port routing.
         name: Name for the route. This is not important yet, but once constraints are implemented, the constraint, depending
             on the constraint class, might check against names to make enforcement or checking decisions.
 
@@ -289,8 +300,10 @@ def route_bundle(
         ```
     """
     name = name or "unnamed_route_bundle"
-    on_collision = on_collision or CONF.on_collision
-    on_placer_error = on_placer_error or CONF.on_placer_error
+    if on_collision is None:
+        on_collision = CONF.on_collision
+    if on_placer_error is None:
+        on_placer_error = CONF.on_placer_error
 
     if raise_on_error is None:
         raise_on_error = CONF.raise_on_error
@@ -570,10 +583,17 @@ def route_bundle(
         route_constraints = list(constraints or [])
 
     try:
-        kf_on_collision = "error" if on_collision == "warning" else on_collision
-        kf_on_placer_error = (
-            "error" if on_placer_error == "warning" else on_placer_error
-        )
+        kf_on_collision = on_collision
+        if kf_on_collision == "warning":
+            kf_on_collision = "error"
+        elif kf_on_collision == "ignore":
+            kf_on_collision = None
+
+        kf_on_placer_error = on_placer_error
+        if kf_on_placer_error == "warning":
+            kf_on_placer_error = "error"
+        elif kf_on_placer_error == "ignore":
+            kf_on_placer_error = None
 
         route = kf.routing.optical.route_bundle(
             component,

--- a/tests/routing/test_route_bundle_on_error_ignore.py
+++ b/tests/routing/test_route_bundle_on_error_ignore.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import warnings
+
+import gdsfactory as gf
+from gdsfactory.typings import Step
+
+# Corners separated by only 1um, far tighter than the default bend radius (~10um).
+# With 3 corners the bends are placed but overlap each other (routing collision).
+COLLIDING_STEPS: list[Step] = [{"dx": 1}, {"dy": 1}, {"dx": 1}]
+
+# With 5 corners the placer gives up before placing anything (placer error).
+UNPLACEABLE_STEPS: list[Step] = [
+    {"dx": 1},
+    {"dy": 1},
+    {"dx": 1},
+    {"dy": 1},
+    {"dx": 1},
+]
+
+
+def _make_route_args() -> tuple[gf.Component, list[gf.Port], list[gf.Port]]:
+    """Return (component, ports1, ports2) to route with the steps above."""
+    c = gf.Component()
+    s1 = c << gf.components.straight(length=5, cross_section="strip")
+    s2 = c << gf.components.straight(length=5, cross_section="strip")
+    s2.dmove((100, 80))
+    return c, [s1.ports["o2"]], [s2.ports["o1"]]
+
+
+def _routing_warnings(records: list[warnings.WarningMessage]) -> list[str]:
+    return [str(r.message) for r in records if "Routing failed" in str(r.message)]
+
+
+def _error_marker_area(c: gf.Component) -> float:
+    """Area of the error path markers placed when a route fails."""
+    layer = gf.get_layer(gf.CONF.layer_error_path)
+    return gf.kdb.Region(c.begin_shapes_rec(layer)).area()
+
+
+def test_route_bundle_on_collision_ignore() -> None:
+    """on_collision='ignore' places the route without checking for collisions."""
+    c, ports1, ports2 = _make_route_args()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        routes = gf.routing.route_bundle(
+            c,
+            ports1,
+            ports2,
+            cross_section="strip",
+            steps=COLLIDING_STEPS,
+            on_collision="ignore",
+            raise_on_error=True,
+        )
+    assert len(routes) == 1
+    assert _routing_warnings(w) == []
+    assert _error_marker_area(c) == 0
+
+
+def test_route_bundle_on_collision_warning() -> None:
+    """on_collision='warning' warns about the same route and falls back to markers."""
+    c, ports1, ports2 = _make_route_args()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gf.routing.route_bundle(
+            c,
+            ports1,
+            ports2,
+            cross_section="strip",
+            steps=COLLIDING_STEPS,
+            on_collision="warning",
+        )
+    assert _routing_warnings(w)
+    assert _error_marker_area(c) > 0
+
+
+def test_route_bundle_on_placer_error_ignore() -> None:
+    """on_placer_error='ignore' skips the route instead of erroring on it."""
+    c, ports1, ports2 = _make_route_args()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gf.routing.route_bundle(
+            c,
+            ports1,
+            ports2,
+            cross_section="strip",
+            steps=UNPLACEABLE_STEPS,
+            # ignored as well, so that only the placer error is under test
+            on_collision="ignore",
+            on_placer_error="ignore",
+            raise_on_error=True,
+        )
+    assert _routing_warnings(w) == []
+    assert _error_marker_area(c) == 0
+
+
+def test_route_bundle_on_placer_error_warning() -> None:
+    """on_placer_error='warning' warns about the same route and falls back to markers."""
+    c, ports1, ports2 = _make_route_args()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gf.routing.route_bundle(
+            c,
+            ports1,
+            ports2,
+            cross_section="strip",
+            steps=UNPLACEABLE_STEPS,
+            on_collision="ignore",
+            on_placer_error="warning",
+        )
+    assert _routing_warnings(w)
+    assert _error_marker_area(c) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.47.0"
+version = "9.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
@@ -2891,7 +2891,7 @@ name = "manifold3d"
 version = "3.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/36/5b11c97e56d2101b1c6e311580f2546dd0d1cf0fbb167ec59e122e195ced/manifold3d-3.5.2.tar.gz", hash = "sha256:8d445798ba5f86efae18e0dca6cb71823165f0887767a274d7c14ed63ab64648", size = 305761, upload-time = "2026-06-27T05:26:54.353Z" }
 wheels = [
@@ -3784,7 +3784,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Initially I was looking at fixing some docstring items like s-bend.
Had the robot do a full docstring review and update it.

Also fixed on_collision/on_placer_error use as part of this PR.

## Test Plan

<!-- How was it tested? -->

## Summary by Sourcery

Fix route_bundle error handling and clarify its public parameter documentation.

New Features:
- Support explicit "ignore" handling for route collisions and placer errors in route_bundle.

Bug Fixes:
- Correctly preserve configured collision and placer-error behavior when options are explicitly provided.

Enhancements:
- Clarify route_bundle parameter documentation, deprecations, defaults, and routing behavior.

Tests:
- Add coverage for ignored and warning-based collision and placer-error handling.