### PR TITLE
add endpoint straight lengths to sbend routers

### DIFF
--- a/gdsfactory/routing/route_bundle_sbend.py
+++ b/gdsfactory/routing/route_bundle_sbend.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import Any
 
 import kfactory as kf
@@ -9,7 +8,7 @@ from kfactory.routing.generic import ManhattanRoute
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.routing.auto_taper import add_auto_tapers
-from gdsfactory.routing.route_single_sbend import _with_endpoint_straights
+from gdsfactory.routing.route_single_sbend import _add_endpoint_straights
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
 from gdsfactory.typings import (
     ComponentSpec,
@@ -97,8 +96,24 @@ def route_bundle_sbend(
                 f"port1 = {p1.orientation} deg and port2 = {p2.orientation}"
             )
 
-        ys = p2.center[1] - p1.center[1]
-        xs = p2.center[0] - p1.center[0]
+        straight_cross_section = (
+            cross_section or p1.info.get("cross_section") or "strip"
+        )
+        bend_width = p1.width if use_port_width else None
+        bend_port1, bend_port2 = _add_endpoint_straights(
+            component,
+            p1,
+            p2,
+            start_straight_length,
+            end_straight_length,
+            straight_cross_section,
+            width=bend_width,
+            allow_width_mismatch=allow_width_mismatch,
+            allow_layer_mismatch=allow_layer_mismatch,
+            allow_type_mismatch=allow_type_mismatch,
+        )
+        ys = bend_port2.center[1] - bend_port1.center[1]
+        xs = bend_port2.center[0] - bend_port1.center[0]
 
         if p1.orientation in [0, 180]:
             xsize = xs
@@ -111,8 +126,6 @@ def route_bundle_sbend(
             xsize = -ys
             ysize = xs
 
-        straight_length = start_straight_length + end_straight_length
-        xsize -= math.copysign(straight_length, xsize)
         bend_kwargs = dict(**kwargs)
         if cross_section is not None:
             bend_kwargs["cross_section"] = cross_section
@@ -122,19 +135,10 @@ def route_bundle_sbend(
             )
         else:
             bend = gf.get_component(bend_s, size=(xsize, ysize), **bend_kwargs)
-
-        if straight_length:
-            bend = _with_endpoint_straights(
-                bend=bend,
-                start_port_name=port_name,
-                start_straight_length=start_straight_length,
-                end_straight_length=end_straight_length,
-                cross_section=cross_section,
-            )
         sbend = component << bend
         sbend.connect(
             port_name,
-            p1,
+            bend_port1,
             allow_width_mismatch=allow_width_mismatch,
             allow_layer_mismatch=allow_layer_mismatch,
             allow_type_mismatch=allow_type_mismatch,

--- a/gdsfactory/routing/route_bundle_sbend.py
+++ b/gdsfactory/routing/route_bundle_sbend.py
@@ -8,7 +8,7 @@ from kfactory.routing.generic import ManhattanRoute
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.routing.auto_taper import add_auto_tapers
-from gdsfactory.routing.route_single_sbend import _add_endpoint_straights
+from gdsfactory.routing.route_single_sbend import add_straight
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
 from gdsfactory.typings import (
     ComponentSpec,
@@ -100,12 +100,22 @@ def route_bundle_sbend(
             cross_section or p1.info.get("cross_section") or "strip"
         )
         bend_width = p1.width if use_port_width else None
-        bend_port1, bend_port2 = _add_endpoint_straights(
+        bend_port1 = add_straight(
             component,
             p1,
-            p2,
             start_straight_length,
+            0,
+            straight_cross_section,
+            width=bend_width,
+            allow_width_mismatch=allow_width_mismatch,
+            allow_layer_mismatch=allow_layer_mismatch,
+            allow_type_mismatch=allow_type_mismatch,
+        )
+        bend_port2 = add_straight(
+            component,
+            p2,
             end_straight_length,
+            1,
             straight_cross_section,
             width=bend_width,
             allow_width_mismatch=allow_width_mismatch,

--- a/gdsfactory/routing/route_bundle_sbend.py
+++ b/gdsfactory/routing/route_bundle_sbend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import kfactory as kf
@@ -33,6 +34,8 @@ def route_bundle_sbend(
     auto_taper: bool = True,
     cross_section: CrossSectionSpec | None = None,
     layer_transitions: LayerTransitions | None = None,
+    start_straight_length: float = 0.0,
+    end_straight_length: float = 0.0,
     **kwargs: Any,
 ) -> list[ManhattanRoute]:
     """Places sbend routes from ports1 to ports2.
@@ -52,6 +55,8 @@ def route_bundle_sbend(
         auto_taper: if True, auto-tapers ports to the cross-section of the route.
         cross_section: cross-section to use for auto-tapering. Required when auto_taper=True.
         layer_transitions: dictionary of layer transitions for auto-tapering.
+        start_straight_length: length of the straight at the start of the route.
+        end_straight_length: length of the straight at the end of the route.
         kwargs: cross_section settings.
 
     """
@@ -105,6 +110,8 @@ def route_bundle_sbend(
             xsize = -ys
             ysize = xs
 
+        straight_length = start_straight_length + end_straight_length
+        xsize -= math.copysign(straight_length, xsize)
         bend_kwargs = dict(**kwargs)
         if cross_section is not None:
             bend_kwargs["cross_section"] = cross_section
@@ -114,6 +121,32 @@ def route_bundle_sbend(
             )
         else:
             bend = gf.get_component(bend_s, size=(xsize, ysize), **bend_kwargs)
+
+        port_names = [port.name for port in bend.ports]
+        straight_cross_section = cross_section or bend.ports[port_name].info.get(
+            "cross_section"
+        )
+        if start_straight_length:
+            bend = gf.components.extend_ports(
+                bend,
+                port_names=(port_name,),
+                extension=gf.components.straight(
+                    length=start_straight_length,
+                    cross_section=straight_cross_section,
+                    width=bend.ports[port_name].width,
+                ),
+            )
+        if end_straight_length:
+            end_port_name = next(name for name in port_names if name != port_name)
+            bend = gf.components.extend_ports(
+                bend,
+                port_names=(end_port_name,),
+                extension=gf.components.straight(
+                    length=end_straight_length,
+                    cross_section=straight_cross_section,
+                    width=bend.ports[end_port_name].width,
+                ),
+            )
         sbend = component << bend
         sbend.connect(
             port_name,

--- a/gdsfactory/routing/route_bundle_sbend.py
+++ b/gdsfactory/routing/route_bundle_sbend.py
@@ -9,6 +9,7 @@ from kfactory.routing.generic import ManhattanRoute
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.routing.auto_taper import add_auto_tapers
+from gdsfactory.routing.route_single_sbend import _with_endpoint_straights
 from gdsfactory.routing.sort_ports import sort_ports as sort_ports_function
 from gdsfactory.typings import (
     ComponentSpec,
@@ -122,30 +123,13 @@ def route_bundle_sbend(
         else:
             bend = gf.get_component(bend_s, size=(xsize, ysize), **bend_kwargs)
 
-        port_names = [port.name for port in bend.ports]
-        straight_cross_section = cross_section or bend.ports[port_name].info.get(
-            "cross_section"
-        )
-        if start_straight_length:
-            bend = gf.components.extend_ports(
-                bend,
-                port_names=(port_name,),
-                extension=gf.components.straight(
-                    length=start_straight_length,
-                    cross_section=straight_cross_section,
-                    width=bend.ports[port_name].width,
-                ),
-            )
-        if end_straight_length:
-            end_port_name = next(name for name in port_names if name != port_name)
-            bend = gf.components.extend_ports(
-                bend,
-                port_names=(end_port_name,),
-                extension=gf.components.straight(
-                    length=end_straight_length,
-                    cross_section=straight_cross_section,
-                    width=bend.ports[end_port_name].width,
-                ),
+        if straight_length:
+            bend = _with_endpoint_straights(
+                bend=bend,
+                start_port_name=port_name,
+                start_straight_length=start_straight_length,
+                end_straight_length=end_straight_length,
+                cross_section=cross_section,
             )
         sbend = component << bend
         sbend.connect(

--- a/gdsfactory/routing/route_single_sbend.py
+++ b/gdsfactory/routing/route_single_sbend.py
@@ -7,29 +7,22 @@ from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Port
 
 
-def _add_endpoint_straights(
+def add_straight(
     component: Component,
-    port1: Port,
-    port2: Port,
-    start_straight_length: float,
-    end_straight_length: float,
+    port: Port,
+    length: float,
+    port_index: int,
     cross_section: CrossSectionSpec,
     width: float | None = None,
     **connect_kwargs: Any,
-) -> tuple[Port, Port]:
-    def add_straight(port: Port, length: float, port_index: int) -> Port:
-        if not length:
-            return port
-        straight = component << gf.components.straight(
-            length=length, cross_section=cross_section, width=width
-        )
-        straight.connect(straight.ports[port_index], port, **connect_kwargs)
-        return straight.ports[1 - port_index]
-
-    return (
-        add_straight(port1, start_straight_length, 0),
-        add_straight(port2, end_straight_length, 1),
+) -> Port:
+    if not length:
+        return port
+    straight = component << gf.components.straight(
+        length=length, cross_section=cross_section, width=width
     )
+    straight.connect(straight.ports[port_index], port, **connect_kwargs)
+    return straight.ports[1 - port_index]
 
 
 def route_bundle_sbend(
@@ -69,12 +62,20 @@ def route_bundle_sbend(
         c.plot()
         ```
     """
-    bend_port1, bend_port2 = _add_endpoint_straights(
+    bend_port1 = add_straight(
         component,
         port1,
-        port2,
         start_straight_length,
+        0,
+        cross_section,
+        allow_layer_mismatch=allow_layer_mismatch,
+        allow_width_mismatch=allow_width_mismatch,
+    )
+    bend_port2 = add_straight(
+        component,
+        port2,
         end_straight_length,
+        1,
         cross_section,
         allow_layer_mismatch=allow_layer_mismatch,
         allow_width_mismatch=allow_width_mismatch,

--- a/gdsfactory/routing/route_single_sbend.py
+++ b/gdsfactory/routing/route_single_sbend.py
@@ -1,45 +1,34 @@
 from __future__ import annotations
 
-import math
+from typing import Any
 
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Port
 
 
-@gf.cell
-def _with_endpoint_straights(
-    bend: ComponentSpec,
-    start_port_name: str,
+def _add_endpoint_straights(
+    component: Component,
+    port1: Port,
+    port2: Port,
     start_straight_length: float,
     end_straight_length: float,
-    cross_section: CrossSectionSpec | None = None,
-) -> Component:
-    bend = gf.get_component(bend)
-    port_names = [port.name for port in bend.ports]
-    end_port_name = next(name for name in port_names if name != start_port_name)
-    cross_section = cross_section or bend.ports[start_port_name].info.get(
-        "cross_section"
-    )
-    start_straight = gf.components.straight(
-        length=start_straight_length,
-        cross_section=cross_section,
-        width=bend.ports[start_port_name].width,
-    )
-    end_straight = gf.components.straight(
-        length=end_straight_length,
-        cross_section=cross_section,
-        width=bend.ports[end_port_name].width,
-    )
-    return gf.components.component_sequence(
-        sequence="SBE",
-        symbol_to_component={
-            "S": (start_straight, "o1", "o2"),
-            "B": (bend, start_port_name, end_port_name),
-            "E": (end_straight, "o1", "o2"),
-        },
-        port_name1=start_port_name,
-        port_name2=end_port_name,
+    cross_section: CrossSectionSpec,
+    width: float | None = None,
+    **connect_kwargs: Any,
+) -> tuple[Port, Port]:
+    def add_straight(port: Port, length: float, port_index: int) -> Port:
+        if not length:
+            return port
+        straight = component << gf.components.straight(
+            length=length, cross_section=cross_section, width=width
+        )
+        straight.connect(straight.ports[port_index], port, **connect_kwargs)
+        return straight.ports[1 - port_index]
+
+    return (
+        add_straight(port1, start_straight_length, 0),
+        add_straight(port2, end_straight_length, 1),
     )
 
 
@@ -80,28 +69,28 @@ def route_bundle_sbend(
         c.plot()
         ```
     """
-    ysize = port2.center[1] - port1.center[1]
-    xsize = port2.center[0] - port1.center[0]
+    bend_port1, bend_port2 = _add_endpoint_straights(
+        component,
+        port1,
+        port2,
+        start_straight_length,
+        end_straight_length,
+        cross_section,
+        allow_layer_mismatch=allow_layer_mismatch,
+        allow_width_mismatch=allow_width_mismatch,
+    )
+    ysize = bend_port2.center[1] - bend_port1.center[1]
+    xsize = bend_port2.center[0] - bend_port1.center[0]
 
     # We need to act differently if the route is orthogonal in x
     # or orthogonal in y
     size = (xsize, ysize) if port1.orientation in [0, 180] else (ysize, -xsize)
-    straight_length = start_straight_length + end_straight_length
-    size = (size[0] - math.copysign(straight_length, size[0]), size[1])
     bend = gf.get_component(bend_s, size=size, cross_section=cross_section)
-    if straight_length:
-        bend = _with_endpoint_straights(
-            bend=bend,
-            start_port_name=bend.ports[0].name,
-            start_straight_length=start_straight_length,
-            end_straight_length=end_straight_length,
-            cross_section=cross_section,
-        )
 
     bend_ref = component << bend
     bend_ref.connect(
         bend_ref.ports[0],
-        port1,
+        bend_port1,
         allow_layer_mismatch=allow_layer_mismatch,
         allow_width_mismatch=allow_width_mismatch,
     )

--- a/gdsfactory/routing/route_single_sbend.py
+++ b/gdsfactory/routing/route_single_sbend.py
@@ -7,6 +7,42 @@ from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Port
 
 
+@gf.cell
+def _with_endpoint_straights(
+    bend: ComponentSpec,
+    start_port_name: str,
+    start_straight_length: float,
+    end_straight_length: float,
+    cross_section: CrossSectionSpec | None = None,
+) -> Component:
+    bend = gf.get_component(bend)
+    port_names = [port.name for port in bend.ports]
+    end_port_name = next(name for name in port_names if name != start_port_name)
+    cross_section = cross_section or bend.ports[start_port_name].info.get(
+        "cross_section"
+    )
+    start_straight = gf.components.straight(
+        length=start_straight_length,
+        cross_section=cross_section,
+        width=bend.ports[start_port_name].width,
+    )
+    end_straight = gf.components.straight(
+        length=end_straight_length,
+        cross_section=cross_section,
+        width=bend.ports[end_port_name].width,
+    )
+    return gf.components.component_sequence(
+        sequence="SBE",
+        symbol_to_component={
+            "S": (start_straight, "o1", "o2"),
+            "B": (bend, start_port_name, end_port_name),
+            "E": (end_straight, "o1", "o2"),
+        },
+        port_name1=start_port_name,
+        port_name2=end_port_name,
+    )
+
+
 def route_bundle_sbend(
     component: Component,
     port1: Port,
@@ -53,27 +89,13 @@ def route_bundle_sbend(
     straight_length = start_straight_length + end_straight_length
     size = (size[0] - math.copysign(straight_length, size[0]), size[1])
     bend = gf.get_component(bend_s, size=size, cross_section=cross_section)
-
-    port_names = [port.name for port in bend.ports]
-    if start_straight_length:
-        bend = gf.components.extend_ports(
-            bend,
-            port_names=(port_names[0],),
-            extension=gf.components.straight(
-                length=start_straight_length,
-                cross_section=cross_section,
-                width=bend.ports[port_names[0]].width,
-            ),
-        )
-    if end_straight_length:
-        bend = gf.components.extend_ports(
-            bend,
-            port_names=(port_names[1],),
-            extension=gf.components.straight(
-                length=end_straight_length,
-                cross_section=cross_section,
-                width=bend.ports[port_names[1]].width,
-            ),
+    if straight_length:
+        bend = _with_endpoint_straights(
+            bend=bend,
+            start_port_name=bend.ports[0].name,
+            start_straight_length=start_straight_length,
+            end_straight_length=end_straight_length,
+            cross_section=cross_section,
         )
 
     bend_ref = component << bend

--- a/gdsfactory/routing/route_single_sbend.py
+++ b/gdsfactory/routing/route_single_sbend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import gdsfactory as gf
 from gdsfactory.component import Component, ComponentReference
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, Port
@@ -13,6 +15,8 @@ def route_bundle_sbend(
     cross_section: CrossSectionSpec = "strip",
     allow_layer_mismatch: bool = False,
     allow_width_mismatch: bool = False,
+    start_straight_length: float = 0.0,
+    end_straight_length: float = 0.0,
 ) -> ComponentReference:
     """Returns an Sbend to connect two ports.
 
@@ -24,6 +28,8 @@ def route_bundle_sbend(
         cross_section: cross_section.
         allow_layer_mismatch: allow layer mismatch.
         allow_width_mismatch: allow width mismatch.
+        start_straight_length: length of the straight at the start of the route.
+        end_straight_length: length of the straight at the end of the route.
 
     Example:
         ```python
@@ -44,7 +50,31 @@ def route_bundle_sbend(
     # We need to act differently if the route is orthogonal in x
     # or orthogonal in y
     size = (xsize, ysize) if port1.orientation in [0, 180] else (ysize, -xsize)
+    straight_length = start_straight_length + end_straight_length
+    size = (size[0] - math.copysign(straight_length, size[0]), size[1])
     bend = gf.get_component(bend_s, size=size, cross_section=cross_section)
+
+    port_names = [port.name for port in bend.ports]
+    if start_straight_length:
+        bend = gf.components.extend_ports(
+            bend,
+            port_names=(port_names[0],),
+            extension=gf.components.straight(
+                length=start_straight_length,
+                cross_section=cross_section,
+                width=bend.ports[port_names[0]].width,
+            ),
+        )
+    if end_straight_length:
+        bend = gf.components.extend_ports(
+            bend,
+            port_names=(port_names[1],),
+            extension=gf.components.straight(
+                length=end_straight_length,
+                cross_section=cross_section,
+                width=bend.ports[port_names[1]].width,
+            ),
+        )
 
     bend_ref = component << bend
     bend_ref.connect(

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -11,14 +11,11 @@ def assert_endpoint_straights(
     end_straight_length: float,
     bend_size: tuple[float, float],
 ) -> None:
-    start_extension = sbend.cell.insts[0]
-    bend = start_extension.cell.insts[0]
+    start_straight, bend, end_straight = sbend.cell.insts
 
     assert bend.cell.settings["size"] == bend_size
-    assert (
-        start_extension.cell.insts[1].cell.settings["length"] == start_straight_length
-    )
-    assert sbend.cell.insts[1].cell.settings["length"] == end_straight_length
+    assert start_straight.cell.settings["length"] == start_straight_length
+    assert end_straight.cell.settings["length"] == end_straight_length
 
 
 def test_route_bundle_sbend() -> None:

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -50,6 +50,23 @@ def test_route_single_sbend_endpoint_straights() -> None:
     assert_endpoint_straights(sbend, 3, 7, (30, 5))
 
 
+def test_route_single_sbend_without_endpoint_straights() -> None:
+    c = gf.Component()
+    left = c << gf.components.straight(length=10)
+    right = c << gf.components.straight(length=10)
+    right.movex(50)
+    right.movey(5)
+
+    sbend = gf.routing.route_single_sbend(
+        c,
+        left.ports["o2"],
+        right.ports["o1"],
+    )
+
+    assert tuple(sbend.ports[0].center) == tuple(left.ports["o2"].center)
+    assert tuple(sbend.ports[1].center) == tuple(right.ports["o1"].center)
+
+
 def test_route_bundle_sbend_endpoint_straights() -> None:
     c = gf.Component()
     left = c << gf.components.straight(length=10)
@@ -76,3 +93,13 @@ def test_route_bundle_sbend_non_orthogonal() -> None:
 
     with pytest.raises(ValueError, match="Ports need to have orthogonal orientation"):
         gf.routing.route_bundle_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])
+
+
+def test_route_single_sbend_non_orthogonal() -> None:
+    c = gf.Component(name="test_route_single_sbend_non_orthogonal")
+    mmi1 = c << gf.components.mmi1x2()
+    mmi2 = c << gf.components.mmi1x2()
+    mmi2.rotate(45)
+
+    with pytest.raises(ValueError, match="Ports need to have orthogonal orientation"):
+        gf.routing.route_single_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -5,6 +5,22 @@ import pytest
 import gdsfactory as gf
 
 
+def assert_endpoint_straights(
+    sbend: gf.ComponentReference,
+    start_straight_length: float,
+    end_straight_length: float,
+    bend_size: tuple[float, float],
+) -> None:
+    start_extension = sbend.cell.insts[0]
+    bend = start_extension.cell.insts[0]
+
+    assert bend.cell.settings["size"] == bend_size
+    assert (
+        start_extension.cell.insts[1].cell.settings["length"] == start_straight_length
+    )
+    assert sbend.cell.insts[1].cell.settings["length"] == end_straight_length
+
+
 def test_route_bundle_sbend() -> None:
     c = gf.Component(name="test_route_bundle_sbend")
     mmi1 = c << gf.components.mmi1x2()
@@ -14,6 +30,42 @@ def test_route_bundle_sbend() -> None:
 
     gf.routing.route_bundle_sbend(c, mmi1.ports["o2"], mmi2.ports["o1"])
     assert len(c.insts) == 3
+
+
+def test_route_single_sbend_endpoint_straights() -> None:
+    c = gf.Component()
+    left = c << gf.components.straight(length=10)
+    right = c << gf.components.straight(length=10)
+    right.movex(50)
+    right.movey(5)
+
+    sbend = gf.routing.route_single_sbend(
+        c,
+        left.ports["o2"],
+        right.ports["o1"],
+        start_straight_length=3,
+        end_straight_length=7,
+    )
+
+    assert_endpoint_straights(sbend, 3, 7, (30, 5))
+
+
+def test_route_bundle_sbend_endpoint_straights() -> None:
+    c = gf.Component()
+    left = c << gf.components.straight(length=10)
+    right = c << gf.components.straight(length=10)
+    right.movex(50)
+    right.movey(5)
+
+    gf.routing.route_bundle_sbend(
+        c,
+        left.ports["o2"],
+        right.ports["o1"],
+        start_straight_length=3,
+        end_straight_length=7,
+    )
+
+    assert_endpoint_straights(c.insts[-1], 3, 7, (30, 5))
 
 
 def test_route_bundle_sbend_non_orthogonal() -> None:

--- a/tests/routing/test_route_single_sbend.py
+++ b/tests/routing/test_route_single_sbend.py
@@ -11,7 +11,7 @@ def assert_endpoint_straights(
     end_straight_length: float,
     bend_size: tuple[float, float],
 ) -> None:
-    start_straight, bend, end_straight = sbend.cell.insts
+    start_straight, end_straight, bend = list(sbend.parent_cell.insts)[-3:]
 
     assert bend.cell.settings["size"] == bend_size
     assert start_straight.cell.settings["length"] == start_straight_length


### PR DESCRIPTION
Closes #4814

Adds route-level start_straight_length and end_straight_length support to route_single_sbend and route_bundle_sbend while preserving their existing default behavior.

<img width="2655" height="1717" alt="image" src="https://github.com/user-attachments/assets/773da6f2-9773-463d-812a-90ad4acde5e8" />


Tests:
- uv run --frozen --extra dev pytest tests/routing -q
- UV_CACHE_DIR=/private/tmp/uvcache uv run pre-commit run --all-files