### PR TITLE
fix add_pads_bot/add_pads_top default component

### DIFF
--- a/gdsfactory/routing/add_pads.py
+++ b/gdsfactory/routing/add_pads.py
@@ -18,7 +18,7 @@ from gdsfactory.typings import (
 
 
 def add_pads_bot(
-    component: ComponentSpec = "straight_heater_metal",
+    component: ComponentSpec = "interdigitated_electrodes",
     select_ports: SelectPorts = select_ports_electrical,
     port_names: Strs | None = None,
     cross_section: CrossSectionSpec = "metal_routing",
@@ -155,7 +155,7 @@ def add_pads_bot(
 
 
 def add_pads_top(
-    component: ComponentSpec = "straight_heater_metal",
+    component: ComponentSpec = "interdigitated_electrodes",
     select_ports: SelectPorts = select_ports_electrical,
     port_names: Strs | None = None,
     cross_section: CrossSectionSpec = "metal_routing",

--- a/tests/routing/test_add_pads.py
+++ b/tests/routing/test_add_pads.py
@@ -22,6 +22,11 @@ def add_pads0() -> Component:
 components = [add_pads0]
 
 
+@pytest.mark.parametrize("add_pads", [gf.routing.add_pads_bot, gf.routing.add_pads_top])
+def test_default_component(add_pads: Any) -> None:
+    add_pads()
+
+
 @pytest.fixture(params=components)
 def component(request: pytest.FixtureRequest) -> Any:
     return request.param()


### PR DESCRIPTION
Closes #4837

- change the default wrapped component from `straight_heater_metal` to the four-port `interdigitated_electrodes`
- verify both helpers can be called with their defaults without routing collisions


**Before**:
<img width="405" height="302" alt="image" src="https://github.com/user-attachments/assets/badf93ff-e6d5-4ef7-aca1-ec137c2f047c" />

**After**:
<img width="405" height="302" alt="image" src="https://github.com/user-attachments/assets/46942409-f13e-48c2-8c58-64bd3311ec10" />


Tests:
- `uv run --no-sync python -m pytest tests/routing/test_add_pads.py::test_default_component -q`
- `uv run --no-sync pre-commit run --all-files`