### PR TITLE
docs: add PCB Gerber notebook tutorial

### DIFF
--- a/docs/notebooks/13_pcb_gerber.ipynb
+++ b/docs/notebooks/13_pcb_gerber.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Writing and reading PCB Gerber layouts\n",
+    "\n",
+    "GDSFactory can export the copper and mechanical geometry in a `Component` as [Gerber X2](https://www.ucamco.com/en/gerber). This notebook creates a small two-layer RF test coupon, writes a Gerber fabrication package, and reads the generated top-copper image back with [Gerbonara](https://github.com/jaseg/gerbonara).\n",
+    "\n",
+    "> **Units:** GDSFactory coordinates are micrometres (`um`), while Gerber files normally use millimetres or inches. `to_gerber` defaults to `um` input and `mm` Gerber output. Set `layout_unit=\"mm\"` only when the component coordinates are already in millimetres.\n",
+    "\n",
+    "GDSFactory provides a Gerber writer, not a native Gerber importer. Gerbonara is used here as an optional independent parser for automated checks; use a PCB CAM viewer such as KiCad Gerber Viewer to inspect the full layer set before fabrication."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Create a board component\n",
+    "\n",
+    "The generic PDK's metal layers stand in for the two PCB copper layers. They are mapped to PCB stackup names when the Gerber files are written."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import gdsfactory as gf\n",
+    "from gdsfactory.gpdk import LAYER\n",
+    "\n",
+    "gf.gpdk.PDK.activate()\n",
+    "\n",
+    "board = gf.Component(\"rf_test_coupon\")\n",
+    "\n",
+    "# Coordinates are in um: this outline is 40 mm by 25 mm.\n",
+    "board.add_polygon(\n",
+    "    [(0, 0), (40_000, 0), (40_000, 25_000), (0, 25_000)],\n",
+    "    layer=LAYER.FLOORPLAN,\n",
+    ")\n",
+    "\n",
+    "# Top copper: a 0.5 mm-wide trace and two pads.\n",
+    "board.add_polygon(\n",
+    "    [(5_000, 12_250), (35_000, 12_250), (35_000, 12_750), (5_000, 12_750)],\n",
+    "    layer=LAYER.M1,\n",
+    ")\n",
+    "for x in (3_000, 35_000):\n",
+    "    board.add_polygon(\n",
+    "        [(x, 10_000), (x + 2_000, 10_000), (x + 2_000, 15_000), (x, 15_000)],\n",
+    "        layer=LAYER.M1,\n",
+    "    )\n",
+    "\n",
+    "# Bottom copper: a small ground plane beneath the trace.\n",
+    "board.add_polygon(\n",
+    "    [(5_000, 5_000), (35_000, 5_000), (35_000, 10_000), (5_000, 10_000)],\n",
+    "    layer=LAYER.M2,\n",
+    ")\n",
+    "\n",
+    "board.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Write the Gerber package\n",
+    "\n",
+    "Map each GDSFactory layer to a filename and [Gerber X2 file function](https://www.ucamco.com/en/gerber). The file function lets CAM software identify the layer role without relying only on its filename."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactory.export import BoardOptions, GerberLayer, GerberOptions, to_gerber\n",
+    "\n",
+    "gerber_dir = Path(\"build/rf_test_coupon_gerbers\")\n",
+    "\n",
+    "written = to_gerber(\n",
+    "    component=board,\n",
+    "    dirpath=gerber_dir,\n",
+    "    layermap_to_gerber_layer={\n",
+    "        LAYER.M1: GerberLayer(\n",
+    "            name=\"F_Cu\",\n",
+    "            function=[\"Copper\", \"L1\", \"Top\"],\n",
+    "            polarity=\"Positive\",\n",
+    "        ),\n",
+    "        LAYER.M2: GerberLayer(\n",
+    "            name=\"B_Cu\",\n",
+    "            function=[\"Copper\", \"L2\", \"Bot\"],\n",
+    "            polarity=\"Positive\",\n",
+    "        ),\n",
+    "        LAYER.FLOORPLAN: GerberLayer(\n",
+    "            name=\"Edge_Cuts\",\n",
+    "            function=[\"Profile\", \"NP\"],\n",
+    "            polarity=\"Positive\",\n",
+    "        ),\n",
+    "    },\n",
+    "    options=GerberOptions(mode=\"mm\", layout_unit=\"um\", resolution=1e-6),\n",
+    "    board=BoardOptions(n_layers=2),\n",
+    ")\n",
+    "\n",
+    "print(*written, sep=\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## Read and validate a Gerber image\n",
+    "\n",
+    "Install the optional parser once with `uv add --group dev gerbonara` or `pip install gerbonara`. A Gerber package has one image per layer, so open each `.gbr` image separately. Here the parser confirms that the 3,000–37,000 um top-copper extents became 3–37 mm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from gerbonara import GerberFile\n",
+    "except ImportError:\n",
+    "    print(\"Install Gerbonara with `pip install gerbonara` to run this check.\")\n",
+    "else:\n",
+    "    top_copper = GerberFile.open(gerber_dir / \"F_Cu.gbr\")\n",
+    "    bbox = top_copper.bounding_box(unit=\"mm\")\n",
+    "\n",
+    "    assert bbox == ((3.0, 10.0), (37.0, 15.0))\n",
+    "    bbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Inspect the fabrication package\n",
+    "\n",
+    "The export directory contains `F_Cu.gbr`, `B_Cu.gbr`, `Edge_Cuts.gbr`, and `rf_test_coupon.gbrjob`. The `.gbrjob` file records the board size, copper-layer count, and image functions. Keep it with the Gerber images and preserve their names.\n",
+    "\n",
+    "For a visual check, open all `.gbr` files together in [KiCad Gerber Viewer](https://docs.kicad.org/9.0/en/gerbview/gerbview.html), then verify the outline, layer order, clearances, and dimensions. If the board is 1,000 times too large or too small, check `GerberOptions.layout_unit`.\n",
+    "\n",
+    "> The exporter writes filled polygons as Gerber regions. It does not create drill (`.drl`), solder-mask, paste, or PCB-netlist files; add those manufacturing deliverables through the appropriate PCB/CAM workflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top_copper_text = (gerber_dir / \"F_Cu.gbr\").read_text()\n",
+    "assert \"%MOMM*%\" in top_copper_text\n",
+    "assert \"%FSLAX46Y46*%\" in top_copper_text"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "custom_cell_magics": "kql"
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/zensical.yml
+++ b/docs/zensical.yml
@@ -14,6 +14,7 @@ nav:
       - workflow.md
       - notebooks/12_config.md
   - Layout:
