### PR TITLE
Fix import sorting in test_layerstack

### DIFF
--- a/tests/technology/test_layerstack.py
+++ b/tests/technology/test_layerstack.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic import ValidationError
+
 import gdsfactory as gf
 from gdsfactory.gpdk import LAYER, LAYER_STACK
 from gdsfactory.technology import LayerLevel, LayerStack, NormalVariation


### PR DESCRIPTION
Restores the ruff isort ordering in tests/technology/test_layerstack.py that efdb012c2 broke, unblocking the pre-commit check on main (and therefore on any open PR that merges main).