### PR TITLE
fix(#4365): safely handle missing brightness fields in LYP files

### DIFF
--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -756,7 +756,8 @@ class LayerView(BaseModel):
             fill_color=getattr(element.find("fill-color"), "text", None),
             frame_color=getattr(element.find("frame-color"), "text", None),
             fill_brightness=getattr(element.find("fill-brightness"), "text", None) or 0,
-            frame_brightness=getattr(element.find("frame-brightness"), "text", None) or 0,
+            frame_brightness=getattr(element.find("frame-brightness"), "text", None)
+            or 0,
             hatch_pattern=hatch_pattern or None,
             line_style=line_style
             if line_style is not None and len(line_style) > 0

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -755,9 +755,8 @@ class LayerView(BaseModel):
             layer=cls._process_layer(element.find("source").text, layer_pattern),  # type: ignore[union-attr,arg-type]
             fill_color=getattr(element.find("fill-color"), "text", None),
             frame_color=getattr(element.find("frame-color"), "text", None),
-            fill_brightness=getattr(element.find("fill-brightness"), "text", None) or 0,
-            frame_brightness=getattr(element.find("frame-brightness"), "text", None)
-            or 0,
+            fill_brightness=getattr(element.find("fill-brightness"), "text", 0),
+            frame_brightness=getattr(element.find("frame-brightness"), "text", 0),
             hatch_pattern=hatch_pattern or None,
             line_style=line_style
             if line_style is not None and len(line_style) > 0

--- a/gdsfactory/technology/layer_views.py
+++ b/gdsfactory/technology/layer_views.py
@@ -755,8 +755,8 @@ class LayerView(BaseModel):
             layer=cls._process_layer(element.find("source").text, layer_pattern),  # type: ignore[union-attr,arg-type]
             fill_color=getattr(element.find("fill-color"), "text", None),
             frame_color=getattr(element.find("frame-color"), "text", None),
-            fill_brightness=element.find("fill-brightness").text or 0,  # type: ignore[union-attr]
-            frame_brightness=element.find("frame-brightness").text or 0,  # type: ignore[union-attr]
+            fill_brightness=getattr(element.find("fill-brightness"), "text", None) or 0,
+            frame_brightness=getattr(element.find("frame-brightness"), "text", None) or 0,
             hatch_pattern=hatch_pattern or None,
             line_style=line_style
             if line_style is not None and len(line_style) > 0


### PR DESCRIPTION
## Summary
Replaced fragile `.find().text` calls with safer `getattr` checks in `layer_views.py` to prevent crashes when LYP files lack brightness metadata.

Fixes #4365

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when LYP files omit fill or frame brightness metadata by defaulting missing values to zero.