### PR TITLE
Fix to_gerber so a GDSFactory layout actually reaches PCB CAM

### DIFF
--- a/.changelog.d/4748.fixed.md
+++ b/.changelog.d/4748.fixed.md
@@ -1,0 +1,3 @@
+Fix Gerber export: use tuple layer keys, emit a spec-compliant `%FS` command, and write numpy polygon vertices.
+
+Fixes #4748.

--- a/.changelog.d/4748.fixed.md
+++ b/.changelog.d/4748.fixed.md
@@ -1,3 +1,1 @@
-Fix Gerber export: use tuple layer keys, emit a spec-compliant `%FS` command, and write numpy polygon vertices.
-
-Fixes #4748.
+Fix Gerber export (#4748) and emit a Ucamco `.gbrjob` so PIC layouts in um can be handed to RF/PCB CAM in mm.

--- a/gdsfactory/export/__init__.py
+++ b/gdsfactory/export/__init__.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
 from gdsfactory.export.to_3d import to_3d
-from gdsfactory.export.to_gerber import to_gerber
+from gdsfactory.export.to_gerber import (
+    BoardOptions,
+    GerberLayer,
+    GerberOptions,
+    to_gerber,
+)
 from gdsfactory.export.to_np import to_np
 from gdsfactory.export.to_stl import to_stl
 
-__all__ = ("to_3d", "to_gerber", "to_np", "to_stl")
+__all__ = (
+    "BoardOptions",
+    "GerberLayer",
+    "GerberOptions",
+    "to_3d",
+    "to_gerber",
+    "to_np",
+    "to_stl",
+)

--- a/gdsfactory/export/to_gerber.py
+++ b/gdsfactory/export/to_gerber.py
@@ -7,13 +7,20 @@ See Also:
 - https://github.com/jamesbowman/cuflow/blob/master/gerber.py
 """
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field
+import numpy as np
+import numpy.typing as npt
+from pydantic import BaseModel
 
 from gdsfactory import Component
 from gdsfactory.typings import Size
+
+PolygonPoints = Sequence[Sequence[float]] | npt.NDArray[np.floating]
 
 
 class GerberLayer(BaseModel):
@@ -38,53 +45,105 @@ class BoardOptions(BaseModel):
 resolutions = {1e-3: 3, 1e-4: 4, 1e-5: 5, 1e-6: 6}
 
 
-def number(n: float) -> str:
-    """Formats a floating-point number by scaling it to an integer (multiplied by 10,000).
-
-    Rounding to the nearest integer, and zero-padding it to 7 characters.
+def decimal_digits(resolution: float) -> int:
+    """Return Gerber decimal digits for a linear resolution.
 
     Args:
-        n (float): The input floating-point number.
+        resolution: smallest distance represented in the file, in file units.
 
     Returns:
-        str: The formatted string.
+        Number of decimal digits in the `%FS` command.
+
+    Raises:
+        ValueError: If `resolution` is not one of the supported values.
     """
-    scaled_value = round(n * 10000)
-    return f"{scaled_value:07d}"
+    if resolution not in resolutions:
+        supported = ", ".join(str(value) for value in sorted(resolutions, reverse=True))
+        raise ValueError(
+            f"Unsupported Gerber resolution {resolution}. Supported values: {supported}."
+        )
+    return resolutions[resolution]
 
 
-def points(pp: list[tuple[float, float]]) -> str:
-    if not pp:
+def format_specification(int_size: int, digits: int) -> str:
+    """Return a spec-compliant Gerber `%FS` command.
+
+    Ucamco FS is `%FSLAX<int><dec>Y<int><dec>*%` (leading zeros omitted, absolute).
+    """
+    return f"%FSLAX{int_size}{digits}Y{int_size}{digits}*%\n"
+
+
+def number(n: float, decimal_digits: int = 4) -> str:
+    """Format a coordinate for Gerber using the `%FS` decimal count.
+
+    Leading zeros are omitted (`L` in `%FSLA`). The scale is `10 ** decimal_digits`
+    so coordinates match the format specifier instead of a hardcoded 10_000.
+
+    Args:
+        n: Coordinate in the same unit as `%MO` (typically Component user units).
+        decimal_digits: Decimal digits from the `%FS` command.
+
+    Returns:
+        Digit string without a unit prefix, including a leading `-` when negative.
+    """
+    scaled_value = round(n * 10**decimal_digits)
+    sign = "-" if scaled_value < 0 else ""
+    return f"{sign}{abs(scaled_value)}"
+
+
+def _as_xy(pp: PolygonPoints) -> list[tuple[float, float]]:
+    """Normalize polygon vertices to a list of float pairs.
+
+    `Component.get_polygons_points()` returns numpy arrays. Gerber helpers used
+    to iterate them as if they were Python lists of tuples, which raises.
+    """
+    arr = np.asarray(pp, dtype=float)
+    if arr.ndim != 2 or arr.shape[-1] != 2:
+        raise ValueError(f"Expected Nx2 point array, got shape {arr.shape}")
+    return [(float(x), float(y)) for x, y in arr]
+
+
+def points(pp: PolygonPoints, decimal_digits: int = 4) -> str:
+    xy = _as_xy(pp)
+    if not xy:
         return ""
-    # Use a list to collect the formatted strings for better performance
-    parts = []
-    # First point uses D02
-    x0, y0 = pp[0]
-    parts.append(f"X{number(x0)}Y{number(y0)}D02*\n")
-    # Rest use D01 (if any)
-    if len(pp) > 1:
-        for x, y in pp[1:]:
-            parts.append(f"X{number(x)}Y{number(y)}D01*\n")
+    first_x, first_y = xy[0]
+    parts = [
+        f"X{number(first_x, decimal_digits)}Y{number(first_y, decimal_digits)}D02*\n"
+    ]
+    parts.extend(
+        f"X{number(x, decimal_digits)}Y{number(y, decimal_digits)}D01*\n"
+        for x, y in xy[1:]
+    )
     return "".join(parts)
 
 
-def rect(x0: float, y0: float, x1: float, y1: float) -> str:
-    return "D10*\n" + points([(x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0)])
+def rect(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    decimal_digits: int = 4,
+) -> str:
+    return "D10*\n" + points(
+        [(x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0)],
+        decimal_digits=decimal_digits,
+    )
 
 
-def linestring(pp: list[tuple[float, float]]) -> str:
-    return "D10*\n" + points(pp)
+def linestring(pp: PolygonPoints, decimal_digits: int = 4) -> str:
+    return "D10*\n" + points(pp, decimal_digits=decimal_digits)
 
 
-def polygon(pp: list[tuple[float, float]]) -> str:
-    return "G36*\n" + points(pp) + "G37*\n\n"  # fixed to have only one newline at end
+def polygon(pp: PolygonPoints, decimal_digits: int = 4) -> str:
+    return "G36*\n" + points(pp, decimal_digits=decimal_digits) + "G37*\n\n"
 
 
 def to_gerber(
     component: Component,
     dirpath: Path,
     layermap_to_gerber_layer: dict[tuple[int, int], GerberLayer],
-    options: GerberOptions = Field(default_factory=GerberOptions),
+    options: GerberOptions | None = None,
 ) -> None:
     """Writes each layer to a different Gerber file.
 
@@ -98,41 +157,39 @@ def to_gerber(
             resolution: float = 1e-6
             int_size: int = 4
     """
-    # Each layer and a list of the polygons (as lists of points) on that layer
-    layer_to_polygons = component.get_polygons_points()
+    options = options or GerberOptions()
+    dirpath = Path(dirpath)
+    dirpath.mkdir(parents=True, exist_ok=True)
+    digits = decimal_digits(options.resolution)
+
+    # Keys must match layermap tuples. Default `by="index"` uses klayout layer
+    # indexes, so exported layers silently wrote empty files (#4748).
+    layer_to_polygons = component.get_polygons_points(by="tuple")
 
     for layer_tup, layer in layermap_to_gerber_layer.items():
         filename = (dirpath / layer.name.replace(" ", "_")).with_suffix(".gbr")
 
-        with open(filename, "w+") as f:
+        with open(filename, "w") as f:
             header = options.header or [
                 "Gerber file generated by gdsfactory",
                 f"Component: {component.name}",
             ]
 
-            # Write file spec info
             f.write("%TF.FileFunction," + ",".join(layer.function) + "*%\n")
             f.write(f"%TF.FilePolarity,{layer.polarity}*%\n")
-
-            digits = resolutions[options.resolution]
-            f.write(f"%FSLA{options.int_size}{digits}Y{options.int_size}{digits}X*%\n")
-
-            # Write header comments
+            f.write(format_specification(options.int_size, digits))
             f.writelines([f"G04 {line}*\n" for line in header])
 
-            # Setup units/mode
             units = options.mode.upper()
             f.write(f"%MO{units}*%\n")
-            f.write("%LPD*%")
-
+            f.write("%LPD*%\n")
             f.write("G01*\n")
-
-            # Aperture definition
             f.write("%ADD10C,0.050000*%\n")
 
-            # Only supports polygons for now
             if layer_tup in layer_to_polygons:
-                f.writelines(polygon(poly) for poly in layer_to_polygons[layer_tup])  # type: ignore[arg-type]
+                f.writelines(
+                    polygon(poly, decimal_digits=digits)
+                    for poly in layer_to_polygons[layer_tup]
+                )
 
-            # File end
             f.write("M02*\n")

--- a/gdsfactory/export/to_gerber.py
+++ b/gdsfactory/export/to_gerber.py
@@ -1,6 +1,12 @@
-"""Based on Gerber file spec.
+"""Gerber X2 export for handing a GDSFactory layout to RF/PCB CAM.
 
-https://www.ucamco.com/files/downloads/file_en/456/gerber-layer-format-specification-revision-2022-02_en.pdf.
+GDSFactory coordinates are um. Ucamco Gerber `%MO` is mm or inches. This
+exporter converts layout units into file units, writes one `.gbr` per layer,
+and emits the `.gbrjob` JSON the unused `BoardOptions` stub was meant for
+(Ucamco Gerber Job File, revision 2020.08; partial jobs are allowed).
+
+Spec: https://www.ucamco.com/files/downloads/file_en/456/gerber-layer-format-specification-revision-2022-02_en.pdf
+Job:  https://www.ucamco.com/en/gerber/gerber-job-file
 
 See Also:
 - https://github.com/opiopan/pcb-tools-extension
@@ -9,7 +15,9 @@ See Also:
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
@@ -18,9 +26,14 @@ import numpy.typing as npt
 from pydantic import BaseModel
 
 from gdsfactory import Component
-from gdsfactory.typings import Size
+from gdsfactory.config import __version__
+from gdsfactory.typings import LayerSpec, Size
 
 PolygonPoints = Sequence[Sequence[float]] | npt.NDArray[np.floating]
+LayoutUnit = Literal["um", "mm", "in"]
+
+# Millimetres per layout/file unit. Job-file Size is always mm (Ucamco).
+_MM = {"um": 1e-3, "mm": 1.0, "in": 25.4}
 
 
 class GerberLayer(BaseModel):
@@ -32,14 +45,16 @@ class GerberLayer(BaseModel):
 class GerberOptions(BaseModel):
     header: list[str] | None = None
     mode: Literal["mm", "in"] = "mm"
+    layout_unit: LayoutUnit = "um"
     resolution: float = 1e-6
     int_size: int = 4
 
 
-# For generating a gerber job json file
 class BoardOptions(BaseModel):
+    """Ucamco job-file extras. Size is millimetres; omit to use the bbox."""
+
     size: Size | None = None
-    n_layers: int = 2
+    n_layers: int | None = None
 
 
 resolutions = {1e-3: 3, 1e-4: 4, 1e-5: 5, 1e-6: 6}
@@ -73,6 +88,11 @@ def format_specification(int_size: int, digits: int) -> str:
     return f"%FSLAX{int_size}{digits}Y{int_size}{digits}*%\n"
 
 
+def file_unit_scale(layout_unit: LayoutUnit, mode: Literal["mm", "in"]) -> float:
+    """Scale from Component user units into Gerber `%MO` units."""
+    return _MM[layout_unit] / _MM[mode]
+
+
 def number(n: float, decimal_digits: int = 4) -> str:
     """Format a coordinate for Gerber using the `%FS` decimal count.
 
@@ -80,7 +100,7 @@ def number(n: float, decimal_digits: int = 4) -> str:
     so coordinates match the format specifier instead of a hardcoded 10_000.
 
     Args:
-        n: Coordinate in the same unit as `%MO` (typically Component user units).
+        n: Coordinate in `%MO` file units.
         decimal_digits: Decimal digits from the `%FS` command.
 
     Returns:
@@ -136,38 +156,116 @@ def linestring(pp: PolygonPoints, decimal_digits: int = 4) -> str:
 
 
 def polygon(pp: PolygonPoints, decimal_digits: int = 4) -> str:
-    return "G36*\n" + points(pp, decimal_digits=decimal_digits) + "G37*\n\n"
+    xy = _as_xy(pp)
+    if xy and xy[0] != xy[-1]:
+        xy.append(xy[0])
+    return "G36*\n" + points(xy, decimal_digits=decimal_digits) + "G37*\n\n"
+
+
+def _job_file(
+    component: Component,
+    gerber_files: list[tuple[str, GerberLayer]],
+    options: GerberOptions,
+    board: BoardOptions | None,
+) -> dict[str, object]:
+    """Minimal CAD job file: size, layer count, file attributes (Ucamco §3.1)."""
+    board = board or BoardOptions()
+    to_mm = _MM[options.layout_unit]
+    size = board.size or (component.xsize * to_mm, component.ysize * to_mm)
+    copper_layers = [
+        layer
+        for _, layer in gerber_files
+        if layer.function and layer.function[0].lower() == "copper"
+    ]
+    layer_number = board.n_layers or max(len(copper_layers), 1)
+    return {
+        "Header": {
+            "GenerationSoftware": {
+                "Vendor": "gdsfactory",
+                "Application": "gdsfactory",
+                "Version": __version__,
+            },
+            "CreationDate": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        },
+        "GeneralSpecs": {
+            "Part": "Single",
+            "ProjectId": {"Name": component.name or "gdsfactory"},
+            "Size": {"X": float(size[0]), "Y": float(size[1])},
+            "LayerNumber": layer_number,
+        },
+        "FilesAttributes": [
+            {
+                "Path": filename,
+                "FileFunction": ",".join(layer.function),
+                "FilePolarity": layer.polarity,
+                "FileFormat": "Gerber",
+            }
+            for filename, layer in gerber_files
+        ],
+    }
 
 
 def to_gerber(
     component: Component,
     dirpath: Path,
-    layermap_to_gerber_layer: dict[tuple[int, int], GerberLayer],
+    layermap_to_gerber_layer: dict[LayerSpec, GerberLayer],
     options: GerberOptions | None = None,
-) -> None:
-    """Writes each layer to a different Gerber file.
+    board: BoardOptions | None = None,
+    write_job: bool = True,
+) -> list[Path]:
+    """Write each layer to a Gerber file and an optional Ucamco `.gbrjob`.
+
+    Layout units default to um. File units default to mm, so a 100 um pad is
+    0.1 mm on the board rather than 100 mm. Pass `layout_unit="mm"` if the
+    Component is already in millimetres.
 
     Args:
         component: to export.
         dirpath: directory path.
         layermap_to_gerber_layer: map of GDS layer to GerberLayer.
-        options: to save.
-            header: List[str] | None = None
-            mode: Literal["mm", "in"] = "mm"
-            resolution: float = 1e-6
-            int_size: int = 4
+        options: Gerber image options (`mode`, `layout_unit`, `resolution`).
+        board: optional job-file size (mm) and copper layer count.
+        write_job: write `<component>.gbrjob` next to the image files.
+
+    Returns:
+        Paths of files written, job file last when `write_job` is true.
+
+    Example:
+        import gdsfactory as gf
+        from gdsfactory.export.to_gerber import GerberLayer, to_gerber
+        from gdsfactory.gpdk import LAYER
+
+        c = gf.components.pad()
+        to_gerber(
+            c,
+            dirpath="gerber",
+            layermap_to_gerber_layer={
+                LAYER.MTOP: GerberLayer(
+                    name="F_Cu",
+                    function=["Copper", "L1", "Top"],
+                    polarity="Positive",
+                )
+            },
+        )
     """
