### PR TITLE
docs: clarify KCell to Component conversion

### DIFF
--- a/docs/notebooks/01_references.ipynb
+++ b/docs/notebooks/01_references.ipynb
@@ -661,7 +661,7 @@
    "source": [
     "## Accessing components from layout\n",
     "\n",
-    "You can also access the Component from the layout by the Component name. You can access the cells from the KCLayout:"
+    "You can access a cell from the `KCLayout` by name. Note that `kcl[cell_name]` returns a `kfactory.KCell`, not a `gf.Component`. Convert it to a gdsfactory Component before using it with gdsfactory APIs. If the cell is registered in the active PDK, use `gf.get_component(registered_name)` instead; the getter already returns a `gf.Component`."
    ]
   },
   {
@@ -671,7 +671,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bend = c.kcl[b.cell.name]\n",
+    "bend = gf.Component(base=c.kcl[b.cell.name].base)\n",
     "print(type(bend))\n",
     "bend"
    ]

--- a/docs/notebooks/08_pdk.ipynb
+++ b/docs/notebooks/08_pdk.ipynb
@@ -489,7 +489,7 @@
    "source": [
     "### ComponentSpec\n",
     "\n",
-    "You can get a component of the active pdk using the cell name (string) or a dict."
+    "You can get a `gf.Component` from the active PDK using a registered cell name (string) or a dict. The PDK getter is preferable when you know the registered name because it returns a gdsfactory Component directly. For a cell name obtained from a `KCLayout` that is not registered as a PDK cell, use `gf.Component(base=kcl[cell_name].base)` to convert the `KCell`."
    ]
   },
   {


### PR DESCRIPTION
## Summary

- clarify that `KCLayout` lookup returns a `kfactory.KCell`
- show conversion to `gf.Component` with `gf.Component(base=...)`
- document using `gf.get_component(...)` for registered PDK cells