### PR TITLE
ci: add merge_group trigger to test_code and docs workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,7 @@
 name: build docs
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -2,6 +2,7 @@ name: Test code
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
       branches:
         - main


### PR DESCRIPTION
Closes #4849

## Problem

Green CI on a PR only proves the PR passed against the base commit it was branched from. By the time it merges, `main` may have moved on, so the merged tree is a combination CI never actually ran. That is how the `isort` violation in #4730 landed on `main` and broke pre-commit for every open PR — the pre-commit job runs `--all-files`, so a broken `main` poisons PRs that never touched the offending file.

## Change

Add a `merge_group:` trigger to the two workflows that gate merges:

- `.github/workflows/test_code.yml` — `pre-commit`, `test_code` matrix, coverage, samples, `ty`
- `.github/workflows/pages.yml` — docs build

With GitHub Merge Queue enabled, these then run against the *actual* final state (PR + latest `main`) before anything lands, closing the stale-ref gap. This is smoother than "require branches to be up to date", which forces constant manual rebases.

Notes on correctness:

- Both workflows' concurrency groups are keyed on `github.ref`. In a merge-queue run that is the unique `refs/heads/gh-readonly-queue/main/...` ref, so queue entries do not cancel each other or in-flight PR runs. No concurrency changes needed.
- `deploy-docs` in `pages.yml` stays gated on `github.ref == 'refs/heads/main'`, so merge-queue runs build the docs without publishing them.
- `test_code_coverage` checks out `github.event.pull_request.head.sha || github.sha`; in a merge-queue run the first is empty and it correctly falls back to the merge-group commit.

## Still needs a maintainer (repository settings, not code)

I cannot change repo settings. To actually get the benefit:

1. Enable **Merge Queue** for `main` in branch protection / rulesets.
2. Mark `pre-commit`, the `test_code` matrix jobs, and `Build docs` as **required status checks** so failures block merges.

## Verification

`pre-commit run --files .github/workflows/test_code.yml .github/workflows/pages.yml` passes clean, including `actionlint` and `yamlfmt`.

Requested by @nikosavola

---

⚠️ This PR was authored by an AI agent. The diff is two lines, but a human still needs to review it before merge — and the settings changes above are the part that actually fixes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