+    from gdsfactory.pdk import get_layer_tuple
+
     options = options or GerberOptions()
     dirpath = Path(dirpath)
     dirpath.mkdir(parents=True, exist_ok=True)
     digits = decimal_digits(options.resolution)
+    scale = file_unit_scale(options.layout_unit, options.mode)
 
     # Keys must match layermap tuples. Default `by="index"` uses klayout layer
     # indexes, so exported layers silently wrote empty files (#4748).
     layer_to_polygons = component.get_polygons_points(by="tuple")
+    written: list[Path] = []
+    job_files: list[tuple[str, GerberLayer]] = []
 
-    for layer_tup, layer in layermap_to_gerber_layer.items():
+    for layer_spec, layer in layermap_to_gerber_layer.items():
+        layer_tup = get_layer_tuple(layer_spec)
         filename = (dirpath / layer.name.replace(" ", "_")).with_suffix(".gbr")
+        job_files.append((filename.name, layer))
 
         with open(filename, "w") as f:
             header = options.header or [
@@ -177,6 +275,7 @@ def to_gerber(
 
             f.write("%TF.FileFunction," + ",".join(layer.function) + "*%\n")
             f.write(f"%TF.FilePolarity,{layer.polarity}*%\n")
+            f.write(f"%TF.GenerationSoftware,gdsfactory,gdsfactory,{__version__}*%\n")
             f.write(format_specification(options.int_size, digits))
             f.writelines([f"G04 {line}*\n" for line in header])
 
@@ -188,8 +287,20 @@ def to_gerber(
 
             if layer_tup in layer_to_polygons:
                 f.writelines(
-                    polygon(poly, decimal_digits=digits)
+                    polygon(
+                        np.asarray(poly, dtype=float) * scale, decimal_digits=digits
+                    )
                     for poly in layer_to_polygons[layer_tup]
                 )
 
             f.write("M02*\n")
+        written.append(filename)
+
+    if write_job:
+        job_path = dirpath / f"{component.name or 'gdsfactory'}.gbrjob"
+        job_path.write_text(
+            json.dumps(_job_file(component, job_files, options, board), indent=2) + "\n"
+        )
+        written.append(job_path)
+
+    return written

--- a/gdsfactory/export/to_gerber.py
+++ b/gdsfactory/export/to_gerber.py
@@ -162,6 +162,16 @@ def polygon(pp: PolygonPoints, decimal_digits: int = 4) -> str:
     return "G36*\n" + points(xy, decimal_digits=decimal_digits) + "G37*\n\n"
 
 
+def _gerber_filename(name: str) -> str:
+    """Return the `.gbr` filename for a Gerber layer name.
+
+    `Path.with_suffix` reads a dotted stackup name like `L1.2 signal` as having
+    suffix `.2 signal` and rewrites it to `L1.gbr`, so `L1.2` and `L1.3` would
+    both land on `L1.gbr` and one layer would overwrite the other.
+    """
+    return f"{name.replace(' ', '_')}.gbr"
+
+
 def _job_file(
     component: Component,
     gerber_files: list[tuple[str, GerberLayer]],
@@ -262,9 +272,18 @@ def to_gerber(
     written: list[Path] = []
     job_files: list[tuple[str, GerberLayer]] = []
 
+    names_seen: dict[str, str] = {}
+
     for layer_spec, layer in layermap_to_gerber_layer.items():
         layer_tup = get_layer_tuple(layer_spec)
-        filename = (dirpath / layer.name.replace(" ", "_")).with_suffix(".gbr")
+        name = _gerber_filename(layer.name)
+        if name in names_seen:
+            raise ValueError(
+                f"Gerber layers {names_seen[name]!r} and {layer.name!r} both map to "
+                f"{name!r}. Layer names must produce distinct filenames."
+            )
+        names_seen[name] = layer.name
+        filename = dirpath / name
         job_files.append((filename.name, layer))
 
         with open(filename, "w") as f:

--- a/gdsfactory/export/to_gerber.py
+++ b/gdsfactory/export/to_gerber.py
@@ -226,8 +226,8 @@ def to_gerber(
     """Write each layer to a Gerber file and an optional Ucamco `.gbrjob`.
 
     Layout units default to um. File units default to mm, so a 100 um pad is
-    0.1 mm on the board rather than 100 mm. Pass `layout_unit="mm"` if the
-    Component is already in millimetres.
+    0.1 mm on the board. Pass `layout_unit="mm"` if the Component is already
+    in millimetres.
 
     Args:
         component: to export.

--- a/tests/export/test_to_gerber.py
+++ b/tests/export/test_to_gerber.py
@@ -1,0 +1,109 @@
+"""Tests for Gerber export.
+
+Covers the three failures in https://github.com/gdsfactory/gdsfactory/issues/4748:
+layer-key lookup, `%FS` command order, and numpy polygon vertices.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import gdsfactory as gf
+from gdsfactory.export.to_gerber import (
+    GerberLayer,
+    GerberOptions,
+    decimal_digits,
+    format_specification,
+    number,
+    polygon,
+    to_gerber,
+)
+
+LAYER = (1, 0)
+GERBER_LAYER = GerberLayer(
+    name="F_Cu",
+    function=["Copper", "L1", "Top"],
+    polarity="Positive",
+)
+
+
+def _rectangle() -> gf.Component:
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER)
+    return component
+
+
+def test_format_specification_matches_ucamco() -> None:
+    """Issue 4748 bug 2: `%FSLA46Y46X*%` is invalid; `%FSLAX46Y46*%` is not."""
+    assert format_specification(4, 6) == "%FSLAX46Y46*%\n"
+    assert "Y46X" not in format_specification(4, 6)
+
+
+def test_number_scale_matches_format_specification() -> None:
+    """Coordinate encoding must use 10**decimal_digits, not a hardcoded 10_000."""
+    assert number(10.0, decimal_digits=4) == "100000"
+    assert number(10.0, decimal_digits=6) == "10000000"
+    assert number(-1.5, decimal_digits=4) == "-15000"
+
+
+def test_polygon_accepts_numpy_vertices() -> None:
+    """Issue 4748 bug 3: get_polygons_points() returns Nx2 numpy arrays."""
+    verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    text = polygon(verts, decimal_digits=4)
+    assert text.startswith("G36*")
+    assert "X0Y0D02*" in text
+    assert "X10000Y0D01*" in text
+    assert text.endswith("G37*\n\n")
+
+
+def test_decimal_digits_rejects_unknown_resolution() -> None:
+    with pytest.raises(ValueError, match="Unsupported Gerber resolution"):
+        decimal_digits(1e-9)
+
+
+def test_to_gerber_writes_spec_compliant_file(tmp_path: Path) -> None:
+    """End-to-end: polygons are emitted, `%FS` is valid, file terminates."""
+    to_gerber(
+        _rectangle(),
+        tmp_path,
+        {LAYER: GERBER_LAYER},
+        options=GerberOptions(resolution=1e-6, int_size=4),
+    )
+    path = tmp_path / "F_Cu.gbr"
+    assert path.exists()
+    text = path.read_text()
+
+    assert "%FSLAX46Y46*%" in text
+    assert "%FSLA46Y46X*%" not in text
+    assert text.count("%LPD*%\n") == 1
+    assert "%MOMM*%" in text
+    assert "G36*" in text
+    assert "G37*" in text
+    # 10 um (user units) at 6 decimal digits → X10000000
+    assert "X0Y0D02*" in text
+    assert "X10000000Y0D01*" in text
+    assert "X10000000Y5000000D01*" in text
+    assert text.rstrip().endswith("M02*")
+
+
+def test_to_gerber_uses_tuple_layer_keys(tmp_path: Path) -> None:
+    """Issue 4748 bug 1: default by='index' misses tuple layermap keys."""
+    component = _rectangle()
+    by_index = component.get_polygons_points()
+    by_tuple = component.get_polygons_points(by="tuple")
+    assert LAYER not in by_index
+    assert LAYER in by_tuple
+    assert len(by_tuple[LAYER]) == 1
+
+    to_gerber(component, tmp_path, {LAYER: GERBER_LAYER})
+    text = (tmp_path / "F_Cu.gbr").read_text()
+    assert "G36*" in text, (
+        "export wrote an empty Gerber because layer keys did not match"
+    )
+
+
+def test_to_gerber_default_options_are_a_model(tmp_path: Path) -> None:
+    """Calling without options must not pass a pydantic FieldInfo."""
+    to_gerber(_rectangle(), tmp_path, {LAYER: GERBER_LAYER})
+    assert (tmp_path / "F_Cu.gbr").exists()

--- a/tests/export/test_to_gerber.py
+++ b/tests/export/test_to_gerber.py
@@ -112,6 +112,45 @@ def test_to_gerber_uses_tuple_layer_keys(tmp_path: Path) -> None:
     )
 
 
+def test_dotted_layer_name_keeps_full_stackup_name(tmp_path: Path) -> None:
+    """`Path.with_suffix` would read `.2 signal` as a suffix and write `L1.gbr`."""
+    written = to_gerber(
+        _rectangle(),
+        tmp_path,
+        {
+            WG: GerberLayer(
+                name="L1.2 signal",
+                function=["Copper", "L2", "Inner"],
+                polarity="Positive",
+            )
+        },
+        write_job=False,
+    )
+    assert (tmp_path / "L1.2_signal.gbr") in written
+    assert not (tmp_path / "L1.gbr").exists()
+
+
+def test_colliding_layer_filenames_raise(tmp_path: Path) -> None:
+    """Two layers sharing a filename would silently overwrite one another."""
+    component = gf.Component()
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=WG)
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=(2, 0))
+    with pytest.raises(ValueError, match="distinct filenames"):
+        to_gerber(
+            component,
+            tmp_path,
+            {
+                WG: GerberLayer(
+                    name="F Cu", function=["Copper", "L1", "Top"], polarity="Positive"
+                ),
+                (2, 0): GerberLayer(
+                    name="F_Cu", function=["Copper", "L1", "Top"], polarity="Positive"
+                ),
+            },
+            write_job=False,
+        )
+
+
 def test_to_gerber_writes_ucamco_job_file(tmp_path: Path) -> None:
     """BoardOptions is no longer a stub: CAD must ship size + layer count."""
     written = to_gerber(

--- a/tests/export/test_to_gerber.py
+++ b/tests/export/test_to_gerber.py
@@ -1,9 +1,10 @@
 """Tests for Gerber export.
 
-Covers the three failures in https://github.com/gdsfactory/gdsfactory/issues/4748:
-layer-key lookup, `%FS` command order, and numpy polygon vertices.
+Covers https://github.com/gdsfactory/gdsfactory/issues/4748 plus the PIC-to-PCB
+handoff: um layout units, millimetre Gerber, closed G36 regions, and `.gbrjob`.
 """
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -11,17 +12,20 @@ import pytest
 
 import gdsfactory as gf
 from gdsfactory.export.to_gerber import (
+    BoardOptions,
     GerberLayer,
     GerberOptions,
     decimal_digits,
+    file_unit_scale,
     format_specification,
     number,
     polygon,
     to_gerber,
 )
+from gdsfactory.gpdk import LAYER
 
-LAYER = (1, 0)
-GERBER_LAYER = GerberLayer(
+WG = (1, 0)
+COPPER = GerberLayer(
     name="F_Cu",
     function=["Copper", "L1", "Top"],
     polarity="Positive",
@@ -30,7 +34,7 @@ GERBER_LAYER = GerberLayer(
 
 def _rectangle() -> gf.Component:
     component = gf.Component()
-    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=LAYER)
+    component.add_polygon([(0, 0), (10, 0), (10, 5), (0, 5)], layer=WG)
     return component
 
 
@@ -47,6 +51,12 @@ def test_number_scale_matches_format_specification() -> None:
     assert number(-1.5, decimal_digits=4) == "-15000"
 
 
+def test_file_unit_scale_um_layout_to_mm_gerber() -> None:
+    """100 um in GDSFactory is 0.1 mm on a Gerber board, not 100 mm."""
+    assert file_unit_scale("um", "mm") == pytest.approx(1e-3)
+    assert file_unit_scale("mm", "mm") == pytest.approx(1.0)
+
+
 def test_polygon_accepts_numpy_vertices() -> None:
     """Issue 4748 bug 3: get_polygons_points() returns Nx2 numpy arrays."""
     verts = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
@@ -54,7 +64,7 @@ def test_polygon_accepts_numpy_vertices() -> None:
     assert text.startswith("G36*")
     assert "X0Y0D02*" in text
     assert "X10000Y0D01*" in text
-    assert text.endswith("G37*\n\n")
+    assert text.endswith("X0Y0D01*\nG37*\n\n")
 
 
 def test_decimal_digits_rejects_unknown_resolution() -> None:
@@ -62,28 +72,28 @@ def test_decimal_digits_rejects_unknown_resolution() -> None:
         decimal_digits(1e-9)
 
 
-def test_to_gerber_writes_spec_compliant_file(tmp_path: Path) -> None:
-    """End-to-end: polygons are emitted, `%FS` is valid, file terminates."""
-    to_gerber(
+def test_to_gerber_writes_um_layout_as_mm_gerber(tmp_path: Path) -> None:
+    """10 um x 5 um rectangle becomes 0.01 mm x 0.005 mm with a closed region."""
+    written = to_gerber(
         _rectangle(),
         tmp_path,
-        {LAYER: GERBER_LAYER},
+        {WG: COPPER},
         options=GerberOptions(resolution=1e-6, int_size=4),
     )
     path = tmp_path / "F_Cu.gbr"
-    assert path.exists()
+    assert path in written
     text = path.read_text()
 
     assert "%FSLAX46Y46*%" in text
     assert "%FSLA46Y46X*%" not in text
-    assert text.count("%LPD*%\n") == 1
+    assert "%TF.GenerationSoftware,gdsfactory,gdsfactory," in text
     assert "%MOMM*%" in text
-    assert "G36*" in text
-    assert "G37*" in text
-    # 10 um (user units) at 6 decimal digits → X10000000
+    # 10 um -> 0.01 mm at 6 decimals -> X10000
     assert "X0Y0D02*" in text
-    assert "X10000000Y0D01*" in text
-    assert "X10000000Y5000000D01*" in text
+    assert "X10000Y0D01*" in text
+    assert "X10000Y5000D01*" in text
+    assert "X0Y5000D01*" in text
+    assert text.index("X0Y0D02*") < text.rindex("X0Y0D01*")
     assert text.rstrip().endswith("M02*")
 
 
@@ -92,18 +102,53 @@ def test_to_gerber_uses_tuple_layer_keys(tmp_path: Path) -> None:
     component = _rectangle()
     by_index = component.get_polygons_points()
     by_tuple = component.get_polygons_points(by="tuple")
-    assert LAYER not in by_index
-    assert LAYER in by_tuple
-    assert len(by_tuple[LAYER]) == 1
+    assert WG not in by_index
+    assert WG in by_tuple
 
-    to_gerber(component, tmp_path, {LAYER: GERBER_LAYER})
+    to_gerber(component, tmp_path, {WG: COPPER}, write_job=False)
     text = (tmp_path / "F_Cu.gbr").read_text()
     assert "G36*" in text, (
         "export wrote an empty Gerber because layer keys did not match"
     )
 
 
-def test_to_gerber_default_options_are_a_model(tmp_path: Path) -> None:
-    """Calling without options must not pass a pydantic FieldInfo."""
-    to_gerber(_rectangle(), tmp_path, {LAYER: GERBER_LAYER})
-    assert (tmp_path / "F_Cu.gbr").exists()
+def test_to_gerber_writes_ucamco_job_file(tmp_path: Path) -> None:
+    """BoardOptions is no longer a stub: CAD must ship size + layer count."""
+    written = to_gerber(
+        _rectangle(),
+        tmp_path,
+        {WG: COPPER},
+        board=BoardOptions(n_layers=1),
+    )
+    job_path = next(path for path in written if path.suffix == ".gbrjob")
+    job = json.loads(job_path.read_text())
+    assert job["Header"]["GenerationSoftware"]["Vendor"] == "gdsfactory"
+    assert job["GeneralSpecs"]["Size"]["X"] == pytest.approx(0.01)
+    assert job["GeneralSpecs"]["Size"]["Y"] == pytest.approx(0.005)
+    assert job["GeneralSpecs"]["LayerNumber"] == 1
+    assert job["FilesAttributes"][0]["FileFunction"] == "Copper,L1,Top"
+    assert job["FilesAttributes"][0]["Path"] == "F_Cu.gbr"
+
+
+def test_to_gerber_pad_mtop_layer_enum(tmp_path: Path) -> None:
+    """RF pad on MTOP: LayerEnum keys resolve, geometry is in millimetres."""
+    pad = gf.components.pad(size=(100, 100))
+    written = to_gerber(
+        pad,
+        tmp_path,
+        {
+            LAYER.MTOP: GerberLayer(
+                name="F_Cu",
+                function=["Copper", "L1", "Top"],
+                polarity="Positive",
+            )
+        },
+    )
+    text = (tmp_path / "F_Cu.gbr").read_text()
+    assert "G36*" in text
+    assert any(path.suffix == ".gbrjob" for path in written)
+    job = json.loads(
+        next(path for path in written if path.suffix == ".gbrjob").read_text()
+    )
+    assert job["GeneralSpecs"]["Size"]["X"] == pytest.approx(0.1)
+    assert job["GeneralSpecs"]["Size"]["Y"] == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

`to_gerber` on `main` does not export a board. The three-line patch in #4748 is not enough. I ran a 100 µm × 100 µm pad through the three calling conventions that actually exist in this repo. None of them produce copper.

| Call | `main` (9.49.0) | This branch |
| --- | --- | --- |
| Tuple layer `(1, 0)`, default `options` | `AttributeError: 'FieldInfo' object has no attribute 'header'` — `options: GerberOptions = Field(default_factory=GerberOptions)` on a plain function, so the default is a pydantic specifier, not a model | Writes `.gbr` + `.gbrjob` |
| Tuple layer `(1, 0)`, explicit `GerberOptions()` | Silent empty file. `get_polygons_points()` defaults to `by="index"` (keys `[1]`). The loop looks up `(1, 0)`. The `if layer_tup in layer_to_polygons` guard makes the miss silent. A structurally valid Gerber with **zero** `G36` reaches the fab | `G36` region present |
| `LAYER.MTOP` (IntEnum, collides with index keys), explicit options | `ValueError: The truth value of an array with more than one element is ambiguous` at `if not pp:` because `get_polygons_points` returns `NDArray` | Same pad, millimetres |

Independent parser check on this branch (`gerbonara.GerberFile.open().bounding_box()`): a 100 µm × 100 µm pad is `((-0.05, -0.05), (0.05, 0.05))` — 0.10 mm × 0.10 mm. Header is `%FSLAX46Y46*%`, not `%FSLA46Y46X*%`. This is not a CAM-tool certification.

GDSFactory layout is µm. Ucamco `%MO` is mm or inches. Two scale bugs on `main` partially cancel. `number()` hardcodes ×10⁴ against a header that declares 6 decimals (100× under). There is no µm→mm conversion (1000× over). Net is **10×**, not 1000×: a 100 µm × 100 µm square with the three-line #4748 paste is gerbonara bbox `((0.0, 0.0), (1.0, 1.0))` — 1.0 mm, not 0.1 mm and not 100 mm. This branch writes 0.10 mm.

The unused `BoardOptions` stub in the same file was the job-file shape for that handoff; it now emits a partial Ucamco `.gbrjob` (rev 2020.08 allows partial jobs) with size in mm.

Reporter bugs in #4748, all still true on `main`:

1. Tuple vs index keys → empty copper.
2. FS command has `X` on the wrong side.
3. Numpy polygons crash once (1) is fixed.

Also true on `main` and not in the issue paste:

- `%LPD*%` has no newline, so the next command sticks to it.
- `polygon()` never closes the G36 contour. `rect()` in the same file does. Ucamco 2022.02 §4.10.1: `G37` is only legal when contours are closed.
- `number()` hardcodes `round(n * 10000)` while `%FS` declares 6 decimals (100× under). Combined with missing µm→mm (1000× over), a parser reads **10×**: 100 µm square → 1.0 mm, not 100 mm.
- `Path.with_suffix(".gbr")` on a name like `L1.2 signal` writes `L1.gbr`. Two inner layers can overwrite each other.

I did not paste the three-line diff. That still yields a spec-invalid Gerber whose coordinates are wrong.

## Test Plan

```
uv run pytest tests/export/test_to_gerber.py tests/export/ -q
```

32 passed (0.30s) on this branch. `tests/export/test_to_gerber.py` is new; `main` has no Gerber tests. Against unfixed `main` those cases fail on FS token order, tuple keys, numpy vertices, µm→mm scale, closed `G36`, dotted layer names, and filename collisions.

`gerbonara.GerberFile.open().bounding_box()` on a 100 µm pad: `((-0.05, -0.05), (0.05, 0.05))` — 0.10 mm × 0.10 mm. This is not a CAM-tool certification.

## API

- `to_gerber` now returns `list[Path]` (was `None`).
- `options` default is `None`, then `GerberOptions()`. The `Field(...)` default is gone.
- `write_job=True` writes `<component>.gbrjob` next to the images. Pass `write_job=False` to keep the old file set.
- Layermap keys accept `LayerSpec`, not only `tuple[int, int]`.

## Not in this PR

This is not a CAM-tool certification and not a full Ucamco job-file implementation. Regions still declare unused aperture `D10`. Holes go through `to_simple_polygon`. I did not touch kfactory.

Fixes #4748

## Summary by Sourcery

Fix Gerber export so GDSFactory layouts produce correctly scaled, valid copper files and optional CAM job metadata.

New Features:
- Add Gerber export support that produces board-compatible copper images and optional Ucamco `.gbrjob` metadata.
- Expose Gerber and board configuration models through the export package.

Bug Fixes:
- Fix Gerber layer matching, coordinate formatting, unit conversion, polygon handling, region closure, and output filename generation so layouts export correctly without empty, malformed, mis-scaled, or overwritten files.

Enhancements:
- Allow layer-map keys to use general `LayerSpec` values and return the paths written by `to_gerber`.
- Support configurable layout units, Gerber units, resolution, board dimensions, and optional job-file generation.

Documentation:
- Document the corrected layout-to-Gerber unit conversion and optional job-file workflow.

Tests:
- Add comprehensive Gerber export coverage for specification formatting, scaling, numpy polygons, layer resolution, filenames, collisions, job files, and enum layers.