### PR TITLE
Applying get_cross_section kwarg overrides for dict spec and kf xs

### DIFF
--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -362,7 +362,7 @@ class Pdk(BaseModel):
                     )
             cell_dict = cast("dict[str, Any]", cell)  # type: ignore[redundant-cast]
             settings = dict(cell_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
 
             cell_name = cell_dict.get("function")
             if not isinstance(cell_name, str) or cell_name not in cells_and_containers:
@@ -480,7 +480,7 @@ class Pdk(BaseModel):
                     )
             component_dict = cast("dict[str, Any]", component)  # type: ignore[redundant-cast]
             settings = dict(component_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
 
             cell_name = component_dict.get("component", None)
             cell_name = cell_name or component_dict.get("function")
@@ -523,7 +523,7 @@ class Pdk(BaseModel):
             if xs_name is None:
                 raise ValueError("cross_section name is required")
             settings = dict(xs_dict.get("settings", {}))
-            settings.update(**kwargs)
+            settings.update(kwargs)
             return self.get_cross_section(xs_name, **settings)
         if isinstance(cross_section, CrossSection):
             if kwargs:

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -556,7 +556,7 @@ class Pdk(BaseModel):
                 radius_min=kf.kcl.to_um(cross_section_.radius_min),
             )
             xs_._name = cross_section_.name
