### PR TITLE
refactor: use match-case for justify in text_freetype

### DIFF
--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -110,15 +110,16 @@ def text_freetype(
 
     justify = justify.lower()
     for inst in t.insts:
-        if justify == "left":
-            inst.xmax = 0
-        elif justify == "center":
-            inst.xmin = -inst.xsize / 2
-        elif justify == "right":
-            inst.xmin = 0
-        else:
-            raise ValueError(
-                f"justify = {justify!r} not in ('center', 'right', 'left')"
-            )
+        match justify:
+            case "left":
+                inst.xmax = 0
+            case "center":
+                inst.xmin = -inst.xsize / 2
+            case "right":
+                inst.xmin = 0
+            case _:
+                raise ValueError(
+                    f"justify = {justify!r} not in ('center', 'right', 'left')"
+                )
     t.flatten()
     return t


### PR DESCRIPTION
Replaces the `if`/`elif`/`else` string dispatch for `justify` in `text_freetype` with structural pattern matching (`match`/`case`). Behavior is unchanged, including the `ValueError` message on an unknown value.

Targets `fix/text-freetype-segfault` (#4705) rather than `main`, since that branch is the one currently touching `text_freetype.py`.

Fixes #4842.

`pre-commit run --files gdsfactory/components/texts/text_freetype.py` passes clean (ruff, ruff format, pyright).

Requested by @nikosavola

⚠️ Opened by an AI agent — the code change still needs human review before merge.