### PR TITLE
Follow KLayout's order for Path transformations

### DIFF
--- a/gdsfactory/path.py
+++ b/gdsfactory/path.py
@@ -184,6 +184,14 @@ class Path(UMGeometricObject):
         trans: kdb.Trans | kdb.DTrans | kdb.ICplxTrans | kdb.DCplxTrans,
         /,
     ) -> Any:
+        """Transforms the Path in place.
+
+        Applies a transformation as a magnification, then a mirroring at
+        the x-axis, then a rotation, then a displacement, following KLayout.
+
+        Args:
+            trans: the transformation to apply.
+        """
         if isinstance(trans, kdb.DCplxTrans):
             trans_ = trans
         elif isinstance(trans, kdb.DTrans):
@@ -193,7 +201,13 @@ class Path(UMGeometricObject):
         else:
             trans_ = trans.to_itrans(gf.kcl.dbu)
 
-        new_points = self.points
+        new_points = np.asarray(self.points, dtype=np.float64)
+
+        if trans_.mag != 1:
+            new_points = new_points * trans_.mag
+
+        if trans_.mirror:
+            new_points = new_points * np.array([1.0, -1.0])
 
         if trans_.angle != 0:
             angle_rad = np.radians(trans_.angle)
@@ -206,19 +220,14 @@ class Path(UMGeometricObject):
                     [-sin_angle, cos_angle],
                 ]
             )
-            new_points = np.dot(self.points, rotation_matrix)
+            new_points = np.dot(new_points, rotation_matrix)
 
         new_points = new_points + np.array([trans_.disp.x, trans_.disp.y])
 
-        if trans_.mirror:
-            new_points[:, 1] = -new_points[:, 1]
-
         self.points = new_points
-        if len(self.points) > 1:
-            nx1, ny1 = self.points[1] - self.points[0]
-            self.start_angle = np.arctan2(ny1, nx1) / np.pi * 180
-            nx2, ny2 = self.points[-1] - self.points[-2]
-            self.end_angle = np.arctan2(ny2, nx2) / np.pi * 180
+        sign = -1 if trans_.mirror else 1
+        self.start_angle = mod(sign * self.start_angle + trans_.angle, 360)
+        self.end_angle = mod(sign * self.end_angle + trans_.angle, 360)
 
     def dbbox(self, layer: int | None = None) -> kdb.DBox:
         return kdb.DBox(*self.bbox_np().flatten())

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -464,6 +464,61 @@ def test_path_transform_icplx() -> None:
     assert gf.path.Path().kcl is gf.kcl
 
 
+@pytest.mark.parametrize(
+    "trans",
+    [
+        kdb.DCplxTrans(3, 4),
+        kdb.DCplxTrans(1, 45, False, 0, 0),
+        kdb.DCplxTrans(1, 0, True, 0, 10),  # what mirror_y(5) builds
+        kdb.DCplxTrans(1, 180, True, 8, 0),  # what mirror_x(4) builds
+        kdb.DCplxTrans(1, 90, True, 5, 7),
+        kdb.DCplxTrans(1, 30, True, -2, 3),
+        kdb.DCplxTrans(2.0, 0, False, 0, 0),
+        kdb.DCplxTrans(1.5, 45, True, 1, -1),
+    ],
+)
+def test_path_transform_matches_klayout(trans: kdb.DCplxTrans) -> None:
+    """Path.transform must compose the transformation the way KLayout does.
+
+    KLayout applies magnification, then mirroring at the x-axis, then rotation,
+    then displacement. Applying the mirror last instead negates the displacement,
+    which makes mirror_y(y) reflect about y = -y.
+    """
+    points = [(0.0, 0.0), (3.0, 0.0), (3.0, 1.0)]
+    path = Path(points)
+    path.transform(trans)
+    expected = np.array(
+        [(p.x, p.y) for p in (trans.trans(kdb.DPoint(*xy)) for xy in points)]
+    )
+    np.testing.assert_allclose(path.points, expected, atol=1e-12)
+
+
+def test_path_transform_keeps_analytic_angles() -> None:
+    """Transform must carry the analytic tangents, not re-derive chord angles."""
+    path = gf.path.euler(radius=10, angle=90)
+    assert (path.start_angle, path.end_angle) == (0, 90)
+
+    # the endpoint chord of the discretized curve is not the tangent, so a chord
+    # based angle would drift away from the exact values below
+    chord = np.degrees(np.arctan2(*(path.points[1] - path.points[0])[::-1]))
+    assert abs(chord) > 1e-6
+
+    moved = path.copy()
+    moved.move((5, 5))
+    assert moved.start_angle == pytest.approx(0, abs=1e-9)
+    assert moved.end_angle == pytest.approx(90, abs=1e-9)
+
+    rotated = path.copy()
+    rotated.rotate(30)
+    assert rotated.start_angle == pytest.approx(30, abs=1e-9)
+    assert rotated.end_angle == pytest.approx(120, abs=1e-9)
+
+    mirrored = path.copy()
+    mirrored.mirror_y(3)
+    assert mirrored.start_angle == pytest.approx(0, abs=1e-9)
+    assert mirrored.end_angle == pytest.approx(270, abs=1e-9)
+
+
 def test_path_smooth() -> None:
     points = np.array([(-50, 50), (-100, 100), (-100, 200)])
 


### PR DESCRIPTION
## Summary

Magnification, then mirroring at the x-axis, then rotation, then displacement.

Also ends up fixing a few more bugs (e.g. missing mag, R+M =/= M+R) and improvements (e.g. analytical angles)

## Test Plan

🤖 🤖 🤖

## Summary by Sourcery

Align Path transformation behavior with KLayout and preserve accurate tangent angles.

Bug Fixes:
- Apply Path transformations in KLayout’s order so magnification, mirroring, rotation, and displacement compose correctly.
- Preserve analytic start and end tangent angles through Path transformations.

Tests:
- Add coverage comparing Path transformations with KLayout and validating analytic tangent-angle preservation.