-            return xs_
+            return xs_.copy(**kwargs) if kwargs else xs_
         raise ValueError(
             "get_cross_section expects a CrossSectionSpec (CrossSection, "
             f"CrossSectionFactory, Transition, string or dict), got {type(cross_section)}"

--- a/gdsfactory/pdk.py
+++ b/gdsfactory/pdk.py
@@ -522,7 +522,8 @@ class Pdk(BaseModel):
             xs_name = xs_dict.get("cross_section", None)
             if xs_name is None:
                 raise ValueError("cross_section name is required")
-            settings = xs_dict.get("settings", {})
+            settings = dict(xs_dict.get("settings", {}))
+            settings.update(**kwargs)
             return self.get_cross_section(xs_name, **settings)
         if isinstance(cross_section, CrossSection):
             if kwargs:

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 from pathlib import Path
 
+import kfactory as kf
 import pytest
 
 import gdsfactory as gf
@@ -350,6 +351,27 @@ def test_get_cross_section_kfactory_applies_kwargs() -> None:
     assert gf.get_cross_section(kf_xs, radius=registered.radius).name == registered.name
 
 
+def test_get_cross_section_kfactory_unknown_layer_keeps_index() -> None:
+    """A SymmetricalCrossSection on an unnameable layer keeps the raw layer index."""
+    enclosure = kf.LayerEnclosure(main_layer=kf.kdb.LayerInfo(999, 999), kcl=gf.kcl)
+    sxs = kf.SymmetricalCrossSection(
+        width=1000, enclosure=enclosure, name="unnamed_layer_xs"
+    )
+
+    xs = gf.get_cross_section(sxs)
+    assert xs.name == "unnamed_layer_xs"
+    assert xs.width == 1.0
+    assert xs.layer == gf.get_layer((999, 999))
+
+
+def test_get_cross_section_invalid_spec_raises() -> None:
+    with pytest.raises(ValueError, match="cross_section name is required"):
+        gf.get_cross_section({"settings": {"width": 1}})
+
+    with pytest.raises(ValueError, match="expects a CrossSectionSpec"):
+        gf.get_cross_section(42)  # type: ignore[arg-type]
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 
@@ -360,3 +382,42 @@ def test_taper_cross_section_instance_matches_str_spec() -> None:
     t_str = gf.components.taper(width2=10, cross_section="strip")
     assert [p.width for p in t_obj.ports] == [0.5, 10.0]
     assert [p.width for p in t_str.ports] == [0.5, 10.0]
+
+
+def test_get_cell_dict_applies_kwargs() -> None:
+    """Overrides win over the dict spec's own settings."""
+    spec = {"function": "straight", "settings": {"length": 5}}
+    assert gf.get_cell(spec)().settings.length == 5
+    assert gf.get_cell(spec, length=20)().settings.length == 20
+    # the override does not write back into spec["settings"]
+    assert spec == {"function": "straight", "settings": {"length": 5}}
+
+    with pytest.raises(ValueError, match="Invalid setting 'bogus'"):
+        gf.get_cell({"function": "straight", "bogus": 1})
+
+    # get_cell only reads "function", so a "component" key resolves to nothing
+    with pytest.raises(ValueError, match="not in cells"):
+        gf.get_cell({"component": "straight"})
+
+
+def test_get_component_dict_applies_kwargs() -> None:
+    """Kwargs beat the dict spec's settings, and the settings argument beats kwargs."""
+    spec = {"component": "straight", "settings": {"length": 5}}
+    assert gf.get_component(spec).settings.length == 5
+    assert gf.get_component(spec, length=20).settings.length == 20
+    assert (
+        gf.get_component(spec, settings={"length": 7}, length=20).settings.length == 7
+    )
+    # the override does not write back into spec["settings"]
+    assert spec == {"component": "straight", "settings": {"length": 5}}
+
+    # a serialized "function" keeps only the last part of the dotted path
+    dotted = {"function": "gdsfactory.components.straight", "settings": {"length": 3}}
+    assert gf.get_component(dotted, length=9).settings.length == 9
+
+    with pytest.raises(ValueError, match="Invalid setting 'bogus'"):
+        gf.get_component({"component": "straight", "bogus": 1})
+
+    # neither "component" nor "function" is given
+    with pytest.raises(ValueError, match=r"'None'.*not in cells"):
+        gf.get_component({"settings": {"length": 1}})

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -337,6 +337,19 @@ def test_get_cross_section_dict_applies_kwargs() -> None:
     assert spec == {"cross_section": "strip", "settings": {"width": 1}}
 
 
+def test_get_cross_section_kfactory_applies_kwargs() -> None:
+    """A kfactory cross_section takes overrides like every other spec does."""
+    kf_xs = gf.components.straight().ports[0].cross_section
+    registered = gf.get_cross_section(kf_xs)
+
+    # the kfactory name describes the original, so an override cannot keep it
+    assert gf.get_cross_section(kf_xs, width=2.0).width == 2.0
+    assert gf.get_cross_section(kf_xs, width=2.0).name != registered.name
+
+    # an override that changes nothing leaves the name alone
+    assert gf.get_cross_section(kf_xs, radius=registered.radius).name == registered.name
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -327,6 +327,16 @@ def test_get_cross_section_instance_applies_kwargs() -> None:
     assert gf.get_cross_section(xs) is xs
 
 
+def test_get_cross_section_dict_applies_kwargs() -> None:
+    """Overrides win over the dict spec's own settings."""
+    spec = {"cross_section": "strip", "settings": {"width": 1}}
+    assert gf.get_cross_section(spec).width == 1
+    assert gf.get_cross_section(spec, width=3.0).width == 3.0
+    assert gf.get_cross_section(spec, radius=20).radius == 20
+    # the override does not write back into spec["settings"]
+    assert spec == {"cross_section": "strip", "settings": {"width": 1}}
+
+
 def test_taper_cross_section_instance_matches_str_spec() -> None:
     """Taper with a resolved CrossSection tapers like the string spec (#4588).
 


### PR DESCRIPTION
## Summary

What it says in the title. I'm pulling this out from the WIP PR since I need it sooner and it's ready to be merged.

## Test Plan

Unit tests

## Summary by Sourcery

Ensure get_cross_section and related specification resolvers honor caller-provided keyword overrides consistently.

Bug Fixes:
- Apply keyword argument overrides consistently to dictionary-based cell, component, and cross-section specifications, including kfactory cross-sections.

Enhancements:
- Preserve cross-section metadata and avoid mutating input specification settings when applying overrides.
- Expand unit coverage for specification overrides, kfactory cross-sections, invalid inputs, and layer handling.

Tests:
- Add unit tests covering dictionary and kfactory cross-section overrides plus cell and component specification behavior.