### PR TITLE
fix: validate zero-width cross-section copy overrides

### DIFF
--- a/gdsfactory/cross_section/base.py
+++ b/gdsfactory/cross_section/base.py
@@ -311,19 +311,26 @@ class CrossSection(BaseModel):
 
         xs_original = self
 
-        if width_function or offset_function or width or layer or sections:
+        if (
+            width_function
+            or offset_function
+            or width is not None
+            or layer is not None
+            or sections is not None
+        ):
             if sections is None:
                 section_list = list(self.sections)
             else:
                 section_list = list(sections)
 
             section_list = [s.model_copy() for s in section_list]
-            section_list[0] = section_list[0].model_copy(
-                update={
+            section_list[0] = Section.model_validate(
+                {
+                    **section_list[0].model_dump(),
                     "width_function": width_function,
                     "offset_function": offset_function,
-                    "width": width or self.width,
-                    "layer": layer or self.layer,
+                    "width": width if width is not None else self.width,
+                    "layer": layer if layer is not None else self.layer,
                 }
             )
             xs = self.model_copy(update={"sections": tuple(section_list), **kwargs})

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -89,6 +89,9 @@ def test_copy() -> None:
     xs2 = xs1.copy(width=10)
     assert xs2.name == xs1.name, f"{xs2.name} != {xs1.name}"
 
+    with pytest.raises(ValueError, match=r"width > 0"):
+        xs1.copy(width=0)
+
 
 def test_name() -> None:
     s = gf.cross_section.strip()


### PR DESCRIPTION
## Summary
- handle explicit falsy width and layer overrides in `CrossSection.copy`
- validate the rebuilt section so invalid `width=0` raises `ValueError`
- add a regression test for zero-width copy overrides

## Test plan
- `uv run pytest tests/test_cross_section.py tests/test_pdk.py -q`
- `uv run ruff check gdsfactory/cross_section/base.py tests/test_cross_section.py`

Follow-up to #4794: this fixes the existing `CrossSection.copy` behavior that its new kfactory override path would exercise.

## Summary by Sourcery

Validate cross-section copies while correctly applying explicit width and layer overrides.

Bug Fixes:
- Preserve explicit falsy cross-section copy overrides and reject invalid zero-width sections with a ValueError.

Tests:
- Add regression coverage for zero-width cross-section copy overrides.