### PR TITLE
Avoid FreeType outline orientation segfault (rebased on main)

### DIFF
--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -110,10 +110,15 @@ def text_freetype(
 
     justify = justify.lower()
     for inst in t.insts:
-        if justify == "center":
-            inst.move((0, 0))
-
-        elif justify == "right":
+        if justify == "left":
             inst.xmax = 0
+        elif justify == "center":
+            inst.xmin = -inst.xsize / 2
+        elif justify == "right":
+            inst.xmin = 0
+        else:
+            raise ValueError(
+                f"justify = {justify!r} not in ('center', 'right', 'left')"
+            )
     t.flatten()
     return t

--- a/gdsfactory/components/texts/text_freetype.py
+++ b/gdsfactory/components/texts/text_freetype.py
@@ -110,15 +110,16 @@ def text_freetype(
 
     justify = justify.lower()
     for inst in t.insts:
-        if justify == "left":
-            inst.xmax = 0
-        elif justify == "center":
-            inst.xmin = -inst.xsize / 2
-        elif justify == "right":
-            inst.xmin = 0
-        else:
-            raise ValueError(
-                f"justify = {justify!r} not in ('center', 'right', 'left')"
-            )
+        match justify:
+            case "left":
+                inst.xmax = 0
+            case "center":
+                inst.xmin = -inst.xsize / 2
+            case "right":
+                inst.xmin = 0
+            case _:
+                raise ValueError(
+                    f"justify = {justify!r} not in ('center', 'right', 'left')"
+                )
     t.flatten()
     return t

--- a/gdsfactory/font.py
+++ b/gdsfactory/font.py
@@ -160,7 +160,6 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
     # Construct the component
     component = Component()
 
-    orientation = freetype.FT_Outline_Get_Orientation(outline._FT_Outline)
     polygons_cw = [p for p in polygons if _polygon_orientation(np.array(p)) == 0]
     polygons_ccw = [p for p in polygons if _polygon_orientation(np.array(p)) == 1]
     c1 = Component()
@@ -169,6 +168,11 @@ def _get_glyph(font: freetype.Face, letter: str) -> tuple[Component, float, floa
         c1.add_polygon(np.array(p), layer=(1, 0))
     for p in polygons_ccw:
         c2.add_polygon(np.array(p), layer=(1, 0))
+    # The largest contour is the outer (filled) outline. Inferring its winding from
+    # the polygon coordinates avoids passing FreeType's private ``_FT_Outline``
+    # pointer back into the C API, which can segfault with some FreeType builds.
+    outer_polygon = max(polygons, key=_polygon_area)
+    orientation = _polygon_orientation(np.asarray(outer_polygon))
     if orientation == 0:
         # TrueType specification, fill the clockwise contour
         component = boolean(c1, c2, operation="not", layer=(1, 0))
@@ -195,3 +199,15 @@ def _polygon_orientation(vertices: npt.NDArray[np.float64]) -> int:
         s += (x2 - x1) * (y2 + y1)
 
     return 0 if s > 0 else 1
+
+
+def _polygon_area(vertices: npt.ArrayLike) -> float:
+    """Return the absolute area of a polygon."""
+    points = np.asarray(vertices)
+    return float(
+        abs(
+            np.dot(points[:, 0], np.roll(points[:, 1], 1))
+            - np.dot(points[:, 1], np.roll(points[:, 0], 1))
+        )
+        / 2
+    )

--- a/gdsfactory/samples/sample_justify.py
+++ b/gdsfactory/samples/sample_justify.py
@@ -1,0 +1,14 @@
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    gf.gpdk.PDK.activate()
+    c = gf.Component("fixed_justify")
+    text1 = gf.components.text_freetype("centered", size=100, justify="center")
+    text2 = gf.components.text_freetype("left", size=100, justify="left")
+    text3 = gf.components.text_freetype("right", size=100, justify="right")
+    text4 = gf.components.text("1234567890", size=100, justify="center")
+    c.add_ref(text1)
+    c.add_ref(text2).movey(-100)
+    c.add_ref(text3).movey(-200)
+    c.add_ref(text4).movey(-300)
+    c.show()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+
+
+def test_text_freetype_renders_geometry() -> None:
+    """FreeType glyph extraction must not crash or return empty text."""
+    component = gf.components.text_freetype("abc")
+
+    assert component.dbbox().width() > 0
+    assert component.dbbox().height() > 0
+    assert component.get_polygons()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import gdsfactory as gf
 
 
@@ -10,3 +12,20 @@ def test_text_freetype_renders_geometry() -> None:
     assert component.dbbox().width() > 0
     assert component.dbbox().height() > 0
     assert component.get_polygons()
+
+
+@pytest.mark.parametrize("justify", ["left", "center", "right"])
+def test_text_freetype_justification(justify: str) -> None:
+    component = gf.components.text_freetype("qwerty", justify=justify)
+
+    if justify == "left":
+        assert component.dxmax == pytest.approx(0)
+    elif justify == "center":
+        assert component.dx == pytest.approx(0)
+    else:
+        assert component.dxmin == pytest.approx(0)
+
+
+def test_text_freetype_rejects_invalid_justification() -> None:
+    with pytest.raises(ValueError, match="not in"):
+        gf.components.text_freetype("abc", justify="invalid")


### PR DESCRIPTION
Rebase of #4705 onto current `main`. Same three commits, original authorship preserved:

- `Avoid FreeType outline orientation segfault` (@joamatab)
- `Fix FreeType text justification (#4722)` (@joamatab)
- `refactor: use match-case for justify in text_freetype`

Fixes #3616.

## Conflict resolution

One conflict, in `uv.lock`: the branch bumped `kfactory` `~=3.0.0` → `~=3.0.2` (lock 3.0.1 → 3.0.4), while `main` has since moved the specifier to `~=3.0.4`. Took `main` unchanged — the branch's lock delta is now a strict subset of what `main` already has, so the rebased branch has **zero** `uv.lock` diff. No dependency change rides along with this fix.

No other conflicts; `font.py`, `text_freetype.py`, `tests/test_font.py` and `samples/sample_justify.py` applied cleanly.

## Verification

`pre-commit run --from-ref origin/main --to-ref HEAD` passes clean (ruff, ruff format, pyright, codespell). I could not run the test suite locally — CI is the first real check.

Supersedes #4705, which was 112 commits behind `main` and failing `test_code` on stale GDS references for `resonator_cpw`, `resonator_lumped` and `flux_qubit_asymmetric` (fixed on `main` by #4832).

Requested by @nikosavola

⚠️ Opened by an AI agent — the code changes still need human review before merge.