### PR TITLE
Fix recursive remap_layers and recursive locking logic in general

### DIFF
--- a/docs/notebooks/03_layer_stack.ipynb
+++ b/docs/notebooks/03_layer_stack.ipynb
@@ -236,7 +236,7 @@
     "\n",
     "# The remap_layers method goes through the component and reassigns layers based on the dictionary provided.\n",
     "# The dictionary {(2, 0): (34, 0)} defines the mapping rule: \"find all shapes on layer (2, 0) and move them to layer (34, 0).\"\n",
-    "# The result is a new component, assigned to the remap variable, where the layer change has been applied.\n",
+    "# remap_layers modifies the component in place and returns it, so remap is the same component as c.\n",
     "remap = c.remap_layers({(2, 0): (34, 0)})\n",
     "remap.plot()"
    ]

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -1044,10 +1044,7 @@ class Component(ComponentBase, kf.DKCell):
         """
         from gdsfactory import get_layer
 
-        if recursive:
-            self.locked = False
-
-        if self.locked:
+        if not recursive and self.locked:
             raise LockedError(self)
 
         layer_index_pairs = [
@@ -1085,10 +1082,7 @@ class Component(ComponentBase, kf.DKCell):
         """
         from gdsfactory import get_layer
 
-        if recursive:
-            self.locked = False
-
-        if self.locked:
+        if not recursive and self.locked:
             raise LockedError(self)
 
         layer_indexes = self.kcl.layer_indexes()
@@ -1128,7 +1122,7 @@ class Component(ComponentBase, kf.DKCell):
         """
         from gdsfactory import get_layer
 
-        if self.locked:
+        if not recursive and self.locked:
             raise LockedError(self)
 
         layer_index_pairs = [

--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import pathlib
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -68,6 +69,17 @@ def _fix_pin_metadata(cell: kf.kcell.ProtoTKCell[Any]) -> None:
         cell.remove_meta_info(name)
         value["ports"] = [str(p) for p in value["ports"]]
         cell.add_meta_info(kdb.LayoutMetaInfo(name, value, None, True))
+
+
+@contextlib.contextmanager
+def _unlocked(cell: kf.kcell.ProtoTKCell[Any]) -> Iterator[None]:
+    """Temporarily unlocks a cell, restoring its previous lock state on exit."""
+    was_locked = cell.locked
+    cell.locked = False
+    try:
+        yield
+    finally:
+        cell.locked = was_locked
 
 
 class AddPortError(ValueError):
@@ -1036,11 +1048,15 @@ class Component(ComponentBase, kf.DKCell):
         layer_map: dict[LayerSpec, LayerSpec],
         recursive: bool = False,
     ) -> Self:
-        """Remaps a list of layers and returns the same Component.
+        """Copies shapes from one layer onto another and returns the same Component.
 
         Args:
-            layer_map: dictionary of layers to copy.
-            recursive: if True, remaps layers recursively.
+            layer_map: dictionary mapping source layers to destination layers.
+            recursive: if True, also applies to every cell called by this one,
+                temporarily unlocking each cell and restoring its lock state
+                afterwards. Child cells are shared, so any other Component
+                referencing them also sees the change. Call `.dup()` on a cell
+                beforehand to leave the cached version untouched.
         """
         from gdsfactory import get_layer
 
@@ -1052,21 +1068,16 @@ class Component(ComponentBase, kf.DKCell):
             for layer, new_layer in layer_map.items()
         ]
         kdb_cell = self.kdb_cell
-        for src_layer_index, dst_layer_index in layer_index_pairs:
-            kdb_cell.copy(src_layer_index, dst_layer_index)
+        with _unlocked(self):
+            for src_layer_index, dst_layer_index in layer_index_pairs:
+                kdb_cell.copy(src_layer_index, dst_layer_index)
 
         if recursive:
             for ci in kdb_cell.called_cells():
                 child = self.kcl[ci]
-                child_cell = child.kdb_cell
-                was_locked = child.locked
-                child.locked = False
-                try:
+                with _unlocked(child):
                     for src_layer_index, dst_layer_index in layer_index_pairs:
