### PR TITLE
ci: run Claude review for fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,13 +1,15 @@
 name: Claude Review
 on:
-  pull_request:
+  # This runs in the trusted base-repository context, so fork PRs can use the
+  # repository's OIDC identity and API key. Do not check out or execute PR code
+  # in this workflow.
+  pull_request_target:
     types: [opened, synchronize]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-claude-pr-review
   cancel-in-progress: true
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,7 +17,7 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - name: Checkout repo
+      - name: Checkout trusted base revision
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
@@ -27,3 +29,7 @@ jobs:
           plugins: code-review@claude-code-plugins
           prompt: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
           claude_args: --max-turns 30
+          # Review PRs from every contributor, including forks and Dependabot.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
+          allowed_bots: "*"


### PR DESCRIPTION
Switch the Claude review workflow to pull_request_target so it can obtain the repository OIDC identity and credentials for fork PRs. The workflow checks out only the trusted base revision, permits reviews from all contributors and bots, and keeps the existing OIDC and PR permissions.