### PR TITLE
fix: keep grid_with_text labels on their anchors

### DIFF
--- a/gdsfactory/grid.py
+++ b/gdsfactory/grid.py
@@ -170,14 +170,14 @@ def grid_with_text(
         if text:
             for text_offset, text_anchor in zip_longest(text_offsets, text_anchors):
                 t = c << gf.get_component(text, text=text_string)
+                if text_mirror:
+                    t.dmirror()
+                if text_rotation:
+                    t.rotate(text_rotation)
                 size_info = instance.dsize_info
                 text_offset = text_offset or (0, 0)
                 text_anchor = text_anchor or "center"
                 o = np.array(text_offset)
                 d = np.array(getattr(size_info, text_anchor))
                 t.move(tuple(o + d))
-                if text_mirror:
-                    t.dmirror()
-                if text_rotation:
-                    t.rotate(text_rotation)
     return c

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,3 +1,5 @@
+import pytest
+
 import gdsfactory as gf
 
 
@@ -23,3 +25,36 @@ def test_grid_with_ports(rows: int = 3, columns: int = 4) -> None:
     components = [gf.c.rectangle(size=(1, 1)) for _ in range(3)]
     c = gf.grid(components=components)
     assert len(c.ports) == n * 4, len(c.ports)
+
+
+def _label_and_anchor_positions(
+    c: gf.Component,
+) -> tuple[list[tuple[float, float]], list[tuple[float, float]]]:
+    labels = [
+        (i.dtrans.disp.x, i.dtrans.disp.y)
+        for i in c.insts
+        if i.cell.name.startswith("text_")
+    ]
+    anchors = [
+        i.dsize_info.center for i in c.insts if i.cell.name.startswith("rectangle")
+    ]
+    return labels, anchors
+
+
+@pytest.mark.parametrize("text_rotation", [0, 90, 180, 270])
+def test_grid_with_text_rotation_keeps_labels_on_anchors(text_rotation: int) -> None:
+    components = [gf.c.rectangle(size=(1, 1)) for _ in range(3)]
+    c = gf.grid_with_text(
+        components, shape=(1, 3), spacing=(5, 5), text_rotation=text_rotation
+    )
+    labels, anchors = _label_and_anchor_positions(c)
+    assert len(labels) == 3
+    assert labels == anchors
+
+
+def test_grid_with_text_mirror_keeps_labels_on_anchors() -> None:
+    components = [gf.c.rectangle(size=(1, 1)) for _ in range(3)]
+    c = gf.grid_with_text(components, shape=(1, 3), spacing=(5, 5), text_mirror=True)
+    labels, anchors = _label_and_anchor_positions(c)
+    assert len(labels) == 3
+    assert labels == anchors


### PR DESCRIPTION
## Summary

`grid_with_text` moved each label to its anchor first and applied `text_mirror` and `text_rotation` afterwards. `rotate()` and `dmirror()` act about the layout origin, not about the instance, so doing them last dragged every label away from the cell it names. On a 3 cell grid of 1x1 rectangles with `text_rotation=180`, the labels land at (0, -3), (-6, -3) and (-12, -3) instead of on their anchors at (0, 3), (6, 3) and (12, 3). `text_mirror=True` scatters them along negative x, and the offset grows with the grid, so on a real mask the labels end up nowhere near the devices.

The fix in gdsfactory/grid.py:171-182 mirrors and rotates the label before moving it to the anchor. That is the order `pack` already uses (gdsfactory/pack.py:273-280) and the order `edge_coupler_array` uses (gdsfactory/components/edge_couplers/edge_coupler_array.py:88-91), so this makes `grid_with_text` agree with the rest of the library rather than inventing a new convention.

Every caller in the repo, `pack_doe_grid` included, uses the defaults `text_rotation=0` and `text_mirror=False`, where both branches are skipped. No reference GDS, netlist or settings fixture changes.

## Test Plan

Added `test_grid_with_text_rotation_keeps_labels_on_anchors` (parametrized over 0, 90, 180, 270) and `test_grid_with_text_mirror_keeps_labels_on_anchors` to tests/test_grid.py. Each asserts that every label instance sits at the `center` anchor of the cell it labels.

`uv run pytest tests/test_grid.py` on main with only the grid.py change reverted: 4 failed, 3 passed. The 90, 180 and 270 rotations and the mirror case fail, `text_rotation=0` passes. With the fix: 7 passed.

`uv run pytest -q -n 2 tests/` after `make test-data`: 1731 passed, 2 skipped, 1 xfailed.

`uv run pytest -q tests/components/test_components.py -k "pack_doe or grid"`: 6 passed, so the `pack_doe_grid` and `bump_pad_grid` geometry still matches the gdsfactory-test-data references.

`uv run pre-commit run --files gdsfactory/grid.py tests/test_grid.py`: all hooks pass, including ruff check, ruff format, codespell and pyright.

## Summary by Sourcery

Fix grid_with_text label placement by applying text transformations before anchoring labels to grid cells.

Bug Fixes:
- Keep grid_with_text labels aligned with their cell anchors when text rotation or mirroring is enabled.

Tests:
- Add coverage for rotated and mirrored grid_with_text labels to verify they remain on their anchors.