### PR TITLE
fix: accept negative standard circular bend angles

### DIFF
--- a/gdsfactory/components/bends/bend_circular.py
+++ b/gdsfactory/components/bends/bend_circular.py
@@ -134,7 +134,7 @@ def bend_circular(
         cross_section: spec (CrossSection, string or dict).
         allow_min_radius_violation: if True allows radius to be smaller than cross_section radius.
     """
-    if angle not in {90, 180}:
+    if abs(angle) not in {90, 180}:
         warnings.warn(
             f"bend_euler angle should be 90 or 180. Got {angle}. Use bend_euler_all_angle instead.",
             UserWarning,

--- a/tests/components/bends/test_bends.py
+++ b/tests/components/bends/test_bends.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -53,6 +55,13 @@ def test_bend_circular() -> None:
 
     ca = bend_circular_all_angle(radius=10, angle=45)
     assert isinstance(ca, gf.ComponentAllAngle)
+
+
+@pytest.mark.parametrize("angle", [-90, -180])
+def test_bend_circular_negative_standard_angle_does_not_warn(angle: float) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        bend_circular(radius=10, angle=angle)
 
 
 def test_bend_circular_layer_width() -> None:


### PR DESCRIPTION
The circular bend geometry supports signed angles, but its warning check only accepted positive 90° and 180° values. Validate the absolute angle, matching the existing Euler-bend behavior, and cover −90°/−180° with a regression test.

## Summary by Sourcery

Accept signed standard angles for circular bends by validating their absolute values.

Bug Fixes:
- Allow standard circular bends with negative 90° and 180° angles without emitting warnings.

Tests:
- Add regression coverage confirming negative standard bend angles do not warn.