### PR TITLE
docs: restore round corners notebook plots

### DIFF
--- a/docs/notebooks/04_components_geometry.ipynb
+++ b/docs/notebooks/04_components_geometry.ipynb
@@ -374,8 +374,8 @@
     "\n",
     "# Round corners for one layer only.\n",
     "for p in c.get_polygons()[LAYER.WG]:\n",
-    "    p_round = p.round_corners(rinner, router, n)\n",
-    "    c2.add_polygon(p_round, layer=LAYER.WG)\n",
+    "    p_round = p.to_simple_polygon().round_corners(rinner, router, n)\n",
+    "    c2.add_polygon(list(p_round.each_point()), layer=LAYER.WG)\n",
     "\n",
     "c2"
    ]
@@ -399,8 +399,8 @@
     "# Round corners for all layers.\n",
     "for layer, polygons in c.get_polygons().items():\n",
     "    for p in polygons:\n",
-    "        p_round = p.round_corners(rinner, router, n)\n",
-    "        c2.add_polygon(p_round, layer=layer)\n",
+    "        p_round = p.to_simple_polygon().round_corners(rinner, router, n)\n",
+    "        c2.add_polygon(list(p_round.each_point()), layer=layer)\n",
     "\n",
     "c2"
    ]


### PR DESCRIPTION
## Summary
- fix the round-corners examples for current KLayout polygon types
- restore both rendered round-corners plots during docs builds

## Verification
- `uv run --extra docs jupyter nbconvert --execute --to markdown --embed-images --ExecutePreprocessor.timeout=600 docs/notebooks/04_components_geometry.ipynb --output-dir /tmp/gdsfactory-nbdocs`
- confirmed generated images for notebook cells 28 and 29

## Summary by Sourcery

Restore working round-corners examples and their rendered plots in the geometry documentation notebook.

Bug Fixes:
- Fix the round-corners notebook examples for current KLayout polygon types and restore rendering of both round-corners plots during documentation builds.

Documentation:
- Update the geometry notebook to support round-corner examples for both single-layer and multi-layer polygons.


Before
<img width="2068" height="1276" alt="image" src="https://github.com/user-attachments/assets/9b25d40e-4b1d-4719-8f3a-d18b02f00c87" />


after
<img width="417" height="520" alt="image" src="https://github.com/user-attachments/assets/10dfcfc1-85e0-4bb2-b9a2-d0af7bfb5214" />
