### PR TITLE
docs: fix component docstrings

### DIFF
--- a/gdsfactory/components/analog/transformers.py
+++ b/gdsfactory/components/analog/transformers.py
@@ -633,6 +633,11 @@ def via3(
 
     Only meaningful once M4 also has real z-geometry — see
     get_extended_layer_stack() for the matching LayerStack entry.
+
+    Args:
+        size: (width, height) of the via square, in um.
+        enclosure: metal enclosure around the via, in um.
+        pitch: via array pitch, in um.
     """
     c = Component()
     w, h = size

--- a/gdsfactory/components/bends/bend_modified_hermite.py
+++ b/gdsfactory/components/bends/bend_modified_hermite.py
@@ -353,7 +353,6 @@ def bend_modified_hermite_s(
 
     Args:
         radius: effective bend radius
-        angle: angle, in degrees.
         inner_tangent_magnitude: a1 parameter from Li et al.
         outer_tangent_magnitude: a2 parameter from Li et al.
         npoints: number of points to use for the inner wall of the curve, and the outer wall.

--- a/gdsfactory/components/dies/die_frame_with_pads.py
+++ b/gdsfactory/components/dies/die_frame_with_pads.py
@@ -17,6 +17,12 @@ def die_frame(
     size: Size = (11200.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
 ) -> gf.Component:
+    """Returns a rectangular die floorplan.
+
+    Args:
+        size: die frame size (width, height), in um.
+        layer_floorplan: layer for the floorplan rectangle.
+    """
     return gf.c.rectangle(
         size=size, layer=layer_floorplan, centered=True, port_type=None
     )
@@ -27,6 +33,12 @@ def die_frame_rf(
     size: Size = (10400.0, 5000.0),
     layer_floorplan: LayerSpec = "FLOORPLAN",
 ) -> gf.Component:
+    """Returns a rectangular die floorplan sized for RF dies.
+
+    Args:
+        size: die frame size (width, height), in um.
+        layer_floorplan: layer for the floorplan rectangle.
+    """
     return gf.c.rectangle(
         size=size, layer=layer_floorplan, centered=True, port_type=None
     )
@@ -426,6 +438,39 @@ def die_frame_phix_dc(
     pad_rotation_dc_south: float = 0,
     pad_side_distance: float = 1160.0,
 ) -> Component:
+    """A PHIX die frame with DC pads only.
+
+    Args:
+        die_frame: die_frame spec.
+        nfibers: the number of grating couplers.
+        npads: the number of pads.
+        npads_rf: the number of RF pads on the left side.
+        fiber_pitch: the pitch of the grating couplers, in um.
+        pad_pitch: the pitch of the pads, in um.
+        pad_pitch_gsg: the pitch of the GSG pads, in um.
+        edge_coupler: the edge coupler component.
+        grating_coupler: Optional grating coupler.
+        cross_section: the cross section.
+        pad: the pad component.
+        pad_gsg: the GSG pad component.
+        edge_to_pad_distance: the distance from the edge to the pads, in um.
+        pad_port_name_top: name of the pad port name at the top facing south.
+        pad_port_name_bot: name of the pad port name at the bottom facing north.
+        layer_fiducial: layer for fiducials.
+        layer_ruler: layer for ruler.
+        ruler_bbox_layers: layers for bbox.
+        ruler_bbox_offset: offset for bbox.
+        ruler_yoffset: y-offset for ruler.
+        ruler_xoffset: x-offset for ruler.
+        with_right_fiber_coupler: if True, adds edge couplers on the right side.
+        with_left_fiber_coupler: if True, adds edge couplers on the left side.
+        fiber_coupler_xoffset: x-offset for fiber couplers.
+        text_offset: offset for text.
+        text: text component spec.
+        pad_rotation_dc_north: rotation for DC pads.
+        pad_rotation_dc_south: rotation for DC pads.
+        pad_side_distance: distance from the die frame side to the first pad, in um.
+    """
     return die_frame_phix(
         die_frame=die_frame,
         nfibers=nfibers,
@@ -494,6 +539,42 @@ def die_frame_phix_rf(
     pad_rotation_dc_north: float = 0,
     pad_rotation_dc_south: float = 0,
 ) -> Component:
+    """A PHIX die frame with DC and RF pads.
+
+    Args:
+        die_frame: die_frame spec.
+        nfibers: the number of grating couplers.
+        npads: the number of pads.
+        npads_rf: the number of RF pads on the left side.
+        fiber_pitch: the pitch of the grating couplers, in um.
+        pad_pitch: the pitch of the pads, in um.
+        pad_pitch_gsg: the pitch of the GSG pads, in um.
+        edge_coupler: the edge coupler component.
+        grating_coupler: Optional grating coupler.
+        cross_section: the cross section.
+        pad: the pad component.
+        pad_gsg: the GSG pad component.
+        edge_to_pad_distance: the distance from the edge to the pads, in um.
+        pad_port_name_top: name of the pad port name at the top facing south.
+        pad_port_name_bot: name of the pad port name at the bottom facing north.
+        pad_port_name_rf: name of the RF pad port name.
+        layer_fiducial: layer for fiducials.
+        layer_ruler: layer for ruler.
+        ruler_bbox_layers: layers for bbox.
+        ruler_bbox_offset: offset for bbox.
+        ruler_yoffset: y-offset for ruler.
+        ruler_xoffset: x-offset for ruler.
+        with_right_fiber_coupler: if True, adds edge couplers on the right side.
+        with_left_fiber_coupler: if True, adds edge couplers on the left side.
+        fiber_coupler_xoffset: x-offset for fiber couplers.
+        text_offset: offset for text.
+        text: text component spec.
+        pad_side_distance: distance from the die frame side to the first pad, in um.
+        xoffset_rf_pads: RF pads x-offset.
+        pad_rotation_rf: rotation for RF pads.
+        pad_rotation_dc_north: rotation for DC pads.
+        pad_rotation_dc_south: rotation for DC pads.
+    """
     return die_frame_phix(
         die_frame=die_frame,
         nfibers=nfibers,

--- a/gdsfactory/components/filters/dbr.py
+++ b/gdsfactory/components/filters/dbr.py
@@ -40,7 +40,6 @@ def dbr_cell(
         l1: thin length in um.
         w2: thick width in um.
         l2: thick length in um.
-        n: number of periods.
         cross_section: cross_section spec.
 
            l1      l2

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_arbitrary.py
@@ -67,11 +67,13 @@ def grating_coupler_elliptical_arbitrary(
             Positive bias increases gap and reduces width to keep period constant.
         cross_section: cross_section spec for waveguide port.
 
-    https://en.wikipedia.org/wiki/Ellipse
-    c = (a1 ** 2 - b1 ** 2) ** 0.5
-    e = (1 - (b1 / a1) ** 2) ** 0.5
-    print(e)
+    Notes:
+        Ellipse conventions, see https://en.wikipedia.org/wiki/Ellipse
 
+        c = (a1 ** 2 - b1 ** 2) ** 0.5
+        e = (1 - (b1 / a1) ** 2) ** 0.5
+
+    ```text
                       fiber
 
                    /  /  /  /
@@ -80,7 +82,7 @@ def grating_coupler_elliptical_arbitrary(
                 _|-|_|-|_|-|___ layer
                    layer_slab |
             o1  ______________|
-
+    ```
     """
     xs = gf.get_cross_section(cross_section)
     wg_width = xs.width

--- a/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
+++ b/gdsfactory/components/grating_couplers/grating_coupler_elliptical_lumerical.py
@@ -106,7 +106,6 @@ def grating_coupler_elliptical_lumerical(
 
     Args:
         parameters: xinput, gap1, width1, gap2, width2 ...
-        layer: for waveguide.
         layer_slab: for slab.
         taper_angle: in deg.
         taper_length: in um.

--- a/gdsfactory/components/mmis/mmi_90degree_hybrid.py
+++ b/gdsfactory/components/mmis/mmi_90degree_hybrid.py
@@ -39,7 +39,6 @@ def mmi_90degree_hybrid(
         width_mmi: in y direction.
         gap_mmi: (width_taper + gap between tapered wg)/2.
         straight: straight function.
-        with_bbox: box in bbox_layers and bbox_offsets avoid DRC sharp edges.
         cross_section: spec.
 
     ```text

--- a/gdsfactory/components/mzis/mzit.py
+++ b/gdsfactory/components/mzis/mzit.py
@@ -215,6 +215,13 @@ def mzit_lattice(
 ) -> Component:
     r"""Mzi fab tolerant lattice filter.
 
+    Args:
+        coupler_lengths: list of coupler lengths, in um. One per coupler.
+        coupler_gaps: list of coupler gaps, in um. One per coupler.
+        delta_lengths: list of length differences between the MZI arms, in um.
+            One per MZI, so one less than the number of couplers.
+        mzi: MZI component spec.
+
     ```text
                     cp1
     o4  o2 __                  __ o3___w0_t2   _w2___

--- a/gdsfactory/components/pads/pad_gsg.py
+++ b/gdsfactory/components/pads/pad_gsg.py
@@ -79,6 +79,12 @@ pad_gsg_open = partial(pad_gsg_short, short=False)
 
 @gf.cell_with_module_name(schematic_function=pad_schematic, tags=["pads"])
 def pad_gsg(length: float = 100, cross_section: str = "gsg") -> gf.Component:
+    """Returns a ground-signal-ground pad with electrical pins.
+
+    Args:
+        length: length of the GSG transmission line, in um.
+        cross_section: GSG cross_section spec.
+    """
     c = gf.c.straight(cross_section=cross_section, length=length)
     for port in c.ports:
         if port.port_type == "electrical":
@@ -88,6 +94,12 @@ def pad_gsg(length: float = 100, cross_section: str = "gsg") -> gf.Component:
 
 @gf.cell_with_module_name(tags=["pads"])
 def pad_gs(length: float = 100, cross_section: str = "gs") -> gf.Component:
+    """Returns a ground-signal pad.
+
+    Args:
+        length: length of the GS transmission line, in um.
+        cross_section: GS cross_section spec.
+    """
     return gf.c.straight(cross_section=cross_section, length=length)
 
 

--- a/gdsfactory/components/pcms/ruler.py
+++ b/gdsfactory/components/pcms/ruler.py
@@ -56,7 +56,6 @@ def ruler(
         layer: Specific layer to put the ruler geometry on.
         bbox_layers: Layers to include in the bounding box.
         bbox_offset: Offsets for each bounding box layer.
-        cross_section: Cross-section spec for the ruler. Overrides layer if provided.
         long_marks: Marks that are long.
         text_size: Size of the text in um.
     """

--- a/gdsfactory/components/pcms/version_stamp.py
+++ b/gdsfactory/components/pcms/version_stamp.py
@@ -14,6 +14,12 @@ from ..texts.text import text
 
 @gf.cell_with_module_name(tags=["pcms"])
 def pixel(size: int = 1, layer: LayerSpec = "WG") -> Component:
+    """Returns a square pixel, the building block of the QR code.
+
+    Args:
+        size: side length of the square, in um.
+        layer: layer to use.
+    """
     c = gf.Component()
     a = size / 2
     c.add_polygon([(a, a), (a, -a), (-a, -a), (-a, a)], layer)

--- a/gdsfactory/components/rings/disk.py
+++ b/gdsfactory/components/rings/disk.py
@@ -104,15 +104,15 @@ def disk(
     """Disk Resonator.
 
     Args:
-       radius: disk resonator radius.
-       gap: Distance between the bus straight and resonator.
-       wrap_angle_deg: Angle in degrees between 0 and 180.
-        determines how much the bus straight wraps along the resonator.
-        0 corresponds to a straight bus straight.
-        180 corresponds to a bus straight wrapped around half of the resonator.
-       parity (1 or -1): 1, resonator left from bus straight, -1 resonator to the right.
-       cross_section: cross_section spec.
-
+        radius: disk resonator radius.
+        gap: Distance between the bus straight and resonator.
+        wrap_angle_deg: Angle in degrees between 0 and 180.
+            determines how much the bus straight wraps along the resonator.
+            0 corresponds to a straight bus straight.
+            180 corresponds to a bus straight wrapped around half of the resonator.
+        parity: 1 or -1. 1 places the resonator left from the bus straight,
+            -1 places it to the right.
+        cross_section: cross_section spec.
     """
     if parity not in (1, -1):
         raise ValueError("parity must be 1 or -1")
@@ -180,20 +180,21 @@ def disk_heater(
     """Disk Resonator with top metal heater.
 
     Args:
-       radius: disk resonator radius.
-       gap: Distance between the bus straight and resonator.
-       wrap_angle_deg: Angle in degrees between 0 and 180.
-        determines how much the bus straight wraps along the resonator.
-        0 corresponds to a straight bus straight.
-        180 corresponds to a bus straight wrapped around half of the resonator.
-       parity (1 or -1): 1, resonator left from bus straight, -1 resonator to the right.
-       cross_section: cross_section spec.
-       heater_layer: layer of the heater.
-       via_stack: via stack component.
-       heater_width: width of the heater.
-       heater_extent: length of heater beyond disk.
-       via_width: size of the square via at the end of the heater.
-       port_orientation: in degrees.
+        radius: disk resonator radius.
+        gap: Distance between the bus straight and resonator.
+        wrap_angle_deg: Angle in degrees between 0 and 180.
+            determines how much the bus straight wraps along the resonator.
+            0 corresponds to a straight bus straight.
+            180 corresponds to a bus straight wrapped around half of the resonator.
+        parity: 1 or -1. 1 places the resonator left from the bus straight,
+            -1 places it to the right.
+        cross_section: cross_section spec.
+        heater_layer: layer of the heater.
+        via_stack: via stack component.
+        heater_width: width of the heater.
+        heater_extent: length of heater beyond disk.
+        via_width: size of the square via at the end of the heater.
+        port_orientation: in degrees.
     """
     c = gf.Component()
     xs = gf.get_cross_section(cross_section=cross_section)

--- a/gdsfactory/components/rings/ring_pn.py
+++ b/gdsfactory/components/rings/ring_pn.py
@@ -76,8 +76,6 @@ def ring_double_pn(
         drop_gap: gap to drop waveguide. Top gap.
         radius: for the bend and coupler.
         doping_angle: angle in degrees representing portion of ring that is doped.
-        length_x: ring coupler length.
-        length_y: vertical straight length.
         cross_section: cross_section spec for non-PN doped rib waveguide sections.
         pn_cross_section: cross section of pn junction.
         doped_heater: boolean for if we include doped heater or not.
@@ -237,8 +235,6 @@ def ring_single_pn(
         gap: gap between for coupler.
         radius: for the bend and coupler.
         doping_angle: angle in degrees representing portion of ring that is doped.
-        length_x: ring coupler length.
-        length_y: vertical straight length.
         cross_section: cross_section spec for non-PN doped rib waveguide sections.
         pn_cross_section: cross section of pn junction.
         doped_heater: boolean for if we include doped heater or not.

--- a/gdsfactory/components/rings/ring_single_bend_coupler.py
+++ b/gdsfactory/components/rings/ring_single_bend_coupler.py
@@ -110,8 +110,6 @@ def coupler_ring_bend(
     Args:
         radius: um. Default is None, which uses the default radius of the cross_section.
         coupler_gap: um.
-        angle_inner: of the inner bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
-        angle_outer: of the outer bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
         coupling_angle_coverage: degrees.
         length_x: horizontal straight length.
         cross_section_inner: spec inner bend.
@@ -177,8 +175,6 @@ def ring_single_bend_coupler(
         radius: um.
         gap: um.
         coupling_angle_coverage: degrees.
-        angle_inner: of the inner bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
-        angle_outer: of the outer bend, from beginning to end. Depending on the bend chosen, gap may not be preserved.
         bend_all_angle: for bend.
         bend: for bend.
         bend_output: for bend.

--- a/gdsfactory/components/waveguides/straight_heater_metal.py
+++ b/gdsfactory/components/waveguides/straight_heater_metal.py
@@ -194,7 +194,6 @@ def straight_heater_metal_simple(
 
     Args:
         length: of the waveguide.
-        length_undercut: length of each undercut section.
         cross_section_heater: for heated sections. heater metal only.
         cross_section_waveguide_heater: for heated sections.
         via_stack: via stack.


### PR DESCRIPTION
Fixes #4828. Requested by @joamatab.

Audit of every `@cell`-decorated component under `gdsfactory/components/` for signature ↔ `Args:` correspondence:

- **Added missing docstrings** — `die_frame`, `die_frame_rf`, `die_frame_phix_dc`, `die_frame_phix_rf`, `pad_gsg`, `pad_gs`, `pixel`. These were being skipped entirely by `extract_args_from_docstring`, so they never made it into `PDK.to_updk()` output.
- **Added missing `Args:` sections** — `mzit_lattice`, `via3`.
- **Removed documented parameters that no longer exist** — `dbr_cell`, `grating_coupler_elliptical_lumerical`, `mmi_90degree_hybrid`, `ruler`, `ring_single_pn`, `ring_double_pn`, `coupler_ring_bend`, `ring_single_bend_coupler`, `straight_heater_metal_simple`, `bend_modified_hermite_s`.
- **Moved trailing ASCII diagrams / ellipse math out of the `Args:` block** so they stop being parsed as parameters — `disk`, `disk_heater`, `grating_coupler_elliptical_arbitrary`.

Docstring-only; `git diff -U0` contains no executable lines. `pre-commit run --files ...` passes clean (ruff check, ruff format, pyright, codespell).

⚠️ AI-authored — a human needs to review the actual wording before merge.

## Summary by Sourcery

Align component docstrings with their current function signatures and improve argument extraction for generated documentation metadata.

Bug Fixes:
- Correct component docstrings and Args sections so component parameters are accurately represented in generated uPDK metadata.

Enhancements:
- Add missing documentation for previously undocumented components and remove stale parameters from existing docstrings.
- Separate explanatory diagrams and mathematical notes from argument lists to prevent them being parsed as parameters.

Documentation:
- Audit and standardize docstrings across the affected component library, including parameter descriptions and formatting.