### PR TITLE
feat: allow custom PHIX die fiducials

### DIFF
--- a/gdsfactory/components/dies/die_frame_with_pads.py
+++ b/gdsfactory/components/dies/die_frame_with_pads.py
@@ -164,6 +164,10 @@ def die_frame_phix(
     pad_port_name_bot: str = "e2",
     pad_port_name_rf: str = "e2",
     layer_fiducial: LayerSpec = "M3",
+    fiducial_top_left: ComponentSpec | None = None,
+    fiducial_top_right: ComponentSpec | None = None,
+    fiducial_bottom_left: ComponentSpec | None = None,
+    fiducial_bottom_right: ComponentSpec | None = None,
     layer_ruler: LayerSpec = "WG",
     ruler_bbox_layers: tuple[LayerSpec, ...] | None = None,
     ruler_bbox_offset: float = 3.0,
@@ -202,6 +206,14 @@ def die_frame_phix(
         pad_port_name_bot: name of the pad port name at the bottom facing north.
         pad_port_name_rf: name of the RF pad port name.
         layer_fiducial: layer for fiducials.
+        fiducial_top_left: optional top-left fiducial. Defaults to the legacy
+            cross on ``layer_fiducial``.
+        fiducial_top_right: optional top-right fiducial. Defaults to the legacy
+            circle on ``layer_fiducial``.
+        fiducial_bottom_left: optional bottom-left fiducial. Defaults to the
+            legacy circle on ``layer_fiducial``.
+        fiducial_bottom_right: optional bottom-right fiducial. Defaults to the
+            legacy circle on ``layer_fiducial``.
         layer_ruler: layer for ruler.
         ruler_bbox_layers: layers for bbox.
         ruler_bbox_offset: offset for bbox.
@@ -359,9 +371,13 @@ def die_frame_phix(
     x0_pads = -xs / 2 + pad_side_distance
     x0 = x0_pads
 
-    top_left = c << gf.c.cross(layer=layer_fiducial, length=150, width=20)
-    top_left.xmax = x0 - 75
-    top_left.y = +ys / 2 - edge_to_pad_distance - 50
+    if fiducial_top_left:
+        top_left = c << gf.get_component(fiducial_top_left)
+        top_left.center = (x0 - 150, +ys / 2 - edge_to_pad_distance - 50)
+    else:
+        top_left = c << gf.c.cross(layer=layer_fiducial, length=150, width=20)
+        top_left.xmax = x0 - 75
+        top_left.y = +ys / 2 - edge_to_pad_distance - 50
 
     # north pads
     for i in range(npads):
@@ -373,13 +389,21 @@ def die_frame_phix(
             name=f"N{i}",
             port=pad_ref.ports[pad_port_name_top],
         )
-    top_right = c << gf.c.circle(layer=layer_fiducial, radius=75)
-    top_right.xmin = pad_ref.xmax + 480
-    top_right.y = +ys / 2 - edge_to_pad_distance - 50
+    if fiducial_top_right:
+        top_right = c << gf.get_component(fiducial_top_right)
+        top_right.center = (pad_ref.xmax + 555, +ys / 2 - edge_to_pad_distance - 50)
+    else:
+        top_right = c << gf.c.circle(layer=layer_fiducial, radius=75)
+        top_right.xmin = pad_ref.xmax + 480
+        top_right.y = +ys / 2 - edge_to_pad_distance - 50
 
-    bot_left = c << gf.c.circle(layer=layer_fiducial, radius=75)
-    bot_left.xmax = x0 - 75
-    bot_left.y = -ys / 2 + edge_to_pad_distance + 50
+    if fiducial_bottom_left:
+        bot_left = c << gf.get_component(fiducial_bottom_left)
+        bot_left.center = (x0 - 150, -ys / 2 + edge_to_pad_distance + 50)
+    else:
+        bot_left = c << gf.c.circle(layer=layer_fiducial, radius=75)
+        bot_left.xmax = x0 - 75
+        bot_left.y = -ys / 2 + edge_to_pad_distance + 50
 
     x0 = x0_pads
 
@@ -394,9 +418,13 @@ def die_frame_phix(
             port=pad_ref.ports[pad_port_name_bot],
         )
 
-    bot_right = c << gf.c.circle(layer=layer_fiducial, radius=75)
-    bot_right.xmin = pad_ref.xmax + 480
-    bot_right.ymin = -ys / 2 + edge_to_pad_distance
+    if fiducial_bottom_right:
+        bot_right = c << gf.get_component(fiducial_bottom_right)
+        bot_right.center = (pad_ref.xmax + 555, -ys / 2 + edge_to_pad_distance + 75)
+    else:
+        bot_right = c << gf.c.circle(layer=layer_fiducial, radius=75)
+        bot_right.xmin = pad_ref.xmax + 480
+        bot_right.ymin = -ys / 2 + edge_to_pad_distance
 
     elec_ports = [p for p in c.ports if p.name and p.port_type == "electrical"]
     for p in elec_ports:
@@ -424,6 +452,10 @@ def die_frame_phix_dc(
     pad_port_name_top: str = "e4",
     pad_port_name_bot: str = "e2",
     layer_fiducial: LayerSpec = "M3",
+    fiducial_top_left: ComponentSpec | None = None,
+    fiducial_top_right: ComponentSpec | None = None,
+    fiducial_bottom_left: ComponentSpec | None = None,
+    fiducial_bottom_right: ComponentSpec | None = None,
     layer_ruler: LayerSpec = "WG",
     ruler_bbox_layers: tuple[LayerSpec, ...] | None = None,
     ruler_bbox_offset: float = 3.0,
@@ -457,6 +489,10 @@ def die_frame_phix_dc(
         pad_port_name_top: name of the pad port name at the top facing south.
         pad_port_name_bot: name of the pad port name at the bottom facing north.
         layer_fiducial: layer for fiducials.
+        fiducial_top_left: optional top-left fiducial; defaults to a cross.
+        fiducial_top_right: optional top-right fiducial; defaults to a circle.
+        fiducial_bottom_left: optional bottom-left fiducial; defaults to a circle.
+        fiducial_bottom_right: optional bottom-right fiducial; defaults to a circle.
         layer_ruler: layer for ruler.
         ruler_bbox_layers: layers for bbox.
         ruler_bbox_offset: offset for bbox.
@@ -488,6 +524,10 @@ def die_frame_phix_dc(
         pad_port_name_top=pad_port_name_top,
         pad_port_name_bot=pad_port_name_bot,
         layer_fiducial=layer_fiducial,
+        fiducial_top_left=fiducial_top_left,
+        fiducial_top_right=fiducial_top_right,
+        fiducial_bottom_left=fiducial_bottom_left,
+        fiducial_bottom_right=fiducial_bottom_right,
         layer_ruler=layer_ruler,
         ruler_bbox_layers=ruler_bbox_layers,
         ruler_bbox_offset=ruler_bbox_offset,
@@ -523,6 +563,10 @@ def die_frame_phix_rf(
     pad_port_name_bot: str = "e2",
     pad_port_name_rf: str = "e2",
     layer_fiducial: LayerSpec = "M3",
+    fiducial_top_left: ComponentSpec | None = None,
+    fiducial_top_right: ComponentSpec | None = None,
+    fiducial_bottom_left: ComponentSpec | None = None,
+    fiducial_bottom_right: ComponentSpec | None = None,
     layer_ruler: LayerSpec = "WG",
     ruler_bbox_layers: tuple[LayerSpec, ...] | None = None,
     ruler_bbox_offset: float = 3.0,
@@ -559,6 +603,10 @@ def die_frame_phix_rf(
         pad_port_name_bot: name of the pad port name at the bottom facing north.
         pad_port_name_rf: name of the RF pad port name.
         layer_fiducial: layer for fiducials.
+        fiducial_top_left: optional top-left fiducial; defaults to a cross.
+        fiducial_top_right: optional top-right fiducial; defaults to a circle.
+        fiducial_bottom_left: optional bottom-left fiducial; defaults to a circle.
+        fiducial_bottom_right: optional bottom-right fiducial; defaults to a circle.
         layer_ruler: layer for ruler.
         ruler_bbox_layers: layers for bbox.
         ruler_bbox_offset: offset for bbox.
@@ -593,6 +641,10 @@ def die_frame_phix_rf(
         pad_port_name_bot=pad_port_name_bot,
         pad_port_name_rf=pad_port_name_rf,
         layer_fiducial=layer_fiducial,
+        fiducial_top_left=fiducial_top_left,
+        fiducial_top_right=fiducial_top_right,
+        fiducial_bottom_left=fiducial_bottom_left,
+        fiducial_bottom_right=fiducial_bottom_right,
         layer_ruler=layer_ruler,
         ruler_bbox_layers=ruler_bbox_layers,
         ruler_bbox_offset=ruler_bbox_offset,

--- a/tests/components/test_die_frame_phix.py
+++ b/tests/components/test_die_frame_phix.py
@@ -1,0 +1,19 @@
+import gdsfactory as gf
+
+
+def test_die_frame_phix_accepts_individual_custom_fiducials() -> None:
+    """Each legacy fiducial can be independently replaced."""
+    layers = [(999, datatype) for datatype in range(4)]
+    fiducials = [
+        gf.c.rectangle(size=(30, 30), layer=layer, centered=True) for layer in layers
+    ]
+
+    die = gf.c.die_frame_phix_dc(
+        fiducial_top_left=fiducials[0],
+        fiducial_top_right=fiducials[1],
+        fiducial_bottom_left=fiducials[2],
+        fiducial_bottom_right=fiducials[3],
+    )
+
+    polygons = die.get_polygons(layers=layers, by="tuple")
+    assert {layer: len(polygons[layer]) for layer in layers} == dict.fromkeys(layers, 1)

--- a/tests/test-data-regression/test_settings_die_frame_phix_dc_.yml
+++ b/tests/test-data-regression/test_settings_die_frame_phix_dc_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: die_frame_phix_dc_gdsfactorypcomponentspdiespdie_frame__9963cae9
+name: die_frame_phix_dc_gdsfactorypcomponentspdiespdie_frame__81e259b1
 settings:
   cross_section: strip
   die_frame: die_frame

--- a/tests/test-data-regression/test_settings_die_frame_phix_rf_.yml
+++ b/tests/test-data-regression/test_settings_die_frame_phix_rf_.yml
@@ -1,5 +1,5 @@
 info: {}
-name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__bb3fe5f0
+name: die_frame_phix_rf_gdsfactorypcomponentspdiespdie_frame__f6e22b50
 settings:
   cross_section: strip
   die_frame: die_frame_rf


### PR DESCRIPTION
Adds independent optional ComponentSpec parameters for the four PHIX die fiducial positions:

- `fiducial_top_left` defaults to the existing 150 um × 20 um cross.
- `fiducial_top_right`, `fiducial_bottom_left`, and `fiducial_bottom_right` each default to the existing 75 um-radius circle.

All default geometry and placement are unchanged. A PDK can replace any subset of markers with foundry-specific, DRC-compliant components; for example, PH18 can provide slotted Metal3 rectangles at the required locations.

Includes a regression test that supplies four different custom markers and verifies that each is independently placed.