+      - PCB Gerber layouts: notebooks/13_pcb_gerber.md
       - notebooks/00_geometry.md
       - notebooks/01_references.md
       - notebooks/03_cells_autoname_and_cache.md

--- a/docs/zensical.yml
+++ b/docs/zensical.yml
@@ -14,7 +14,6 @@ nav:
       - workflow.md
       - notebooks/12_config.md
   - Layout:
-      - PCB Gerber layouts: notebooks/13_pcb_gerber.md
       - notebooks/00_geometry.md
       - notebooks/01_references.md
       - notebooks/03_cells_autoname_and_cache.md
@@ -28,6 +27,7 @@ nav:
       - notebooks/07_mask.md
       - notebooks/11_best_practices.md
       - notebooks/12_grid_snapping.md
+      - PCB Gerber layouts: notebooks/13_pcb_gerber.md
   - Schematic:
       - notebooks/10_schematic.md
       - notebooks/10_yaml_component.md


### PR DESCRIPTION
## Summary

- add an executable notebook for writing PCB Gerber X2 layouts
- validate exported geometry with the optional Gerbonara parser, following the independent-parser approach in #4802
- add the notebook to the Layout documentation navigation

## Test Plan

- execute the notebook in memory with Gerbonara installed
- build the documentation with `zensical build --strict -f docs/zensical.yml`

## Summary by Sourcery

Add a documented workflow for exporting and independently validating PCB Gerber layouts.

New Features:
- Add an executable tutorial demonstrating PCB Gerber X2 export for a multilayer board layout.
- Validate exported top-copper geometry with the optional Gerbonara parser.

Documentation:
- Add the PCB Gerber tutorial to the Layout documentation navigation.