### PR TITLE
fix: use the capacitor's electrical ports in resonator_lumped

### DIFF
--- a/gdsfactory/components/quantum/resonator.py
+++ b/gdsfactory/components/quantum/resonator.py
@@ -283,7 +283,7 @@ def resonator_lumped(
     link = c << gf.components.straight(length=coupling_gap, cross_section=xs)
     link.connect(
         "o1",
-        cap_ref.ports["o2"],
+        cap_ref.ports["e2"],
         allow_width_mismatch=True,
         allow_type_mismatch=True,
     )
@@ -297,7 +297,7 @@ def resonator_lumped(
         port=link.ports["o2"],
     )
 
-    c.add_port(name="input", port=cap_ref.ports["o1"], port_type=port_type)
+    c.add_port(name="input", port=cap_ref.ports["e1"], port_type=port_type)
     c.add_port(name="output", port=ind_out)
 
     # Add metadata

--- a/tests/test-data-regression/test_netlists_resonator_lumped_.yml
+++ b/tests/test-data-regression/test_netlists_resonator_lumped_.yml
@@ -208,4 +208,5 @@ placements:
     x: 97
     y: -27
 ports:
+  input: interdigital_capacitor_gdsfactorypcomponentspanalogpint_412debcc_0_0,e1
   output: straight_gdsfactorypcomponentspwaveguidespstraight_L60__e2aa7e80_97000_m107000_A180,o2


### PR DESCRIPTION
Fixes #4844.

7be33dc ("fix: use electrical ports for analog components") moved `interdigital_capacitor` to electrical ports `e1`/`e2`, but `resonator_lumped` still looked up `o1`/`o2` on the capacitor instance, so building the cell raised:

```
KeyError: "key='o2' is not a valid port name or index. Available ports: ['e1', 'e2']"
```

That broke `test_gds[resonator_lumped]`, `test_settings[resonator_lumped]`, `test_netlists[resonator_lumped]`, and `test_updk_generic` (which builds every cell in the generic PDK).

## Regenerated test data

`tests/test-data-regression/test_netlists_resonator_lumped_.yml` gains one line:

```yaml
ports:
+  input: interdigital_capacitor_..._0_0,e1
   output: straight_...,o2
```

The top-level `input` port is declared with `port_type="electrical"`. Previously it pointed at an *optical* capacitor port, so `get_netlist` could not resolve it to an instance port and dropped it from the netlist entirely. Now that the capacitor port is electrical the mapping resolves, and `input` appears alongside `output` — the netlist is more correct than before, not merely different.

## Note on the GDS references

The two remaining failures on `main`, `test_gds[spiral_inductor]` and `test_gds[interdigital_capacitor]`, are stale references in the test-data repo (old `WG (1/0)` geometry vs. the new `M1 (41/0)`). They are fixed by gdsfactory/gdsfactory-test-data#14, **which needs to merge first** — `test_gds` stays red here until it does.

## Verification

Full suite green locally with both changes in place: `1757 passed, 2 skipped, 1 xfailed`. `pre-commit` passes clean on the changed files.

Requested by @nikosavola. Reminder: this is an AI-authored PR — a human still needs to review the actual code changes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)