### PR TITLE
Fix asymmetric flux qubit geometry and ports

### DIFF
--- a/gdsfactory/components/quantum/flux_qubit.py
+++ b/gdsfactory/components/quantum/flux_qubit.py
@@ -275,10 +275,24 @@ def flux_qubit_asymmetric(
         (-loop_width / 2, loop_height / 2),
     ]
 
+    # Offset the slanted wall along its normal.  Simply subtracting
+    # ``wire_width`` from x (as for a rectangular loop) produces a different
+    # wire width on the slanted side.
+    right_inset = wire_width / np.cos(angle_rad)
+
+    def right_edge(y: float) -> float:
+        return loop_width / 2 + (y + loop_height / 2) * np.tan(angle_rad)
+
     inner_points = [
         (-loop_width / 2 + wire_width, -loop_height / 2 + wire_width),
-        (loop_width / 2 - wire_width, -loop_height / 2 + wire_width),
-        (loop_width / 2 - wire_width + x_offset, loop_height / 2 - wire_width),
+        (
+            right_edge(-loop_height / 2 + wire_width) - right_inset,
+            -loop_height / 2 + wire_width,
+        ),
+        (
+            right_edge(loop_height / 2 - wire_width) - right_inset,
+            loop_height / 2 - wire_width,
+        ),
         (-loop_width / 2 + wire_width, loop_height / 2 - wire_width),
     ]
 
@@ -290,9 +304,23 @@ def flux_qubit_asymmetric(
 
     loop = gf.boolean(outer_comp, inner_comp, operation="not", layer=layer_metal)
 
-    # Cut the loop at each Josephson-junction location. The right edge is
-    # slanted, so its center at y=0 is displaced by half of ``x_offset``.
+    # Cut the loop at each Josephson-junction location. The right-edge gap
+    # and junction follow the slanted wire, so their dimensions remain
+    # correct normal and tangential to that wire.
     gap_margin = 0.05
+
+    def slanted_rectangle(
+        center: tuple[float, float], width: float, height: float
+    ) -> list[tuple[float, float]]:
+        """Returns a rectangle with width normal to the slanted right edge."""
+        normal = np.array((np.cos(angle_rad), -np.sin(angle_rad)))
+        tangent = np.array((np.sin(angle_rad), np.cos(angle_rad)))
+        center_array = np.asarray(center)
+        return [
+            tuple(center_array + sx * width / 2 * normal + sy * height / 2 * tangent)
+            for sx, sy in ((-1, -1), (1, -1), (1, 1), (-1, 1))
+        ]
+
     alpha_gap = Component()
     alpha_gap_ref = alpha_gap.add_ref(
         gf.components.rectangle(
@@ -315,19 +343,19 @@ def flux_qubit_asymmetric(
         (-loop_width / 2 - gap_margin, -junction_height / 2 - gap_margin)
     )
 
-    right_edge_at_junction = loop_width / 2 + x_offset / 2
-    beta_gap_right = Component()
-    beta_gap_right_ref = beta_gap_right.add_ref(
-        gf.components.rectangle(
-            size=(wire_width + 2 * gap_margin, junction_height + 2 * gap_margin),
-            layer=layer_metal,
-        )
+    right_edge_at_junction = right_edge(0)
+    right_normal = np.array((np.cos(angle_rad), -np.sin(angle_rad)))
+    right_junction_center = np.asarray((right_edge_at_junction, 0.0)) - (
+        wire_width / 2 * right_normal
     )
-    beta_gap_right_ref.move(
-        (
-            right_edge_at_junction - wire_width - gap_margin,
-            -junction_height / 2 - gap_margin,
-        )
+    beta_gap_right = Component()
+    beta_gap_right.add_polygon(
+        slanted_rectangle(
+            tuple(right_junction_center),
+            wire_width + 2 * gap_margin,
+            junction_height + 2 * gap_margin,
+        ),
+        layer=layer_metal,
     )
 
     for gap in (alpha_gap, beta_gap_left, beta_gap_right):
@@ -357,18 +385,29 @@ def flux_qubit_asymmetric(
         (-loop_width / 2 + wire_width / 2 - junction_width / 2, -junction_height / 2)
     )
 
-    # Right side center x is shifted by half the x_offset
-    right_center_x = loop_width / 2 - wire_width / 2 + x_offset / 2
-    beta_junction_right = gf.components.rectangle(
-        size=(junction_width, junction_height),
+    c.add_polygon(
+        slanted_rectangle(
+            tuple(right_junction_center), junction_width, junction_height
+        ),
         layer=layer_junction,
     )
-    beta_junction_right_ref = c.add_ref(beta_junction_right)
-    beta_junction_right_ref.move(
-        (right_center_x - junction_width / 2, -junction_height / 2)
-    )
 
-    # Add control and readout ports
+    # Add metal leads that terminate at the two external ports.  Ports must be
+    # on physical conductor ends, not floating outside the qubit loop.
+    flux_lead = c.add_ref(
+        gf.components.rectangle(size=(wire_width, 10.0), layer=layer_metal)
+    )
+    flux_lead.move((-wire_width / 2, loop_height / 2))
+
+    readout_y = loop_height / 4
+    readout_start_x = right_edge(readout_y) - wire_width / 2
+    readout_lead = c.add_ref(
+        gf.components.rectangle(
+            size=(10.0 + wire_width / 2, wire_width), layer=layer_metal
+        )
+    )
+    readout_lead.move((readout_start_x, readout_y - wire_width / 2))
+
     c.add_port(
         name="flux_control",
         center=(0, loop_height / 2 + 10.0),
@@ -380,7 +419,7 @@ def flux_qubit_asymmetric(
 
     c.add_port(
         name="readout",
-        center=(loop_width / 2 + x_offset + 10.0, 0),
+        center=(right_edge(readout_y) + 10.0, readout_y),
         width=wire_width,
         orientation=0,
         layer=layer_metal,


### PR DESCRIPTION
## Summary
- preserve the requested wire width normal to the asymmetric slanted arm
- align the right beta-junction cut and junction polygon to that arm
- add metal leads so flux-control and readout ports end on conductors

## Validation
- `uv run ruff check gdsfactory/components/quantum/flux_qubit.py`
- `uv run ruff format --check gdsfactory/components/quantum/flux_qubit.py`
- `uv run pytest tests/components/test_components.py -k 'flux_qubit and not test_gds' -q --tb=short`\n- rendered and inspected `flux_qubit_asymmetric`; verified both port centers intersect the metal layer\n\nThe GDS reference under `test-data-gds/` is locally ignored, so it is not included in this change; its geometry is intentionally superseded by this fix.