-                        child_cell.copy(src_layer_index, dst_layer_index)
-                finally:
-                    if was_locked:
-                        child.locked = True
+                        child.kdb_cell.copy(src_layer_index, dst_layer_index)
         return self
 
     def remove_layers(
@@ -1078,7 +1089,11 @@ class Component(ComponentBase, kf.DKCell):
 
         Args:
             layers: list of layers to remove.
-            recursive: if True, removes layers recursively and temporarily unlocks components.
+            recursive: if True, also applies to every cell called by this one,
+                temporarily unlocking each cell and restoring its lock state
+                afterwards. Child cells are shared, so any other Component
+                referencing them also sees the change. Call `.dup()` on a cell
+                beforehand to leave the cached version untouched.
         """
         from gdsfactory import get_layer
 
@@ -1086,39 +1101,39 @@ class Component(ComponentBase, kf.DKCell):
             raise LockedError(self)
 
         layer_indexes = self.kcl.layer_indexes()
-        layer_indexes_to_remove = [get_layer(layer) for layer in layers]
         layer_indices = [
-            layer for layer in layer_indexes_to_remove if layer in layer_indexes
+            layer_index
+            for layer_index in (get_layer(layer) for layer in layers)
+            if layer_index in layer_indexes
         ]
         if not layer_indices:
             return self
 
         kdb_cell = self.kdb_cell
-        for layer_index in layer_indices:
-            kdb_cell.shapes(layer_index).clear()
+        with _unlocked(self):
+            for layer_index in layer_indices:
+                kdb_cell.shapes(layer_index).clear()
 
         if recursive:
             for ci in kdb_cell.called_cells():
                 child = self.kcl[ci]
-                child_cell = child.kdb_cell
-                was_locked = child.locked
-                child.locked = False
-                try:
-                    for layer_idx in layer_indices:
-                        child_cell.shapes(layer_idx).clear()
-                finally:
-                    if was_locked:
-                        child.locked = True
+                with _unlocked(child):
+                    for layer_index in layer_indices:
+                        child.kdb_cell.shapes(layer_index).clear()
         return self
 
     def remap_layers(
         self, layer_map: dict[LayerSpec, LayerSpec], recursive: bool = False
     ) -> Self:
-        """Remaps a list of layers and returns the same Component.
+        """Moves shapes from one layer onto another and returns the same Component.
 
         Args:
-            layer_map: dictionary of layers to remap.
-            recursive: if True, remaps layers recursively.
+            layer_map: dictionary mapping source layers to destination layers.
+            recursive: if True, also applies to every cell called by this one,
+                temporarily unlocking each cell and restoring its lock state
+                afterwards. Child cells are shared, so any other Component
+                referencing them also sees the change. Call `.dup()` on a cell
+                beforehand to leave the cached version untouched.
         """
         from gdsfactory import get_layer
 
@@ -1130,14 +1145,16 @@ class Component(ComponentBase, kf.DKCell):
             for layer, new_layer in layer_map.items()
         ]
         kdb_cell = self.kdb_cell
-        for src_layer_index, dst_layer_index in layer_index_pairs:
-            kdb_cell.move(src_layer_index, dst_layer_index)
+        with _unlocked(self):
+            for src_layer_index, dst_layer_index in layer_index_pairs:
+                kdb_cell.move(src_layer_index, dst_layer_index)
 
         if recursive:
             for ci in kdb_cell.called_cells():
-                child_cell = self.kcl[ci].kdb_cell
-                for src_layer_index, dst_layer_index in layer_index_pairs:
-                    child_cell.move(src_layer_index, dst_layer_index)
+                child = self.kcl[ci]
+                with _unlocked(child):
+                    for src_layer_index, dst_layer_index in layer_index_pairs:
+                        child.kdb_cell.move(src_layer_index, dst_layer_index)
         return self
 
     def to_3d(

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 import kfactory as kf
@@ -629,6 +630,48 @@ def test_copy_layers_recursive_multiple_layers_restores_lock() -> None:
     child.locked = False
     c.delete()
     child.delete()
+
+
+def test_remap_layers_recursive_locked_child() -> None:
+    """Recursive remap must work through a locked (cached) child cell.
+
+    Component.locked is backed by KLayout's own cell lock, so remapping a locked
+    child used to raise `RuntimeError: ... cannot be modified as it is locked`.
+    """
+    child = gf.components.straight(length=10, width=1)
+    assert child.locked, "expected a cached component to be locked"
+
+    c = gf.Component()
+    c << child
+    c.remap_layers({(1, 0): (2, 0)}, recursive=True)
+
+    assert child.area((1, 0)) == 0, f"{child.area((1, 0))}"
+    assert child.area((2, 0)) == 10, f"{child.area((2, 0))}"
+    assert child.locked, "child lock should be restored"
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda c: c.remap_layers({(1, 0): (2, 0)}, recursive=True),
+        lambda c: c.copy_layers({(1, 0): (2, 0)}, recursive=True),
+        lambda c: c.remove_layers([(1, 0)], recursive=True),
+    ],
+    ids=["remap_layers", "copy_layers", "remove_layers"],
+)
+def test_layer_ops_recursive_restore_parent_lock(
+    operation: Callable[[gf.Component], gf.Component],
+) -> None:
+    """A recursive layer op must not leave a locked parent permanently unlocked."""
+    c = gf.Component()
+    c.add_polygon([(0, 0), (0, 10), (10, 10), (10, 0)], layer=(1, 0))
+    c.locked = True
+
+    operation(c)
+
+    assert c.locked, "parent lock should be restored"
+    c.locked = False
+    c.delete()
 
 
 def test_get_labels() -> None:


### PR DESCRIPTION
## Summary

- Locking state should be restored to what it was before
- Recursive `remap_layers` was pretty much broken

## Test Plan

🤖 🧪

## Summary by Sourcery

Fix recursive layer operations to support locked cells while preserving their original locking state.

Bug Fixes:
- Restore each component’s previous lock state after recursive layer operations.
- Fix recursive remapping of layers through locked child cells.

Enhancements:
- Clarify layer-operation behavior and in-place component updates in the API documentation and notebook example.

Documentation:
- Update the layer-stack notebook to document that remap_layers modifies and returns the same component.

Tests:
- Add coverage for recursive layer operations on locked children and restoration of parent lock state.